### PR TITLE
fix: add depth check to skills sync validation

### DIFF
--- a/scripts/check-skills-sync.sh
+++ b/scripts/check-skills-sync.sh
@@ -8,6 +8,24 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SKILLS_SRC="$REPO_ROOT/skills"
 out_of_sync=false
 
+# Check structure: skills must be flat (skills/<name>/SKILL.md, not nested)
+nested=$(find "$SKILLS_SRC" -mindepth 2 -type d -name "skills" 2>/dev/null)
+if [ -n "$nested" ]; then
+  echo "ERROR: Nested skills/ directories found. Skills must be flat."
+  echo "Expected: skills/<skill-name>/SKILL.md"
+  echo "Found nested dirs:"
+  echo "$nested"
+  exit 1
+fi
+
+deep=$(find "$SKILLS_SRC" -name SKILL.md -mindepth 3 2>/dev/null)
+if [ -n "$deep" ]; then
+  echo "ERROR: SKILL.md files found too deep. Skills must be at skills/<name>/SKILL.md."
+  echo "Found:"
+  echo "$deep"
+  exit 1
+fi
+
 for provider in claude cursor; do
   target="$REPO_ROOT/providers/$provider/plugin/skills"
 


### PR DESCRIPTION
Adds structural validation to `check-skills-sync.sh` to prevent re-introducing nested skill directories. CI will fail if:

- Any nested `skills/` subdirectories exist inside skill directories
- Any `SKILL.md` files are deeper than `skills/<name>/SKILL.md`

Tested: verified it catches bad structure and passes on correct structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)