### PR TITLE
fix(opencode): regenerate package-lock.json for publish workflow

### DIFF
--- a/plugins/opencode/package-lock.json
+++ b/plugins/opencode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@telnyx/opencode",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@telnyx/opencode",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@opencode-ai/plugin": "^1.2.27"


### PR DESCRIPTION
## Summary

- Regenerates `plugins/opencode/package-lock.json` to sync version from `0.1.0` to `0.1.1` to match `package.json`
- The lockfile was stale after PR #161 bumped the package version but didn't regenerate the lockfile
- `npm ci` in the publish-npm.yml workflow was failing because the lockfile version didn't match package.json

## Context

PR #161 (fix/opencode-plugin-tui-export) bumped the package version from 0.1.0 to 0.1.1 in `package.json`, but the `package-lock.json` was not regenerated. The publish-npm.yml workflow runs `npm ci` which validates the lockfile against `package.json` and fails when they're out of sync.

## Verification

- `npm install --package-lock-only` run in `plugins/opencode/`
- `npm ci` succeeds (exit 0, 319 packages installed)
- Lockfile version fields match `package.json` (both 0.1.1)
- Only change: two version string fields from `"0.1.0"` → `"0.1.1"`