### PR TITLE
Add WebRTC client SDK skills plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -218,6 +218,18 @@
         "./telnyx-ruby/skills/telnyx-voice-streaming-ruby",
         "./telnyx-ruby/skills/telnyx-webrtc-ruby"
       ]
+    },
+    {
+      "name": "telnyx-webrtc-client",
+      "description": "Telnyx WebRTC client SDK skills \u2014 build VoIP calling apps on web, iOS, Android, Flutter, and React Native. Covers authentication, call controls, push notifications, call quality metrics, and AI Agent integration.",
+      "source": "./telnyx-webrtc-client",
+      "skills": [
+        "./telnyx-webrtc-client/skills/telnyx-webrtc-client-js",
+        "./telnyx-webrtc-client/skills/telnyx-webrtc-client-ios",
+        "./telnyx-webrtc-client/skills/telnyx-webrtc-client-android",
+        "./telnyx-webrtc-client/skills/telnyx-webrtc-client-flutter",
+        "./telnyx-webrtc-client/skills/telnyx-webrtc-client-react-native"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds 5 hand-authored WebRTC client SDK skills (JS, iOS, Android, Flutter, React Native) as a new `telnyx-webrtc-client` plugin
- Registers the plugin in `marketplace.json` so it's discoverable via `/plugin install telnyx-webrtc-client@telnyx-agent-skills`
- Adds `.manual-plugins.json` to define manual plugin entries separately from auto-generated ones

## Test plan
- [ ] Run `/plugin marketplace add team-telnyx/telnyx-ext-agent-skills` (or `/plugin marketplace update telnyx-agent-skills` if already added)
- [ ] Run `/plugin install telnyx-webrtc-client@telnyx-agent-skills` and verify it installs successfully
- [ ] Verify each skill loads: `telnyx-webrtc-client-js`, `telnyx-webrtc-client-ios`, `telnyx-webrtc-client-android`, `telnyx-webrtc-client-flutter`, `telnyx-webrtc-client-react-native`

🤖 Generated with [Claude Code](https://claude.com/claude-code)