### PR TITLE
Add import skills for Vapi, Retell, and ElevenLabs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -295,6 +295,30 @@
       "skills": [
         "./telnyx-cli/skills/telnyx-cli"
       ]
+    },
+    {
+      "name": "telnyx-import-vapi",
+      "description": "Import Vapi voice assistants into Telnyx \u2014 preserves instructions, greeting, voice settings, tools, and call analysis. Multi-language SDK examples.",
+      "source": "./telnyx-import-vapi",
+      "skills": [
+        "./telnyx-import-vapi/skills/telnyx-import-vapi"
+      ]
+    },
+    {
+      "name": "telnyx-import-retell",
+      "description": "Import Retell AI agents into Telnyx \u2014 supports single-prompt and multi-prompt agents. Preserves instructions, voice settings, tools, and call analysis.",
+      "source": "./telnyx-import-retell",
+      "skills": [
+        "./telnyx-import-retell/skills/telnyx-import-retell"
+      ]
+    },
+    {
+      "name": "telnyx-import-elevenlabs",
+      "description": "Import ElevenLabs conversational AI agents into Telnyx \u2014 preserves instructions, voice settings, tools, and call analysis. Multi-language SDK examples.",
+      "source": "./telnyx-import-elevenlabs",
+      "skills": [
+        "./telnyx-import-elevenlabs/skills/telnyx-import-elevenlabs"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Replace `telnyx-python` with the plugin for your stack:
 | `telnyx-ruby` | Ruby |
 | `telnyx-webrtc-client` | WebRTC client SDKs (JS, iOS, Android, Flutter, React Native) |
 | `telnyx-twilio-migration` | Migrate from Twilio to Telnyx |
+| `telnyx-import-vapi` | Import Vapi voice assistants into Telnyx |
+| `telnyx-import-retell` | Import Retell AI agents into Telnyx |
+| `telnyx-import-elevenlabs` | Import ElevenLabs conversational AI agents into Telnyx |
 | `telnyx-cli` | Telnyx CLI |
 <!-- END GENERATED PLUGIN_TABLE -->
 
@@ -192,6 +195,26 @@ A comprehensive migration guide for moving from Twilio to Telnyx across all prod
 Includes parameter-by-parameter mapping tables, multi-language code examples (Python, Node, Go, Java, Ruby, curl), error code mapping, and migration plan/report templates.
 
 > **Note:** After migrating, install a language plugin (e.g. `telnyx-python`) for deeper SDK examples, and `telnyx-webrtc-client` if building a calling app.
+
+## Import from Vapi, Retell, or ElevenLabs
+
+Already running voice AI agents on another platform? Import them directly into Telnyx with a single API call. Each import skill walks through storing your provider API key, running the import, and verifying the result — with examples in all supported languages.
+
+```bash
+/plugin install telnyx-import-vapi@telnyx-skills
+/plugin install telnyx-import-retell@telnyx-skills
+/plugin install telnyx-import-elevenlabs@telnyx-skills
+```
+
+| Plugin | What it imports |
+|--------|----------------|
+| `telnyx-import-vapi` | Vapi voice assistants — instructions, greeting, voice config, tools, MCP servers, call analysis |
+| `telnyx-import-retell` | Retell AI agents (single-prompt and multi-prompt) — instructions, voice config, tools, call analysis |
+| `telnyx-import-elevenlabs` | ElevenLabs conversational AI agents — instructions, voice config, tools, call analysis |
+
+All three use the same underlying API (`POST /ai/assistants/import`) with provider-specific guidance. Knowledge bases and tool secrets require manual setup after import — each skill includes a post-import checklist.
+
+> **Note:** For a full codebase migration from Twilio (not just agent import), use `telnyx-twilio-migration` instead.
 
 ## Installation for Other Agents
 

--- a/telnyx-import-elevenlabs/skills/telnyx-import-elevenlabs/SKILL.md
+++ b/telnyx-import-elevenlabs/skills/telnyx-import-elevenlabs/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: telnyx-import-elevenlabs
+description: >-
+  Import ElevenLabs conversational AI agents into Telnyx. Preserves
+  instructions, voice settings, tools, and call analysis. Supports
+  all SDK languages.
+user_invocable: true
+metadata:
+  author: telnyx
+  product: import-elevenlabs
+  compatibility: "Requires a Telnyx API key and an ElevenLabs API key stored as a Telnyx integration secret."
+---
+
+# Import ElevenLabs Agents into Telnyx
+
+Migrate your ElevenLabs conversational AI agents to Telnyx in minutes. The import API pulls agent configurations directly from ElevenLabs using your API key and recreates them as Telnyx AI Assistants.
+
+**Interaction model**: Collect the user's Telnyx API key and ElevenLabs API key, store the ElevenLabs key as a Telnyx integration secret, run the import, then verify. Do NOT skip the secret-creation step — the import endpoint requires a secret reference, not a raw key.
+
+## What Gets Imported
+
+| Component | Imported? | Notes |
+|-----------|-----------|-------|
+| Instructions | Yes | Imported as-is |
+| Greeting / first message | Yes | Maps to assistant `greeting` |
+| Voice configuration | Yes | ElevenLabs voice ID and settings preserved |
+| Dynamic variables | Yes | Default values carried over |
+| Tools (hangup, transfer, webhook) | Yes | Tool definitions and configurations |
+| MCP Server integrations | Yes | Server URLs and tool mappings |
+| Call analysis / insights | Yes | Mapped to `insight_settings` |
+| Data retention preferences | Yes | Mapped to `privacy_settings` |
+| Knowledge base | **No** | Must be manually added post-import |
+| Secrets (API keys in tools) | **Partial** | Placeholder secrets created — you must re-enter values in the Telnyx portal |
+
+## Prerequisites
+
+1. **Telnyx API key** — get one at https://portal.telnyx.com/#/app/api-keys
+2. **ElevenLabs API key** — from your ElevenLabs dashboard (Profile → API Keys)
+3. Store the ElevenLabs API key as a Telnyx integration secret at https://portal.telnyx.com/#/app/integration-secrets
+
+## Step 1: Store Your ElevenLabs API Key as a Telnyx Secret
+
+Before importing, store your ElevenLabs API key as an integration secret in Telnyx. Note the secret reference name (e.g., `elevenlabs_api_key`) — you'll use it in the import call.
+
+You can create integration secrets via the Telnyx Portal under **Integration Secrets**, or via the API.
+
+## Step 2: Import All ElevenLabs Agents
+
+Import every conversational AI agent from your ElevenLabs account:
+
+### curl
+
+```bash
+curl \
+  -X POST \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "provider": "elevenlabs",
+  "api_key_ref": "elevenlabs_api_key"
+}' \
+  "https://api.telnyx.com/v2/ai/assistants/import"
+```
+
+### Python
+
+```python
+import os
+from telnyx import Telnyx
+
+client = Telnyx(api_key=os.environ.get("TELNYX_API_KEY"))
+
+assistants = client.ai.assistants.imports(
+    provider="elevenlabs",
+    api_key_ref="elevenlabs_api_key",
+)
+
+for assistant in assistants.data:
+    print(f"Imported: {assistant.name} (ID: {assistant.id})")
+```
+
+### JavaScript
+
+```javascript
+import Telnyx from 'telnyx';
+
+const client = new Telnyx();
+
+const assistants = await client.ai.assistants.imports({
+  provider: 'elevenlabs',
+  api_key_ref: 'elevenlabs_api_key',
+});
+
+for (const assistant of assistants.data) {
+  console.log(`Imported: ${assistant.name} (ID: ${assistant.id})`);
+}
+```
+
+### Go
+
+```go
+assistants, err := client.AI.Assistants.Imports(context.TODO(), telnyx.AIAssistantImportsParams{
+    Provider:  telnyx.AIAssistantImportsParamsProviderElevenlabs,
+    APIKeyRef: "elevenlabs_api_key",
+})
+if err != nil {
+    panic(err.Error())
+}
+for _, a := range assistants.Data {
+    fmt.Printf("Imported: %s (ID: %s)\n", a.Name, a.ID)
+}
+```
+
+### Java
+
+```java
+import com.telnyx.sdk.models.ai.assistants.AssistantImportsParams;
+import com.telnyx.sdk.models.ai.assistants.AssistantsList;
+
+AssistantImportsParams params = AssistantImportsParams.builder()
+    .provider(AssistantImportsParams.Provider.ELEVENLABS)
+    .apiKeyRef("elevenlabs_api_key")
+    .build();
+AssistantsList assistants = client.ai().assistants().imports(params);
+assistants.getData().forEach(a ->
+    System.out.printf("Imported: %s (ID: %s)%n", a.getName(), a.getId()));
+```
+
+### Ruby
+
+```ruby
+assistants = client.ai.assistants.imports(
+  provider: :elevenlabs,
+  api_key_ref: "elevenlabs_api_key"
+)
+
+assistants.data.each do |a|
+  puts "Imported: #{a.name} (ID: #{a.id})"
+end
+```
+
+## Step 2 (Alternative): Import Specific Agents
+
+To import only certain agents, pass their ElevenLabs agent IDs in `import_ids`:
+
+### curl
+
+```bash
+curl \
+  -X POST \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "provider": "elevenlabs",
+  "api_key_ref": "elevenlabs_api_key",
+  "import_ids": ["elevenlabs-agent-id-1", "elevenlabs-agent-id-2"]
+}' \
+  "https://api.telnyx.com/v2/ai/assistants/import"
+```
+
+### Python
+
+```python
+assistants = client.ai.assistants.imports(
+    provider="elevenlabs",
+    api_key_ref="elevenlabs_api_key",
+    import_ids=["elevenlabs-agent-id-1", "elevenlabs-agent-id-2"],
+)
+```
+
+### JavaScript
+
+```javascript
+const assistants = await client.ai.assistants.imports({
+  provider: 'elevenlabs',
+  api_key_ref: 'elevenlabs_api_key',
+  import_ids: ['elevenlabs-agent-id-1', 'elevenlabs-agent-id-2'],
+});
+```
+
+## Step 3: Verify the Import
+
+List your Telnyx assistants to confirm the import succeeded:
+
+### curl
+
+```bash
+curl -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/ai/assistants"
+```
+
+### Python
+
+```python
+assistants = client.ai.assistants.list()
+for a in assistants.data:
+    print(f"{a.name} — {a.id} — imported: {a.import_metadata}")
+```
+
+### JavaScript
+
+```javascript
+const assistants = await client.ai.assistants.list();
+for (const a of assistants.data) {
+  console.log(`${a.name} — ${a.id} — imported:`, a.import_metadata);
+}
+```
+
+## Step 4: Post-Import Checklist
+
+After importing, complete these manual steps:
+
+1. **Re-enter secrets** — Any API keys referenced by tools were imported as placeholders. Go to https://portal.telnyx.com/#/app/integration-secrets and supply the actual values.
+2. **Add knowledge bases** — Knowledge base content is not imported. Upload files or add URLs in the assistant's Knowledge Base settings.
+3. **Assign a phone number** — Connect a Telnyx phone number to your imported assistant to start receiving calls.
+4. **Test the assistant** — Use the Telnyx assistant testing API or make a test call to verify behavior.
+
+## Re-importing
+
+Running the import again for the same ElevenLabs agents will **overwrite** the existing Telnyx copies with the latest configuration from ElevenLabs. This is useful for syncing changes during a gradual migration.
+
+## API Reference
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `provider` | string | Yes | Must be `"elevenlabs"` |
+| `api_key_ref` | string | Yes | Name of the Telnyx integration secret containing your ElevenLabs API key |
+| `import_ids` | array[string] | No | Specific ElevenLabs agent IDs to import. Omit to import all. |
+
+Endpoint: `POST https://api.telnyx.com/v2/ai/assistants/import`
+
+Full API docs: https://developers.telnyx.com/api-reference/assistants/import-assistants-from-external-provider

--- a/telnyx-import-retell/skills/telnyx-import-retell/SKILL.md
+++ b/telnyx-import-retell/skills/telnyx-import-retell/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: telnyx-import-retell
+description: >-
+  Import Retell AI agents into Telnyx — both single-prompt and multi-prompt
+  configurations. Preserves instructions, voice settings, tools, and call
+  analysis. Supports all SDK languages.
+user_invocable: true
+metadata:
+  author: telnyx
+  product: import-retell
+  compatibility: "Requires a Telnyx API key and a Retell API key stored as a Telnyx integration secret."
+---
+
+# Import Retell Agents into Telnyx
+
+Migrate your Retell AI agents to Telnyx in minutes. The import API pulls agent configurations directly from Retell using your API key and recreates them as Telnyx AI Assistants. Both single-prompt and multi-prompt Retell agents are supported.
+
+**Interaction model**: Collect the user's Telnyx API key and Retell API key, store the Retell key as a Telnyx integration secret, run the import, then verify. Do NOT skip the secret-creation step — the import endpoint requires a secret reference, not a raw key.
+
+## What Gets Imported
+
+| Component | Imported? | Notes |
+|-----------|-----------|-------|
+| Instructions | Yes | Imported as-is (both single and multi-prompt) |
+| Greeting / first message | Yes | Maps to assistant `greeting` |
+| Voice configuration | Yes | Voice provider and voice ID preserved |
+| Dynamic variables | Yes | Default values carried over |
+| Tools (hangup, transfer, webhook) | Yes | Tool definitions and configurations |
+| MCP Server integrations | Yes | Server URLs and tool mappings |
+| Call analysis / insights | Yes | Mapped to `insight_settings` |
+| Data retention preferences | Yes | Mapped to `privacy_settings` |
+| Knowledge base | **No** | Must be manually added post-import |
+| Secrets (API keys in tools) | **Partial** | Placeholder secrets created — you must re-enter values in the Telnyx portal |
+
+## Prerequisites
+
+1. **Telnyx API key** — get one at https://portal.telnyx.com/#/app/api-keys
+2. **Retell API key** — from your Retell dashboard
+3. Store the Retell API key as a Telnyx integration secret at https://portal.telnyx.com/#/app/integration-secrets
+
+## Step 1: Store Your Retell API Key as a Telnyx Secret
+
+Before importing, store your Retell API key as an integration secret in Telnyx. Note the secret reference name (e.g., `retell_api_key`) — you'll use it in the import call.
+
+You can create integration secrets via the Telnyx Portal under **Integration Secrets**, or via the API.
+
+## Step 2: Import All Retell Agents
+
+Import every agent from your Retell account:
+
+### curl
+
+```bash
+curl \
+  -X POST \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "provider": "retell",
+  "api_key_ref": "retell_api_key"
+}' \
+  "https://api.telnyx.com/v2/ai/assistants/import"
+```
+
+### Python
+
+```python
+import os
+from telnyx import Telnyx
+
+client = Telnyx(api_key=os.environ.get("TELNYX_API_KEY"))
+
+assistants = client.ai.assistants.imports(
+    provider="retell",
+    api_key_ref="retell_api_key",
+)
+
+for assistant in assistants.data:
+    print(f"Imported: {assistant.name} (ID: {assistant.id})")
+```
+
+### JavaScript
+
+```javascript
+import Telnyx from 'telnyx';
+
+const client = new Telnyx();
+
+const assistants = await client.ai.assistants.imports({
+  provider: 'retell',
+  api_key_ref: 'retell_api_key',
+});
+
+for (const assistant of assistants.data) {
+  console.log(`Imported: ${assistant.name} (ID: ${assistant.id})`);
+}
+```
+
+### Go
+
+```go
+assistants, err := client.AI.Assistants.Imports(context.TODO(), telnyx.AIAssistantImportsParams{
+    Provider:  telnyx.AIAssistantImportsParamsProviderRetell,
+    APIKeyRef: "retell_api_key",
+})
+if err != nil {
+    panic(err.Error())
+}
+for _, a := range assistants.Data {
+    fmt.Printf("Imported: %s (ID: %s)\n", a.Name, a.ID)
+}
+```
+
+### Java
+
+```java
+import com.telnyx.sdk.models.ai.assistants.AssistantImportsParams;
+import com.telnyx.sdk.models.ai.assistants.AssistantsList;
+
+AssistantImportsParams params = AssistantImportsParams.builder()
+    .provider(AssistantImportsParams.Provider.RETELL)
+    .apiKeyRef("retell_api_key")
+    .build();
+AssistantsList assistants = client.ai().assistants().imports(params);
+assistants.getData().forEach(a ->
+    System.out.printf("Imported: %s (ID: %s)%n", a.getName(), a.getId()));
+```
+
+### Ruby
+
+```ruby
+assistants = client.ai.assistants.imports(
+  provider: :retell,
+  api_key_ref: "retell_api_key"
+)
+
+assistants.data.each do |a|
+  puts "Imported: #{a.name} (ID: #{a.id})"
+end
+```
+
+## Step 2 (Alternative): Import Specific Agents
+
+To import only certain agents, pass their Retell agent IDs in `import_ids`:
+
+### curl
+
+```bash
+curl \
+  -X POST \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "provider": "retell",
+  "api_key_ref": "retell_api_key",
+  "import_ids": ["retell-agent-id-1", "retell-agent-id-2"]
+}' \
+  "https://api.telnyx.com/v2/ai/assistants/import"
+```
+
+### Python
+
+```python
+assistants = client.ai.assistants.imports(
+    provider="retell",
+    api_key_ref="retell_api_key",
+    import_ids=["retell-agent-id-1", "retell-agent-id-2"],
+)
+```
+
+### JavaScript
+
+```javascript
+const assistants = await client.ai.assistants.imports({
+  provider: 'retell',
+  api_key_ref: 'retell_api_key',
+  import_ids: ['retell-agent-id-1', 'retell-agent-id-2'],
+});
+```
+
+## Step 3: Verify the Import
+
+List your Telnyx assistants to confirm the import succeeded:
+
+### curl
+
+```bash
+curl -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/ai/assistants"
+```
+
+### Python
+
+```python
+assistants = client.ai.assistants.list()
+for a in assistants.data:
+    print(f"{a.name} — {a.id} — imported: {a.import_metadata}")
+```
+
+### JavaScript
+
+```javascript
+const assistants = await client.ai.assistants.list();
+for (const a of assistants.data) {
+  console.log(`${a.name} — ${a.id} — imported:`, a.import_metadata);
+}
+```
+
+## Step 4: Post-Import Checklist
+
+After importing, complete these manual steps:
+
+1. **Re-enter secrets** — Any API keys referenced by tools were imported as placeholders. Go to https://portal.telnyx.com/#/app/integration-secrets and supply the actual values.
+2. **Add knowledge bases** — Knowledge base content is not imported. Upload files or add URLs in the assistant's Knowledge Base settings.
+3. **Assign a phone number** — Connect a Telnyx phone number to your imported assistant to start receiving calls.
+4. **Test the assistant** — Use the Telnyx assistant testing API or make a test call to verify behavior.
+
+## Re-importing
+
+Running the import again for the same Retell agents will **overwrite** the existing Telnyx copies with the latest configuration from Retell. This is useful for syncing changes during a gradual migration.
+
+## API Reference
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `provider` | string | Yes | Must be `"retell"` |
+| `api_key_ref` | string | Yes | Name of the Telnyx integration secret containing your Retell API key |
+| `import_ids` | array[string] | No | Specific Retell agent IDs to import. Omit to import all. |
+
+Endpoint: `POST https://api.telnyx.com/v2/ai/assistants/import`
+
+Full API docs: https://developers.telnyx.com/api-reference/assistants/import-assistants-from-external-provider

--- a/telnyx-import-vapi/skills/telnyx-import-vapi/SKILL.md
+++ b/telnyx-import-vapi/skills/telnyx-import-vapi/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: telnyx-import-vapi
+description: >-
+  Import Vapi voice assistants into Telnyx with all configurations —
+  instructions, greeting, voice settings, tools, and call analysis.
+  Supports selective import by assistant ID and covers all SDK languages.
+user_invocable: true
+metadata:
+  author: telnyx
+  product: import-vapi
+  compatibility: "Requires a Telnyx API key and a Vapi API key stored as a Telnyx integration secret."
+---
+
+# Import Vapi Assistants into Telnyx
+
+Migrate your Vapi voice assistants to Telnyx in minutes. The import API pulls assistant configurations directly from Vapi using your API key and recreates them as Telnyx AI Assistants.
+
+**Interaction model**: Collect the user's Telnyx API key and Vapi API key, store the Vapi key as a Telnyx integration secret, run the import, then verify. Do NOT skip the secret-creation step — the import endpoint requires a secret reference, not a raw key.
+
+## What Gets Imported
+
+| Component | Imported? | Notes |
+|-----------|-----------|-------|
+| Instructions | Yes | Imported as-is |
+| Greeting / first message | Yes | Maps to assistant `greeting` |
+| Voice configuration | Yes | Voice provider and voice ID preserved |
+| Dynamic variables | Yes | Default values carried over |
+| Tools (hangup, transfer, webhook) | Yes | Tool definitions and configurations |
+| MCP Server integrations | Yes | Server URLs and tool mappings |
+| Call analysis / insights | Yes | Mapped to `insight_settings` |
+| Data retention preferences | Yes | Mapped to `privacy_settings` |
+| Knowledge base | **No** | Must be manually added post-import |
+| Secrets (API keys in tools) | **Partial** | Placeholder secrets created — you must re-enter values in the Telnyx portal |
+
+## Prerequisites
+
+1. **Telnyx API key** — get one at https://portal.telnyx.com/#/app/api-keys
+2. **Vapi API key** — from your Vapi dashboard
+3. Store the Vapi API key as a Telnyx integration secret at https://portal.telnyx.com/#/app/integration-secrets
+
+## Step 1: Store Your Vapi API Key as a Telnyx Secret
+
+Before importing, store your Vapi API key as an integration secret in Telnyx. Note the secret reference name (e.g., `vapi_api_key`) — you'll use it in the import call.
+
+You can create integration secrets via the Telnyx Portal under **Integration Secrets**, or via the API.
+
+## Step 2: Import All Vapi Assistants
+
+Import every assistant from your Vapi account:
+
+### curl
+
+```bash
+curl \
+  -X POST \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "provider": "vapi",
+  "api_key_ref": "vapi_api_key"
+}' \
+  "https://api.telnyx.com/v2/ai/assistants/import"
+```
+
+### Python
+
+```python
+import os
+from telnyx import Telnyx
+
+client = Telnyx(api_key=os.environ.get("TELNYX_API_KEY"))
+
+assistants = client.ai.assistants.imports(
+    provider="vapi",
+    api_key_ref="vapi_api_key",
+)
+
+for assistant in assistants.data:
+    print(f"Imported: {assistant.name} (ID: {assistant.id})")
+```
+
+### JavaScript
+
+```javascript
+import Telnyx from 'telnyx';
+
+const client = new Telnyx();
+
+const assistants = await client.ai.assistants.imports({
+  provider: 'vapi',
+  api_key_ref: 'vapi_api_key',
+});
+
+for (const assistant of assistants.data) {
+  console.log(`Imported: ${assistant.name} (ID: ${assistant.id})`);
+}
+```
+
+### Go
+
+```go
+assistants, err := client.AI.Assistants.Imports(context.TODO(), telnyx.AIAssistantImportsParams{
+    Provider:  telnyx.AIAssistantImportsParamsProviderVapi,
+    APIKeyRef: "vapi_api_key",
+})
+if err != nil {
+    panic(err.Error())
+}
+for _, a := range assistants.Data {
+    fmt.Printf("Imported: %s (ID: %s)\n", a.Name, a.ID)
+}
+```
+
+### Java
+
+```java
+import com.telnyx.sdk.models.ai.assistants.AssistantImportsParams;
+import com.telnyx.sdk.models.ai.assistants.AssistantsList;
+
+AssistantImportsParams params = AssistantImportsParams.builder()
+    .provider(AssistantImportsParams.Provider.VAPI)
+    .apiKeyRef("vapi_api_key")
+    .build();
+AssistantsList assistants = client.ai().assistants().imports(params);
+assistants.getData().forEach(a ->
+    System.out.printf("Imported: %s (ID: %s)%n", a.getName(), a.getId()));
+```
+
+### Ruby
+
+```ruby
+assistants = client.ai.assistants.imports(
+  provider: :vapi,
+  api_key_ref: "vapi_api_key"
+)
+
+assistants.data.each do |a|
+  puts "Imported: #{a.name} (ID: #{a.id})"
+end
+```
+
+## Step 2 (Alternative): Import Specific Assistants
+
+To import only certain assistants, pass their Vapi assistant IDs in `import_ids`:
+
+### curl
+
+```bash
+curl \
+  -X POST \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "provider": "vapi",
+  "api_key_ref": "vapi_api_key",
+  "import_ids": ["vapi-assistant-id-1", "vapi-assistant-id-2"]
+}' \
+  "https://api.telnyx.com/v2/ai/assistants/import"
+```
+
+### Python
+
+```python
+assistants = client.ai.assistants.imports(
+    provider="vapi",
+    api_key_ref="vapi_api_key",
+    import_ids=["vapi-assistant-id-1", "vapi-assistant-id-2"],
+)
+```
+
+### JavaScript
+
+```javascript
+const assistants = await client.ai.assistants.imports({
+  provider: 'vapi',
+  api_key_ref: 'vapi_api_key',
+  import_ids: ['vapi-assistant-id-1', 'vapi-assistant-id-2'],
+});
+```
+
+## Step 3: Verify the Import
+
+List your Telnyx assistants to confirm the import succeeded:
+
+### curl
+
+```bash
+curl -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/ai/assistants"
+```
+
+### Python
+
+```python
+assistants = client.ai.assistants.list()
+for a in assistants.data:
+    print(f"{a.name} — {a.id} — imported: {a.import_metadata}")
+```
+
+### JavaScript
+
+```javascript
+const assistants = await client.ai.assistants.list();
+for (const a of assistants.data) {
+  console.log(`${a.name} — ${a.id} — imported:`, a.import_metadata);
+}
+```
+
+## Step 4: Post-Import Checklist
+
+After importing, complete these manual steps:
+
+1. **Re-enter secrets** — Any API keys referenced by tools were imported as placeholders. Go to https://portal.telnyx.com/#/app/integration-secrets and supply the actual values.
+2. **Add knowledge bases** — Knowledge base content is not imported. Upload files or add URLs in the assistant's Knowledge Base settings.
+3. **Assign a phone number** — Connect a Telnyx phone number to your imported assistant to start receiving calls.
+4. **Test the assistant** — Use the Telnyx assistant testing API or make a test call to verify behavior.
+
+## Re-importing
+
+Running the import again for the same Vapi assistants will **overwrite** the existing Telnyx copies with the latest configuration from Vapi. This is useful for syncing changes during a gradual migration.
+
+## API Reference
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `provider` | string | Yes | Must be `"vapi"` |
+| `api_key_ref` | string | Yes | Name of the Telnyx integration secret containing your Vapi API key |
+| `import_ids` | array[string] | No | Specific Vapi assistant IDs to import. Omit to import all. |
+
+Endpoint: `POST https://api.telnyx.com/v2/ai/assistants/import`
+
+Full API docs: https://developers.telnyx.com/api-reference/assistants/import-assistants-from-external-provider


### PR DESCRIPTION
## Summary

- Adds three new skills for importing voice AI agents from competing platforms into Telnyx:
  - **`telnyx-import-vapi`** — Import Vapi voice assistants
  - **`telnyx-import-retell`** — Import Retell AI agents (single-prompt and multi-prompt)
  - **`telnyx-import-elevenlabs`** — Import ElevenLabs conversational AI agents
- Each skill includes examples in all 6 SDK languages (Python, JS, Go, Java, Ruby, curl)
- Covers the full workflow: store provider API key as integration secret → import all or selective agents → verify → post-import checklist
- Updates `marketplace.json` to register the three new plugins
- Updates `README.md` with a new "Import from Vapi, Retell, or ElevenLabs" section and plugin table entries

All three skills wrap `POST /ai/assistants/import` with provider-specific guidance based on https://developers.telnyx.com/docs/inference/ai-assistants/importing

## Test plan

- [ ] Verify each SKILL.md renders correctly with valid YAML frontmatter
- [ ] Confirm marketplace.json is valid JSON with the new plugin entries
- [ ] Test `/plugin install telnyx-import-vapi@telnyx-skills` in Claude Code
- [ ] Verify code examples match the current SDK method signatures (`client.ai.assistants.imports()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)