### PR TITLE
chore: scaffold plugins/ and inference/ directories

### DIFF
--- a/inference/README.md
+++ b/inference/README.md
@@ -1,0 +1,9 @@
+# Inference
+
+Telnyx-as-LLM-backend integrations for AI application frameworks.
+
+Each subdirectory provides a provider/adapter that lets a framework route inference calls to Telnyx-hosted models. Planned entries include Vercel AI SDK, LangChain (Py + JS), LlamaIndex (Py + JS), LiteLLM, Haystack, Semantic Kernel, AutoGen, Dify, and Flowise.
+
+This directory is named `inference/` rather than `providers/` to avoid collision with the existing top-level `providers/` (which currently holds coding-assistant configs and will be consolidated under `plugins/` in a follow-up step).
+
+See the repo root `README.md` for the full architecture.

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,9 @@
+# Plugins
+
+Coding-assistant plugins that wire Telnyx into AI IDEs and CLIs (Claude Code, Cursor, Gemini CLI, OpenCode, …).
+
+Each subdirectory contains one plugin: its manifest, source (if applicable), and install instructions.
+
+This directory is being populated as part of a repo-wide reorganization. Existing plugin assets currently live at `.claude-plugin/`, `.cursor-plugin/`, `providers/claude/`, `providers/cursor/`, `gemini-extension.json`, and `agent.json`, and will be consolidated here in a follow-up step. The separate `team-telnyx/opencode-telnyx-auth` repo will also be absorbed as `plugins/opencode/`.
+
+See the repo root `README.md` for the full architecture.


### PR DESCRIPTION
## Summary
- Adds empty `plugins/` and `inference/` top-level directories, each with a placeholder `README.md` describing what will live there.
- Pure addition — no existing files are moved, renamed, or deleted in this PR.

## Context
Step 1 of a planned repo reorganization to support upcoming framework integrations (Vercel AI SDK, LangChain, LlamaIndex, LiteLLM, Haystack, Semantic Kernel, AutoGen, Dify, Flowise, Spring AI) alongside the existing coding-assistant plugins.

The new top-level layout will be:
- `plugins/` — coding-assistant plugins (Claude Code, Cursor, Gemini CLI, OpenCode). Consolidates assets currently scattered across `.claude-plugin/`, `.cursor-plugin/`, `providers/claude/`, `providers/cursor/`, `gemini-extension.json`, `agent.json`, and the external `team-telnyx/opencode-telnyx-auth` repo.
- `inference/` — framework-level "Telnyx as LLM backend" adapters. Named `inference/` rather than `providers/` to avoid collision with the existing `providers/` directory, which will be emptied and removed in a later step.

Subsequent steps (separate PRs) will absorb OpenCode, consolidate coding-assistant configs into `plugins/`, rename `tools/` → `toolkits/`, lift `tools/mcp/` → `mcp/`, add monorepo tooling, and begin populating `inference/`.

## Test plan
- [ ] CI passes (no code changes, README-only)
- [ ] Confirm `plugins/` and `inference/` appear at repo root and render their READMEs on GitHub
- [ ] No references to existing paths were altered

🤖 Generated with [Claude Code](https://claude.com/claude-code)