### PR TITLE
fix(ci): use --legacy-peer-deps for opencode publish workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: plugins/opencode
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Publish @telnyx/opencode
         run: bash ./.github/bin/publish-npm plugins/opencode


### PR DESCRIPTION
## Summary

- Adds `--legacy-peer-deps` flag to the `npm ci` step in the opencode publish job in `.github/workflows/publish-npm.yml`
- Fixes CI failure where `planck@1.5.0` (dev+optional dep) has an unresolved peer dep on `stage-js@1.0.2` that causes `npm ci` to fail
- One-line change, no other modifications

## Why `--legacy-peer-deps`

`npm ci` by default (npm v7+) auto-installs peer dependencies. `planck@1.5.0` declares a peer dependency on `stage-js`, but `stage-js` isn't resolved in the lockfile. This causes `npm ci` to fail with a missing peer dependency error. The `--legacy-peer-deps` flag tells npm to skip auto-installing peer deps, using the legacy (npm v6) resolution algorithm instead. The needed peer deps are already present in devDependencies, so this is safe.