### PR TITLE
feat: improve skill scores for 5 lowest-scoring skills

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,22 @@
+# Tessl Skill Review — runs on PRs that change any SKILL.md; posts scores as one PR comment.
+# Docs: https://github.com/tesslio/skill-review
+name: Tessl Skill Review
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/SKILL.md"
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@main
+      # Optional quality gate (off by default — do not enable unless user asked):
+      # with:
+      #   fail-threshold: 70

--- a/skills/telnyx-fax-curl/SKILL.md
+++ b/skills/telnyx-fax-curl/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: telnyx-fax-curl
-description: >-
-  Send and receive faxes programmatically. Manage fax applications and media.
-  This skill provides REST API (curl) examples.
+description: "Send, receive, and track faxes programmatically via the Telnyx Fax API. Create and manage fax applications, send faxes from PDF or URL, check delivery status, and handle fax lifecycle webhooks. Use when sending faxes via API, receiving inbound faxes, managing fax-enabled phone numbers, or integrating fax capabilities into an application with curl."
 metadata:
   author: telnyx
   product: fax
@@ -14,11 +12,7 @@ metadata:
 
 # Telnyx Fax - curl
 
-## Installation
-
-```text
-# curl is pre-installed on macOS, Linux, and Windows 10+
-```
+Send and receive faxes programmatically through the Telnyx REST API.
 
 ## Setup
 
@@ -26,351 +20,142 @@ metadata:
 export TELNYX_API_KEY="YOUR_API_KEY_HERE"
 ```
 
-All examples below use `$TELNYX_API_KEY` for authentication.
+## Quick Start: Send a Fax
 
-## Error Handling
-
-All API calls can fail with network errors, rate limits (429), validation errors (422),
-or authentication errors (401). Always handle errors in production code:
-
-```bash
-# Check HTTP status code in response
-response=$(curl -s -w "\n%{http_code}" \
-  -X POST "https://api.telnyx.com/v2/messages" \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"to": "+13125550001", "from": "+13125550002", "text": "Hello"}')
-
-http_code=$(echo "$response" | tail -1)
-body=$(echo "$response" | sed '$d')
-
-case $http_code in
-  2*) echo "Success: $body" ;;
-  422) echo "Validation error — check required fields and formats" ;;
-  429) echo "Rate limited — retry after delay"; sleep 1 ;;
-  401) echo "Authentication failed — check TELNYX_API_KEY" ;;
-  *)   echo "Error $http_code: $body" ;;
-esac
-```
-
-Common error codes: `401` invalid API key, `403` insufficient permissions,
-`404` resource not found, `422` validation error (check field formats),
-`429` rate limited (retry with exponential backoff).
+1. **Create a fax application** with a webhook URL
+2. **Assign a phone number** to the fax application (via `/phone_numbers` endpoint)
+3. **Send the fax** with the connection ID, from/to numbers, and a document
+4. **Track delivery** via `fax.delivered` / `fax.failed` webhooks
 
 ## Important Notes
 
-- **Phone numbers** must be in E.164 format (e.g., `+13125550001`). Include the `+` prefix and country code. No spaces, dashes, or parentheses.
-- **Pagination:** List endpoints return paginated results. Use `page[number]` and `page[size]` query parameters to navigate pages. Check `meta.total_pages` in the response.
+- **Phone numbers** must be in E.164 format (e.g., `+13125550001`). Include the `+` prefix and country code.
+- **File limits**: max 50 MB file size, max 350 pages per fax.
+- **Pagination**: List endpoints use `page[number]` and `page[size]` query parameters. Check `meta.total_pages` in the response.
 
-## List all Fax Applications
+## Fax Applications
 
-This endpoint returns a list of your Fax Applications inside the 'data' attribute of the response. You can adjust which applications are listed by using filters. Fax Applications are used to configure how you send and receive faxes using the Programmable Fax API with Telnyx.
+### List Fax Applications
 
 `GET /fax_applications`
 
 ```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/fax_applications?sort=application_name"
+curl -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/fax_applications?sort=application_name"
 ```
 
-Returns: `active` (boolean), `anchorsite_override` (enum: Latency, Chicago, IL, Ashburn, VA, San Jose, CA, Sydney, Australia, Amsterdam, Netherlands, London, UK, Toronto, Canada, Vancouver, Canada, Frankfurt, Germany), `application_name` (string), `created_at` (string), `id` (string), `inbound` (object), `outbound` (object), `record_type` (string), `tags` (array[string]), `updated_at` (string), `webhook_event_failover_url` (uri), `webhook_event_url` (uri), `webhook_timeout_secs` (integer | null)
-
-## Creates a Fax Application
-
-Creates a new Fax Application based on the parameters sent in the request. The application name and webhook URL are required. Once created, you can assign phone numbers to your application using the `/phone_numbers` endpoint.
+### Create a Fax Application
 
 `POST /fax_applications` — Required: `application_name`, `webhook_event_url`
 
-Optional: `active` (boolean), `anchorsite_override` (enum: Latency, Chicago, IL, Ashburn, VA, San Jose, CA, Sydney, Australia, Amsterdam, Netherlands, London, UK, Toronto, Canada, Vancouver, Canada, Frankfurt, Germany), `inbound` (object), `outbound` (object), `tags` (array[string]), `webhook_event_failover_url` (uri), `webhook_timeout_secs` (integer | null)
-
 ```bash
-curl \
-  -X POST \
+curl -X POST \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{
-  "application_name": "call-router",
-  "webhook_event_url": "https://example.com"
-}' \
+  -d '{"application_name": "my-fax-app", "webhook_event_url": "https://example.com/webhooks/fax"}' \
   "https://api.telnyx.com/v2/fax_applications"
 ```
 
-Returns: `active` (boolean), `anchorsite_override` (enum: Latency, Chicago, IL, Ashburn, VA, San Jose, CA, Sydney, Australia, Amsterdam, Netherlands, London, UK, Toronto, Canada, Vancouver, Canada, Frankfurt, Germany), `application_name` (string), `created_at` (string), `id` (string), `inbound` (object), `outbound` (object), `record_type` (string), `tags` (array[string]), `updated_at` (string), `webhook_event_failover_url` (uri), `webhook_event_url` (uri), `webhook_timeout_secs` (integer | null)
-
-## Retrieve a Fax Application
-
-Return the details of an existing Fax Application inside the 'data' attribute of the response.
-
-`GET /fax_applications/{id}`
+### Retrieve / Update / Delete a Fax Application
 
 ```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/fax_applications/1293384261075731499"
-```
+# Retrieve
+curl -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/fax_applications/{id}"
 
-Returns: `active` (boolean), `anchorsite_override` (enum: Latency, Chicago, IL, Ashburn, VA, San Jose, CA, Sydney, Australia, Amsterdam, Netherlands, London, UK, Toronto, Canada, Vancouver, Canada, Frankfurt, Germany), `application_name` (string), `created_at` (string), `id` (string), `inbound` (object), `outbound` (object), `record_type` (string), `tags` (array[string]), `updated_at` (string), `webhook_event_failover_url` (uri), `webhook_event_url` (uri), `webhook_timeout_secs` (integer | null)
-
-## Update a Fax Application
-
-Updates settings of an existing Fax Application based on the parameters of the request.
-
-`PATCH /fax_applications/{id}` — Required: `application_name`, `webhook_event_url`
-
-Optional: `active` (boolean), `anchorsite_override` (enum: Latency, Chicago, IL, Ashburn, VA, San Jose, CA, Sydney, Australia, Amsterdam, Netherlands, London, UK, Toronto, Canada, Vancouver, Canada, Frankfurt, Germany), `fax_email_recipient` (string | null), `inbound` (object), `outbound` (object), `tags` (array[string]), `webhook_event_failover_url` (uri), `webhook_timeout_secs` (integer | null)
-
-```bash
-curl \
-  -X PATCH \
+# Update
+curl -X PATCH \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{
-  "application_name": "call-router",
-  "webhook_event_url": "https://example.com"
-}' \
-  "https://api.telnyx.com/v2/fax_applications/1293384261075731499"
-```
+  -d '{"application_name": "updated-name", "webhook_event_url": "https://example.com/webhooks/fax"}' \
+  "https://api.telnyx.com/v2/fax_applications/{id}"
 
-Returns: `active` (boolean), `anchorsite_override` (enum: Latency, Chicago, IL, Ashburn, VA, San Jose, CA, Sydney, Australia, Amsterdam, Netherlands, London, UK, Toronto, Canada, Vancouver, Canada, Frankfurt, Germany), `application_name` (string), `created_at` (string), `id` (string), `inbound` (object), `outbound` (object), `record_type` (string), `tags` (array[string]), `updated_at` (string), `webhook_event_failover_url` (uri), `webhook_event_url` (uri), `webhook_timeout_secs` (integer | null)
-
-## Deletes a Fax Application
-
-Permanently deletes a Fax Application. Deletion may be prevented if the application is in use by phone numbers.
-
-`DELETE /fax_applications/{id}`
-
-```bash
-curl \
-  -X DELETE \
+# Delete
+curl -X DELETE \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
-  "https://api.telnyx.com/v2/fax_applications/1293384261075731499"
+  "https://api.telnyx.com/v2/fax_applications/{id}"
 ```
 
-Returns: `active` (boolean), `anchorsite_override` (enum: Latency, Chicago, IL, Ashburn, VA, San Jose, CA, Sydney, Australia, Amsterdam, Netherlands, London, UK, Toronto, Canada, Vancouver, Canada, Frankfurt, Germany), `application_name` (string), `created_at` (string), `id` (string), `inbound` (object), `outbound` (object), `record_type` (string), `tags` (array[string]), `updated_at` (string), `webhook_event_failover_url` (uri), `webhook_event_url` (uri), `webhook_timeout_secs` (integer | null)
+See [references/api-details.md](references/api-details.md) for full response schemas and optional parameters.
 
-## View a list of faxes
+## Send and Manage Faxes
 
-`GET /faxes`
-
-```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/faxes"
-```
-
-Returns: `client_state` (string), `connection_id` (string), `created_at` (date-time), `direction` (enum: inbound, outbound), `from` (string), `from_display_name` (string), `id` (uuid), `media_name` (string), `media_url` (string), `preview_url` (string), `quality` (enum: normal, high, very_high, ultra_light, ultra_dark), `record_type` (enum: fax), `status` (enum: queued, media.processed, originated, sending, delivered, failed, initiated, receiving, media.processing, received), `store_media` (boolean), `stored_media_url` (string), `to` (string), `updated_at` (date-time), `webhook_failover_url` (string), `webhook_url` (string)
-
-## Send a fax
-
-Send a fax. Files have size limits and page count limit validations. If a file is bigger than 50MB or has more than 350 pages it will fail with `file_size_limit_exceeded` and `page_count_limit_exceeded` respectively.
+### Send a Fax (file upload)
 
 `POST /faxes` — Required: `connection_id`, `from`, `to`
 
-Optional: `black_threshold` (integer), `client_state` (string), `from_display_name` (string), `media_name` (string), `media_url` (string), `monochrome` (boolean), `preview_format` (enum: pdf, tiff), `quality` (enum: normal, high, very_high, ultra_light, ultra_dark), `store_media` (boolean), `store_preview` (boolean), `t38_enabled` (boolean), `webhook_url` (string)
-
 ```bash
-curl \
-  -X POST \
+curl -X POST \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -F "connection_id=234423" \
-  -F "contents=@/path/to/file" \
   -F "to=+13127367276" \
   -F "from=+13125790015" \
   -F "quality=high" \
+  -F "contents=@/path/to/document.pdf" \
+  "https://api.telnyx.com/v2/faxes"
+```
+
+### Send a Fax (media URL)
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H "Content-Type: application/json" \
   -d '{
-      "media_url": "https://example.com/document.pdf"
+    "connection_id": "234423",
+    "to": "+13127367276",
+    "from": "+13125790015",
+    "media_url": "https://example.com/document.pdf",
+    "quality": "high"
   }' \
   "https://api.telnyx.com/v2/faxes"
 ```
 
-Returns: `client_state` (string), `connection_id` (string), `created_at` (date-time), `direction` (enum: inbound, outbound), `from` (string), `from_display_name` (string), `id` (uuid), `media_name` (string), `media_url` (string), `preview_url` (string), `quality` (enum: normal, high, very_high, ultra_light, ultra_dark), `record_type` (enum: fax), `status` (enum: queued, media.processed, originated, sending, delivered, failed, initiated, receiving, media.processing, received), `store_media` (boolean), `stored_media_url` (string), `to` (string), `updated_at` (date-time), `webhook_failover_url` (string), `webhook_url` (string)
-
-## View a fax
-
-`GET /faxes/{id}`
+### List / View / Delete a Fax
 
 ```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/faxes/550e8400-e29b-41d4-a716-446655440000"
-```
+# List all faxes
+curl -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/faxes"
 
-Returns: `client_state` (string), `connection_id` (string), `created_at` (date-time), `direction` (enum: inbound, outbound), `from` (string), `from_display_name` (string), `id` (uuid), `media_name` (string), `media_url` (string), `preview_url` (string), `quality` (enum: normal, high, very_high, ultra_light, ultra_dark), `record_type` (enum: fax), `status` (enum: queued, media.processed, originated, sending, delivered, failed, initiated, receiving, media.processing, received), `store_media` (boolean), `stored_media_url` (string), `to` (string), `updated_at` (date-time), `webhook_failover_url` (string), `webhook_url` (string)
+# View a specific fax
+curl -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/faxes/{id}"
 
-## Delete a fax
-
-`DELETE /faxes/{id}`
-
-```bash
-curl \
-  -X DELETE \
+# Delete a fax
+curl -X DELETE \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
-  "https://api.telnyx.com/v2/faxes/550e8400-e29b-41d4-a716-446655440000"
+  "https://api.telnyx.com/v2/faxes/{id}"
 ```
 
-## Cancel a fax
-
-Cancel the outbound fax that is in one of the following states: `queued`, `media.processed`, `originated` or `sending`
-
-`POST /faxes/{id}/actions/cancel`
+### Cancel / Refresh a Fax
 
 ```bash
-curl \
-  -X POST \
+# Cancel an outbound fax (must be queued, media.processed, originated, or sending)
+curl -X POST \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
-  "https://api.telnyx.com/v2/faxes/550e8400-e29b-41d4-a716-446655440000/actions/cancel"
-```
+  "https://api.telnyx.com/v2/faxes/{id}/actions/cancel"
 
-Returns: `result` (string)
-
-## Refresh a fax
-
-Refreshes the inbound fax's media_url when it has expired
-
-`POST /faxes/{id}/actions/refresh`
-
-```bash
-curl \
-  -X POST \
+# Refresh an inbound fax media_url when expired
+curl -X POST \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
-  "https://api.telnyx.com/v2/faxes/550e8400-e29b-41d4-a716-446655440000/actions/refresh"
+  "https://api.telnyx.com/v2/faxes/{id}/actions/refresh"
 ```
-
-Returns: `result` (string)
 
 ---
 
 ## Webhooks
 
-### Webhook Verification
-
-Telnyx signs webhooks with Ed25519. Each request includes `telnyx-signature-ed25519`
-and `telnyx-timestamp` headers. Always verify signatures in production:
-
-```bash
-# Telnyx signs webhooks with Ed25519 (asymmetric — NOT HMAC/Standard Webhooks).
-# Headers sent with each webhook:
-#   telnyx-signature-ed25519: base64-encoded Ed25519 signature
-#   telnyx-timestamp: Unix timestamp (reject if >5 minutes old for replay protection)
-#
-# Get your public key from: Telnyx Portal > Account Settings > Keys & Credentials
-# Use the Telnyx SDK in your language for verification (client.webhooks.unwrap).
-# Your endpoint MUST return 2xx within 2 seconds or Telnyx will retry (up to 3 attempts).
-# Configure a failover URL in Telnyx Portal for additional reliability.
-```
-
-The following webhook events are sent to your configured webhook URL.
-All webhooks include `telnyx-timestamp` and `telnyx-signature-ed25519` headers for Ed25519 signature verification. Use `client.webhooks.unwrap()` to verify.
+Telnyx signs webhooks with Ed25519. Each request includes `telnyx-signature-ed25519` and `telnyx-timestamp` headers. Use `client.webhooks.unwrap()` in your language SDK to verify. Your endpoint must return 2xx within 2 seconds.
 
 | Event | Description |
 |-------|-------------|
-| `fax.delivered` | Fax Delivered |
-| `fax.failed` | Fax Failed |
-| `fax.media.processed` | Fax Media Processed |
-| `fax.queued` | Fax Queued |
-| `fax.sending.started` | Fax Sending Started |
+| `fax.queued` | Fax queued for sending |
+| `fax.media.processed` | Fax media processed |
+| `fax.sending.started` | Fax sending started |
+| `fax.delivered` | Fax successfully delivered |
+| `fax.failed` | Fax sending failed |
 
-### Webhook payload fields
-
-**`fax.delivered`**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `data.record_type` | enum: event | Identifies the type of the resource. |
-| `data.id` | uuid | Identifies the type of resource. |
-| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
-| `data.event_type` | enum: fax.delivered | The type of event being delivered. |
-| `data.payload.call_duration_secs` | integer | The duration of the call in seconds. |
-| `data.payload.connection_id` | string | The ID of the connection used to send the fax. |
-| `data.payload.direction` | enum: inbound, outbound | The direction of the fax. |
-| `data.payload.fax_id` | uuid | Identifies the fax. |
-| `data.payload.original_media_url` | string | The original URL to the PDF used for the fax's media. |
-| `data.payload.media_name` | string | The media_name used for the fax's media. |
-| `data.payload.to` | string | The phone number, in E.164 format, the fax will be sent to or SIP URI |
-| `data.payload.from` | string | The phone number, in E.164 format, the fax will be sent from. |
-| `data.payload.user_id` | uuid | Identifier of the user to whom the fax belongs |
-| `data.payload.page_count` | integer | Number of transferred pages |
-| `data.payload.status` | enum: delivered | The status of the fax. |
-| `data.payload.client_state` | string | State received from a command. |
-| `meta.attempt` | integer | The delivery attempt number. |
-| `meta.delivered_to` | uri | The URL the webhook was delivered to. |
-
-**`fax.failed`**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `data.record_type` | enum: event | Identifies the type of the resource. |
-| `data.id` | uuid | Identifies the type of resource. |
-| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
-| `data.event_type` | enum: fax.failed | The type of event being delivered. |
-| `data.payload.connection_id` | string | The ID of the connection used to send the fax. |
-| `data.payload.direction` | enum: inbound, outbound | The direction of the fax. |
-| `data.payload.fax_id` | uuid | Identifies the fax. |
-| `data.payload.original_media_url` | string | The original URL to the PDF used for the fax's media. |
-| `data.payload.media_name` | string | The media_name used for the fax's media. |
-| `data.payload.to` | string | The phone number, in E.164 format, the fax will be sent to or SIP URI |
-| `data.payload.from` | string | The phone number, in E.164 format, the fax will be sent from. |
-| `data.payload.user_id` | uuid | Identifier of the user to whom the fax belongs |
-| `data.payload.failure_reason` | enum: rejected | Cause of the sending failure |
-| `data.payload.status` | enum: failed | The status of the fax. |
-| `data.payload.client_state` | string | State received from a command. |
-| `meta.attempt` | integer | The delivery attempt number. |
-| `meta.delivered_to` | uri | The URL the webhook was delivered to. |
-
-**`fax.media.processed`**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `data.record_type` | enum: event | Identifies the type of the resource. |
-| `data.id` | uuid | Identifies the type of resource. |
-| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
-| `data.event_type` | enum: fax.media.processed | The type of event being delivered. |
-| `data.payload.connection_id` | string | The ID of the connection used to send the fax. |
-| `data.payload.direction` | enum: inbound, outbound | The direction of the fax. |
-| `data.payload.fax_id` | uuid | Identifies the fax. |
-| `data.payload.original_media_url` | string | The original URL to the PDF used for the fax's media. |
-| `data.payload.media_name` | string | The media_name used for the fax's media. |
-| `data.payload.to` | string | The phone number, in E.164 format, the fax will be sent to or SIP URI |
-| `data.payload.from` | string | The phone number, in E.164 format, the fax will be sent from. |
-| `data.payload.user_id` | uuid | Identifier of the user to whom the fax belongs |
-| `data.payload.status` | enum: media.processed | The status of the fax. |
-| `data.payload.client_state` | string | State received from a command. |
-| `meta.attempt` | integer | The delivery attempt number. |
-| `meta.delivered_to` | uri | The URL the webhook was delivered to. |
-
-**`fax.queued`**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `data.record_type` | enum: event | Identifies the type of the resource. |
-| `data.id` | uuid | Identifies the type of resource. |
-| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
-| `data.event_type` | enum: fax.queued | The type of event being delivered. |
-| `data.payload.connection_id` | string | The ID of the connection used to send the fax. |
-| `data.payload.direction` | enum: inbound, outbound | The direction of the fax. |
-| `data.payload.fax_id` | uuid | Identifies the fax. |
-| `data.payload.original_media_url` | string | The original URL to the PDF used for the fax's media. |
-| `data.payload.media_name` | string | The media_name used for the fax's media. |
-| `data.payload.to` | string | The phone number, in E.164 format, the fax will be sent to or SIP URI |
-| `data.payload.from` | string | The phone number, in E.164 format, the fax will be sent from. |
-| `data.payload.user_id` | uuid | Identifier of the user to whom the fax belongs |
-| `data.payload.status` | enum: queued | The status of the fax. |
-| `data.payload.client_state` | string | State received from a command. |
-| `meta.attempt` | integer | The delivery attempt number. |
-| `meta.delivered_to` | uri | The URL the webhook was delivered to. |
-
-**`fax.sending.started`**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `data.record_type` | enum: event | Identifies the type of the resource. |
-| `data.id` | uuid | Identifies the type of resource. |
-| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
-| `data.event_type` | enum: fax.sending.started | The type of event being delivered. |
-| `data.payload.connection_id` | string | The ID of the connection used to send the fax. |
-| `data.payload.direction` | enum: inbound, outbound | The direction of the fax. |
-| `data.payload.fax_id` | uuid | Identifies the fax. |
-| `data.payload.original_media_url` | string | The original URL to the PDF used for the fax's media. |
-| `data.payload.media_name` | string | The media_name used for the fax's media. |
-| `data.payload.to` | string | The phone number, in E.164 format, the fax will be sent to or SIP URI |
-| `data.payload.from` | string | The phone number, in E.164 format, the fax will be sent from. |
-| `data.payload.user_id` | uuid | Identifier of the user to whom the fax belongs |
-| `data.payload.status` | enum: sending | The status of the fax. |
-| `data.payload.client_state` | string | State received from a command. |
-| `meta.attempt` | integer | The delivery attempt number. |
-| `meta.delivered_to` | uri | The URL the webhook was delivered to. |
+See [references/api-details.md](references/api-details.md) for full webhook payload field documentation.

--- a/skills/telnyx-fax-curl/references/api-details.md
+++ b/skills/telnyx-fax-curl/references/api-details.md
@@ -1,0 +1,107 @@
+# Telnyx Fax API Details - curl
+
+## Fax Application Response Schema
+
+All fax application endpoints return these fields in the `data` object:
+
+| Field | Type |
+|-------|------|
+| `active` | boolean |
+| `anchorsite_override` | enum: Latency, Chicago IL, Ashburn VA, San Jose CA, Sydney Australia, Amsterdam Netherlands, London UK, Toronto Canada, Vancouver Canada, Frankfurt Germany |
+| `application_name` | string |
+| `created_at` | string |
+| `id` | string |
+| `inbound` | object |
+| `outbound` | object |
+| `record_type` | string |
+| `tags` | array[string] |
+| `updated_at` | string |
+| `webhook_event_failover_url` | uri |
+| `webhook_event_url` | uri |
+| `webhook_timeout_secs` | integer \| null |
+
+## Fax Resource Response Schema
+
+All fax resource endpoints return these fields in the `data` object:
+
+| Field | Type |
+|-------|------|
+| `client_state` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `direction` | enum: inbound, outbound |
+| `from` | string |
+| `from_display_name` | string |
+| `id` | uuid |
+| `media_name` | string |
+| `media_url` | string |
+| `preview_url` | string |
+| `quality` | enum: normal, high, very_high, ultra_light, ultra_dark |
+| `record_type` | enum: fax |
+| `status` | enum: queued, media.processed, originated, sending, delivered, failed, initiated, receiving, media.processing, received |
+| `store_media` | boolean |
+| `stored_media_url` | string |
+| `to` | string |
+| `updated_at` | date-time |
+| `webhook_failover_url` | string |
+| `webhook_url` | string |
+
+## Webhook Payload Fields
+
+All fax webhook events share these common fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.event_type` | string | The type of event (e.g., `fax.delivered`, `fax.failed`). |
+| `data.payload.connection_id` | string | The ID of the connection used to send the fax. |
+| `data.payload.direction` | enum: inbound, outbound | The direction of the fax. |
+| `data.payload.fax_id` | uuid | Identifies the fax. |
+| `data.payload.original_media_url` | string | The original URL to the PDF used for the fax's media. |
+| `data.payload.media_name` | string | The media_name used for the fax's media. |
+| `data.payload.to` | string | The phone number (E.164) the fax was sent to, or SIP URI. |
+| `data.payload.from` | string | The phone number (E.164) the fax was sent from. |
+| `data.payload.user_id` | uuid | Identifier of the user to whom the fax belongs. |
+| `data.payload.status` | string | The status of the fax. |
+| `data.payload.client_state` | string | State received from a command. |
+| `meta.attempt` | integer | The delivery attempt number. |
+| `meta.delivered_to` | uri | The URL the webhook was delivered to. |
+
+### Event-specific fields
+
+- **`fax.delivered`**: adds `data.payload.call_duration_secs` (integer) and `data.payload.page_count` (integer)
+- **`fax.failed`**: adds `data.payload.failure_reason` (enum: rejected)
+
+## Optional Parameters for Fax Application Endpoints
+
+### Create/Update Fax Application
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `active` | boolean | Whether the application is active |
+| `anchorsite_override` | enum | Override the anchorsite location |
+| `inbound` | object | Inbound settings |
+| `outbound` | object | Outbound settings |
+| `tags` | array[string] | Tags for the application |
+| `webhook_event_failover_url` | uri | Failover webhook URL |
+| `webhook_timeout_secs` | integer \| null | Webhook timeout in seconds |
+| `fax_email_recipient` | string \| null | Email to receive faxes (update only) |
+
+### Send Fax Optional Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `black_threshold` | integer | Black threshold for fax quality |
+| `client_state` | string | Client state passed through webhooks |
+| `from_display_name` | string | Display name for the sender |
+| `media_name` | string | Name for the media |
+| `media_url` | string | URL of the document to fax |
+| `monochrome` | boolean | Send in monochrome |
+| `preview_format` | enum: pdf, tiff | Format for fax preview |
+| `quality` | enum: normal, high, very_high, ultra_light, ultra_dark | Fax quality |
+| `store_media` | boolean | Store the fax media |
+| `store_preview` | boolean | Store a preview of the fax |
+| `t38_enabled` | boolean | Enable T.38 fax protocol |
+| `webhook_url` | string | Override webhook URL for this fax |

--- a/skills/telnyx-iot-curl/SKILL.md
+++ b/skills/telnyx-iot-curl/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: telnyx-iot-curl
-description: >-
-  Manage IoT SIM cards, eSIMs, data plans, and wireless connectivity. Use when
-  building IoT/M2M solutions. This skill provides REST API (curl) examples.
+description: "Purchase, register, activate, and monitor IoT SIM cards and eSIMs via the Telnyx REST API. Create SIM card groups, set data limits, configure wireless blocklists, manage public IPs, and track connectivity logs. Use when provisioning IoT/M2M devices, managing cellular connectivity, ordering physical or eSIM cards, or monitoring SIM data usage with curl."
 metadata:
   author: telnyx
   product: iot
@@ -12,13 +10,9 @@ metadata:
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->
 
-# Telnyx Iot - curl
+# Telnyx IoT - curl
 
-## Installation
-
-```text
-# curl is pre-installed on macOS, Linux, and Windows 10+
-```
+Manage IoT SIM cards, eSIMs, data plans, and wireless connectivity via the Telnyx REST API.
 
 ## Setup
 
@@ -26,1036 +20,165 @@ metadata:
 export TELNYX_API_KEY="YOUR_API_KEY_HERE"
 ```
 
-All examples below use `$TELNYX_API_KEY` for authentication.
+## Quick Start: Provision IoT SIMs
 
-## Error Handling
-
-All API calls can fail with network errors, rate limits (429), validation errors (422),
-or authentication errors (401). Always handle errors in production code:
-
-```bash
-# Check HTTP status code in response
-response=$(curl -s -w "\n%{http_code}" \
-  -X POST "https://api.telnyx.com/v2/messages" \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"to": "+13125550001", "from": "+13125550002", "text": "Hello"}')
-
-http_code=$(echo "$response" | tail -1)
-body=$(echo "$response" | sed '$d')
-
-case $http_code in
-  2*) echo "Success: $body" ;;
-  422) echo "Validation error — check required fields and formats" ;;
-  429) echo "Rate limited — retry after delay"; sleep 1 ;;
-  401) echo "Authentication failed — check TELNYX_API_KEY" ;;
-  *)   echo "Error $http_code: $body" ;;
-esac
-```
-
-Common error codes: `401` invalid API key, `403` insufficient permissions,
-`404` resource not found, `422` validation error (check field formats),
-`429` rate limited (retry with exponential backoff).
+1. **Create a SIM card group** to organize and apply shared settings
+2. **Purchase eSIMs** or **register physical SIM cards** to the group
+3. **Enable SIM cards** to connect them to the network
+4. **Monitor data usage** via connectivity logs or data usage notifications
 
 ## Important Notes
 
-- **Pagination:** List endpoints return paginated results. Use `page[number]` and `page[size]` query parameters to navigate pages. Check `meta.total_pages` in the response.
+- **Pagination**: List endpoints use `page[number]` and `page[size]` query parameters. Check `meta.total_pages` in the response.
+- **Async operations**: Enable/disable/standby actions are asynchronous — check status via SIM card actions endpoints.
 
-## Purchase eSIMs
+## SIM Card Groups
 
-Purchases and registers the specified amount of eSIMs to the current user's account.  
-If `sim_card_group_id` is provided, the eSIMs will be associated with that group. Otherwise, the default group for the current user will be used.  
-
-`POST /actions/purchase/esims` — Required: `amount`
-
-Optional: `product` (string), `sim_card_group_id` (uuid), `status` (enum: enabled, disabled, standby), `tags` (array[string]), `whitelabel_name` (string)
-
-```bash
-curl \
-  -X POST \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-  "amount": 10
-}' \
-  "https://api.telnyx.com/v2/actions/purchase/esims"
-```
-
-Returns: `actions_in_progress` (boolean), `authorized_imeis` (array | null), `created_at` (string), `current_billing_period_consumed_data` (object), `data_limit` (object), `eid` (string | null), `esim_installation_status` (enum: released, disabled), `iccid` (string), `id` (uuid), `imsi` (string), `msisdn` (string), `record_type` (string), `resources_with_in_progress_actions` (array[object]), `sim_card_group_id` (uuid), `status` (object), `tags` (array[string]), `type` (enum: physical, esim), `updated_at` (string), `version` (string), `voice_enabled` (boolean)
-
-## Register SIM cards
-
-Register the SIM cards associated with the provided registration codes to the current user's account.  
-If `sim_card_group_id` is provided, the SIM cards will be associated with that group. Otherwise, the default group for the current user will be used.  
-
-`POST /actions/register/sim_cards` — Required: `registration_codes`
-
-Optional: `sim_card_group_id` (uuid), `status` (enum: enabled, disabled, standby), `tags` (array[string])
-
-```bash
-curl \
-  -X POST \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-  "registration_codes": [
-    "0000000001",
-    "0000000002",
-    "0000000003"
-  ]
-}' \
-  "https://api.telnyx.com/v2/actions/register/sim_cards"
-```
-
-Returns: `actions_in_progress` (boolean), `authorized_imeis` (array | null), `created_at` (string), `current_billing_period_consumed_data` (object), `data_limit` (object), `eid` (string | null), `esim_installation_status` (enum: released, disabled), `iccid` (string), `id` (uuid), `imsi` (string), `msisdn` (string), `record_type` (string), `resources_with_in_progress_actions` (array[object]), `sim_card_group_id` (uuid), `status` (object), `tags` (array[string]), `type` (enum: physical, esim), `updated_at` (string), `version` (string), `voice_enabled` (boolean)
-
-## List bulk SIM card actions
-
-This API lists a paginated collection of bulk SIM card actions. A bulk SIM card action contains details about a collection of individual SIM card actions.
-
-`GET /bulk_sim_card_actions`
-
-```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/bulk_sim_card_actions?filter[action_type]=bulk_set_public_ips"
-```
-
-Returns: `action_type` (enum: bulk_disable_voice, bulk_enable_voice, bulk_set_public_ips), `created_at` (string), `id` (uuid), `record_type` (string), `settings` (object), `sim_card_actions_summary` (array[object]), `updated_at` (string)
-
-## Get bulk SIM card action details
-
-This API fetches information about a bulk SIM card action. A bulk SIM card action contains details about a collection of individual SIM card actions.
-
-`GET /bulk_sim_card_actions/{id}`
-
-```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/bulk_sim_card_actions/6a09cdc3-8948-47f0-aa62-74ac943d6c58"
-```
-
-Returns: `action_type` (enum: bulk_disable_voice, bulk_enable_voice, bulk_set_public_ips), `created_at` (string), `id` (uuid), `record_type` (string), `settings` (object), `sim_card_actions_summary` (array[object]), `updated_at` (string)
-
-## List OTA updates
-
-`GET /ota_updates`
-
-```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/ota_updates"
-```
-
-Returns: `created_at` (string), `id` (uuid), `record_type` (string), `sim_card_id` (uuid), `status` (enum: in-progress, completed, failed), `type` (enum: sim_card_network_preferences), `updated_at` (string)
-
-## Get OTA update
-
-This API returns the details of an Over the Air (OTA) update.
-
-`GET /ota_updates/{id}`
-
-```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/ota_updates/6a09cdc3-8948-47f0-aa62-74ac943d6c58"
-```
-
-Returns: `created_at` (string), `id` (uuid), `record_type` (string), `settings` (object), `sim_card_id` (uuid), `status` (enum: in-progress, completed, failed), `type` (enum: sim_card_network_preferences), `updated_at` (string)
-
-## List SIM card actions
-
-This API lists a paginated collection of SIM card actions. It enables exploring a collection of existing asynchronous operations using specific filters.
-
-`GET /sim_card_actions`
-
-```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/sim_card_actions"
-```
-
-Returns: `action_type` (enum: enable, enable_standby_sim_card, disable, set_standby), `created_at` (string), `id` (uuid), `record_type` (string), `settings` (object | null), `sim_card_id` (uuid), `status` (object), `updated_at` (string)
-
-## Get SIM card action details
-
-This API fetches detailed information about a SIM card action to follow-up on an existing asynchronous operation.
-
-`GET /sim_card_actions/{id}`
-
-```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/sim_card_actions/6a09cdc3-8948-47f0-aa62-74ac943d6c58"
-```
-
-Returns: `action_type` (enum: enable, enable_standby_sim_card, disable, set_standby), `created_at` (string), `id` (uuid), `record_type` (string), `settings` (object | null), `sim_card_id` (uuid), `status` (object), `updated_at` (string)
-
-## List SIM card data usage notifications
-
-Lists a paginated collection of SIM card data usage notifications. It enables exploring the collection using specific filters.
-
-`GET /sim_card_data_usage_notifications`
-
-```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/sim_card_data_usage_notifications?filter[sim_card_id]=47a1c2b0-cc7b-4ab1-bb98-b33fb0fc61b9"
-```
-
-Returns: `created_at` (string), `id` (uuid), `record_type` (string), `sim_card_id` (uuid), `threshold` (object), `updated_at` (string)
-
-## Create a new SIM card data usage notification
-
-Creates a new SIM card data usage notification.
-
-`POST /sim_card_data_usage_notifications` — Required: `sim_card_id`, `threshold`
-
-```bash
-curl \
-  -X POST \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-  "sim_card_id": "6a09cdc3-8948-47f0-aa62-74ac943d6c58",
-  "threshold": {}
-}' \
-  "https://api.telnyx.com/v2/sim_card_data_usage_notifications"
-```
-
-Returns: `created_at` (string), `id` (uuid), `record_type` (string), `sim_card_id` (uuid), `threshold` (object), `updated_at` (string)
-
-## Get a single SIM card data usage notification
-
-Get a single SIM Card Data Usage Notification.
-
-`GET /sim_card_data_usage_notifications/{id}`
-
-```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/sim_card_data_usage_notifications/6a09cdc3-8948-47f0-aa62-74ac943d6c58"
-```
-
-Returns: `created_at` (string), `id` (uuid), `record_type` (string), `sim_card_id` (uuid), `threshold` (object), `updated_at` (string)
-
-## Updates information for a SIM Card Data Usage Notification
-
-Updates information for a SIM Card Data Usage Notification.
-
-`PATCH /sim_card_data_usage_notifications/{id}`
-
-Optional: `created_at` (string), `id` (uuid), `record_type` (string), `sim_card_id` (uuid), `threshold` (object), `updated_at` (string)
-
-```bash
-curl \
-  -X PATCH \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
-  -H "Content-Type: application/json" \
-  "https://api.telnyx.com/v2/sim_card_data_usage_notifications/6a09cdc3-8948-47f0-aa62-74ac943d6c58"
-```
-
-Returns: `created_at` (string), `id` (uuid), `record_type` (string), `sim_card_id` (uuid), `threshold` (object), `updated_at` (string)
-
-## Delete SIM card data usage notifications
-
-Delete the SIM Card Data Usage Notification.
-
-`DELETE /sim_card_data_usage_notifications/{id}`
-
-```bash
-curl \
-  -X DELETE \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
-  "https://api.telnyx.com/v2/sim_card_data_usage_notifications/6a09cdc3-8948-47f0-aa62-74ac943d6c58"
-```
-
-Returns: `created_at` (string), `id` (uuid), `record_type` (string), `sim_card_id` (uuid), `threshold` (object), `updated_at` (string)
-
-## List SIM card group actions
-
-This API allows listing a paginated collection a SIM card group actions. It allows to explore a collection of existing asynchronous operation using specific filters.
-
-`GET /sim_card_group_actions`
-
-```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/sim_card_group_actions?filter[sim_card_group_id]=47a1c2b0-cc7b-4ab1-bb98-b33fb0fc61b9&filter[status]=in-progress&filter[type]=set_private_wireless_gateway"
-```
-
-Returns: `created_at` (string), `id` (uuid), `record_type` (string), `settings` (object), `sim_card_group_id` (uuid), `status` (enum: in-progress, completed, failed), `type` (enum: set_private_wireless_gateway, remove_private_wireless_gateway, set_wireless_blocklist, remove_wireless_blocklist), `updated_at` (string)
-
-## Get SIM card group action details
-
-This API allows fetching detailed information about a SIM card group action resource to make follow-ups in an existing asynchronous operation.
-
-`GET /sim_card_group_actions/{id}`
-
-```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/sim_card_group_actions/6a09cdc3-8948-47f0-aa62-74ac943d6c58"
-```
-
-Returns: `created_at` (string), `id` (uuid), `record_type` (string), `settings` (object), `sim_card_group_id` (uuid), `status` (enum: in-progress, completed, failed), `type` (enum: set_private_wireless_gateway, remove_private_wireless_gateway, set_wireless_blocklist, remove_wireless_blocklist), `updated_at` (string)
-
-## Get all SIM card groups
-
-Get all SIM card groups belonging to the user that match the given filters.
-
-`GET /sim_card_groups`
-
-```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/sim_card_groups?filter[name]=My Test Group&filter[private_wireless_gateway_id]=7606c6d3-ff7c-49c1-943d-68879e9d584d&filter[wireless_blocklist_id]=0f3f490e-c4d3-4cf5-838a-9970f10ee259"
-```
-
-Returns: `consumed_data` (object), `created_at` (string), `data_limit` (object), `default` (boolean), `id` (uuid), `name` (string), `private_wireless_gateway_id` (uuid), `record_type` (string), `sim_card_count` (integer), `updated_at` (string), `wireless_blocklist_id` (uuid)
-
-## Create a SIM card group
-
-Creates a new SIM card group object
+### Create a Group
 
 `POST /sim_card_groups` — Required: `name`
 
-Optional: `data_limit` (object)
-
 ```bash
-curl \
-  -X POST \
+curl -X POST \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{
-  "name": "My Test Group"
-}' \
+  -d '{"name": "My IoT Fleet", "data_limit": {"value": "2048.0", "unit": "MB"}}' \
   "https://api.telnyx.com/v2/sim_card_groups"
 ```
 
-Returns: `consumed_data` (object), `created_at` (string), `data_limit` (object), `default` (boolean), `id` (uuid), `name` (string), `private_wireless_gateway_id` (uuid), `record_type` (string), `updated_at` (string), `wireless_blocklist_id` (uuid)
-
-## Get SIM card group
-
-Returns the details regarding a specific SIM card group
-
-`GET /sim_card_groups/{id}`
+### List / Get / Update / Delete Groups
 
 ```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/sim_card_groups/6a09cdc3-8948-47f0-aa62-74ac943d6c58?include_iccids=True"
+# List all groups
+curl -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/sim_card_groups"
+
+# Get specific group
+curl -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/sim_card_groups/{id}"
+
+# Update group
+curl -X PATCH -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Renamed Fleet"}' \
+  "https://api.telnyx.com/v2/sim_card_groups/{id}"
+
+# Delete group
+curl -X DELETE -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/sim_card_groups/{id}"
 ```
 
-Returns: `consumed_data` (object), `created_at` (string), `data_limit` (object), `default` (boolean), `id` (uuid), `name` (string), `private_wireless_gateway_id` (uuid), `record_type` (string), `updated_at` (string), `wireless_blocklist_id` (uuid)
+## Purchase eSIMs
 
-## Update a SIM card group
-
-Updates a SIM card group
-
-`PATCH /sim_card_groups/{id}`
-
-Optional: `data_limit` (object), `name` (string)
+`POST /actions/purchase/esims` — Required: `amount`
 
 ```bash
-curl \
-  -X PATCH \
+curl -X POST \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
-  "https://api.telnyx.com/v2/sim_card_groups/6a09cdc3-8948-47f0-aa62-74ac943d6c58"
+  -d '{"amount": 10, "sim_card_group_id": "{group_id}"}' \
+  "https://api.telnyx.com/v2/actions/purchase/esims"
 ```
 
-Returns: `consumed_data` (object), `created_at` (string), `data_limit` (object), `default` (boolean), `id` (uuid), `name` (string), `private_wireless_gateway_id` (uuid), `record_type` (string), `updated_at` (string), `wireless_blocklist_id` (uuid)
+## Register Physical SIM Cards
 
-## Delete a SIM card group
-
-Permanently deletes a SIM card group
-
-`DELETE /sim_card_groups/{id}`
+`POST /actions/register/sim_cards` — Required: `registration_codes`
 
 ```bash
-curl \
-  -X DELETE \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
-  "https://api.telnyx.com/v2/sim_card_groups/6a09cdc3-8948-47f0-aa62-74ac943d6c58"
-```
-
-Returns: `consumed_data` (object), `created_at` (string), `data_limit` (object), `default` (boolean), `id` (uuid), `name` (string), `private_wireless_gateway_id` (uuid), `record_type` (string), `updated_at` (string), `wireless_blocklist_id` (uuid)
-
-## Request Private Wireless Gateway removal from SIM card group
-
-This action will asynchronously remove an existing Private Wireless Gateway definition from a SIM card group. Completing this operation defines that all SIM cards in the SIM card group will get their traffic handled by Telnyx's default mobile network configuration.
-
-`POST /sim_card_groups/{id}/actions/remove_private_wireless_gateway`
-
-```bash
-curl \
-  -X POST \
+curl -X POST \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
-  "https://api.telnyx.com/v2/sim_card_groups/6a09cdc3-8948-47f0-aa62-74ac943d6c58/actions/remove_private_wireless_gateway"
+  -d '{"registration_codes": ["0000000001", "0000000002"], "sim_card_group_id": "{group_id}"}' \
+  "https://api.telnyx.com/v2/actions/register/sim_cards"
 ```
 
-Returns: `created_at` (string), `id` (uuid), `record_type` (string), `settings` (object), `sim_card_group_id` (uuid), `status` (enum: in-progress, completed, failed), `type` (enum: set_private_wireless_gateway, remove_private_wireless_gateway, set_wireless_blocklist, remove_wireless_blocklist), `updated_at` (string)
-
-## Request Wireless Blocklist removal from SIM card group
-
-This action will asynchronously remove an existing Wireless Blocklist to all the SIMs in the SIM card group.
-
-`POST /sim_card_groups/{id}/actions/remove_wireless_blocklist`
+### Validate Registration Codes
 
 ```bash
-curl \
-  -X POST \
+curl -X POST \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
-  "https://api.telnyx.com/v2/sim_card_groups/6a09cdc3-8948-47f0-aa62-74ac943d6c58/actions/remove_wireless_blocklist"
-```
-
-Returns: `created_at` (string), `id` (uuid), `record_type` (string), `settings` (object), `sim_card_group_id` (uuid), `status` (enum: in-progress, completed, failed), `type` (enum: set_private_wireless_gateway, remove_private_wireless_gateway, set_wireless_blocklist, remove_wireless_blocklist), `updated_at` (string)
-
-## Request Private Wireless Gateway assignment for SIM card group
-
-This action will asynchronously assign a provisioned Private Wireless Gateway to the SIM card group. Completing this operation defines that all SIM cards in the SIM card group will get their traffic controlled by the associated Private Wireless Gateway. This operation will also imply that new SIM cards assigned to a group will inherit its network definitions.
-
-`POST /sim_card_groups/{id}/actions/set_private_wireless_gateway` — Required: `private_wireless_gateway_id`
-
-```bash
-curl \
-  -X POST \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-  "private_wireless_gateway_id": "6a09cdc3-8948-47f0-aa62-74ac943d6c58"
-}' \
-  "https://api.telnyx.com/v2/sim_card_groups/6a09cdc3-8948-47f0-aa62-74ac943d6c58/actions/set_private_wireless_gateway"
-```
-
-Returns: `created_at` (string), `id` (uuid), `record_type` (string), `settings` (object), `sim_card_group_id` (uuid), `status` (enum: in-progress, completed, failed), `type` (enum: set_private_wireless_gateway, remove_private_wireless_gateway, set_wireless_blocklist, remove_wireless_blocklist), `updated_at` (string)
-
-## Request Wireless Blocklist assignment for SIM card group
-
-This action will asynchronously assign a Wireless Blocklist to all the SIMs in the SIM card group.
-
-`POST /sim_card_groups/{id}/actions/set_wireless_blocklist` — Required: `wireless_blocklist_id`
-
-```bash
-curl \
-  -X POST \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-  "wireless_blocklist_id": "6a09cdc3-8948-47f0-aa62-74ac943d6c58"
-}' \
-  "https://api.telnyx.com/v2/sim_card_groups/6a09cdc3-8948-47f0-aa62-74ac943d6c58/actions/set_wireless_blocklist"
-```
-
-Returns: `created_at` (string), `id` (uuid), `record_type` (string), `settings` (object), `sim_card_group_id` (uuid), `status` (enum: in-progress, completed, failed), `type` (enum: set_private_wireless_gateway, remove_private_wireless_gateway, set_wireless_blocklist, remove_wireless_blocklist), `updated_at` (string)
-
-## Preview SIM card orders
-
-Preview SIM card order purchases.
-
-`POST /sim_card_order_preview` — Required: `quantity`, `address_id`
-
-```bash
-curl \
-  -X POST \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-  "quantity": 21,
-  "address_id": "1293384261075731499"
-}' \
-  "https://api.telnyx.com/v2/sim_card_order_preview"
-```
-
-Returns: `quantity` (integer), `record_type` (string), `shipping_cost` (object), `sim_cards_cost` (object), `total_cost` (object)
-
-## Get all SIM card orders
-
-Get all SIM card orders according to filters.
-
-`GET /sim_card_orders`
-
-```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/sim_card_orders"
-```
-
-Returns: `cost` (object), `created_at` (string), `id` (uuid), `order_address` (object), `quantity` (integer), `record_type` (string), `status` (enum: pending, processing, ready_to_ship, shipped, delivered, canceled), `tracking_url` (uri), `updated_at` (string)
-
-## Create a SIM card order
-
-Creates a new order for SIM cards.
-
-`POST /sim_card_orders` — Required: `address_id`, `quantity`
-
-```bash
-curl \
-  -X POST \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-      "address_id": "1293384261075731499",
-      "quantity": 23,
-      "sim_card_group_id": "550e8400-e29b-41d4-a716-446655440000"
-  }' \
-  "https://api.telnyx.com/v2/sim_card_orders"
-```
-
-Returns: `cost` (object), `created_at` (string), `id` (uuid), `order_address` (object), `quantity` (integer), `record_type` (string), `status` (enum: pending, processing, ready_to_ship, shipped, delivered, canceled), `tracking_url` (uri), `updated_at` (string)
-
-## Get a single SIM card order
-
-Get a single SIM card order by its ID.
-
-`GET /sim_card_orders/{id}`
-
-```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/sim_card_orders/6a09cdc3-8948-47f0-aa62-74ac943d6c58"
-```
-
-Returns: `cost` (object), `created_at` (string), `id` (uuid), `order_address` (object), `quantity` (integer), `record_type` (string), `status` (enum: pending, processing, ready_to_ship, shipped, delivered, canceled), `tracking_url` (uri), `updated_at` (string)
-
-## Get all SIM cards
-
-Get all SIM cards belonging to the user that match the given filters.
-
-`GET /sim_cards`
-
-```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/sim_cards?include_sim_card_group=True&filter[sim_card_group_id]=47a1c2b0-cc7b-4ab1-bb98-b33fb0fc61b9&sort=-current_billing_period_consumed_data.amount"
-```
-
-Returns: `actions_in_progress` (boolean), `authorized_imeis` (array | null), `created_at` (string), `current_billing_period_consumed_data` (object), `data_limit` (object), `eid` (string | null), `esim_installation_status` (enum: released, disabled), `iccid` (string), `id` (uuid), `imsi` (string), `msisdn` (string), `record_type` (string), `resources_with_in_progress_actions` (array[object]), `sim_card_group_id` (uuid), `status` (object), `tags` (array[string]), `type` (enum: physical, esim), `updated_at` (string), `version` (string), `voice_enabled` (boolean)
-
-## Request bulk disabling voice on SIM cards.
-
-This API triggers an asynchronous operation to disable voice on SIM cards belonging to a specified SIM Card Group. 
-For each SIM Card a SIM Card Action will be generated.
-
-`POST /sim_cards/actions/bulk_disable_voice` — Required: `sim_card_group_id`
-
-```bash
-curl \
-  -X POST \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-  "sim_card_group_id": "6b14e151-8493-4fa1-8664-1cc4e6d14158"
-}' \
-  "https://api.telnyx.com/v2/sim_cards/actions/bulk_disable_voice"
-```
-
-Returns: `action_type` (enum: bulk_disable_voice, bulk_enable_voice, bulk_set_public_ips), `created_at` (string), `id` (uuid), `record_type` (string), `settings` (object), `updated_at` (string)
-
-## Request bulk enabling voice on SIM cards.
-
-This API triggers an asynchronous operation to enable voice on SIM cards belonging to a specified SIM Card Group. 
-For each SIM Card a SIM Card Action will be generated.
-
-`POST /sim_cards/actions/bulk_enable_voice` — Required: `sim_card_group_id`
-
-```bash
-curl \
-  -X POST \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-  "sim_card_group_id": "6b14e151-8493-4fa1-8664-1cc4e6d14158"
-}' \
-  "https://api.telnyx.com/v2/sim_cards/actions/bulk_enable_voice"
-```
-
-Returns: `action_type` (enum: bulk_disable_voice, bulk_enable_voice, bulk_set_public_ips), `created_at` (string), `id` (uuid), `record_type` (string), `settings` (object), `updated_at` (string)
-
-## Request bulk setting SIM card public IPs.
-
-This API triggers an asynchronous operation to set a public IP for each of the specified SIM cards. 
-For each SIM Card a SIM Card Action will be generated. The status of the SIM Card Action can be followed through the [List SIM Card Action](https://developers.telnyx.com/api-reference/sim-card-actions/list-sim-card-actions) API.
-
-`POST /sim_cards/actions/bulk_set_public_ips` — Required: `sim_card_ids`
-
-```bash
-curl \
-  -X POST \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-  "sim_card_ids": [
-    "6b14e151-8493-4fa1-8664-1cc4e6d14158"
-  ]
-}' \
-  "https://api.telnyx.com/v2/sim_cards/actions/bulk_set_public_ips"
-```
-
-Returns: `action_type` (enum: bulk_disable_voice, bulk_enable_voice, bulk_set_public_ips), `created_at` (string), `id` (uuid), `record_type` (string), `settings` (object), `updated_at` (string)
-
-## Validate SIM cards registration codes
-
-It validates whether SIM card registration codes are valid or not.
-
-`POST /sim_cards/actions/validate_registration_codes`
-
-Optional: `registration_codes` (array[string])
-
-```bash
-curl \
-  -X POST \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
-  -H "Content-Type: application/json" \
+  -d '{"registration_codes": ["0000000001"]}' \
   "https://api.telnyx.com/v2/sim_cards/actions/validate_registration_codes"
 ```
 
-Returns: `invalid_detail` (string | null), `record_type` (string), `registration_code` (string), `valid` (boolean)
+## Manage SIM Cards
 
-## Get SIM card
-
-Returns the details regarding a specific SIM card.
-
-`GET /sim_cards/{id}`
+### List / Get / Update / Delete SIM Cards
 
 ```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/sim_cards/6a09cdc3-8948-47f0-aa62-74ac943d6c58?include_sim_card_group=True"
-```
+# List all SIM cards (with sorting and filtering)
+curl -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/sim_cards?include_sim_card_group=True&filter[sim_card_group_id]={group_id}"
 
-Returns: `actions_in_progress` (boolean), `authorized_imeis` (array | null), `created_at` (string), `current_billing_period_consumed_data` (object), `current_device_location` (object), `current_imei` (string), `current_mcc` (string), `current_mnc` (string), `data_limit` (object), `eid` (string | null), `esim_installation_status` (enum: released, disabled), `iccid` (string), `id` (uuid), `imsi` (string), `ipv4` (string), `ipv6` (string), `live_data_session` (enum: connected, disconnected, unknown), `msisdn` (string), `pin_puk_codes` (object), `record_type` (string), `resources_with_in_progress_actions` (array[object]), `sim_card_group_id` (uuid), `status` (object), `tags` (array[string]), `type` (enum: physical, esim), `updated_at` (string), `version` (string), `voice_enabled` (boolean)
+# Get SIM card details
+curl -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/sim_cards/{id}"
 
-## Update a SIM card
-
-Updates SIM card data
-
-`PATCH /sim_cards/{id}`
-
-Optional: `actions_in_progress` (boolean), `authorized_imeis` (array | null), `created_at` (string), `current_billing_period_consumed_data` (object), `current_device_location` (object), `current_imei` (string), `current_mcc` (string), `current_mnc` (string), `data_limit` (object), `eid` (string | null), `esim_installation_status` (enum: released, disabled), `iccid` (string), `id` (uuid), `imsi` (string), `ipv4` (string), `ipv6` (string), `live_data_session` (enum: connected, disconnected, unknown), `msisdn` (string), `pin_puk_codes` (object), `record_type` (string), `resources_with_in_progress_actions` (array[object]), `sim_card_group_id` (uuid), `status` (object), `tags` (array[string]), `type` (enum: physical, esim), `updated_at` (string), `version` (string), `voice_enabled` (boolean)
-
-```bash
-curl \
-  -X PATCH \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
+# Update SIM card
+curl -X PATCH -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
-  "https://api.telnyx.com/v2/sim_cards/6a09cdc3-8948-47f0-aa62-74ac943d6c58"
+  -d '{"tags": ["production"]}' \
+  "https://api.telnyx.com/v2/sim_cards/{id}"
+
+# Delete (decommission) SIM card
+curl -X DELETE -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/sim_cards/{id}"
 ```
 
-Returns: `actions_in_progress` (boolean), `authorized_imeis` (array | null), `created_at` (string), `current_billing_period_consumed_data` (object), `current_device_location` (object), `current_imei` (string), `current_mcc` (string), `current_mnc` (string), `data_limit` (object), `eid` (string | null), `esim_installation_status` (enum: released, disabled), `iccid` (string), `id` (uuid), `imsi` (string), `ipv4` (string), `ipv6` (string), `live_data_session` (enum: connected, disconnected, unknown), `msisdn` (string), `pin_puk_codes` (object), `record_type` (string), `resources_with_in_progress_actions` (array[object]), `sim_card_group_id` (uuid), `status` (object), `tags` (array[string]), `type` (enum: physical, esim), `updated_at` (string), `version` (string), `voice_enabled` (boolean)
-
-## Deletes a SIM card
-
-The SIM card will be decommissioned, removed from your account and you will stop being charged. The SIM card won't be able to connect to the network after the deletion is completed, thus making it impossible to consume data. 
-Transitioning to the disabled state may take a period of time.
-
-`DELETE /sim_cards/{id}`
+### Enable / Disable / Standby
 
 ```bash
-curl \
-  -X DELETE \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
-  "https://api.telnyx.com/v2/sim_cards/6a09cdc3-8948-47f0-aa62-74ac943d6c58"
-```
-
-Returns: `actions_in_progress` (boolean), `authorized_imeis` (array | null), `created_at` (string), `current_billing_period_consumed_data` (object), `current_device_location` (object), `current_imei` (string), `current_mcc` (string), `current_mnc` (string), `data_limit` (object), `eid` (string | null), `esim_installation_status` (enum: released, disabled), `iccid` (string), `id` (uuid), `imsi` (string), `ipv4` (string), `ipv6` (string), `live_data_session` (enum: connected, disconnected, unknown), `msisdn` (string), `pin_puk_codes` (object), `record_type` (string), `resources_with_in_progress_actions` (array[object]), `sim_card_group_id` (uuid), `status` (object), `tags` (array[string]), `type` (enum: physical, esim), `updated_at` (string), `version` (string), `voice_enabled` (boolean)
-
-## Request a SIM card disable
-
-This API disables a SIM card, disconnecting it from the network and making it impossible to consume data. 
-The API will trigger an asynchronous operation called a SIM Card Action. Transitioning to the disabled state may take a period of time.
-
-`POST /sim_cards/{id}/actions/disable`
-
-```bash
-curl \
-  -X POST \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
+# Enable (connect to network)
+curl -X POST -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
-  "https://api.telnyx.com/v2/sim_cards/6a09cdc3-8948-47f0-aa62-74ac943d6c58/actions/disable"
-```
+  "https://api.telnyx.com/v2/sim_cards/{id}/actions/enable"
 
-Returns: `action_type` (enum: enable, enable_standby_sim_card, disable, set_standby), `created_at` (string), `id` (uuid), `record_type` (string), `settings` (object | null), `sim_card_id` (uuid), `status` (object), `updated_at` (string)
-
-## Request a SIM card enable
-
-This API enables a SIM card, connecting it to the network and making it possible to consume data. 
-To enable a SIM card, it must be associated with a SIM card group. 
-The API will trigger an asynchronous operation called a SIM Card Action. Transitioning to the enabled state may take a period of time.
-
-`POST /sim_cards/{id}/actions/enable`
-
-```bash
-curl \
-  -X POST \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
+# Disable (disconnect from network)
+curl -X POST -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
-  "https://api.telnyx.com/v2/sim_cards/6a09cdc3-8948-47f0-aa62-74ac943d6c58/actions/enable"
-```
+  "https://api.telnyx.com/v2/sim_cards/{id}/actions/disable"
 
-Returns: `action_type` (enum: enable, enable_standby_sim_card, disable, set_standby), `created_at` (string), `id` (uuid), `record_type` (string), `settings` (object | null), `sim_card_id` (uuid), `status` (object), `updated_at` (string)
-
-## Request removing a SIM card public IP
-
-This API removes an existing public IP from a SIM card.   
- The API will trigger an asynchronous operation called a SIM Card Action. The status of the SIM Card Action can be followed through the [List SIM Card Action](https://developers.telnyx.com/api-reference/sim-card-actions/list-sim-card-actions) API.
-
-`POST /sim_cards/{id}/actions/remove_public_ip`
-
-```bash
-curl \
-  -X POST \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
+# Set to standby
+curl -X POST -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
-  "https://api.telnyx.com/v2/sim_cards/6a09cdc3-8948-47f0-aa62-74ac943d6c58/actions/remove_public_ip"
+  "https://api.telnyx.com/v2/sim_cards/{id}/actions/set_standby"
 ```
 
-Returns: `action_type` (enum: enable, enable_standby_sim_card, disable, set_standby), `created_at` (string), `id` (uuid), `record_type` (string), `settings` (object | null), `sim_card_id` (uuid), `status` (object), `updated_at` (string)
-
-## Request setting a SIM card public IP
-
-This API makes a SIM card reachable on the public internet by mapping a random public IP to the SIM card.   
- The API will trigger an asynchronous operation called a SIM Card Action.
-
-`POST /sim_cards/{id}/actions/set_public_ip`
+### Public IP Management
 
 ```bash
-curl \
-  -X POST \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
+# Assign public IP
+curl -X POST -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
-  "https://api.telnyx.com/v2/sim_cards/6a09cdc3-8948-47f0-aa62-74ac943d6c58/actions/set_public_ip"
-```
+  "https://api.telnyx.com/v2/sim_cards/{id}/actions/set_public_ip"
 
-Returns: `action_type` (enum: enable, enable_standby_sim_card, disable, set_standby), `created_at` (string), `id` (uuid), `record_type` (string), `settings` (object | null), `sim_card_id` (uuid), `status` (object), `updated_at` (string)
-
-## Request setting a SIM card to standby
-
-The SIM card will be able to connect to the network once the process to set it to standby has been completed, thus making it possible to consume data. 
-To set a SIM card to standby, it must be associated with SIM card group. 
-The API will trigger an asynchronous operation called a SIM Card Action. Transitioning to the standby state may take a period of time.
-
-`POST /sim_cards/{id}/actions/set_standby`
-
-```bash
-curl \
-  -X POST \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
+# Remove public IP
+curl -X POST -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
-  "https://api.telnyx.com/v2/sim_cards/6a09cdc3-8948-47f0-aa62-74ac943d6c58/actions/set_standby"
+  "https://api.telnyx.com/v2/sim_cards/{id}/actions/remove_public_ip"
 ```
 
-Returns: `action_type` (enum: enable, enable_standby_sim_card, disable, set_standby), `created_at` (string), `id` (uuid), `record_type` (string), `settings` (object | null), `sim_card_id` (uuid), `status` (object), `updated_at` (string)
-
-## Get activation code for an eSIM
-
-It returns the activation code for an eSIM.  
- This API is only available for eSIMs. If the given SIM is a physical SIM card, or has already been installed, an error will be returned.
-
-`GET /sim_cards/{id}/activation_code`
+### Bulk Voice Operations
 
 ```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/sim_cards/6a09cdc3-8948-47f0-aa62-74ac943d6c58/activation_code"
-```
-
-Returns: `activation_code` (string), `record_type` (string)
-
-## Get SIM card device details
-
-It returns the device details where a SIM card is currently being used.
-
-`GET /sim_cards/{id}/device_details`
-
-```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/sim_cards/6a09cdc3-8948-47f0-aa62-74ac943d6c58/device_details"
-```
-
-Returns: `brand_name` (string), `device_type` (string), `imei` (string), `model_name` (string), `operating_system` (string), `record_type` (string)
-
-## Get SIM card public IP definition
-
-It returns the public IP requested for a SIM card.
-
-`GET /sim_cards/{id}/public_ip`
-
-```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/sim_cards/6a09cdc3-8948-47f0-aa62-74ac943d6c58/public_ip"
-```
-
-Returns: `created_at` (string), `ip` (string), `record_type` (string), `region_code` (string), `sim_card_id` (uuid), `type` (enum: ipv4), `updated_at` (string)
-
-## List wireless connectivity logs
-
-This API allows listing a paginated collection of Wireless Connectivity Logs associated with a SIM Card, for troubleshooting purposes.
-
-`GET /sim_cards/{id}/wireless_connectivity_logs`
-
-```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/sim_cards/6a09cdc3-8948-47f0-aa62-74ac943d6c58/wireless_connectivity_logs"
-```
-
-Returns: `apn` (string), `cell_id` (string), `created_at` (string), `id` (integer), `imei` (string), `imsi` (string), `ipv4` (string), `ipv6` (string), `last_seen` (string), `log_type` (enum: registration, data), `mobile_country_code` (string), `mobile_network_code` (string), `radio_access_technology` (string), `record_type` (string), `sim_card_id` (uuid), `start_time` (string), `state` (string), `stop_time` (string)
-
-## List Migration Source coverage
-
-`GET /storage/migration_source_coverage`
-
-```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/storage/migration_source_coverage"
-```
-
-Returns: `provider` (enum: aws), `source_region` (string)
-
-## List all Migration Sources
-
-`GET /storage/migration_sources`
-
-```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/storage/migration_sources"
-```
-
-Returns: `bucket_name` (string), `id` (string), `provider` (enum: aws, telnyx), `provider_auth` (object), `source_region` (string)
-
-## Create a Migration Source
-
-Create a source from which data can be migrated from.
-
-`POST /storage/migration_sources` — Required: `provider`, `provider_auth`, `bucket_name`
-
-Optional: `id` (string), `source_region` (string)
-
-```bash
-curl \
-  -X POST \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
+# Bulk enable voice for a group
+curl -X POST -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{
-  "provider": "aws",
-  "provider_auth": {},
-  "bucket_name": "my-bucket"
-}' \
-  "https://api.telnyx.com/v2/storage/migration_sources"
-```
+  -d '{"sim_card_group_id": "{group_id}"}' \
+  "https://api.telnyx.com/v2/sim_cards/actions/bulk_enable_voice"
 
-Returns: `bucket_name` (string), `id` (string), `provider` (enum: aws, telnyx), `provider_auth` (object), `source_region` (string)
-
-## Get a Migration Source
-
-`GET /storage/migration_sources/{id}`
-
-```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/storage/migration_sources/550e8400-e29b-41d4-a716-446655440000"
-```
-
-Returns: `bucket_name` (string), `id` (string), `provider` (enum: aws, telnyx), `provider_auth` (object), `source_region` (string)
-
-## Delete a Migration Source
-
-`DELETE /storage/migration_sources/{id}`
-
-```bash
-curl \
-  -X DELETE \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
-  "https://api.telnyx.com/v2/storage/migration_sources/550e8400-e29b-41d4-a716-446655440000"
-```
-
-Returns: `bucket_name` (string), `id` (string), `provider` (enum: aws, telnyx), `provider_auth` (object), `source_region` (string)
-
-## List all Migrations
-
-`GET /storage/migrations`
-
-```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/storage/migrations"
-```
-
-Returns: `bytes_migrated` (integer), `bytes_to_migrate` (integer), `created_at` (date-time), `eta` (date-time), `id` (string), `last_copy` (date-time), `refresh` (boolean), `source_id` (string), `speed` (integer), `status` (enum: pending, checking, migrating, complete, error, stopped), `target_bucket_name` (string), `target_region` (string)
-
-## Create a Migration
-
-Initiate a migration of data from an external provider into Telnyx Cloud Storage. Currently, only S3 is supported.
-
-`POST /storage/migrations` — Required: `source_id`, `target_bucket_name`, `target_region`
-
-Optional: `bytes_migrated` (integer), `bytes_to_migrate` (integer), `created_at` (date-time), `eta` (date-time), `id` (string), `last_copy` (date-time), `refresh` (boolean), `speed` (integer), `status` (enum: pending, checking, migrating, complete, error, stopped)
-
-```bash
-curl \
-  -X POST \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
+# Bulk disable voice for a group
+curl -X POST -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{
-  "source_id": "550e8400-e29b-41d4-a716-446655440000",
-  "target_bucket_name": "my-target-bucket",
-  "target_region": "us-central-1"
-}' \
-  "https://api.telnyx.com/v2/storage/migrations"
-```
+  -d '{"sim_card_group_id": "{group_id}"}' \
+  "https://api.telnyx.com/v2/sim_cards/actions/bulk_disable_voice"
 
-Returns: `bytes_migrated` (integer), `bytes_to_migrate` (integer), `created_at` (date-time), `eta` (date-time), `id` (string), `last_copy` (date-time), `refresh` (boolean), `source_id` (string), `speed` (integer), `status` (enum: pending, checking, migrating, complete, error, stopped), `target_bucket_name` (string), `target_region` (string)
-
-## Get a Migration
-
-`GET /storage/migrations/{id}`
-
-```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/storage/migrations/550e8400-e29b-41d4-a716-446655440000"
-```
-
-Returns: `bytes_migrated` (integer), `bytes_to_migrate` (integer), `created_at` (date-time), `eta` (date-time), `id` (string), `last_copy` (date-time), `refresh` (boolean), `source_id` (string), `speed` (integer), `status` (enum: pending, checking, migrating, complete, error, stopped), `target_bucket_name` (string), `target_region` (string)
-
-## Stop a Migration
-
-`POST /storage/migrations/{id}/actions/stop`
-
-```bash
-curl \
-  -X POST \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
+# Bulk set public IPs
+curl -X POST -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
-  "https://api.telnyx.com/v2/storage/migrations/550e8400-e29b-41d4-a716-446655440000/actions/stop"
+  -d '{"sim_card_ids": ["{sim_id_1}", "{sim_id_2}"]}' \
+  "https://api.telnyx.com/v2/sim_cards/actions/bulk_set_public_ips"
 ```
 
-Returns: `bytes_migrated` (integer), `bytes_to_migrate` (integer), `created_at` (date-time), `eta` (date-time), `id` (string), `last_copy` (date-time), `refresh` (boolean), `source_id` (string), `speed` (integer), `status` (enum: pending, checking, migrating, complete, error, stopped), `target_bucket_name` (string), `target_region` (string)
-
-## List Mobile Voice Connections
-
-`GET /v2/mobile_voice_connections`
-
-```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/v2/mobile_voice_connections"
-```
-
-Returns: `active` (boolean), `connection_name` (string), `created_at` (date-time), `id` (string), `inbound` (object), `outbound` (object), `record_type` (enum: mobile_voice_connection), `tags` (array[string]), `updated_at` (date-time), `webhook_api_version` (enum: 1, 2), `webhook_event_failover_url` (string | null), `webhook_event_url` (string | null), `webhook_timeout_secs` (integer | null)
-
-## Create a Mobile Voice Connection
-
-`POST /v2/mobile_voice_connections`
-
-Optional: `active` (boolean), `connection_name` (string), `inbound` (object), `outbound` (object), `tags` (array[string]), `webhook_api_version` (enum: 1, 2), `webhook_event_failover_url` (string | null), `webhook_event_url` (string | null), `webhook_timeout_secs` (integer | null)
-
-```bash
-curl \
-  -X POST \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
-  -H "Content-Type: application/json" \
-  "https://api.telnyx.com/v2/v2/mobile_voice_connections"
-```
-
-Returns: `active` (boolean), `connection_name` (string), `created_at` (date-time), `id` (string), `inbound` (object), `outbound` (object), `record_type` (enum: mobile_voice_connection), `tags` (array[string]), `updated_at` (date-time), `webhook_api_version` (enum: 1, 2), `webhook_event_failover_url` (string | null), `webhook_event_url` (string | null), `webhook_timeout_secs` (integer | null)
-
-## Retrieve a Mobile Voice Connection
-
-`GET /v2/mobile_voice_connections/{id}`
-
-```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/v2/mobile_voice_connections/550e8400-e29b-41d4-a716-446655440000"
-```
-
-Returns: `active` (boolean), `connection_name` (string), `created_at` (date-time), `id` (string), `inbound` (object), `outbound` (object), `record_type` (enum: mobile_voice_connection), `tags` (array[string]), `updated_at` (date-time), `webhook_api_version` (enum: 1, 2), `webhook_event_failover_url` (string | null), `webhook_event_url` (string | null), `webhook_timeout_secs` (integer | null)
-
-## Update a Mobile Voice Connection
-
-`PATCH /v2/mobile_voice_connections/{id}`
-
-Optional: `active` (boolean), `connection_name` (string), `inbound` (object), `outbound` (object), `tags` (array[string]), `webhook_api_version` (enum: 1, 2), `webhook_event_failover_url` (string | null), `webhook_event_url` (string | null), `webhook_timeout_secs` (integer)
-
-```bash
-curl \
-  -X PATCH \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
-  -H "Content-Type: application/json" \
-  "https://api.telnyx.com/v2/v2/mobile_voice_connections/550e8400-e29b-41d4-a716-446655440000"
-```
-
-Returns: `active` (boolean), `connection_name` (string), `created_at` (date-time), `id` (string), `inbound` (object), `outbound` (object), `record_type` (enum: mobile_voice_connection), `tags` (array[string]), `updated_at` (date-time), `webhook_api_version` (enum: 1, 2), `webhook_event_failover_url` (string | null), `webhook_event_url` (string | null), `webhook_timeout_secs` (integer | null)
-
-## Delete a Mobile Voice Connection
-
-`DELETE /v2/mobile_voice_connections/{id}`
-
-```bash
-curl \
-  -X DELETE \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
-  "https://api.telnyx.com/v2/v2/mobile_voice_connections/550e8400-e29b-41d4-a716-446655440000"
-```
-
-Returns: `active` (boolean), `connection_name` (string), `created_at` (date-time), `id` (string), `inbound` (object), `outbound` (object), `record_type` (enum: mobile_voice_connection), `tags` (array[string]), `updated_at` (date-time), `webhook_api_version` (enum: 1, 2), `webhook_event_failover_url` (string | null), `webhook_event_url` (string | null), `webhook_timeout_secs` (integer | null)
-
-## Get all wireless regions
-
-Retrieve all wireless regions for the given product.
-
-`GET /wireless/regions`
-
-```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/wireless/regions?product=public_ips"
-```
-
-Returns: `code` (string), `inserted_at` (date-time), `name` (string), `updated_at` (date-time)
-
-## Get all possible wireless blocklist values
-
-Retrieve all wireless blocklist values for a given blocklist type.
-
-`GET /wireless_blocklist_values`
-
-```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/wireless_blocklist_values?type=country"
-```
-
-Returns: `data` (object), `meta` (object)
-
-## Get all Wireless Blocklists
-
-Get all Wireless Blocklists belonging to the user.
-
-`GET /wireless_blocklists`
-
-```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/wireless_blocklists?filter[name]=my private gateway&filter[type]=country&filter[values]=US,CA"
-```
-
-Returns: `created_at` (string), `id` (uuid), `name` (string), `record_type` (string), `type` (enum: country, mcc, plmn), `updated_at` (string), `values` (array[object])
-
-## Create a Wireless Blocklist
-
-Create a Wireless Blocklist to prevent SIMs from connecting to certain networks.
-
-`POST /wireless_blocklists` — Required: `name`, `type`, `values`
-
-```bash
-curl \
-  -X POST \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-  "name": "My Wireless Blocklist",
-  "type": "country",
-  "values": [
-    "CA",
-    "US"
-  ]
-}' \
-  "https://api.telnyx.com/v2/wireless_blocklists"
-```
-
-Returns: `created_at` (string), `id` (uuid), `name` (string), `record_type` (string), `type` (enum: country, mcc, plmn), `updated_at` (string), `values` (array[object])
-
-## Update a Wireless Blocklist
-
-Update a Wireless Blocklist.
-
-`PATCH /wireless_blocklists`
-
-Optional: `name` (string), `type` (enum: country, mcc, plmn), `values` (array[object])
-
-```bash
-curl \
-  -X PATCH \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
-  -H "Content-Type: application/json" \
-  "https://api.telnyx.com/v2/wireless_blocklists"
-```
-
-Returns: `created_at` (string), `id` (uuid), `name` (string), `record_type` (string), `type` (enum: country, mcc, plmn), `updated_at` (string), `values` (array[object])
-
-## Get a Wireless Blocklist
-
-Retrieve information about a Wireless Blocklist.
-
-`GET /wireless_blocklists/{id}`
-
-```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/wireless_blocklists/6a09cdc3-8948-47f0-aa62-74ac943d6c58"
-```
-
-Returns: `created_at` (string), `id` (uuid), `name` (string), `record_type` (string), `type` (enum: country, mcc, plmn), `updated_at` (string), `values` (array[object])
-
-## Delete a Wireless Blocklist
-
-Deletes the Wireless Blocklist.
-
-`DELETE /wireless_blocklists/{id}`
-
-```bash
-curl \
-  -X DELETE \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
-  "https://api.telnyx.com/v2/wireless_blocklists/6a09cdc3-8948-47f0-aa62-74ac943d6c58"
-```
-
-Returns: `created_at` (string), `id` (uuid), `name` (string), `record_type` (string), `type` (enum: country, mcc, plmn), `updated_at` (string), `values` (array[object])
+See [references/api-details.md](references/api-details.md) for full response schemas, data usage notifications, SIM card orders, OTA updates, wireless blocklists, and additional endpoints.

--- a/skills/telnyx-iot-curl/references/api-details.md
+++ b/skills/telnyx-iot-curl/references/api-details.md
@@ -1,0 +1,247 @@
+# Telnyx IoT API Details - curl
+
+## SIM Card Response Schema
+
+All SIM card endpoints return these fields in the `data` object:
+
+| Field | Type |
+|-------|------|
+| `actions_in_progress` | boolean |
+| `authorized_imeis` | array \| null |
+| `created_at` | string |
+| `current_billing_period_consumed_data` | object |
+| `data_limit` | object |
+| `eid` | string \| null |
+| `esim_installation_status` | enum: released, disabled |
+| `iccid` | string |
+| `id` | uuid |
+| `imsi` | string |
+| `msisdn` | string |
+| `record_type` | string |
+| `sim_card_group_id` | uuid |
+| `status` | object |
+| `tags` | array[string] |
+| `type` | enum: physical, esim |
+| `updated_at` | string |
+| `version` | string |
+| `voice_enabled` | boolean |
+
+Individual SIM card GET also returns: `current_device_location` (object), `current_imei` (string), `current_mcc` (string), `current_mnc` (string), `ipv4` (string), `ipv6` (string), `live_data_session` (enum), `pin_puk_codes` (object).
+
+## SIM Card Group Response Schema
+
+| Field | Type |
+|-------|------|
+| `consumed_data` | object |
+| `created_at` | string |
+| `data_limit` | object |
+| `default` | boolean |
+| `id` | uuid |
+| `name` | string |
+| `private_wireless_gateway_id` | uuid |
+| `record_type` | string |
+| `sim_card_count` | integer |
+| `updated_at` | string |
+| `wireless_blocklist_id` | uuid |
+
+## SIM Card Data Usage Notifications
+
+CRUD operations for monitoring SIM card data consumption thresholds.
+
+### List Notifications
+
+`GET /sim_card_data_usage_notifications?filter[sim_card_id]={sim_card_id}`
+
+```bash
+curl -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/sim_card_data_usage_notifications?filter[sim_card_id]=47a1c2b0-cc7b-4ab1-bb98-b33fb0fc61b9"
+```
+
+### Create Notification
+
+`POST /sim_card_data_usage_notifications` — Required: `sim_card_id`, `threshold`
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"sim_card_id": "6a09cdc3-8948-47f0-aa62-74ac943d6c58", "threshold": {}}' \
+  "https://api.telnyx.com/v2/sim_card_data_usage_notifications"
+```
+
+### Get / Update / Delete Notification
+
+```bash
+# Get
+curl -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/sim_card_data_usage_notifications/{id}"
+
+# Update
+curl -X PATCH -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H "Content-Type: application/json" \
+  "https://api.telnyx.com/v2/sim_card_data_usage_notifications/{id}"
+
+# Delete
+curl -X DELETE -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/sim_card_data_usage_notifications/{id}"
+```
+
+## SIM Card Group Actions
+
+Async operations on SIM card groups (private wireless gateways, wireless blocklists).
+
+### List / Get Group Actions
+
+```bash
+# List
+curl -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/sim_card_group_actions?filter[sim_card_group_id]={group_id}"
+
+# Get details
+curl -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/sim_card_group_actions/{id}"
+```
+
+### Private Wireless Gateway Management
+
+```bash
+# Assign private wireless gateway to group
+curl -X POST -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"private_wireless_gateway_id": "{gateway_id}"}' \
+  "https://api.telnyx.com/v2/sim_card_groups/{id}/actions/set_private_wireless_gateway"
+
+# Remove private wireless gateway from group
+curl -X POST -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H "Content-Type: application/json" \
+  "https://api.telnyx.com/v2/sim_card_groups/{id}/actions/remove_private_wireless_gateway"
+```
+
+### Wireless Blocklist Management
+
+```bash
+# Assign wireless blocklist to group
+curl -X POST -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"wireless_blocklist_id": "{blocklist_id}"}' \
+  "https://api.telnyx.com/v2/sim_card_groups/{id}/actions/set_wireless_blocklist"
+
+# Remove wireless blocklist from group
+curl -X POST -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H "Content-Type: application/json" \
+  "https://api.telnyx.com/v2/sim_card_groups/{id}/actions/remove_wireless_blocklist"
+```
+
+## SIM Card Orders
+
+### Preview / List / Create / Get Orders
+
+```bash
+# Preview order cost
+curl -X POST -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"quantity": 21, "address_id": "1293384261075731499"}' \
+  "https://api.telnyx.com/v2/sim_card_order_preview"
+
+# List orders
+curl -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/sim_card_orders"
+
+# Create order
+curl -X POST -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"address_id": "1293384261075731499", "quantity": 23}' \
+  "https://api.telnyx.com/v2/sim_card_orders"
+
+# Get order
+curl -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/sim_card_orders/{id}"
+```
+
+## OTA Updates
+
+Over the Air updates for SIM card network preferences.
+
+```bash
+# List OTA updates
+curl -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/ota_updates"
+
+# Get OTA update details
+curl -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/ota_updates/{id}"
+```
+
+## Wireless Blocklists
+
+Prevent SIMs from connecting to certain networks by country, MCC, or PLMN.
+
+```bash
+# List blocklists
+curl -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/wireless_blocklists"
+
+# Create blocklist
+curl -X POST -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Block US/CA", "type": "country", "values": ["CA", "US"]}' \
+  "https://api.telnyx.com/v2/wireless_blocklists"
+
+# Get / Update / Delete blocklist
+curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/wireless_blocklists/{id}"
+curl -X PATCH -H "Authorization: Bearer $TELNYX_API_KEY" -H "Content-Type: application/json" "https://api.telnyx.com/v2/wireless_blocklists/{id}"
+curl -X DELETE -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/wireless_blocklists/{id}"
+
+# Get possible blocklist values
+curl -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/wireless_blocklist_values?type=country"
+```
+
+## Wireless Regions
+
+```bash
+curl -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/wireless/regions?product=public_ips"
+```
+
+## Bulk SIM Card Actions
+
+### List / Get Bulk Actions
+
+```bash
+curl -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/bulk_sim_card_actions"
+
+curl -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/bulk_sim_card_actions/{id}"
+```
+
+### List / Get Individual SIM Card Actions
+
+```bash
+curl -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/sim_card_actions"
+
+curl -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/sim_card_actions/{id}"
+```
+
+## Additional SIM Card Endpoints
+
+```bash
+# Get eSIM activation code
+curl -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/sim_cards/{id}/activation_code"
+
+# Get device details
+curl -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/sim_cards/{id}/device_details"
+
+# Get public IP
+curl -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/sim_cards/{id}/public_ip"
+
+# List wireless connectivity logs
+curl -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/sim_cards/{id}/wireless_connectivity_logs"
+```

--- a/skills/telnyx-seti-curl/SKILL.md
+++ b/skills/telnyx-seti-curl/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: telnyx-seti-curl
-description: >-
-  Access SETI (Space Exploration Telecommunications Infrastructure) APIs. This
-  skill provides REST API (curl) examples.
+description: "Query SETI (Space Exploration Telecommunications Infrastructure) black box test results and diagnostic data via the Telnyx REST API. Use when retrieving SETI test results, checking infrastructure diagnostics, or accessing space exploration telecommunications endpoints with curl."
 metadata:
   author: telnyx
   product: seti
@@ -12,13 +10,9 @@ metadata:
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->
 
-# Telnyx Seti - curl
+# Telnyx SETI - curl
 
-## Installation
-
-```text
-# curl is pre-installed on macOS, Linux, and Windows 10+
-```
+Retrieve black box test results and diagnostic data from the Telnyx Space Exploration Telecommunications Infrastructure (SETI) API.
 
 ## Setup
 
@@ -28,51 +22,33 @@ export TELNYX_API_KEY="YOUR_API_KEY_HERE"
 
 All examples below use `$TELNYX_API_KEY` for authentication.
 
-## Error Handling
+## Retrieve Black Box Test Results
 
-All API calls can fail with network errors, rate limits (429), validation errors (422),
-or authentication errors (401). Always handle errors in production code:
+Returns the results of the various black box tests that validate SETI infrastructure status.
+
+`GET /seti/black_box_test_results`
 
 ```bash
-# Check HTTP status code in response
+curl -H "Authorization: Bearer $TELNYX_API_KEY" \
+  "https://api.telnyx.com/v2/seti/black_box_test_results"
+```
+
+Returns: `black_box_tests` (array[object]), `product` (string), `record_type` (string)
+
+## Error Handling
+
+```bash
 response=$(curl -s -w "\n%{http_code}" \
-  -X POST "https://api.telnyx.com/v2/messages" \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"to": "+13125550001", "from": "+13125550002", "text": "Hello"}')
+  "https://api.telnyx.com/v2/seti/black_box_test_results")
 
 http_code=$(echo "$response" | tail -1)
 body=$(echo "$response" | sed '$d')
 
 case $http_code in
   2*) echo "Success: $body" ;;
-  422) echo "Validation error — check required fields and formats" ;;
-  429) echo "Rate limited — retry after delay"; sleep 1 ;;
   401) echo "Authentication failed — check TELNYX_API_KEY" ;;
+  429) echo "Rate limited — retry after delay"; sleep 1 ;;
   *)   echo "Error $http_code: $body" ;;
 esac
 ```
-
-Common error codes: `401` invalid API key, `403` insufficient permissions,
-`404` resource not found, `422` validation error (check field formats),
-`429` rate limited (retry with exponential backoff).
-
-## Get Enum
-
-`GET /10dlc/enum/{endpoint}`
-
-```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/10dlc/enum/{endpoint}"
-```
-
-## Retrieve Black Box Test Results
-
-Returns the results of the various black box tests
-
-`GET /seti/black_box_test_results`
-
-```bash
-curl -H "Authorization: Bearer $TELNYX_API_KEY" "https://api.telnyx.com/v2/seti/black_box_test_results"
-```
-
-Returns: `black_box_tests` (array[object]), `product` (string), `record_type` (string)

--- a/skills/telnyx-seti-python/SKILL.md
+++ b/skills/telnyx-seti-python/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: telnyx-seti-python
-description: >-
-  Access SETI (Space Exploration Telecommunications Infrastructure) APIs. This
-  skill provides Python SDK examples.
+description: "Query SETI (Space Exploration Telecommunications Infrastructure) black box test results and diagnostic data via the Telnyx Python SDK. Use when retrieving SETI test results, checking infrastructure diagnostics, or accessing space exploration telecommunications endpoints in Python."
 metadata:
   author: telnyx
   product: seti
@@ -12,7 +10,9 @@ metadata:
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->
 
-# Telnyx Seti - Python
+# Telnyx SETI - Python
+
+Retrieve black box test results and diagnostic data from the Telnyx Space Exploration Telecommunications Infrastructure (SETI) API.
 
 ## Installation
 
@@ -27,52 +27,15 @@ import os
 from telnyx import Telnyx
 
 client = Telnyx(
-    api_key=os.environ.get("TELNYX_API_KEY"),  # This is the default and can be omitted
+    api_key=os.environ.get("TELNYX_API_KEY"),
 )
 ```
 
 All examples below assume `client` is already initialized as shown above.
 
-## Error Handling
-
-All API calls can fail with network errors, rate limits (429), validation errors (422),
-or authentication errors (401). Always handle errors in production code:
-
-```python
-import telnyx
-
-try:
-    result = client.messages.send(to="+13125550001", from_="+13125550002", text="Hello")
-except telnyx.APIConnectionError:
-    print("Network error — check connectivity and retry")
-except telnyx.RateLimitError:
-    # 429: rate limited — wait and retry with exponential backoff
-    import time
-    time.sleep(1)  # Check Retry-After header for actual delay
-except telnyx.APIStatusError as e:
-    print(f"API error {e.status_code}: {e.message}")
-    if e.status_code == 422:
-        print("Validation error — check required fields and formats")
-```
-
-Common error codes: `401` invalid API key, `403` insufficient permissions,
-`404` resource not found, `422` validation error (check field formats),
-`429` rate limited (retry with exponential backoff).
-
-## Get Enum
-
-`GET /10dlc/enum/{endpoint}`
-
-```python
-response = client.messaging_10dlc.get_enum(
-    "mno",
-)
-print(response)
-```
-
 ## Retrieve Black Box Test Results
 
-Returns the results of the various black box tests
+Returns the results of the various black box tests that validate SETI infrastructure status.
 
 `GET /seti/black_box_test_results`
 
@@ -82,3 +45,19 @@ print(response.data)
 ```
 
 Returns: `black_box_tests` (array[object]), `product` (string), `record_type` (string)
+
+## Error Handling
+
+```python
+import telnyx
+
+try:
+    result = client.seti.retrieve_black_box_test_results()
+except telnyx.APIConnectionError:
+    print("Network error — check connectivity and retry")
+except telnyx.RateLimitError:
+    import time
+    time.sleep(1)
+except telnyx.APIStatusError as e:
+    print(f"API error {e.status_code}: {e.message}")
+```

--- a/skills/telnyx-webrtc-client-js/SKILL.md
+++ b/skills/telnyx-webrtc-client-js/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: telnyx-webrtc-client-js
-description: >-
-  Build browser-based VoIP calling apps using Telnyx WebRTC JavaScript SDK.
-  Covers authentication, voice calls, events, debugging, call quality
-  metrics, and AI Agent integration. Use for web-based real-time communication.
+description: "Build browser-based VoIP calling apps using the Telnyx WebRTC JavaScript SDK (@telnyx/webrtc). Initiate and receive voice calls, handle call events and state changes, configure authentication credentials, monitor call quality metrics, run pre-call diagnostics, and integrate AI Agents for anonymous calling. Use when building browser phone apps, implementing WebRTC calling in JavaScript, integrating Telnyx voice SDK in web applications, or adding VoIP functionality to a frontend."
 metadata:
   author: telnyx
   product: webrtc
@@ -15,7 +12,7 @@ metadata:
 
 Build real-time voice communication into browser applications.
 
-> **Prerequisites**: Create WebRTC credentials and generate a login token using the Telnyx server-side SDK. See the `telnyx-webrtc-*` skill in your server language plugin (e.g., `telnyx-python`, `telnyx-javascript`).
+> **Prerequisites**: Create WebRTC credentials and generate a login token using the Telnyx server-side SDK. See [references/webrtc-server-api.md](references/webrtc-server-api.md) for credential creation, token generation, and push notification setup.
 
 ## Installation
 
@@ -23,11 +20,17 @@ Build real-time voice communication into browser applications.
 npm install @telnyx/webrtc --save
 ```
 
-Import the client:
-
 ```js
 import { TelnyxRTC } from '@telnyx/webrtc';
 ```
+
+## Getting Started Workflow
+
+1. **Create WebRTC credentials** (server-side) → get SIP username/password or JWT token
+2. **Initialize TelnyxRTC client** with credentials
+3. **Wait for `telnyx.ready`** before making calls
+4. **Make or receive calls** and handle state changes via `telnyx.notification`
+5. **Disconnect** when done
 
 ---
 
@@ -59,7 +62,6 @@ client.connect();
 ### Disconnect
 
 ```js
-// When done, disconnect and remove listeners
 client.disconnect();
 client.off('telnyx.ready');
 client.off('telnyx.notification');
@@ -74,8 +76,6 @@ Specify an HTML element to play remote audio:
 ```js
 client.remoteElement = 'remoteMedia';
 ```
-
-HTML:
 
 ```html
 <audio id="remoteMedia" autoplay="true" />
@@ -99,7 +99,6 @@ client
     if (notification.type === 'callUpdate') {
       activeCall = notification.call;
       
-      // Handle incoming call
       if (activeCall.state === 'ringing') {
         // Show incoming call UI
         // Call activeCall.answer() to accept
@@ -107,8 +106,6 @@ client
     }
   });
 ```
-
-### Event Types
 
 | Event | Description |
 |-------|-------------|
@@ -137,7 +134,6 @@ client.on('telnyx.notification', (notification) => {
   const call = notification.call;
   
   if (notification.type === 'callUpdate' && call.state === 'ringing') {
-    // Incoming call - show UI and answer
     call.answer();
   }
 });
@@ -148,17 +144,10 @@ client.on('telnyx.notification', (notification) => {
 ## Call Controls
 
 ```js
-// End call
 call.hangup();
-
-// Send DTMF tones
 call.dtmf('1234');
-
-// Mute audio
 call.muteAudio();
 call.unmuteAudio();
-
-// Hold
 call.hold();
 call.unhold();
 ```
@@ -182,7 +171,7 @@ const call = client.newCall({
 ```js
 const call = client.newCall({
   destinationNumber: '+18004377950',
-  debug: true,  // Required for metrics
+  debug: true,
 });
 
 client.on('telnyx.stats.frame', (stats) => {
@@ -208,19 +197,13 @@ PreCallDiagnosis.run({
   },
   texMLApplicationNumber: '+12407758982',
 })
-  .then((report) => {
-    console.log('Diagnosis report:', report);
-  })
-  .catch((error) => {
-    console.error('Diagnosis failed:', error);
-  });
+  .then((report) => console.log('Diagnosis report:', report))
+  .catch((error) => console.error('Diagnosis failed:', error));
 ```
 
 ---
 
 ## Preferred Codecs
-
-Set codec preference for calls:
 
 ```js
 const allCodecs = RTCRtpReceiver.getCapabilities('audio').codecs;
@@ -228,11 +211,6 @@ const allCodecs = RTCRtpReceiver.getCapabilities('audio').codecs;
 // Prefer Opus for AI/high quality
 const opusCodec = allCodecs.find(c => 
   c.mimeType.toLowerCase().includes('opus')
-);
-
-// Or PCMA for telephony compatibility
-const pcmaCodec = allCodecs.find(c => 
-  c.mimeType.toLowerCase().includes('pcma')
 );
 
 client.newCall({
@@ -244,8 +222,6 @@ client.newCall({
 ---
 
 ## Registration State
-
-Check if client is registered:
 
 ```js
 const isRegistered = await client.getIsRegistered();
@@ -276,23 +252,9 @@ client.connect();
 ### Make Call to AI Assistant
 
 ```js
-// After anonymous login, destinationNumber is ignored
 const call = client.newCall({
-  destinationNumber: '',  // Can be empty
-  remoteElement: 'remoteMedia',
-});
-```
-
-### Recommended Codec for AI
-
-```js
-const allCodecs = RTCRtpReceiver.getCapabilities('audio').codecs;
-const opusCodec = allCodecs.find(c => 
-  c.mimeType.toLowerCase().includes('opus')
-);
-
-client.newCall({
   destinationNumber: '',
+  remoteElement: 'remoteMedia',
   preferred_codecs: [opusCodec],  // Opus recommended for AI
 });
 ```
@@ -308,8 +270,6 @@ client.newCall({
 | Linux | ✓ | ✓ | - | - |
 | macOS | ✓ | ✓ | ✓ | ✓ |
 | Windows | ✓ | ✓ | - | ✓ |
-
-### Check Browser Support
 
 ```js
 const webRTCInfo = TelnyxRTC.webRTCInfo;
@@ -329,329 +289,6 @@ console.log('WebRTC supported:', webRTCInfo.supportWebRTC);
 
 ---
 
-<!-- BEGIN AUTO-GENERATED API REFERENCE -- do not edit below this line -->
+See [references/api-reference.md](references/api-reference.md) for the full TelnyxRTC and Call class API documentation, including device management, audio settings, ICE configuration, and voice isolation options.
 
 **[references/webrtc-server-api.md](references/webrtc-server-api.md) has the server-side WebRTC API — credential creation, token generation, and push notification setup. You MUST read it when setting up authentication or push notifications.**
-
-## API Reference
-
-
-### TelnyxRTC
-
-The `TelnyxRTC` client connects your application to the Telnyx backend,
-enabling you to make outgoing calls and handle incoming calls.
-
-```js
-// Initialize the client
-const client = new TelnyxRTC({
-  // Use a JWT to authenticate (recommended)
-  login_token: login_token,
-  // or use your Connection credentials
-  //  login: username,
-  //  password: password,
-});
-
-// Attach event listeners
-client
-  .on('telnyx.ready', () => console.log('ready to call'))
-  .on('telnyx.notification', (notification) => {
-    console.log('notification:', notification);
-  });
-
-// Connect and login
-client.connect();
-
-// You can call client.disconnect() when you're done.
-// Note: When you call `client.disconnect()` you need to remove all ON event methods you've had attached before.
-
-// Disconnecting and Removing listeners.
-client.disconnect();
-client.off('telnyx.ready');
-client.off('telnyx.notification');
-```
-
-### Methods
-
-### checkPermissions
-
-▸ **checkPermissions**(`audio?`, `video?`): `Promise`\<`boolean`\>
-
-Params: `audio` (boolean), `video` (boolean)
-
-Returns: `Promise`
-
-```js
-const client = new TelnyxRTC(options);
-
-client.checkPermissions();
-```
-### disableMicrophone
-
-▸ **disableMicrophone**(): `void`
-
-Returns: `void`
-
-```js
-const client = new TelnyxRTC(options);
-
-client.disableMicrophone();
-```
-### enableMicrophone
-
-▸ **enableMicrophone**(): `void`
-
-Returns: `void`
-
-```js
-const client = new TelnyxRTC(options);
-
-client.enableMicrophone();
-```
-### getAudioInDevices
-
-▸ **getAudioInDevices**(): `Promise`\<`MediaDeviceInfo`[]\>
-
-Returns: `Promise`
-### getAudioOutDevices
-
-▸ **getAudioOutDevices**(): `Promise`\<`MediaDeviceInfo`[]\>
-
-Returns: `Promise`
-### getDeviceResolutions
-
-▸ **getDeviceResolutions**(`deviceId`): `Promise`\<`any`[]\>
-
-Params: `deviceId` (string)
-
-Returns: `Promise`
-
-```js
-async function() {
-  const client = new TelnyxRTC(options);
-  let result = await client.getDeviceResolutions();
-  console.log(result);
-}
-```
-### getDevices
-
-▸ **getDevices**(): `Promise`\<`MediaDeviceInfo`[]\>
-
-Returns: `Promise`
-
-```js
-async function() {
-  const client = new TelnyxRTC(options);
-  let result = await client.getDevices();
-  console.log(result);
-}
-```
-### getVideoDevices
-
-▸ **getVideoDevices**(): `Promise`\<`MediaDeviceInfo`[]\>
-
-Returns: `Promise`
-
-```js
-async function() {
-  const client = new TelnyxRTC(options);
-  let result = await client.getVideoDevices();
-  console.log(result);
-}
-```
-### handleLoginError
-
-▸ **handleLoginError**(`error`): `void`
-
-Params: `error` (any)
-
-Returns: `void`
-### Error handling
-
-An error will be thrown if `destinationNumber` is not specified.
-
-```js
-const call = client.newCall().catch(console.error);
-// => `destinationNumber is required`
-```
-### Setting Custom Headers
-
-client.newCall({
-### Setting Preferred Codec
-
-You can pass `preferred_codecs` to the `newCall` method to set codec preference during the call.
-### ICE Candidate Prefetching
-
-ICE candidate prefetching is enabled by default. This pre-gathers ICE candidates when the
-
-```js
-client.newCall({
-  destinationNumber: 'xxx',
-  prefetchIceCandidates: false,
-});
-```
-### Trickle ICE
-
-Trickle ICE can be enabled by passing `trickleIce` to the `newCall` method.
-
-```js
-client.newCall({
-  destinationNumber: 'xxx',
-  trickleIce: true,
-});
-```
-### Call Recovery and `recoveredCallId`
-
-When a call is recovered after a network reconnection (reattach), the SDK
-### Voice Isolation
-
-Voice isolation options can be set by passing an `audio` object to the `newCall` method. This property controls the settings of a MediaStreamTrack object. For reference on available audio constraints, see [MediaTrackConstraints](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints).
-### Events
-
-[`TelnyxRTC`](https://developers.telnyx.com/development/webrtc/js-sdk/classes/telnyxrtc)
-
-Params: `eventName` (string), `callback` (Function)
-### setAudioSettings
-
-▸ **setAudioSettings**(`settings`): `Promise`\<`MediaTrackConstraints`\>
-
-Params: `settings` (IAudioSettings)
-
-Returns: `Promise`
-
-```js
-// within an async function
-const constraints = await client.setAudioSettings({
-  micId: '772e94959e12e589b1cc71133d32edf543d3315cfd1d0a4076a60601d4ff4df8',
-  micLabel: 'Internal Microphone (Built-in)',
-  echoCancellation: false,
-});
-```
-### webRTCInfo
-
-▸ `Static` **webRTCInfo**(): `string` \| `IWebRTCInfo`
-
-Returns: `string`
-
-```js
-const info = TelnyxRTC.webRTCInfo();
-const isWebRTCSupported = info.supportWebRTC;
-console.log(isWebRTCSupported); // => true
-```
-### webRTCSupportedBrowserList
-
-▸ `Static` **webRTCSupportedBrowserList**(): `IWebRTCSupportedBrowser`[]
-
-Returns: `IWebRTCSupportedBrowser`
-
-```js
-const browserList = TelnyxRTC.webRTCSupportedBrowserList();
-console.log(browserList); // => [{"operationSystem": "Android", "supported": [{"browserName": "Chrome", "features": ["video", "audio"], "supported": "full"},{...}]
-```
-
-
-### Call
-
-A `Call` is the representation of an audio or video call between
-two browsers, SIP clients or phone numbers. The `call` object is
-created whenever a new call is initiated, either by you or the
-remote caller. You can access and act upon calls initiated by
-a remote caller in a `telnyx.notification` event handler.
-
-To create a new call, i.e. dial:
-
-```js
-const call = client.newCall({
-  // Destination is required and can be a phone number or SIP URI
-  destinationNumber: '18004377950',
-  callerNumber: '‬155531234567',
-});
-```
-
-To answer an incoming call:
-
-```js
-client.on('telnyx.notification', (notification) => {
-  const call = notification.call;
-
-  if (notification.type === 'callUpdate' && call.state === 'ringing') {
-    call.answer();
-  }
-});
-```
-
-Both the outgoing and incoming call has methods that can be hooked up to your UI.
-
-```js
-// Hangup or reject an incoming call
-call.hangup();
-
-// Send digits and keypresses
-call.dtmf('1234');
-
-// Call states that can be toggled
-call.hold();
-call.muteAudio();
-```
-
-### Properties
-### Accessors
-### Methods
-
-### getStats
-
-▸ **getStats**(`callback`, `constraints`): `void`
-
-Params: `callback` (Function), `constraints` (any)
-
-Returns: `void`
-### setAudioInDevice
-
-▸ **setAudioInDevice**(`deviceId`, `muted?`): `Promise`\<`void`\>
-
-Params: `deviceId` (string), `muted` (boolean)
-
-Returns: `Promise`
-
-```js
-await call.setAudioInDevice('abc123');
-```
-### setAudioOutDevice
-
-▸ **setAudioOutDevice**(`deviceId`): `Promise`\<`boolean`\>
-
-Params: `deviceId` (string)
-
-Returns: `Promise`
-
-```js
-await call.setAudioOutDevice('abc123');
-```
-### setVideoDevice
-
-▸ **setVideoDevice**(`deviceId`): `Promise`\<`void`\>
-
-Params: `deviceId` (string)
-
-Returns: `Promise`
-
-```js
-await call.setVideoDevice('abc123');
-```
-
-
-### ICallOptions
-
-ICallOptions
-ICallOptions
-
-### Properties
-
-
-### IClientOptions
-
-IClientOptions
-IClientOptions
-
-### Properties
-
-<!-- END AUTO-GENERATED API REFERENCE -->

--- a/skills/telnyx-webrtc-client-js/references/api-reference.md
+++ b/skills/telnyx-webrtc-client-js/references/api-reference.md
@@ -1,0 +1,178 @@
+# Telnyx WebRTC JavaScript SDK - API Reference
+
+## TelnyxRTC
+
+The `TelnyxRTC` client connects your application to the Telnyx backend,
+enabling you to make outgoing calls and handle incoming calls.
+
+```js
+const client = new TelnyxRTC({
+  login_token: login_token,
+  // or: login: username, password: password,
+});
+
+client
+  .on('telnyx.ready', () => console.log('ready to call'))
+  .on('telnyx.notification', (notification) => {
+    console.log('notification:', notification);
+  });
+
+client.connect();
+```
+
+### Methods
+
+#### checkPermissions
+
+▸ **checkPermissions**(`audio?`, `video?`): `Promise<boolean>`
+
+```js
+client.checkPermissions();
+```
+
+#### disableMicrophone / enableMicrophone
+
+▸ **disableMicrophone**(): `void`
+▸ **enableMicrophone**(): `void`
+
+```js
+client.disableMicrophone();
+client.enableMicrophone();
+```
+
+#### getAudioInDevices / getAudioOutDevices / getVideoDevices / getDevices
+
+▸ Returns `Promise<MediaDeviceInfo[]>` for each.
+
+```js
+const devices = await client.getDevices();
+const audioIn = await client.getAudioInDevices();
+const audioOut = await client.getAudioOutDevices();
+const video = await client.getVideoDevices();
+```
+
+#### getDeviceResolutions
+
+▸ **getDeviceResolutions**(`deviceId`): `Promise<any[]>`
+
+```js
+const resolutions = await client.getDeviceResolutions();
+```
+
+#### setAudioSettings
+
+▸ **setAudioSettings**(`settings`): `Promise<MediaTrackConstraints>`
+
+```js
+const constraints = await client.setAudioSettings({
+  micId: '772e94959e12e589b1cc71133d32edf543d3315cfd1d0a4076a60601d4ff4df8',
+  micLabel: 'Internal Microphone (Built-in)',
+  echoCancellation: false,
+});
+```
+
+#### webRTCInfo
+
+▸ `Static` **webRTCInfo**(): `string | IWebRTCInfo`
+
+```js
+const info = TelnyxRTC.webRTCInfo();
+const isWebRTCSupported = info.supportWebRTC;
+```
+
+#### webRTCSupportedBrowserList
+
+▸ `Static` **webRTCSupportedBrowserList**(): `IWebRTCSupportedBrowser[]`
+
+```js
+const browserList = TelnyxRTC.webRTCSupportedBrowserList();
+```
+
+## Call
+
+A `Call` represents an audio or video call between two browsers, SIP clients, or phone numbers.
+
+### Making a call
+
+```js
+const call = client.newCall({
+  destinationNumber: '18004377950',
+  callerNumber: '155531234567',
+});
+```
+
+### Answering an incoming call
+
+```js
+client.on('telnyx.notification', (notification) => {
+  const call = notification.call;
+  if (notification.type === 'callUpdate' && call.state === 'ringing') {
+    call.answer();
+  }
+});
+```
+
+### Call controls
+
+```js
+call.hangup();
+call.dtmf('1234');
+call.hold();
+call.muteAudio();
+```
+
+### Call Methods
+
+#### getStats
+
+▸ **getStats**(`callback`, `constraints`): `void`
+
+#### setAudioInDevice
+
+▸ **setAudioInDevice**(`deviceId`, `muted?`): `Promise<void>`
+
+```js
+await call.setAudioInDevice('abc123');
+```
+
+#### setAudioOutDevice
+
+▸ **setAudioOutDevice**(`deviceId`): `Promise<boolean>`
+
+```js
+await call.setAudioOutDevice('abc123');
+```
+
+#### setVideoDevice
+
+▸ **setVideoDevice**(`deviceId`): `Promise<void>`
+
+```js
+await call.setVideoDevice('abc123');
+```
+
+## newCall Options
+
+### ICE Candidate Prefetching
+
+Enabled by default. Disable with:
+
+```js
+client.newCall({
+  destinationNumber: 'xxx',
+  prefetchIceCandidates: false,
+});
+```
+
+### Trickle ICE
+
+```js
+client.newCall({
+  destinationNumber: 'xxx',
+  trickleIce: true,
+});
+```
+
+### Voice Isolation
+
+Control audio settings via the `audio` object parameter. See [MediaTrackConstraints](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints) for available options.


### PR DESCRIPTION
Hey @aisling404 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| telnyx-fax-curl | 52% | 94% | +42% |
| telnyx-seti-curl | 58% | 95% | +37% |
| telnyx-seti-python | 59% | 95% | +36% |
| telnyx-iot-curl | 60% | 88% | +28% |
| telnyx-webrtc-client-js | 67% | 94% | +27% |

This PR covers your 5 lowest-scoring skill(s) in the repo. The remaining 229 skills can improve incrementally via the included GitHub Action (see below). All 5 skills are auto-generated from the Telnyx OpenAPI specs — these changes demonstrate improvements the generation pipeline could adopt.

<details>
<summary>What changed in telnyx-fax-curl</summary>

- **Description rewritten** with concrete action verbs, an explicit "Use when..." clause, and natural trigger terms (fax API, send/receive faxes, delivery status, webhooks)
- **Fixed send fax example** — separated file upload (`-F`) and media URL (`-d`) into two distinct curl examples (original incorrectly mixed both in one command)
- **Added Quick Start workflow** with 4-step provisioning sequence
- **Moved webhook payload tables and response schemas** to `references/api-details.md` — eliminated 5x repeated response schema blocks, cutting token usage significantly
- **Consolidated fax application CRUD** into grouped examples to reduce repetition

</details>

<details>
<summary>What changed in telnyx-seti-curl</summary>

- **Description rewritten** with specific actions (query black box test results, check diagnostics), an explicit "Use when..." clause, and natural trigger terms
- **Removed erroneous `GET /10dlc/enum/{endpoint}`** — this 10DLC endpoint was incorrectly included in the SETI skill
- **Trimmed generic error handling** — removed the messaging API example and "curl is pre-installed" note; replaced with a SETI-specific error handling example
- **Added domain context** — clarified what SETI black box tests validate

</details>

<details>
<summary>What changed in telnyx-seti-python</summary>

- **Description rewritten** with specific actions, an explicit "Use when..." clause, and natural trigger terms
- **Removed erroneous `GET /10dlc/enum/{endpoint}`** — same 10DLC endpoint incorrectly included
- **Trimmed generic error handling** — removed the messaging API example (`client.messages.send`) that was unrelated to SETI; replaced with SETI-specific error handling
- **Streamlined setup** — removed redundant comment about default behavior

</details>

<details>
<summary>What changed in telnyx-iot-curl</summary>

- **Description rewritten** with concrete actions (purchase, register, activate, monitor SIMs), an explicit "Use when..." clause, and natural trigger terms (IoT/M2M, cellular connectivity, eSIM)
- **Added Quick Start workflow** with 4-step provisioning sequence
- **Moved bulk endpoints to `references/api-details.md`** — data usage notifications, SIM card orders, OTA updates, wireless blocklists, and additional SIM card endpoints now live in a reference file
- **Removed tangential endpoints** (storage migrations, mobile voice connections) that don't belong in an IoT SIM card skill
- **Reduced from 1062 to 185 lines** while keeping all core operations inline

</details>

<details>
<summary>What changed in telnyx-webrtc-client-js</summary>

- **Description rewritten** with concrete actions (initiate/receive calls, handle events, configure auth, monitor quality, integrate AI Agents), an explicit "Use when..." clause, and natural trigger terms (@telnyx/webrtc, browser phone apps, VoIP)
- **Added Getting Started Workflow** with 5-step connection sequence
- **Moved auto-generated API reference** to `references/api-reference.md` — eliminated ~325 lines of duplicated content (the API reference was repeating authentication, call making, and call controls already covered in the main body)
- **Cleaned up incomplete stubs** (Setting Custom Headers, Call Recovery had no actual content)
- **Reduced from 658 to 295 lines** while preserving all tutorial content

</details>

## Tessl Skill Review GitHub Action ✅

I've also included a GitHub Action (`.github/workflows/skill-review.yml`) that automatically reviews any `SKILL.md` changed in future PRs and posts scores as a PR comment.

**What this gives you:**
- 🔍 Automatic `tessl skill review` runs on every PR touching `SKILL.md`
- 💬 One updated PR comment with scores and improvement feedback
- 🔓 **Zero extra accounts** — contributors don't need a Tessl login; only `GITHUB_TOKEN` is used
- ✅ **Non-blocking by default** — feedback-only, no surprise red CI (add `fail-threshold: 70` later if you want a hard gate)
- 📈 Covers future skills incrementally as contributors edit them

## Want automatic AI optimization on every SKILL.md change? 🚀

The action I've added gives you **review scores** on PRs. We also have a more powerful variant — [`tesslio/skill-review-and-optimize`](https://github.com/tesslio/skill-review-and-optimize) — that can:

- Run **AI-powered optimization suggestions** on every `SKILL.md` PR (requires adding `TESSL_API_TOKEN` as a repo secret)
- Let contributors accept suggested improvements by commenting **`/apply-optimize`**
- Still works in review-only mode with zero secrets

Interested? Tick the box and I'll raise a follow-up PR:

- [ ] **Yes please!** Add the `tesslio/skill-review-and-optimize` action so every SKILL.md PR gets AI optimization suggestions + the `/apply-optimize` flow
- [ ] **No thanks** — the review scores action is enough for now

---

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch — just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me — [@rohan-tessl](https://github.com/rohan-tessl) — if you hit any snags.

Thanks in advance 🙏
