### PR TITLE
Update migration skill description to mention Call Control

### DIFF
--- a/telnyx-twilio-migration/skills/telnyx-twilio-migration/SKILL.md
+++ b/telnyx-twilio-migration/skills/telnyx-twilio-migration/SKILL.md
@@ -2,9 +2,9 @@
 name: telnyx-twilio-migration
 description: >-
   Migrate from Twilio to Telnyx. Covers voice (TwiML to TeXML with full verb
-  reference), messaging, WebRTC, number porting via FastPort, and Verify.
-  Includes product mapping, migration scripts, and key differences in auth,
-  webhooks, and payload format.
+  reference, Call Control API guidance), messaging, WebRTC, number porting via
+  FastPort, and Verify. Includes product mapping, migration scripts, and key
+  differences in auth, webhooks, and payload format.
 metadata:
   author: telnyx
   product: migration


### PR DESCRIPTION
## Summary
- Adds "Call Control API guidance" to the migration skill's frontmatter description
- The skill already covers Call Control (comparison table, decision guide, code example) but the description didn't mention it, making it undiscoverable

## Test plan
- [ ] Verify frontmatter YAML parses correctly
- [ ] Confirm description renders properly in marketplace

🤖 Generated with [Claude Code](https://claude.com/claude-code)