### PR TITLE
Update skills from Stainless spec

### DIFF
--- a/telnyx-go/skills/telnyx-ai-inference-go/SKILL.md
+++ b/telnyx-go/skills/telnyx-ai-inference-go/SKILL.md
@@ -817,22 +817,6 @@ Generate and fetch speech to text usage report synchronously. This endpoint will
 
 Returns: `data` (object)
 
-## Speech to text over WebSocket
-
-Open a WebSocket connection to stream audio and receive transcriptions in real-time. Authentication is provided via the standard `Authorization: Bearer <API_KEY>` header. Supported engines: `Azure`, `Deepgram`, `Google`, `Telnyx`.
-
-`GET /speech-to-text/transcription`
-
-```go
-	err := client.SpeechToText.Transcribe(context.TODO(), telnyx.SpeechToTextTranscribeParams{
-		InputFormat:         telnyx.SpeechToTextTranscribeParamsInputFormatMP3,
-		TranscriptionEngine: telnyx.SpeechToTextTranscribeParamsTranscriptionEngineAzure,
-	})
-	if err != nil {
-		panic(err.Error())
-	}
-```
-
 ## Generate speech from text
 
 Generate synthesized speech audio from text input. Returns audio in the requested format (binary audio stream, base64-encoded JSON, or an audio URL for later retrieval). Authentication is provided via the standard `Authorization: Bearer <API_KEY>` header.

--- a/telnyx-java/skills/telnyx-ai-inference-java/SKILL.md
+++ b/telnyx-java/skills/telnyx-ai-inference-java/SKILL.md
@@ -755,22 +755,6 @@ UsageReportRetrieveSpeechToTextResponse response = client.legacy().reporting().u
 
 Returns: `data` (object)
 
-## Speech to text over WebSocket
-
-Open a WebSocket connection to stream audio and receive transcriptions in real-time. Authentication is provided via the standard `Authorization: Bearer <API_KEY>` header. Supported engines: `Azure`, `Deepgram`, `Google`, `Telnyx`.
-
-`GET /speech-to-text/transcription`
-
-```java
-import com.telnyx.sdk.models.speechtotext.SpeechToTextTranscribeParams;
-
-SpeechToTextTranscribeParams params = SpeechToTextTranscribeParams.builder()
-    .inputFormat(SpeechToTextTranscribeParams.InputFormat.MP3)
-    .transcriptionEngine(SpeechToTextTranscribeParams.TranscriptionEngine.AZURE)
-    .build();
-client.speechToText().transcribe(params);
-```
-
 ## Generate speech from text
 
 Generate synthesized speech audio from text input. Returns audio in the requested format (binary audio stream, base64-encoded JSON, or an audio URL for later retrieval). Authentication is provided via the standard `Authorization: Bearer <API_KEY>` header.

--- a/telnyx-javascript/skills/telnyx-ai-inference-javascript/SKILL.md
+++ b/telnyx-javascript/skills/telnyx-ai-inference-javascript/SKILL.md
@@ -691,16 +691,6 @@ console.log(response.data);
 
 Returns: `data` (object)
 
-## Speech to text over WebSocket
-
-Open a WebSocket connection to stream audio and receive transcriptions in real-time. Authentication is provided via the standard `Authorization: Bearer <API_KEY>` header. Supported engines: `Azure`, `Deepgram`, `Google`, `Telnyx`.
-
-`GET /speech-to-text/transcription`
-
-```javascript
-await client.speechToText.transcribe({ input_format: 'mp3', transcription_engine: 'Azure' });
-```
-
 ## Generate speech from text
 
 Generate synthesized speech audio from text input. Returns audio in the requested format (binary audio stream, base64-encoded JSON, or an audio URL for later retrieval). Authentication is provided via the standard `Authorization: Bearer <API_KEY>` header.

--- a/telnyx-python/skills/telnyx-ai-inference-python/SKILL.md
+++ b/telnyx-python/skills/telnyx-ai-inference-python/SKILL.md
@@ -695,19 +695,6 @@ print(response.data)
 
 Returns: `data` (object)
 
-## Speech to text over WebSocket
-
-Open a WebSocket connection to stream audio and receive transcriptions in real-time. Authentication is provided via the standard `Authorization: Bearer <API_KEY>` header. Supported engines: `Azure`, `Deepgram`, `Google`, `Telnyx`.
-
-`GET /speech-to-text/transcription`
-
-```python
-client.speech_to_text.transcribe(
-    input_format="mp3",
-    transcription_engine="Azure",
-)
-```
-
 ## Generate speech from text
 
 Generate synthesized speech audio from text input. Returns audio in the requested format (binary audio stream, base64-encoded JSON, or an audio URL for later retrieval). Authentication is provided via the standard `Authorization: Bearer <API_KEY>` header.

--- a/telnyx-ruby/skills/telnyx-ai-inference-ruby/SKILL.md
+++ b/telnyx-ruby/skills/telnyx-ai-inference-ruby/SKILL.md
@@ -676,18 +676,6 @@ puts(response)
 
 Returns: `data` (object)
 
-## Speech to text over WebSocket
-
-Open a WebSocket connection to stream audio and receive transcriptions in real-time. Authentication is provided via the standard `Authorization: Bearer <API_KEY>` header. Supported engines: `Azure`, `Deepgram`, `Google`, `Telnyx`.
-
-`GET /speech-to-text/transcription`
-
-```ruby
-result = client.speech_to_text.transcribe(input_format: :mp3, transcription_engine: :Azure)
-
-puts(result)
-```
-
 ## Generate speech from text
 
 Generate synthesized speech audio from text input. Returns audio in the requested format (binary audio stream, base64-encoded JSON, or an audio URL for later retrieval). Authentication is provided via the standard `Authorization: Bearer <API_KEY>` header.

--- a/telnyx-twilio-migration/skills/telnyx-twilio-migration/sdk-reference/go/ai-inference.md
+++ b/telnyx-twilio-migration/skills/telnyx-twilio-migration/sdk-reference/go/ai-inference.md
@@ -805,22 +805,6 @@ Generate and fetch speech to text usage report synchronously. This endpoint will
 
 Returns: `data` (object)
 
-## Speech to text over WebSocket
-
-Open a WebSocket connection to stream audio and receive transcriptions in real-time. Authentication is provided via the standard `Authorization: Bearer <API_KEY>` header. Supported engines: `Azure`, `Deepgram`, `Google`, `Telnyx`.
-
-`GET /speech-to-text/transcription`
-
-```go
-	err := client.SpeechToText.Transcribe(context.TODO(), telnyx.SpeechToTextTranscribeParams{
-		InputFormat:         telnyx.SpeechToTextTranscribeParamsInputFormatMP3,
-		TranscriptionEngine: telnyx.SpeechToTextTranscribeParamsTranscriptionEngineAzure,
-	})
-	if err != nil {
-		panic(err.Error())
-	}
-```
-
 ## Generate speech from text
 
 Generate synthesized speech audio from text input. Returns audio in the requested format (binary audio stream, base64-encoded JSON, or an audio URL for later retrieval). Authentication is provided via the standard `Authorization: Bearer <API_KEY>` header.

--- a/telnyx-twilio-migration/skills/telnyx-twilio-migration/sdk-reference/java/ai-inference.md
+++ b/telnyx-twilio-migration/skills/telnyx-twilio-migration/sdk-reference/java/ai-inference.md
@@ -743,22 +743,6 @@ UsageReportRetrieveSpeechToTextResponse response = client.legacy().reporting().u
 
 Returns: `data` (object)
 
-## Speech to text over WebSocket
-
-Open a WebSocket connection to stream audio and receive transcriptions in real-time. Authentication is provided via the standard `Authorization: Bearer <API_KEY>` header. Supported engines: `Azure`, `Deepgram`, `Google`, `Telnyx`.
-
-`GET /speech-to-text/transcription`
-
-```java
-import com.telnyx.sdk.models.speechtotext.SpeechToTextTranscribeParams;
-
-SpeechToTextTranscribeParams params = SpeechToTextTranscribeParams.builder()
-    .inputFormat(SpeechToTextTranscribeParams.InputFormat.MP3)
-    .transcriptionEngine(SpeechToTextTranscribeParams.TranscriptionEngine.AZURE)
-    .build();
-client.speechToText().transcribe(params);
-```
-
 ## Generate speech from text
 
 Generate synthesized speech audio from text input. Returns audio in the requested format (binary audio stream, base64-encoded JSON, or an audio URL for later retrieval). Authentication is provided via the standard `Authorization: Bearer <API_KEY>` header.

--- a/telnyx-twilio-migration/skills/telnyx-twilio-migration/sdk-reference/javascript/ai-inference.md
+++ b/telnyx-twilio-migration/skills/telnyx-twilio-migration/sdk-reference/javascript/ai-inference.md
@@ -679,16 +679,6 @@ console.log(response.data);
 
 Returns: `data` (object)
 
-## Speech to text over WebSocket
-
-Open a WebSocket connection to stream audio and receive transcriptions in real-time. Authentication is provided via the standard `Authorization: Bearer <API_KEY>` header. Supported engines: `Azure`, `Deepgram`, `Google`, `Telnyx`.
-
-`GET /speech-to-text/transcription`
-
-```javascript
-await client.speechToText.transcribe({ input_format: 'mp3', transcription_engine: 'Azure' });
-```
-
 ## Generate speech from text
 
 Generate synthesized speech audio from text input. Returns audio in the requested format (binary audio stream, base64-encoded JSON, or an audio URL for later retrieval). Authentication is provided via the standard `Authorization: Bearer <API_KEY>` header.

--- a/telnyx-twilio-migration/skills/telnyx-twilio-migration/sdk-reference/python/ai-inference.md
+++ b/telnyx-twilio-migration/skills/telnyx-twilio-migration/sdk-reference/python/ai-inference.md
@@ -683,19 +683,6 @@ print(response.data)
 
 Returns: `data` (object)
 
-## Speech to text over WebSocket
-
-Open a WebSocket connection to stream audio and receive transcriptions in real-time. Authentication is provided via the standard `Authorization: Bearer <API_KEY>` header. Supported engines: `Azure`, `Deepgram`, `Google`, `Telnyx`.
-
-`GET /speech-to-text/transcription`
-
-```python
-client.speech_to_text.transcribe(
-    input_format="mp3",
-    transcription_engine="Azure",
-)
-```
-
 ## Generate speech from text
 
 Generate synthesized speech audio from text input. Returns audio in the requested format (binary audio stream, base64-encoded JSON, or an audio URL for later retrieval). Authentication is provided via the standard `Authorization: Bearer <API_KEY>` header.

--- a/telnyx-twilio-migration/skills/telnyx-twilio-migration/sdk-reference/ruby/ai-inference.md
+++ b/telnyx-twilio-migration/skills/telnyx-twilio-migration/sdk-reference/ruby/ai-inference.md
@@ -664,18 +664,6 @@ puts(response)
 
 Returns: `data` (object)
 
-## Speech to text over WebSocket
-
-Open a WebSocket connection to stream audio and receive transcriptions in real-time. Authentication is provided via the standard `Authorization: Bearer <API_KEY>` header. Supported engines: `Azure`, `Deepgram`, `Google`, `Telnyx`.
-
-`GET /speech-to-text/transcription`
-
-```ruby
-result = client.speech_to_text.transcribe(input_format: :mp3, transcription_engine: :Azure)
-
-puts(result)
-```
-
 ## Generate speech from text
 
 Generate synthesized speech audio from text input. Returns audio in the requested format (binary audio stream, base64-encoded JSON, or an audio URL for later retrieval). Authentication is provided via the standard `Authorization: Bearer <API_KEY>` header.


### PR DESCRIPTION
## Auto-generated skills update

Regenerated from upstream Telnyx OpenAPI specs.

| Metric | Count |
|--------|-------|
| Auto-generated skills | 216 |
| Manual skills (preserved) | 8 |
| Total skills | 224 |
| SDK reference files (migration) | 198 |
| WebRTC skills augmented | 5 |

Generated: 2026-03-05 06:21 UTC