### PR TITLE
feat(opencode): add oc-plugin metadata and install docs for 0.1.2

### DIFF
--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-04-24
+
+### Added
+
+- Added `oc-plugin` field declaring both server and TUI targets for `opencode plugin install` compatibility
+
+### Fixed
+
+- Fixed README install instructions to use `opencode plugin install` (the standard method that auto-configures both `opencode.json` and `tui.json`)
+
 ## [0.1.1] - 2026-04-24
 
 ### Fixed

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -5,19 +5,16 @@
 ## Install
 
 ```bash
-npm install @telnyx/opencode
+opencode plugin install @telnyx/opencode
 ```
 
-Add the package to `~/.config/opencode/opencode.json`:
+This auto-detects both the server and TUI targets and adds the plugin to `opencode.json` (server) and `tui.json` (TUI) automatically.
 
-```jsonc
-{
-  "$schema": "https://opencode.ai/config.json",
-  "plugin": ["@telnyx/opencode"]
-}
+For global install (all projects):
+
+```bash
+opencode plugin install -g @telnyx/opencode
 ```
-
-OpenCode loads the package's server and TUI plugin entrypoints from the same npm package, so a separate `tui.json` entry is not required.
 
 ## What it does
 
@@ -178,4 +175,13 @@ Some smaller models cannot fit OpenCode's full tool list and system prompt into 
 
 ### `/telnyx` does not appear
 
-Make sure the package is listed in `opencode.json`, then restart OpenCode so the TUI entrypoint is reloaded.
+The TUI plugin requires a `tui.json` entry. Run `opencode plugin install @telnyx/opencode` which configures both `opencode.json` and `tui.json` automatically. If you added the plugin manually to `opencode.json`, you also need `tui.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/tui.json",
+  "plugin": ["@telnyx/opencode"]
+}
+```
+
+Then restart OpenCode.

--- a/plugins/opencode/package-lock.json
+++ b/plugins/opencode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@telnyx/opencode",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@telnyx/opencode",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@opencode-ai/plugin": "^1.2.27"

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telnyx/opencode",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Telnyx auth and provider plugin for OpenCode",
   "license": "MIT",
   "type": "module",
@@ -16,6 +16,7 @@
     "directory": "plugins/opencode"
   },
   "bugs": { "url": "https://github.com/team-telnyx/ai/issues" },
+  "oc-plugin": ["server", "tui"],
   "publishConfig": { "access": "public" },
   "scripts": {
     "build": "npm run build:clean && npm run build:server && npm run build:tui && npm run build:types",


### PR DESCRIPTION
## Summary

- Adds `oc-plugin: ["server", "tui"]` to `package.json` so `opencode plugin install @telnyx/opencode` can auto-detect and configure both the server and TUI targets
- Bumps `@telnyx/opencode` from 0.1.1 to 0.1.2
- Updates README to recommend `opencode plugin install` as the standard one-command install flow (replaces the old `npm install` + manual config instructions)
- Documents the manual `tui.json` fallback in troubleshooting for users who prefer to configure by hand
- Changelog updated for 0.1.2

## Why

OpenCode has separate server and TUI config pipelines (`opencode.json` and `tui.json`). The `opencode plugin install` command reads the `oc-plugin` field from `package.json` to detect which targets a package provides, then writes entries to the correct config files automatically. Without this field, the one-command install flow can't discover the TUI target, and users had to manually edit both config files.

## Changed files

- `plugins/opencode/package.json` — version bump + `oc-plugin` field
- `plugins/opencode/package-lock.json` — version bump
- `plugins/opencode/CHANGELOG.md` — 0.1.2 entry
- `plugins/opencode/README.md` — install docs + troubleshooting