### PR TITLE
Optimize README for user experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,57 @@ Official skills for AI coding agents to integrate Telnyx APIs using the native S
 
 These skills follow the [Agent Skills specification](https://agentskills.io/specification) and can be installed in AI coding assistants like [Claude Code](https://docs.anthropic.com/en/docs/claude-code), Cursor, Windsurf, and other compatible agents.
 
+## Quick Start (Claude Code)
+
+Add the Telnyx marketplace and install the plugin for your language:
+
+```bash
+/plugin marketplace add team-telnyx/telnyx-ext-agent-skills
+/plugin install telnyx-python@telnyx-agent-skills
+```
+
+That's it. Your agent now knows how to use every Telnyx API in Python — messaging, voice, numbers, IoT, AI, and more (35 products, 175 skills total).
+
+**Other languages:** replace `telnyx-python` with `telnyx-javascript`, `telnyx-go`, `telnyx-java`, or `telnyx-ruby`.
+
+**WebRTC client SDKs:** `/plugin install telnyx-webrtc-client@telnyx-agent-skills` (JS, iOS, Android, Flutter, React Native)
+
+## Example
+
+After installing, your AI agent knows how to write correct Telnyx SDK code:
+
+```python
+import os
+from telnyx import Telnyx
+
+client = Telnyx(api_key=os.environ.get("TELNYX_API_KEY"))
+
+# Send an SMS
+response = client.messages.send(
+    from_="+15550001234",
+    to="+18445550001",
+    text="Hello from Telnyx!",
+)
+print(response.data)
+```
+
 ## Available Skills
 
-Skills are organized by product and language. Each skill teaches an AI agent how to use Telnyx SDKs correctly with code examples generated from the official OpenAPI specifications.
+Skills are organized by product and language. Each product is available in **JavaScript**, **Python**, **Go**, **Java**, and **Ruby** (append the language suffix, e.g. `telnyx-messaging-python`).
 
-### Products
+#### Messaging
 
-| Product | Description |
-|---------|-------------|
-| **Messaging** | |
+| Skill | Description |
+|-------|-------------|
 | `telnyx-messaging-*` | Send/receive SMS/MMS, manage messaging numbers, handle opt-outs |
 | `telnyx-messaging-profiles-*` | Messaging profiles, number pools, short codes |
 | `telnyx-messaging-hosted-*` | Hosted SMS numbers, toll-free verification, RCS |
 | `telnyx-10dlc-*` | 10DLC brand/campaign registration for A2P compliance |
-| **Voice** | |
+
+#### Voice
+
+| Skill | Description |
+|-------|-------------|
 | `telnyx-voice-*` | Call control: dial, answer, hangup, transfer, bridge |
 | `telnyx-voice-media-*` | Audio playback, text-to-speech, call recording |
 | `telnyx-voice-gather-*` | DTMF/speech input collection, AI-powered gather |
@@ -25,22 +62,38 @@ Skills are organized by product and language. Each skill teaches an AI agent how
 | `telnyx-voice-conferencing-*` | Conference calls, queues, multi-party sessions |
 | `telnyx-voice-advanced-*` | DTMF sending, SIPREC, noise suppression, supervisor |
 | `telnyx-texml-*` | TeXML (TwiML-compatible) voice applications |
-| **Connectivity** | |
+
+#### Connectivity
+
+| Skill | Description |
+|-------|-------------|
 | `telnyx-sip-*` | SIP trunking connections, outbound voice profiles |
 | `telnyx-sip-integrations-*` | Call recordings, media storage, Dialogflow integration |
-| `telnyx-webrtc-*` | WebRTC credentials and mobile push notifications (server-side REST API) |
-| **Phone Numbers** | |
+| `telnyx-webrtc-*` | WebRTC credentials and push notification setup (server-side — see [Client SDKs](#webrtc-client-sdks) for the calling UI) |
+
+#### Phone Numbers
+
+| Skill | Description |
+|-------|-------------|
 | `telnyx-numbers-*` | Search, order, and manage phone numbers |
 | `telnyx-numbers-config-*` | Phone number configuration and settings |
 | `telnyx-numbers-compliance-*` | Regulatory requirements, bundles, documents |
 | `telnyx-numbers-services-*` | Voicemail, voice channels, E911 |
 | `telnyx-porting-in-*` | Port numbers into Telnyx |
 | `telnyx-porting-out-*` | Manage port-out requests |
-| **Identity & AI** | |
+
+#### Identity & AI
+
+| Skill | Description |
+|-------|-------------|
 | `telnyx-verify-*` | Phone verification, number lookup, 2FA |
 | `telnyx-ai-assistants-*` | AI voice assistants with knowledge bases |
 | `telnyx-ai-inference-*` | LLM inference, embeddings, AI analytics |
-| **Other** | |
+
+#### Other
+
+| Skill | Description |
+|-------|-------------|
 | `telnyx-iot-*` | IoT SIM cards, eSIMs, data plans |
 | `telnyx-networking-*` | Private networks, VPN gateways |
 | `telnyx-storage-*` | S3-compatible cloud storage |
@@ -48,16 +101,22 @@ Skills are organized by product and language. Each skill teaches an AI agent how
 | `telnyx-fax-*` | Programmable fax |
 | `telnyx-seti-*` | Space Exploration Telecommunications Infrastructure |
 | `telnyx-oauth-*` | OAuth 2.0 authentication flows |
-| **Account** | |
+
+#### Account
+
+| Skill | Description |
+|-------|-------------|
 | `telnyx-account-*` | Balance, payments, invoices, webhooks, audit logs |
 | `telnyx-account-access-*` | Addresses, auth providers, IP access, billing groups |
 | `telnyx-account-management-*` | Sub-account management (resellers) |
 | `telnyx-account-notifications-*` | Notification channels and settings |
 | `telnyx-account-reports-*` | Usage reports for billing and analytics |
 
-### WebRTC Client-Side SDKs
+## WebRTC Client SDKs
 
-In addition to the server-side REST API skills above, we provide skills for the **client-side WebRTC SDKs** — native libraries for building VoIP calling apps on web and mobile platforms.
+The skills above cover **server-side** Telnyx APIs (REST calls from your backend). If you're building a **calling app** where users make or receive VoIP calls directly from a device, you also need the client-side WebRTC SDKs.
+
+These are platform-specific native libraries — separate from the server-side language plugins:
 
 | Skill | Platform | Language |
 |-------|----------|----------|
@@ -67,70 +126,29 @@ In addition to the server-side REST API skills above, we provide skills for the 
 | `telnyx-webrtc-client-flutter` | Flutter (Android/iOS/Web) | Dart |
 | `telnyx-webrtc-client-react-native` | React Native (Android/iOS) | TypeScript |
 
-These skills cover authentication, call controls, push notifications, call quality metrics, and AI Agent integration. Install the `telnyx-webrtc-client` plugin to get all five.
+Each skill covers authentication, making/receiving calls, call controls (hold, mute, transfer), push notifications, call quality metrics, and AI Agent integration.
 
-### Languages
-
-Each product is available for:
-- **JavaScript** (`-javascript`)
-- **Python** (`-python`)
-- **Go** (`-go`)
-- **Java** (`-java`)
-- **Ruby** (`-ruby`)
-
-## Installation
-
-### Claude Code
-
-First, add the Telnyx skills marketplace:
-
-```bash
-/plugin marketplace add team-telnyx/telnyx-ext-agent-skills
-```
-
-Then install the plugin for your language. Each plugin includes all 35 Telnyx products (messaging, voice, numbers, IoT, AI, and more):
-
-#### Python
-```bash
-/plugin install telnyx-python@telnyx-agent-skills
-```
-
-#### JavaScript / Node.js
-```bash
-/plugin install telnyx-javascript@telnyx-agent-skills
-```
-
-#### Go
-```bash
-/plugin install telnyx-go@telnyx-agent-skills
-```
-
-#### Java
-```bash
-/plugin install telnyx-java@telnyx-agent-skills
-```
-
-#### Ruby
-```bash
-/plugin install telnyx-ruby@telnyx-agent-skills
-```
-
-#### WebRTC Client SDKs (all platforms)
 ```bash
 /plugin install telnyx-webrtc-client@telnyx-agent-skills
 ```
 
+> **Note:** Building a calling app typically requires both plugins — a server-side plugin (e.g. `telnyx-python`) to create WebRTC credentials and generate login tokens, and `telnyx-webrtc-client` for the client-side calling UI.
+
+## Installation for Other Agents
+
 ### Cursor
 
-Add Telnyx skills as project context by referencing the raw `SKILL.md` files from GitHub:
-
 1. Open **Cursor Settings > Rules > Project Rules**
-2. Create a rule file (e.g., `.cursor/rules/telnyx.mdc`) and paste the contents of the desired `SKILL.md` file
-3. Alternatively, download the `SKILL.md` file into your project and add it via **@Files** in the chat
+2. Create a rule file (e.g., `.cursor/rules/telnyx.mdc`)
+3. Paste the contents of the `SKILL.md` for the product and language you need
+
+You can find skill files in this repo under `telnyx-{language}/skills/telnyx-{product}-{language}/SKILL.md`, or fetch them directly:
+
+```
+https://raw.githubusercontent.com/team-telnyx/telnyx-ext-agent-skills/main/telnyx-python/skills/telnyx-messaging-python/SKILL.md
+```
 
 ### Windsurf
-
-Add skills to Windsurf via project rules:
 
 1. Create a `.windsurfrules` file in your project root
 2. Paste the contents of the desired `SKILL.md` file(s) into it
@@ -141,39 +159,7 @@ For any agent that supports the [Agent Skills specification](https://agentskills
 
 ## Skill Structure
 
-Each skill contains a single `SKILL.md` file with:
-- YAML frontmatter (name, description, metadata)
-- Installation instructions for the SDK
-- A setup section with client initialization (shown once)
-- Concise code examples for every API operation
-- Webhook event reference tables where applicable
-
-All code examples are extracted from Telnyx OpenAPI specifications and are designed to work with the latest SDK versions.
-
-## Example
-
-After installing `telnyx-messaging-python`, your AI agent will know how to:
-
-```python
-import os
-from telnyx import Telnyx
-
-client = Telnyx(
-    api_key=os.environ.get("TELNYX_API_KEY"),
-)
-
-# Send a message
-response = client.messages.send(
-    to="+18445550001",
-)
-print(response.data)
-
-# Retrieve a message
-message = client.messages.retrieve(
-    "182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e",
-)
-print(message.data)
-```
+Each skill contains a single `SKILL.md` file with YAML frontmatter, SDK installation instructions, client setup, code examples for every API operation, and webhook event reference tables where applicable. All code examples are generated from the official Telnyx OpenAPI specifications.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
- Add Quick Start section at the top with 2-command install
- Move Example up with realistic message send params (from, to, text)
- Restructure products table with subheadings instead of empty table cells
- Promote WebRTC Client SDKs to its own top-level section with clear server-side vs client-side distinction
- Cross-link server-side `telnyx-webrtc-*` entry to client SDK section
- Add concrete raw GitHub URL template for Cursor/Windsurf users
- Condense Skill Structure section

## Test plan
- [ ] Verify rendered markdown looks correct on the PR Files tab
- [ ] Confirm anchor link `[Client SDKs](#webrtc-client-sdks)` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)