### PR TITLE
Fix CODEOWNERS: correct Oliver-Zimmerman handle

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # All changes require approval from a codeowner
-* @aisling404 @oliverzimmerman @gbattistel
+* @aisling404 @Oliver-Zimmerman @gbattistel


### PR DESCRIPTION
## Summary
- The CODEOWNERS file referenced `@oliverzimmerman`, which is not a valid GitHub handle for any collaborator on this repo.
- Oliver's actual GitHub username is `@Oliver-Zimmerman` (with the hyphen and capitalization).
- Because the old handle didn't resolve, Oliver's reviews weren't actually counted as code-owner approvals, contributing to the bottleneck where only @aisling404 could move PRs through.

## Test plan
- [ ] Verify @Oliver-Zimmerman is now auto-requested as a reviewer on new PRs
- [ ] Confirm his approval satisfies the code-owner review requirement