### PR TITLE
Fix traffic workflow repo name

### DIFF
--- a/.github/workflows/repo-traffic.yml
+++ b/.github/workflows/repo-traffic.yml
@@ -1,0 +1,29 @@
+name: Collect traffic data
+
+on:
+  schedule:
+    # Run daily at 03:00 UTC (before GitHub resets the 14-day window)
+    - cron: "0 3 * * *"
+  workflow_dispatch: # Allow manual runs
+
+jobs:
+  collect-traffic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: traffic-data
+
+      - name: Fetch traffic data
+        uses: jgehrcke/github-repo-stats@v1.6.0
+        with:
+          ghtoken: ${{ secrets.TRAFFIC_TOKEN }}
+          repository: team-telnyx/telnyx-skills
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git diff --staged --quiet || git commit -m "Update traffic data $(date -u +%Y-%m-%d)"
+          git push


### PR DESCRIPTION
Updates repo-traffic.yml to reference telnyx-skills instead of the old telnyx-ext-agent-skills name.