### PR TITLE
fix: exclude SKILL-DIAGNOSTIC.json from validation scans

### DIFF
--- a/telnyx-twilio-migration/skills/telnyx-twilio-migration/scripts/validate-migration.sh
+++ b/telnyx-twilio-migration/skills/telnyx-twilio-migration/scripts/validate-migration.sh
@@ -45,7 +45,7 @@ KEPT_ON_TWILIO=""
 EXTRA_EXCLUDE_DIRS=""
 
 EXCLUDE_DIRS="node_modules .git vendor __pycache__ venv .venv dist build"
-EXCLUDE_FILES="MIGRATION-PLAN.md MIGRATION-REPORT.md twilio-scan.json twilio-deep-scan.json migration-state.json"
+EXCLUDE_FILES="MIGRATION-PLAN.md MIGRATION-REPORT.md twilio-scan.json twilio-deep-scan.json migration-state.json SKILL-DIAGNOSTIC.json"
 EXCLUDE_LOCK_FILES="--exclude=package-lock.json --exclude=yarn.lock --exclude=pnpm-lock.yaml --exclude=Gemfile.lock --exclude=Pipfile.lock --exclude=poetry.lock --exclude=go.sum"
 
 # JSON accumulator


### PR DESCRIPTION
## Summary
- Adds `SKILL-DIAGNOSTIC.json` to the excluded files list in `validate-migration.sh`
- Fixes a self-referencing false positive where the diagnostic output file contains Twilio pattern strings (e.g., `hmac_sha1`) from its own analysis, causing `validate-migration.sh` to flag them as unmigrated code

## Test plan
- [ ] Run `validate-migration.sh` on a project that has a `SKILL-DIAGNOSTIC.json` in its root — confirm no false positives from diagnostic output
- [ ] Run `validate-migration.sh` on a project without `SKILL-DIAGNOSTIC.json` — confirm no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)