### PR TITLE
fix(opencode): simplify TUI export format, bump to 0.1.1

### DIFF
--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-04-24
+
+### Fixed
+
+- Simplified `./tui` export to plain string format, matching the convention used by all other opencode TUI plugins
+
+## [0.1.0] - 2026-04-23
+
 ### Added
 
 - initial Telnyx auth and provider plugin for OpenCode

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@telnyx/opencode",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Telnyx auth and provider plugin for OpenCode",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {
     "./server": { "types": "./dist/index.d.ts", "import": "./dist/index.js" },
-    "./tui":    { "types": "./dist/tui.d.ts",   "import": "./src/tui.tsx" }
+    "./tui":    "./src/tui.tsx"
   },
   "files": ["dist", "src", "README.md"],
   "repository": {


### PR DESCRIPTION
## Changes

- Simplified `./tui` export from conditional object `{ types, import }` to plain string `"./src/tui.tsx"`
- Added CHANGELOG entries for 0.1.0 and 0.1.1
- Bumped version to 0.1.1

## Why

Every other opencode TUI plugin uses plain string exports for `./tui`:
- `@codemcp/workflows-opencode-tui`: `"./tui": "./workflows-phase.tsx"`
- `@opencode-ai/plugin` SDK: `"./tui": "./src/tui.ts"`

Aligns with ecosystem convention. The conditional object format also works with opencode's `extractExportValue`, but plain strings are the established norm.

## After merge

Trigger `publish-npm.yml` workflow with `package=opencode` to publish 0.1.1 to npm. Then:
```bash
rm -rf ~/.cache/opencode/packages/@telnyx/
# restart opencode to pick up 0.1.1
```