### PR TITLE
feat(mcp): resolve per-tenant endpoint with shared-URL fallback

### DIFF
--- a/tools/mcp/README.md
+++ b/tools/mcp/README.md
@@ -40,6 +40,10 @@ npx -y @telnyx/mcp
 
 Only opt in if you understand and accept this trade. A future release will swap the raw API key for a scoped, short-lived credential — see the deployment strategy doc for context.
 
+### Inbound auth: `SHARED_SECRET`
+
+The deployed func enforces bearer-token auth on inbound MCP requests using a `SHARED_SECRET` distinct from your Telnyx API key. The deploy API generates one server-side and returns it once; the shim caches the value at `~/.telnyx/mcp-endpoint.json` (mode 0600) and uses it as the bearer for every MCP message it proxies. If the cache is lost, the value cannot be recovered (Telnyx secrets list returns names only) — run `--reset` to provision a fresh secret.
+
 ## Flags and environment
 
 | Flag / env | Description |

--- a/tools/mcp/README.md
+++ b/tools/mcp/README.md
@@ -4,8 +4,6 @@ The Telnyx [Model Context Protocol](https://modelcontextprotocol.com/) server al
 
 ## Setup
 
-Telnyx hosts a remote MCP server at `https://api.telnyx.com/v2/mcp`.
-
 To run the Telnyx MCP server locally using npx:
 
 ```bash
@@ -21,4 +19,14 @@ npx -y @telnyx/mcp
 
 ## How it works
 
-This package proxies MCP requests to the remote Telnyx MCP server over HTTP.
+On first run, the shim provisions an isolated MCP endpoint on Telnyx Edge Compute for your account and caches the URL at `~/.telnyx/mcp-endpoint.json`. Subsequent runs reuse the cached endpoint. If per-tenant provisioning is unavailable, the shim falls back to the shared hosted endpoint at `https://api.telnyx.com/v2/mcp` so connections keep working.
+
+Messages flow stdio ↔ Streamable HTTP between your MCP client and the resolved endpoint.
+
+## Flags and environment
+
+| Flag / env | Description |
+|---|---|
+| `--api-key <key>` / `TELNYX_API_KEY` | Telnyx API key. Required. |
+| `--reset` / `TELNYX_MCP_RESET=1` | Discard cached endpoint and re-provision on this run. |
+| `TELNYX_MCP_URL` | Override the resolved endpoint with an explicit URL (advanced). Skips provisioning and cache entirely. |

--- a/tools/mcp/README.md
+++ b/tools/mcp/README.md
@@ -19,14 +19,32 @@ npx -y @telnyx/mcp
 
 ## How it works
 
-On first run, the shim provisions an isolated MCP endpoint on Telnyx Edge Compute for your account and caches the URL at `~/.telnyx/mcp-endpoint.json`. Subsequent runs reuse the cached endpoint. If per-tenant provisioning is unavailable, the shim falls back to the shared hosted endpoint at `https://api.telnyx.com/v2/mcp` so connections keep working.
+The shim resolves an MCP endpoint URL and proxies messages stdio ↔ Streamable HTTP between your MCP client and the resolved endpoint.
 
-Messages flow stdio ↔ Streamable HTTP between your MCP client and the resolved endpoint.
+Resolution order:
+1. `TELNYX_MCP_URL` override, if set
+2. Cached per-tenant URL from a prior successful provision (`~/.telnyx/mcp-endpoint.json`)
+3. Fresh provision on Telnyx Edge Compute (opt-in — see below)
+4. Shared hosted endpoint at `https://api.telnyx.com/v2/mcp` (fallback)
+
+## Opting in to an isolated per-account endpoint
+
+By default the shim uses the shared hosted endpoint. To get a dedicated, Firecracker-isolated MCP server provisioned for your account:
+
+```bash
+export TELNYX_MCP_ACCEPT_FULL_SCOPE=1
+npx -y @telnyx/mcp
+```
+
+**⚠️ Security note.** With opt-in enabled, the shim creates a Telnyx Edge Compute secret holding your **raw, full-scope** Telnyx API key and deploys an MCP func that reads it at runtime. Firecracker isolates each customer's func from every other customer's — but inside the func, a compromise (e.g., prompt-injected agent code running under Deno `eval`) would see the raw API key. That key has full access to your Telnyx account: buying numbers, spending balance, reading recordings, etc.
+
+Only opt in if you understand and accept this trade. A future release will swap the raw API key for a scoped, short-lived credential — see the deployment strategy doc for context.
 
 ## Flags and environment
 
 | Flag / env | Description |
 |---|---|
 | `--api-key <key>` / `TELNYX_API_KEY` | Telnyx API key. Required. |
+| `TELNYX_MCP_ACCEPT_FULL_SCOPE` | Set to `1` to opt in to per-account provisioning. Required; see security note above. |
 | `--reset` / `TELNYX_MCP_RESET=1` | Discard cached endpoint and re-provision on this run. |
 | `TELNYX_MCP_URL` | Override the resolved endpoint with an explicit URL (advanced). Skips provisioning and cache entirely. |

--- a/tools/mcp/package-lock.json
+++ b/tools/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@telnyx/mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@telnyx/mcp",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1"
@@ -16,8 +16,451 @@
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
+        "tsx": "^4.19.0",
         "typescript": "^5.8.0"
       },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
       "engines": {
         "node": ">=18"
       }
@@ -348,6 +791,48 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -506,6 +991,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -550,6 +1050,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/gopd": {
@@ -900,6 +1413,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -1082,6 +1605,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/type-is": {

--- a/tools/mcp/package.json
+++ b/tools/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@telnyx/mcp",
-  "version": "0.1.0",
-  "description": "Telnyx MCP server — proxies to the remote Telnyx MCP endpoint for use with Claude Desktop, Cursor, and other MCP clients",
+  "version": "0.2.0",
+  "description": "Telnyx MCP server — provisions an isolated per-account MCP endpoint on Telnyx Edge Compute (falls back to shared hosted endpoint) for use with Claude Desktop, Cursor, and other MCP clients",
   "main": "dist/index.js",
   "bin": {
     "telnyx-mcp": "dist/cli.js"
@@ -9,7 +9,9 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/cli.js",
-    "dev": "npx tsx src/cli.ts"
+    "dev": "npx tsx src/cli.ts",
+    "test": "tsx --test tests/*.test.ts",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "telnyx",
@@ -32,6 +34,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.5.0",
+    "tsx": "^4.19.0",
     "typescript": "^5.8.0"
   },
   "publishConfig": {

--- a/tools/mcp/src/cli.ts
+++ b/tools/mcp/src/cli.ts
@@ -59,7 +59,7 @@ falls back to the shared hosted endpoint at https://api.telnyx.com/v2/mcp.`);
 
   const reset = process.argv.includes("--reset");
   const apiKey = getApiKey();
-  const { url, source } = await resolveEndpoint({ apiKey, reset });
+  const { url, remoteAuthToken, source } = await resolveEndpoint({ apiKey, reset });
 
   switch (source) {
     case "provisioned":
@@ -79,7 +79,7 @@ falls back to the shared hosted endpoint at https://api.telnyx.com/v2/mcp.`);
     // "cache" and "override" stay silent.
   }
 
-  await createProxy({ apiKey, remoteUrl: url });
+  await createProxy({ remoteUrl: url, remoteAuthToken });
 }
 
 main().catch((error) => {

--- a/tools/mcp/src/cli.ts
+++ b/tools/mcp/src/cli.ts
@@ -39,14 +39,21 @@ Options:
   --help, -h       Show this help message
 
 Environment:
-  TELNYX_API_KEY   Telnyx API key (alternative to --api-key)
-  TELNYX_MCP_URL   Override resolved endpoint with an explicit URL (advanced)
-  TELNYX_MCP_RESET Any non-empty value acts like --reset
+  TELNYX_API_KEY                  Telnyx API key (alternative to --api-key).
+  TELNYX_MCP_ACCEPT_FULL_SCOPE    Set to 1 to opt in to per-account
+                                  provisioning. The injected secret is your
+                                  raw Telnyx API key — VM escape or prompt
+                                  injection inside the MCP func can exfiltrate
+                                  a full-scope key. Without this var, the
+                                  shim stays on the shared hosted endpoint.
+  TELNYX_MCP_URL                  Override the resolved endpoint with an
+                                  explicit URL (advanced).
+  TELNYX_MCP_RESET                Any non-empty value acts like --reset.
 
-On first run, the shim provisions an isolated MCP endpoint on Telnyx
-Edge Compute for your account and caches it at ~/.telnyx/mcp-endpoint.json.
-If provisioning is unavailable, it falls back to the shared hosted endpoint
-at https://api.telnyx.com/v2/mcp.`);
+On first run (with consent), the shim creates a secret and provisions an
+isolated MCP endpoint on Telnyx Edge Compute for your account, then caches
+the URL at ~/.telnyx/mcp-endpoint.json. If provisioning is unavailable, it
+falls back to the shared hosted endpoint at https://api.telnyx.com/v2/mcp.`);
     process.exit(0);
   }
 
@@ -54,10 +61,22 @@ at https://api.telnyx.com/v2/mcp.`);
   const apiKey = getApiKey();
   const { url, source } = await resolveEndpoint({ apiKey, reset });
 
-  if (source === "provisioned") {
-    console.error(`[telnyx-mcp] provisioned isolated endpoint: ${url}`);
-  } else if (source === "fallback") {
-    console.error(`[telnyx-mcp] using shared endpoint (provisioning unavailable)`);
+  switch (source) {
+    case "provisioned":
+      console.error(`[telnyx-mcp] provisioned isolated endpoint: ${url}`);
+      break;
+    case "fallback-no-consent":
+      console.error(
+        "[telnyx-mcp] using shared hosted endpoint. To provision an isolated " +
+          "per-account endpoint, set TELNYX_MCP_ACCEPT_FULL_SCOPE=1 (see --help)."
+      );
+      break;
+    case "fallback-error":
+      console.error(
+        "[telnyx-mcp] provisioning unavailable — falling back to shared endpoint."
+      );
+      break;
+    // "cache" and "override" stay silent.
   }
 
   await createProxy({ apiKey, remoteUrl: url });

--- a/tools/mcp/src/cli.ts
+++ b/tools/mcp/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { createProxy } from "./index.js";
+import { resolveEndpoint } from "./endpoint.js";
 
 function getApiKey(): string {
   const args = process.argv.slice(2);
@@ -34,15 +35,32 @@ async function main(): Promise<void> {
 
 Options:
   --api-key <key>  Telnyx API key (or set TELNYX_API_KEY env var)
+  --reset          Discard cached endpoint and re-provision on this run
   --help, -h       Show this help message
 
-Proxies MCP requests from your IDE to the remote Telnyx MCP server
-at https://api.telnyx.com/v2/mcp`);
+Environment:
+  TELNYX_API_KEY   Telnyx API key (alternative to --api-key)
+  TELNYX_MCP_URL   Override resolved endpoint with an explicit URL (advanced)
+  TELNYX_MCP_RESET Any non-empty value acts like --reset
+
+On first run, the shim provisions an isolated MCP endpoint on Telnyx
+Edge Compute for your account and caches it at ~/.telnyx/mcp-endpoint.json.
+If provisioning is unavailable, it falls back to the shared hosted endpoint
+at https://api.telnyx.com/v2/mcp.`);
     process.exit(0);
   }
 
+  const reset = process.argv.includes("--reset");
   const apiKey = getApiKey();
-  await createProxy({ apiKey });
+  const { url, source } = await resolveEndpoint({ apiKey, reset });
+
+  if (source === "provisioned") {
+    console.error(`[telnyx-mcp] provisioned isolated endpoint: ${url}`);
+  } else if (source === "fallback") {
+    console.error(`[telnyx-mcp] using shared endpoint (provisioning unavailable)`);
+  }
+
+  await createProxy({ apiKey, remoteUrl: url });
 }
 
 main().catch((error) => {

--- a/tools/mcp/src/endpoint.ts
+++ b/tools/mcp/src/endpoint.ts
@@ -17,6 +17,13 @@ interface CacheEntry {
   url: string;
   funcId: string;
   secretId: string;
+  /**
+   * Bearer token the shim must send when proxying MCP requests to {@link url}.
+   * Generated server-side by the deploy API and returned exactly once — there
+   * is no API to recover the value if cache is lost (Telnyx secrets list
+   * returns names only). On cache loss, --reset re-provisions a fresh secret.
+   */
+  sharedSecret: string;
   provisionedAt: string;
 }
 
@@ -26,7 +33,10 @@ interface ResolveOptions {
 }
 
 export interface ResolveResult {
+  /** URL to proxy MCP traffic to. */
   url: string;
+  /** Bearer token to send with MCP requests to {@link url}. */
+  remoteAuthToken: string;
   source:
     | "override"
     | "cache"
@@ -123,15 +133,18 @@ async function provision(apiKey: string): Promise<CacheEntry | null> {
     });
     if (!deployRes.ok) return null;
     const body = (await deployRes.json()) as {
-      data?: { url?: string; func_id?: string };
+      data?: { url?: string; func_id?: string; shared_secret?: string };
     };
-    if (!body.data?.url || !body.data.func_id) return null;
+    if (!body.data?.url || !body.data.func_id || !body.data.shared_secret) {
+      return null;
+    }
 
     return {
       apiKeyFingerprint: fp,
       url: body.data.url,
       funcId: body.data.func_id,
       secretId,
+      sharedSecret: body.data.shared_secret,
       provisionedAt: new Date().toISOString(),
     };
   } catch {
@@ -142,7 +155,7 @@ async function provision(apiKey: string): Promise<CacheEntry | null> {
 }
 
 /**
- * Resolve the MCP endpoint URL for this API key.
+ * Resolve the MCP endpoint URL and the bearer token to use against it.
  *
  * Order of preference:
  *   1. TELNYX_MCP_URL env var (explicit override)
@@ -150,14 +163,24 @@ async function provision(apiKey: string): Promise<CacheEntry | null> {
  *   3. Fresh provision via deploy API (requires TELNYX_MCP_ACCEPT_FULL_SCOPE)
  *   4. Shared hosted URL (fallback)
  *
+ * Per-tenant URLs require an inbound SHARED_SECRET as bearer (separate from
+ * the user's API key, which the deployed func uses for upstream Telnyx calls).
+ * The shared URL accepts the API key directly. This resolver returns the
+ * appropriate bearer for the chosen URL so callers don't have to track which.
+ *
  * Provisioning is gated on TELNYX_MCP_ACCEPT_FULL_SCOPE because the injected
- * secret is the user's raw Telnyx API key — compromise of the Firecracker VM
- * (e.g., via prompt-injected agent code in Code Mode) leaks a full-scope key.
- * Users opt in explicitly; otherwise the shim stays on the shared URL.
+ * upstream secret is the user's raw Telnyx API key — compromise of the
+ * Firecracker VM (e.g., via prompt-injected agent code in Code Mode) leaks a
+ * full-scope key. Users opt in explicitly; otherwise the shim stays on the
+ * shared URL.
  */
 export async function resolveEndpoint(options: ResolveOptions): Promise<ResolveResult> {
   const override = process.env.TELNYX_MCP_URL;
-  if (override) return { url: override, source: "override" };
+  if (override) {
+    // Override skips provisioning — caller must trust the URL accepts the
+    // raw API key as bearer (matches the shared-URL contract).
+    return { url: override, remoteAuthToken: options.apiKey, source: "override" };
+  }
 
   if (options.reset || process.env.TELNYX_MCP_RESET) {
     await clearCache();
@@ -166,18 +189,34 @@ export async function resolveEndpoint(options: ResolveOptions): Promise<ResolveR
   const fp = fingerprint(options.apiKey);
   const cached = await readCache();
   if (cached && cached.apiKeyFingerprint === fp) {
-    return { url: cached.url, source: "cache" };
+    return {
+      url: cached.url,
+      remoteAuthToken: cached.sharedSecret,
+      source: "cache",
+    };
   }
 
   if (!hasConsent()) {
-    return { url: SHARED_MCP_URL, source: "fallback-no-consent" };
+    return {
+      url: SHARED_MCP_URL,
+      remoteAuthToken: options.apiKey,
+      source: "fallback-no-consent",
+    };
   }
 
   const provisioned = await provision(options.apiKey);
   if (provisioned) {
     await writeCache(provisioned);
-    return { url: provisioned.url, source: "provisioned" };
+    return {
+      url: provisioned.url,
+      remoteAuthToken: provisioned.sharedSecret,
+      source: "provisioned",
+    };
   }
 
-  return { url: SHARED_MCP_URL, source: "fallback-error" };
+  return {
+    url: SHARED_MCP_URL,
+    remoteAuthToken: options.apiKey,
+    source: "fallback-error",
+  };
 }

--- a/tools/mcp/src/endpoint.ts
+++ b/tools/mcp/src/endpoint.ts
@@ -4,6 +4,7 @@ import { join, dirname } from "node:path";
 import { createHash } from "node:crypto";
 
 export const SHARED_MCP_URL = "https://api.telnyx.com/v2/mcp";
+const SECRETS_API = "https://api.telnyx.com/v2/compute/secrets";
 const DEPLOY_API = "https://api.telnyx.com/v2/compute/mcp/deploy";
 const PROVISION_TIMEOUT_MS = 10_000;
 
@@ -15,6 +16,7 @@ interface CacheEntry {
   apiKeyFingerprint: string;
   url: string;
   funcId: string;
+  secretId: string;
   provisionedAt: string;
 }
 
@@ -25,11 +27,21 @@ interface ResolveOptions {
 
 export interface ResolveResult {
   url: string;
-  source: "override" | "cache" | "provisioned" | "fallback";
+  source:
+    | "override"
+    | "cache"
+    | "provisioned"
+    | "fallback-no-consent"
+    | "fallback-error";
 }
 
 function fingerprint(apiKey: string): string {
   return createHash("sha256").update(apiKey).digest("hex").slice(0, 16);
+}
+
+function hasConsent(): boolean {
+  const v = process.env.TELNYX_MCP_ACCEPT_FULL_SCOPE;
+  return !!v && v !== "0" && v.toLowerCase() !== "false";
 }
 
 async function readCache(): Promise<CacheEntry | null> {
@@ -54,26 +66,72 @@ async function clearCache(): Promise<void> {
   }
 }
 
+function authHeaders(apiKey: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${apiKey}`,
+    "Content-Type": "application/json",
+  };
+}
+
+/**
+ * Find an existing secret by name, or create a new one holding the API key.
+ * Uses a deterministic name derived from the API key fingerprint so repeated
+ * calls with the same key reuse the same secret (idempotent across cache resets
+ * and cold starts without relying on POST-side 409 handling).
+ */
+async function ensureSecret(apiKey: string, fp: string, signal: AbortSignal): Promise<string | null> {
+  const secretName = `mcp-shim-${fp}`;
+  const headers = authHeaders(apiKey);
+
+  // Look up existing secret by name first.
+  const listUrl = `${SECRETS_API}?filter[name]=${encodeURIComponent(secretName)}`;
+  const listRes = await fetch(listUrl, { headers, signal });
+  if (listRes.ok) {
+    const body = (await listRes.json()) as { data?: Array<{ id?: string; name?: string }> };
+    const existing = body.data?.find((s) => s.name === secretName);
+    if (existing?.id) return existing.id;
+  }
+
+  // Create new.
+  const createRes = await fetch(SECRETS_API, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ name: secretName, value: apiKey }),
+    signal,
+  });
+  if (!createRes.ok) return null;
+  const body = (await createRes.json()) as { data?: { id?: string } };
+  return body.data?.id ?? null;
+}
+
 async function provision(apiKey: string): Promise<CacheEntry | null> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), PROVISION_TIMEOUT_MS);
+  const fp = fingerprint(apiKey);
   try {
-    const res = await fetch(DEPLOY_API, {
+    const secretId = await ensureSecret(apiKey, fp, controller.signal);
+    if (!secretId) return null;
+
+    const deployRes = await fetch(DEPLOY_API, {
       method: "POST",
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ name: "default-mcp" }),
+      headers: authHeaders(apiKey),
+      body: JSON.stringify({
+        name: "default-mcp",
+        api_key_secret_id: secretId,
+      }),
       signal: controller.signal,
     });
-    if (!res.ok) return null;
-    const body = (await res.json()) as { data?: { url?: string; func_id?: string } };
+    if (!deployRes.ok) return null;
+    const body = (await deployRes.json()) as {
+      data?: { url?: string; func_id?: string };
+    };
     if (!body.data?.url || !body.data.func_id) return null;
+
     return {
-      apiKeyFingerprint: fingerprint(apiKey),
+      apiKeyFingerprint: fp,
       url: body.data.url,
       funcId: body.data.func_id,
+      secretId,
       provisionedAt: new Date().toISOString(),
     };
   } catch {
@@ -88,9 +146,14 @@ async function provision(apiKey: string): Promise<CacheEntry | null> {
  *
  * Order of preference:
  *   1. TELNYX_MCP_URL env var (explicit override)
- *   2. Cached per-tenant URL from a prior successful provision (if fingerprint matches)
- *   3. Fresh provision via deploy API
- *   4. Shared hosted URL (fallback — preserves today's behavior if deploy unavailable)
+ *   2. Cached per-tenant URL (if API-key fingerprint matches)
+ *   3. Fresh provision via deploy API (requires TELNYX_MCP_ACCEPT_FULL_SCOPE)
+ *   4. Shared hosted URL (fallback)
+ *
+ * Provisioning is gated on TELNYX_MCP_ACCEPT_FULL_SCOPE because the injected
+ * secret is the user's raw Telnyx API key — compromise of the Firecracker VM
+ * (e.g., via prompt-injected agent code in Code Mode) leaks a full-scope key.
+ * Users opt in explicitly; otherwise the shim stays on the shared URL.
  */
 export async function resolveEndpoint(options: ResolveOptions): Promise<ResolveResult> {
   const override = process.env.TELNYX_MCP_URL;
@@ -106,11 +169,15 @@ export async function resolveEndpoint(options: ResolveOptions): Promise<ResolveR
     return { url: cached.url, source: "cache" };
   }
 
+  if (!hasConsent()) {
+    return { url: SHARED_MCP_URL, source: "fallback-no-consent" };
+  }
+
   const provisioned = await provision(options.apiKey);
   if (provisioned) {
     await writeCache(provisioned);
     return { url: provisioned.url, source: "provisioned" };
   }
 
-  return { url: SHARED_MCP_URL, source: "fallback" };
+  return { url: SHARED_MCP_URL, source: "fallback-error" };
 }

--- a/tools/mcp/src/endpoint.ts
+++ b/tools/mcp/src/endpoint.ts
@@ -1,0 +1,116 @@
+import { promises as fs } from "node:fs";
+import { homedir } from "node:os";
+import { join, dirname } from "node:path";
+import { createHash } from "node:crypto";
+
+export const SHARED_MCP_URL = "https://api.telnyx.com/v2/mcp";
+const DEPLOY_API = "https://api.telnyx.com/v2/compute/mcp/deploy";
+const PROVISION_TIMEOUT_MS = 10_000;
+
+function cachePath(): string {
+  return join(homedir(), ".telnyx", "mcp-endpoint.json");
+}
+
+interface CacheEntry {
+  apiKeyFingerprint: string;
+  url: string;
+  funcId: string;
+  provisionedAt: string;
+}
+
+interface ResolveOptions {
+  apiKey: string;
+  reset?: boolean;
+}
+
+export interface ResolveResult {
+  url: string;
+  source: "override" | "cache" | "provisioned" | "fallback";
+}
+
+function fingerprint(apiKey: string): string {
+  return createHash("sha256").update(apiKey).digest("hex").slice(0, 16);
+}
+
+async function readCache(): Promise<CacheEntry | null> {
+  try {
+    const raw = await fs.readFile(cachePath(), "utf8");
+    return JSON.parse(raw) as CacheEntry;
+  } catch {
+    return null;
+  }
+}
+
+async function writeCache(entry: CacheEntry): Promise<void> {
+  await fs.mkdir(dirname(cachePath()), { recursive: true });
+  await fs.writeFile(cachePath(), JSON.stringify(entry, null, 2), { mode: 0o600 });
+}
+
+async function clearCache(): Promise<void> {
+  try {
+    await fs.unlink(cachePath());
+  } catch {
+    // cache already absent — fine
+  }
+}
+
+async function provision(apiKey: string): Promise<CacheEntry | null> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), PROVISION_TIMEOUT_MS);
+  try {
+    const res = await fetch(DEPLOY_API, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ name: "default-mcp" }),
+      signal: controller.signal,
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as { data?: { url?: string; func_id?: string } };
+    if (!body.data?.url || !body.data.func_id) return null;
+    return {
+      apiKeyFingerprint: fingerprint(apiKey),
+      url: body.data.url,
+      funcId: body.data.func_id,
+      provisionedAt: new Date().toISOString(),
+    };
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Resolve the MCP endpoint URL for this API key.
+ *
+ * Order of preference:
+ *   1. TELNYX_MCP_URL env var (explicit override)
+ *   2. Cached per-tenant URL from a prior successful provision (if fingerprint matches)
+ *   3. Fresh provision via deploy API
+ *   4. Shared hosted URL (fallback — preserves today's behavior if deploy unavailable)
+ */
+export async function resolveEndpoint(options: ResolveOptions): Promise<ResolveResult> {
+  const override = process.env.TELNYX_MCP_URL;
+  if (override) return { url: override, source: "override" };
+
+  if (options.reset || process.env.TELNYX_MCP_RESET) {
+    await clearCache();
+  }
+
+  const fp = fingerprint(options.apiKey);
+  const cached = await readCache();
+  if (cached && cached.apiKeyFingerprint === fp) {
+    return { url: cached.url, source: "cache" };
+  }
+
+  const provisioned = await provision(options.apiKey);
+  if (provisioned) {
+    await writeCache(provisioned);
+    return { url: provisioned.url, source: "provisioned" };
+  }
+
+  return { url: SHARED_MCP_URL, source: "fallback" };
+}

--- a/tools/mcp/src/index.ts
+++ b/tools/mcp/src/index.ts
@@ -2,25 +2,23 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 
-const REMOTE_MCP_URL = "https://api.telnyx.com/v2/mcp";
-
 export interface ProxyOptions {
   apiKey: string;
-  remoteUrl?: string;
+  remoteUrl: string;
 }
 
 /**
  * Creates a bidirectional proxy between a local stdio MCP transport
- * and the remote Telnyx MCP server over Streamable HTTP.
+ * and a remote Telnyx MCP server over Streamable HTTP.
  */
 export async function createProxy(options: ProxyOptions): Promise<void> {
-  const { apiKey, remoteUrl = REMOTE_MCP_URL } = options;
+  const { apiKey, remoteUrl } = options;
 
   const stdioTransport = new StdioServerTransport();
 
   const headers: Record<string, string> = {
     Authorization: `Bearer ${apiKey}`,
-    "User-Agent": `telnyx-mcp-proxy/0.1.0`,
+    "User-Agent": `telnyx-mcp-proxy/0.2.0`,
   };
 
   const remoteTransport = new StreamableHTTPClientTransport(
@@ -60,3 +58,6 @@ export async function createProxy(options: ProxyOptions): Promise<void> {
   await stdioTransport.start();
   await remoteTransport.start();
 }
+
+export { resolveEndpoint, SHARED_MCP_URL } from "./endpoint.js";
+export type { ResolveResult } from "./endpoint.js";

--- a/tools/mcp/src/index.ts
+++ b/tools/mcp/src/index.ts
@@ -3,8 +3,13 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 
 export interface ProxyOptions {
-  apiKey: string;
   remoteUrl: string;
+  /**
+   * Bearer token to send with requests to {@link remoteUrl}. For the shared
+   * hosted URL this is the user's Telnyx API key; for a per-tenant Edge
+   * Compute func it is the SHARED_SECRET returned by the deploy API.
+   */
+  remoteAuthToken: string;
 }
 
 /**
@@ -12,12 +17,12 @@ export interface ProxyOptions {
  * and a remote Telnyx MCP server over Streamable HTTP.
  */
 export async function createProxy(options: ProxyOptions): Promise<void> {
-  const { apiKey, remoteUrl } = options;
+  const { remoteUrl, remoteAuthToken } = options;
 
   const stdioTransport = new StdioServerTransport();
 
   const headers: Record<string, string> = {
-    Authorization: `Bearer ${apiKey}`,
+    Authorization: `Bearer ${remoteAuthToken}`,
     "User-Agent": `telnyx-mcp-proxy/0.2.0`,
   };
 

--- a/tools/mcp/tests/endpoint.test.ts
+++ b/tools/mcp/tests/endpoint.test.ts
@@ -10,6 +10,7 @@ const API_KEY = "KEY_test_1234";
 const PER_TENANT_URL = "https://default-mcp-acme.telnyxcompute.com/mcp";
 const FUNC_ID = "func_01HXYZ";
 const SECRET_ID = "sec_01HABC";
+const SHARED_SECRET = "ss_abc123def456";
 
 const SECRETS_API = "https://api.telnyx.com/v2/compute/secrets";
 const DEPLOY_API = "https://api.telnyx.com/v2/compute/mcp/deploy";
@@ -79,7 +80,12 @@ function secretsCreateOk(): Response {
 function deployOk(): Response {
   return new Response(
     JSON.stringify({
-      data: { url: PER_TENANT_URL, func_id: FUNC_ID, status: "ready" },
+      data: {
+        url: PER_TENANT_URL,
+        func_id: FUNC_ID,
+        shared_secret: SHARED_SECRET,
+        status: "ready",
+      },
     }),
     { status: 200 },
   );
@@ -112,25 +118,27 @@ afterEach(async () => {
 
 describe("resolveEndpoint", () => {
   describe("override", () => {
-    it("TELNYX_MCP_URL wins over everything else", async () => {
+    it("TELNYX_MCP_URL wins over everything else; uses API key as bearer", async () => {
       process.env.TELNYX_MCP_URL = "https://custom.example/mcp";
       globalThis.fetch = (async () => {
         throw new Error("fetch should not be called when override is set");
       }) as typeof fetch;
-      const { url, source } = await resolveEndpoint({ apiKey: API_KEY });
+      const { url, remoteAuthToken, source } = await resolveEndpoint({ apiKey: API_KEY });
       assert.equal(url, "https://custom.example/mcp");
+      assert.equal(remoteAuthToken, API_KEY);
       assert.equal(source, "override");
     });
   });
 
   describe("consent gate", () => {
-    it("without TELNYX_MCP_ACCEPT_FULL_SCOPE, skips provisioning", async () => {
+    it("without TELNYX_MCP_ACCEPT_FULL_SCOPE, falls back with API key as bearer", async () => {
       delete process.env.TELNYX_MCP_ACCEPT_FULL_SCOPE;
       globalThis.fetch = (async () => {
         throw new Error("fetch should not be called without consent");
       }) as typeof fetch;
-      const { url, source } = await resolveEndpoint({ apiKey: API_KEY });
+      const { url, remoteAuthToken, source } = await resolveEndpoint({ apiKey: API_KEY });
       assert.equal(url, SHARED_MCP_URL);
+      assert.equal(remoteAuthToken, API_KEY);
       assert.equal(source, "fallback-no-consent");
     });
 
@@ -148,14 +156,15 @@ describe("resolveEndpoint", () => {
   });
 
   describe("provisioning — new secret", () => {
-    it("creates secret when none exists, then deploys with secret id", async () => {
+    it("creates secret, deploys with secret id, returns shared_secret as bearer", async () => {
       const calls = installFetchRouter({
         secretsList: async () => secretsListEmpty(),
         secretsCreate: async () => secretsCreateOk(),
         deploy: async () => deployOk(),
       });
-      const { url, source } = await resolveEndpoint({ apiKey: API_KEY });
+      const { url, remoteAuthToken, source } = await resolveEndpoint({ apiKey: API_KEY });
       assert.equal(url, PER_TENANT_URL);
+      assert.equal(remoteAuthToken, SHARED_SECRET);
       assert.equal(source, "provisioned");
 
       assert.equal(calls.length, 3);
@@ -172,6 +181,26 @@ describe("resolveEndpoint", () => {
       assert.equal(cached.url, PER_TENANT_URL);
       assert.equal(cached.funcId, FUNC_ID);
       assert.equal(cached.secretId, SECRET_ID);
+      assert.equal(cached.sharedSecret, SHARED_SECRET);
+    });
+
+    it("deploy response missing shared_secret is treated as failure", async () => {
+      installFetchRouter({
+        secretsList: async () => secretsListEmpty(),
+        secretsCreate: async () => secretsCreateOk(),
+        deploy: async () =>
+          new Response(
+            JSON.stringify({
+              data: { url: PER_TENANT_URL, func_id: FUNC_ID, status: "ready" },
+            }),
+            { status: 200 },
+          ),
+      });
+      const { url, remoteAuthToken, source } = await resolveEndpoint({ apiKey: API_KEY });
+      assert.equal(source, "fallback-error");
+      assert.equal(url, SHARED_MCP_URL);
+      assert.equal(remoteAuthToken, API_KEY);
+      await assert.rejects(fs.access(cacheFile()));
     });
   });
 
@@ -249,7 +278,7 @@ describe("resolveEndpoint", () => {
   });
 
   describe("cache hits", () => {
-    it("returns cached URL without any fetch calls", async () => {
+    it("returns cached URL and shared_secret without any fetch calls", async () => {
       installFetchRouter({
         secretsList: async () => secretsListEmpty(),
         secretsCreate: async () => secretsCreateOk(),
@@ -264,6 +293,7 @@ describe("resolveEndpoint", () => {
       const second = await resolveEndpoint({ apiKey: API_KEY });
       assert.equal(second.source, "cache");
       assert.equal(second.url, PER_TENANT_URL);
+      assert.equal(second.remoteAuthToken, SHARED_SECRET);
     });
 
     it("different API key invalidates cache and re-provisions", async () => {
@@ -304,7 +334,7 @@ describe("resolveEndpoint", () => {
   });
 
   describe("request headers", () => {
-    it("sends Bearer auth and JSON content-type to both endpoints", async () => {
+    it("uses API key as bearer for secrets + deploy control-plane calls", async () => {
       const calls = installFetchRouter({
         secretsList: async () => secretsListEmpty(),
         secretsCreate: async () => secretsCreateOk(),

--- a/tools/mcp/tests/endpoint.test.ts
+++ b/tools/mcp/tests/endpoint.test.ts
@@ -9,29 +9,84 @@ import { resolveEndpoint, SHARED_MCP_URL } from "../src/endpoint.js";
 const API_KEY = "KEY_test_1234";
 const PER_TENANT_URL = "https://default-mcp-acme.telnyxcompute.com/mcp";
 const FUNC_ID = "func_01HXYZ";
+const SECRET_ID = "sec_01HABC";
+
+const SECRETS_API = "https://api.telnyx.com/v2/compute/secrets";
+const DEPLOY_API = "https://api.telnyx.com/v2/compute/mcp/deploy";
 
 const originalFetch = globalThis.fetch;
 const originalHome = process.env.HOME;
 const originalMcpUrl = process.env.TELNYX_MCP_URL;
 const originalMcpReset = process.env.TELNYX_MCP_RESET;
+const originalConsent = process.env.TELNYX_MCP_ACCEPT_FULL_SCOPE;
 
 let tmpHome: string;
 
-function setFetch(impl: typeof fetch): void {
-  globalThis.fetch = impl;
+interface CapturedCall {
+  url: string;
+  init: RequestInit;
 }
 
-function cacheFile(): string {
-  return join(tmpHome, ".telnyx", "mcp-endpoint.json");
+/**
+ * Install a simple fetch stub that routes by URL prefix.
+ * Returns an array that captures every call for assertions.
+ */
+function installFetchRouter(handlers: {
+  secretsList?: (url: string, init: RequestInit) => Promise<Response>;
+  secretsCreate?: (url: string, init: RequestInit) => Promise<Response>;
+  deploy?: (url: string, init: RequestInit) => Promise<Response>;
+}): CapturedCall[] {
+  const captured: CapturedCall[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const initOrEmpty = init ?? {};
+    captured.push({ url, init: initOrEmpty });
+    if (url.startsWith(SECRETS_API) && initOrEmpty.method === "POST") {
+      if (!handlers.secretsCreate) throw new Error(`unexpected POST ${url}`);
+      return handlers.secretsCreate(url, initOrEmpty);
+    }
+    if (url.startsWith(SECRETS_API)) {
+      if (!handlers.secretsList) throw new Error(`unexpected GET ${url}`);
+      return handlers.secretsList(url, initOrEmpty);
+    }
+    if (url.startsWith(DEPLOY_API)) {
+      if (!handlers.deploy) throw new Error(`unexpected deploy ${url}`);
+      return handlers.deploy(url, initOrEmpty);
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  }) as typeof fetch;
+  return captured;
 }
 
-function successResponse(): Response {
+function secretsListEmpty(): Response {
+  return new Response(JSON.stringify({ data: [] }), { status: 200 });
+}
+
+function secretsListExisting(name: string): Response {
+  return new Response(
+    JSON.stringify({ data: [{ id: SECRET_ID, name }] }),
+    { status: 200 },
+  );
+}
+
+function secretsCreateOk(): Response {
+  return new Response(
+    JSON.stringify({ data: { id: SECRET_ID, name: "mcp-shim-xxx" } }),
+    { status: 201 },
+  );
+}
+
+function deployOk(): Response {
   return new Response(
     JSON.stringify({
       data: { url: PER_TENANT_URL, func_id: FUNC_ID, status: "ready" },
     }),
-    { status: 200, headers: { "Content-Type": "application/json" } },
+    { status: 200 },
   );
+}
+
+function cacheFile(): string {
+  return join(tmpHome, ".telnyx", "mcp-endpoint.json");
 }
 
 beforeEach(() => {
@@ -39,6 +94,7 @@ beforeEach(() => {
   process.env.HOME = tmpHome;
   delete process.env.TELNYX_MCP_URL;
   delete process.env.TELNYX_MCP_RESET;
+  process.env.TELNYX_MCP_ACCEPT_FULL_SCOPE = "1";
 });
 
 afterEach(async () => {
@@ -49,6 +105,8 @@ afterEach(async () => {
   else process.env.TELNYX_MCP_URL = originalMcpUrl;
   if (originalMcpReset === undefined) delete process.env.TELNYX_MCP_RESET;
   else process.env.TELNYX_MCP_RESET = originalMcpReset;
+  if (originalConsent === undefined) delete process.env.TELNYX_MCP_ACCEPT_FULL_SCOPE;
+  else process.env.TELNYX_MCP_ACCEPT_FULL_SCOPE = originalConsent;
   await fs.rm(tmpHome, { recursive: true, force: true });
 });
 
@@ -56,150 +114,208 @@ describe("resolveEndpoint", () => {
   describe("override", () => {
     it("TELNYX_MCP_URL wins over everything else", async () => {
       process.env.TELNYX_MCP_URL = "https://custom.example/mcp";
-      setFetch(async () => {
+      globalThis.fetch = (async () => {
         throw new Error("fetch should not be called when override is set");
-      });
+      }) as typeof fetch;
       const { url, source } = await resolveEndpoint({ apiKey: API_KEY });
       assert.equal(url, "https://custom.example/mcp");
       assert.equal(source, "override");
     });
   });
 
-  describe("provisioning success", () => {
-    it("calls deploy API, caches, returns per-tenant URL", async () => {
-      let callCount = 0;
-      setFetch(async () => {
-        callCount++;
-        return successResponse();
+  describe("consent gate", () => {
+    it("without TELNYX_MCP_ACCEPT_FULL_SCOPE, skips provisioning", async () => {
+      delete process.env.TELNYX_MCP_ACCEPT_FULL_SCOPE;
+      globalThis.fetch = (async () => {
+        throw new Error("fetch should not be called without consent");
+      }) as typeof fetch;
+      const { url, source } = await resolveEndpoint({ apiKey: API_KEY });
+      assert.equal(url, SHARED_MCP_URL);
+      assert.equal(source, "fallback-no-consent");
+    });
+
+    it("TELNYX_MCP_ACCEPT_FULL_SCOPE=0 is treated as no consent", async () => {
+      process.env.TELNYX_MCP_ACCEPT_FULL_SCOPE = "0";
+      const { source } = await resolveEndpoint({ apiKey: API_KEY });
+      assert.equal(source, "fallback-no-consent");
+    });
+
+    it("TELNYX_MCP_ACCEPT_FULL_SCOPE=false is treated as no consent", async () => {
+      process.env.TELNYX_MCP_ACCEPT_FULL_SCOPE = "false";
+      const { source } = await resolveEndpoint({ apiKey: API_KEY });
+      assert.equal(source, "fallback-no-consent");
+    });
+  });
+
+  describe("provisioning — new secret", () => {
+    it("creates secret when none exists, then deploys with secret id", async () => {
+      const calls = installFetchRouter({
+        secretsList: async () => secretsListEmpty(),
+        secretsCreate: async () => secretsCreateOk(),
+        deploy: async () => deployOk(),
       });
       const { url, source } = await resolveEndpoint({ apiKey: API_KEY });
       assert.equal(url, PER_TENANT_URL);
       assert.equal(source, "provisioned");
-      assert.equal(callCount, 1);
+
+      assert.equal(calls.length, 3);
+      const [list, create, deploy] = calls;
+      assert.match(list.url, /filter\[name\]=mcp-shim-/);
+      assert.equal(create.init.method, "POST");
+      assert.equal(deploy.url, DEPLOY_API);
+
+      const deployBody = JSON.parse(String(deploy.init.body));
+      assert.equal(deployBody.name, "default-mcp");
+      assert.equal(deployBody.api_key_secret_id, SECRET_ID);
 
       const cached = JSON.parse(await fs.readFile(cacheFile(), "utf8"));
       assert.equal(cached.url, PER_TENANT_URL);
       assert.equal(cached.funcId, FUNC_ID);
-      assert.ok(cached.apiKeyFingerprint);
-      assert.ok(cached.provisionedAt);
+      assert.equal(cached.secretId, SECRET_ID);
     });
+  });
 
-    it("response missing data.url is treated as failure", async () => {
-      setFetch(async () =>
-        new Response(JSON.stringify({ data: { func_id: FUNC_ID } }), { status: 200 }),
-      );
+  describe("provisioning — existing secret", () => {
+    it("reuses secret when list returns a match, skipping create", async () => {
+      const calls = installFetchRouter({
+        secretsList: async (url) => {
+          const match = url.match(/filter\[name\]=([^&]+)/);
+          return secretsListExisting(decodeURIComponent(match![1]));
+        },
+        secretsCreate: async () => {
+          throw new Error("create should not be called when secret exists");
+        },
+        deploy: async () => deployOk(),
+      });
+      const { url, source } = await resolveEndpoint({ apiKey: API_KEY });
+      assert.equal(source, "provisioned");
+      assert.equal(url, PER_TENANT_URL);
+      assert.equal(calls.length, 2, "only list + deploy, no create");
+    });
+  });
+
+  describe("provisioning failure modes", () => {
+    it("secret create 500 falls back", async () => {
+      installFetchRouter({
+        secretsList: async () => secretsListEmpty(),
+        secretsCreate: async () => new Response("oops", { status: 500 }),
+      });
       const { url, source } = await resolveEndpoint({ apiKey: API_KEY });
       assert.equal(url, SHARED_MCP_URL);
-      assert.equal(source, "fallback");
+      assert.equal(source, "fallback-error");
+      await assert.rejects(fs.access(cacheFile()));
+    });
+
+    it("deploy 404 falls back", async () => {
+      installFetchRouter({
+        secretsList: async () => secretsListEmpty(),
+        secretsCreate: async () => secretsCreateOk(),
+        deploy: async () => new Response("nope", { status: 404 }),
+      });
+      const { source } = await resolveEndpoint({ apiKey: API_KEY });
+      assert.equal(source, "fallback-error");
+      await assert.rejects(fs.access(cacheFile()));
+    });
+
+    it("deploy response missing url is treated as failure", async () => {
+      installFetchRouter({
+        secretsList: async () => secretsListEmpty(),
+        secretsCreate: async () => secretsCreateOk(),
+        deploy: async () =>
+          new Response(JSON.stringify({ data: { func_id: FUNC_ID } }), {
+            status: 200,
+          }),
+      });
+      const { source } = await resolveEndpoint({ apiKey: API_KEY });
+      assert.equal(source, "fallback-error");
+    });
+
+    it("network error during secret step falls back", async () => {
+      globalThis.fetch = (async () => {
+        throw new TypeError("fetch failed");
+      }) as typeof fetch;
+      const { url, source } = await resolveEndpoint({ apiKey: API_KEY });
+      assert.equal(url, SHARED_MCP_URL);
+      assert.equal(source, "fallback-error");
+    });
+
+    it("aborted fetch falls back", async () => {
+      globalThis.fetch = (async () => {
+        throw new DOMException("aborted", "AbortError");
+      }) as typeof fetch;
+      const { source } = await resolveEndpoint({ apiKey: API_KEY });
+      assert.equal(source, "fallback-error");
     });
   });
 
   describe("cache hits", () => {
-    it("returns cached URL without calling deploy API", async () => {
-      let callCount = 0;
-      setFetch(async () => {
-        callCount++;
-        return successResponse();
+    it("returns cached URL without any fetch calls", async () => {
+      installFetchRouter({
+        secretsList: async () => secretsListEmpty(),
+        secretsCreate: async () => secretsCreateOk(),
+        deploy: async () => deployOk(),
       });
       await resolveEndpoint({ apiKey: API_KEY });
+
+      // Fail any further fetch call — second resolve should not need fetch.
+      globalThis.fetch = (async () => {
+        throw new Error("cache hit should not call fetch");
+      }) as typeof fetch;
       const second = await resolveEndpoint({ apiKey: API_KEY });
-      assert.equal(callCount, 1, "deploy API should be called exactly once");
-      assert.equal(second.url, PER_TENANT_URL);
       assert.equal(second.source, "cache");
+      assert.equal(second.url, PER_TENANT_URL);
     });
 
-    it("re-provisions when API key changes (fingerprint mismatch)", async () => {
-      let callCount = 0;
-      setFetch(async () => {
-        callCount++;
-        return successResponse();
+    it("different API key invalidates cache and re-provisions", async () => {
+      installFetchRouter({
+        secretsList: async () => secretsListEmpty(),
+        secretsCreate: async () => secretsCreateOk(),
+        deploy: async () => deployOk(),
       });
       await resolveEndpoint({ apiKey: API_KEY });
-      const rotated = await resolveEndpoint({ apiKey: "KEY_different_key" });
-      assert.equal(callCount, 2);
+      const rotated = await resolveEndpoint({ apiKey: "KEY_rotated_9999" });
       assert.equal(rotated.source, "provisioned");
     });
   });
 
   describe("reset", () => {
-    it("--reset flag clears cache and re-provisions", async () => {
-      let callCount = 0;
-      setFetch(async () => {
-        callCount++;
-        return successResponse();
+    it("--reset clears cache and re-provisions", async () => {
+      installFetchRouter({
+        secretsList: async () => secretsListEmpty(),
+        secretsCreate: async () => secretsCreateOk(),
+        deploy: async () => deployOk(),
       });
       await resolveEndpoint({ apiKey: API_KEY });
       const reset = await resolveEndpoint({ apiKey: API_KEY, reset: true });
-      assert.equal(callCount, 2);
       assert.equal(reset.source, "provisioned");
     });
 
     it("TELNYX_MCP_RESET env var clears cache", async () => {
-      let callCount = 0;
-      setFetch(async () => {
-        callCount++;
-        return successResponse();
+      installFetchRouter({
+        secretsList: async () => secretsListEmpty(),
+        secretsCreate: async () => secretsCreateOk(),
+        deploy: async () => deployOk(),
       });
       await resolveEndpoint({ apiKey: API_KEY });
       process.env.TELNYX_MCP_RESET = "1";
       const reset = await resolveEndpoint({ apiKey: API_KEY });
-      assert.equal(callCount, 2);
       assert.equal(reset.source, "provisioned");
     });
   });
 
-  describe("fallback paths", () => {
-    it("404 falls back to shared URL, no cache write", async () => {
-      setFetch(async () => new Response("Not Found", { status: 404 }));
-      const { url, source } = await resolveEndpoint({ apiKey: API_KEY });
-      assert.equal(url, SHARED_MCP_URL);
-      assert.equal(source, "fallback");
-      await assert.rejects(fs.access(cacheFile()));
-    });
-
-    it("500 falls back to shared URL, no cache write", async () => {
-      setFetch(async () => new Response("Internal Server Error", { status: 500 }));
-      const { url, source } = await resolveEndpoint({ apiKey: API_KEY });
-      assert.equal(url, SHARED_MCP_URL);
-      assert.equal(source, "fallback");
-      await assert.rejects(fs.access(cacheFile()));
-    });
-
-    it("network error falls back to shared URL", async () => {
-      setFetch(async () => {
-        throw new TypeError("fetch failed");
-      });
-      const { url, source } = await resolveEndpoint({ apiKey: API_KEY });
-      assert.equal(url, SHARED_MCP_URL);
-      assert.equal(source, "fallback");
-    });
-
-    it("aborted fetch falls back to shared URL", async () => {
-      setFetch(async () => {
-        throw new DOMException("aborted", "AbortError");
-      });
-      const { url, source } = await resolveEndpoint({ apiKey: API_KEY });
-      assert.equal(url, SHARED_MCP_URL);
-      assert.equal(source, "fallback");
-    });
-  });
-
-  describe("request shape", () => {
-    it("sends Bearer auth and JSON body to deploy endpoint", async () => {
-      let captured: { url: string; init: RequestInit } | null = null;
-      setFetch(async (input, init) => {
-        captured = { url: String(input), init: init! };
-        return successResponse();
+  describe("request headers", () => {
+    it("sends Bearer auth and JSON content-type to both endpoints", async () => {
+      const calls = installFetchRouter({
+        secretsList: async () => secretsListEmpty(),
+        secretsCreate: async () => secretsCreateOk(),
+        deploy: async () => deployOk(),
       });
       await resolveEndpoint({ apiKey: API_KEY });
-      assert.ok(captured, "fetch should have been called");
-      assert.equal(captured!.url, "https://api.telnyx.com/v2/compute/mcp/deploy");
-      assert.equal(captured!.init.method, "POST");
-      const headers = captured!.init.headers as Record<string, string>;
-      assert.equal(headers.Authorization, `Bearer ${API_KEY}`);
-      assert.equal(headers["Content-Type"], "application/json");
-      const body = JSON.parse(String(captured!.init.body));
-      assert.equal(body.name, "default-mcp");
+      for (const c of calls) {
+        const headers = c.init.headers as Record<string, string>;
+        assert.equal(headers.Authorization, `Bearer ${API_KEY}`);
+        assert.equal(headers["Content-Type"], "application/json");
+      }
     });
   });
 });

--- a/tools/mcp/tests/endpoint.test.ts
+++ b/tools/mcp/tests/endpoint.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveEndpoint, SHARED_MCP_URL } from "../src/endpoint.js";
+
+const API_KEY = "KEY_test_1234";
+const PER_TENANT_URL = "https://default-mcp-acme.telnyxcompute.com/mcp";
+const FUNC_ID = "func_01HXYZ";
+
+const originalFetch = globalThis.fetch;
+const originalHome = process.env.HOME;
+const originalMcpUrl = process.env.TELNYX_MCP_URL;
+const originalMcpReset = process.env.TELNYX_MCP_RESET;
+
+let tmpHome: string;
+
+function setFetch(impl: typeof fetch): void {
+  globalThis.fetch = impl;
+}
+
+function cacheFile(): string {
+  return join(tmpHome, ".telnyx", "mcp-endpoint.json");
+}
+
+function successResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      data: { url: PER_TENANT_URL, func_id: FUNC_ID, status: "ready" },
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), "telnyx-mcp-test-"));
+  process.env.HOME = tmpHome;
+  delete process.env.TELNYX_MCP_URL;
+  delete process.env.TELNYX_MCP_RESET;
+});
+
+afterEach(async () => {
+  globalThis.fetch = originalFetch;
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalMcpUrl === undefined) delete process.env.TELNYX_MCP_URL;
+  else process.env.TELNYX_MCP_URL = originalMcpUrl;
+  if (originalMcpReset === undefined) delete process.env.TELNYX_MCP_RESET;
+  else process.env.TELNYX_MCP_RESET = originalMcpReset;
+  await fs.rm(tmpHome, { recursive: true, force: true });
+});
+
+describe("resolveEndpoint", () => {
+  describe("override", () => {
+    it("TELNYX_MCP_URL wins over everything else", async () => {
+      process.env.TELNYX_MCP_URL = "https://custom.example/mcp";
+      setFetch(async () => {
+        throw new Error("fetch should not be called when override is set");
+      });
+      const { url, source } = await resolveEndpoint({ apiKey: API_KEY });
+      assert.equal(url, "https://custom.example/mcp");
+      assert.equal(source, "override");
+    });
+  });
+
+  describe("provisioning success", () => {
+    it("calls deploy API, caches, returns per-tenant URL", async () => {
+      let callCount = 0;
+      setFetch(async () => {
+        callCount++;
+        return successResponse();
+      });
+      const { url, source } = await resolveEndpoint({ apiKey: API_KEY });
+      assert.equal(url, PER_TENANT_URL);
+      assert.equal(source, "provisioned");
+      assert.equal(callCount, 1);
+
+      const cached = JSON.parse(await fs.readFile(cacheFile(), "utf8"));
+      assert.equal(cached.url, PER_TENANT_URL);
+      assert.equal(cached.funcId, FUNC_ID);
+      assert.ok(cached.apiKeyFingerprint);
+      assert.ok(cached.provisionedAt);
+    });
+
+    it("response missing data.url is treated as failure", async () => {
+      setFetch(async () =>
+        new Response(JSON.stringify({ data: { func_id: FUNC_ID } }), { status: 200 }),
+      );
+      const { url, source } = await resolveEndpoint({ apiKey: API_KEY });
+      assert.equal(url, SHARED_MCP_URL);
+      assert.equal(source, "fallback");
+    });
+  });
+
+  describe("cache hits", () => {
+    it("returns cached URL without calling deploy API", async () => {
+      let callCount = 0;
+      setFetch(async () => {
+        callCount++;
+        return successResponse();
+      });
+      await resolveEndpoint({ apiKey: API_KEY });
+      const second = await resolveEndpoint({ apiKey: API_KEY });
+      assert.equal(callCount, 1, "deploy API should be called exactly once");
+      assert.equal(second.url, PER_TENANT_URL);
+      assert.equal(second.source, "cache");
+    });
+
+    it("re-provisions when API key changes (fingerprint mismatch)", async () => {
+      let callCount = 0;
+      setFetch(async () => {
+        callCount++;
+        return successResponse();
+      });
+      await resolveEndpoint({ apiKey: API_KEY });
+      const rotated = await resolveEndpoint({ apiKey: "KEY_different_key" });
+      assert.equal(callCount, 2);
+      assert.equal(rotated.source, "provisioned");
+    });
+  });
+
+  describe("reset", () => {
+    it("--reset flag clears cache and re-provisions", async () => {
+      let callCount = 0;
+      setFetch(async () => {
+        callCount++;
+        return successResponse();
+      });
+      await resolveEndpoint({ apiKey: API_KEY });
+      const reset = await resolveEndpoint({ apiKey: API_KEY, reset: true });
+      assert.equal(callCount, 2);
+      assert.equal(reset.source, "provisioned");
+    });
+
+    it("TELNYX_MCP_RESET env var clears cache", async () => {
+      let callCount = 0;
+      setFetch(async () => {
+        callCount++;
+        return successResponse();
+      });
+      await resolveEndpoint({ apiKey: API_KEY });
+      process.env.TELNYX_MCP_RESET = "1";
+      const reset = await resolveEndpoint({ apiKey: API_KEY });
+      assert.equal(callCount, 2);
+      assert.equal(reset.source, "provisioned");
+    });
+  });
+
+  describe("fallback paths", () => {
+    it("404 falls back to shared URL, no cache write", async () => {
+      setFetch(async () => new Response("Not Found", { status: 404 }));
+      const { url, source } = await resolveEndpoint({ apiKey: API_KEY });
+      assert.equal(url, SHARED_MCP_URL);
+      assert.equal(source, "fallback");
+      await assert.rejects(fs.access(cacheFile()));
+    });
+
+    it("500 falls back to shared URL, no cache write", async () => {
+      setFetch(async () => new Response("Internal Server Error", { status: 500 }));
+      const { url, source } = await resolveEndpoint({ apiKey: API_KEY });
+      assert.equal(url, SHARED_MCP_URL);
+      assert.equal(source, "fallback");
+      await assert.rejects(fs.access(cacheFile()));
+    });
+
+    it("network error falls back to shared URL", async () => {
+      setFetch(async () => {
+        throw new TypeError("fetch failed");
+      });
+      const { url, source } = await resolveEndpoint({ apiKey: API_KEY });
+      assert.equal(url, SHARED_MCP_URL);
+      assert.equal(source, "fallback");
+    });
+
+    it("aborted fetch falls back to shared URL", async () => {
+      setFetch(async () => {
+        throw new DOMException("aborted", "AbortError");
+      });
+      const { url, source } = await resolveEndpoint({ apiKey: API_KEY });
+      assert.equal(url, SHARED_MCP_URL);
+      assert.equal(source, "fallback");
+    });
+  });
+
+  describe("request shape", () => {
+    it("sends Bearer auth and JSON body to deploy endpoint", async () => {
+      let captured: { url: string; init: RequestInit } | null = null;
+      setFetch(async (input, init) => {
+        captured = { url: String(input), init: init! };
+        return successResponse();
+      });
+      await resolveEndpoint({ apiKey: API_KEY });
+      assert.ok(captured, "fetch should have been called");
+      assert.equal(captured!.url, "https://api.telnyx.com/v2/compute/mcp/deploy");
+      assert.equal(captured!.init.method, "POST");
+      const headers = captured!.init.headers as Record<string, string>;
+      assert.equal(headers.Authorization, `Bearer ${API_KEY}`);
+      assert.equal(headers["Content-Type"], "application/json");
+      const body = JSON.parse(String(captured!.init.body));
+      assert.equal(body.name, "default-mcp");
+    });
+  });
+});


### PR DESCRIPTION
> **Status:** Draft. Phase 0 of the per-tenant Edge Compute MCP plan. Code is complete and tests pass — held in draft pending contract confirmation from the Edge Compute team (see [Open questions](#open-questions-for-edge-compute-team)). No user-visible behavior change on merge: shim falls back to today's shared hosted URL until both the new deploy API ships and a follow-up PR flips the plugin manifests.

## What this PR does

`@telnyx/mcp` becomes a small resolver-then-proxy:

1. On first invocation (with explicit consent), ensure a Telnyx Edge Compute secret exists holding the user's API key — deterministic name by key fingerprint, idempotent across cache resets via the upsert-by-name semantics of `secrets add`.
2. Call `POST /v2/compute/mcp/deploy` with `api_key_secret_id`. Cache the returned per-tenant URL **and** the server-generated `SHARED_SECRET` at `~/.telnyx/mcp-endpoint.json` (mode 0600).
3. Proxy stdio ↔ Streamable HTTP to the per-tenant URL using `SHARED_SECRET` as the inbound bearer.

If any step fails, or the user hasn't opted in, the shim transparently falls back to today's shared hosted endpoint `https://api.telnyx.com/v2/mcp` using the API key as bearer — current behavior preserved exactly.

## What's NOT in this PR (deliberately)

- Plugin manifest flips for `providers/claude/`, `providers/cursor/`, or `gemini-extension.json` — those wait until `@telnyx/mcp@0.2.0` is on npm.
- Any changes to today's shared hosted MCP endpoint or its routing.
- Calls to the deploy API endpoint (`/v2/compute/mcp/deploy`) from any production code path. The path 404s today; the shim swallows that and falls back.

## Background

- Use case + deployment strategy: [mcp-server-deployment-strategy.md](https://github.com/team-telnyx/product-management-monorepo/blob/main/mcp-server/mcp-server-deployment-strategy.md) (Xingda)
- Reference deployable example: [team-telnyx/edge-compute/examples/ts/mcp-server](https://github.com/team-telnyx/edge-compute/tree/main/examples/ts/mcp-server) (Yiu Ming)

## Two distinct credentials — explicit for the first time

The reference example surfaces a split that the original deployment doc didn't fully spell out. This PR encodes it:

| Credential | Used by | Where stored |
|---|---|---|
| `TELNYX_API_KEY` | The deployed func, to call Telnyx APIs upstream | Telnyx secret (org-scoped), referenced by `api_key_secret_id` |
| `SHARED_SECRET` | The MCP client (this shim), to authenticate inbound to the func | Returned by deploy API, cached locally; **server-generated, returned once** |

Server-generation of `SHARED_SECRET` is intentional. Telnyx `secrets list` returns names only — values are unrecoverable from the API once written. A client-generated value stored as a Telnyx secret would be lost forever on local cache loss. Server-managed avoids the dual-source-of-truth and keeps recovery simple: cache loss → `--reset` → new value.

## Consent gate

Provisioning is opt-in via `TELNYX_MCP_ACCEPT_FULL_SCOPE=1`. The injected upstream secret is the user's **raw, full-scope** Telnyx API key — VM-internal compromise inside the Code Mode MCP func (Deno eval on agent-written TS, `--allow-env` unrestricted) would exfiltrate it. Firecracker protects cluster blast radius but not account blast radius. Without the env var, the shim stays on the shared URL.

v2 hardening candidate: swap raw API key for a scoped, short-lived credential. Tracked as open question 5 below; not blocking.

## Validated against the live API (read-only probing)

| Endpoint | Status | Meaning |
|---|---|---|
| `GET /v2/compute/funcs` | 401 | Path exists, needs auth |
| `GET /v2/compute/secrets` | 401 | Path exists, needs auth |
| `GET /v2/compute/mcp/deploy` | 404 | Endpoint genuinely net-new; Xingda's team to build |
| `GET /v2/compute/funcs/{id}/secrets` | 404 | No nested secrets resource |

Public docs further confirm: secrets are org-scoped, `secrets add` is upsert by name, secret values are never returned via list, Telnyx API key auth IS supported by the Edge Compute control plane (`auth api-key set`), per-tenant URL pattern is `https://{funcName}-{orgId}.telnyxcompute.com`.

## Tests

`npm test` — 17/17 passing. Coverage:
- Override (`TELNYX_MCP_URL`) wins, uses API key as bearer
- Consent gate (`TELNYX_MCP_ACCEPT_FULL_SCOPE` unset / `0` / `false` all skip provisioning, return shared URL)
- Provisioning happy path (new secret + existing secret reuse + deploy with `api_key_secret_id`)
- Failure modes (secret 500, deploy 404, missing `url` / `func_id` / `shared_secret` in response, network error, abort)
- Cache hits (URL **and** `SHARED_SECRET` returned without any fetch calls)
- Reset (`--reset` + `TELNYX_MCP_RESET` env var)
- Request headers (Bearer + JSON content-type on every control-plane call)
- `remoteAuthToken` assertions across every source: API key for shared/override/no-consent, `SHARED_SECRET` for cache/provisioned

## Open questions for Edge Compute team

The shim is built against best-guess shapes for the new `mcp/deploy` endpoint. Each unconfirmed assumption below has a fallback path that keeps users on the shared URL — wrong guesses don't break anything, they just leave per-tenant URLs unused. Still want explicit answers before flipping plugin manifests:

1. **Idempotency** — is `POST /v2/compute/mcp/deploy` idempotent by `name` within an org? Shim calls deploy on every cache miss and assumes "yes."
2. **Response envelope** — shim parses `{ data: { url, func_id, shared_secret, status, ... } }`. Confirm field names and JSON envelope.
3. **Server-generated `shared_secret`** — confirmed approach? Alternative is shim-generated; server-managed is cleaner per the unrecoverability constraint.
4. **Synchronous vs polling** — shim treats `res.ok === false` as failure. If the endpoint can return `202` for long provisioning with a separate poll URL, first-run users silently stay on shared URL until we add polling logic.
5. **Scoped credentials (v2 hardening)** — is there (or can there be) an API to mint a short-lived, narrower-scope credential the shim could inject as `TELNYX_API_KEY` instead of the user's raw key?
6. **`SHARED_SECRET` rotation** — separate endpoint to rotate without redeploying, or is `--reset` the only path?

## Sequencing

- [x] Code complete on branch (3 commits)
- [x] Tests passing (17/17)
- [x] Endpoint shapes validated via probing
- [ ] **(blocking)** Xingda confirms questions 1–4
- [ ] Address any contract deltas in this branch
- [ ] Mark PR ready for review, get review, merge
- [ ] Publish `@telnyx/mcp@0.2.0` via manual `workflow_dispatch` on `publish-npm.yml`
- [ ] Follow-up PR flips plugin manifests to spawn the shim
- [ ] Edge Compute team ships pre-baked MCP image + deploy API
- [ ] End-to-end smoke test with real API key
- [ ] Monitor fallback rate; investigate any non-cache-hit fallback in steady state

## Files changed

`tools/mcp/` only:
- `src/endpoint.ts` (new) — resolver, secret ensure, deploy call, cache
- `src/index.ts` — `createProxy` takes `remoteAuthToken` instead of `apiKey`; drops hardcoded URL constant
- `src/cli.ts` — wires resolver to proxy, expanded help text
- `tests/endpoint.test.ts` (new) — 17 cases
- `package.json` — bump to 0.2.0, add `test` + `typecheck` scripts, add `tsx` devDep
- `package-lock.json` — tsx
- `README.md` — documents dual-credential model and opt-in flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)