### PR TITLE
chore(plugins): refresh README to reflect OpenCode landed

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,9 +1,15 @@
 # Plugins
 
-Coding-assistant plugins that wire Telnyx into AI IDEs and CLIs (Claude Code, Cursor, Gemini CLI, OpenCode, …).
+Coding-assistant plugins that wire Telnyx into AI IDEs and CLIs.
 
-Each subdirectory contains one plugin: its manifest, source (if applicable), and install instructions.
+## Current contents
 
-This directory is being populated as part of a repo-wide reorganization. Existing plugin assets currently live at `.claude-plugin/`, `.cursor-plugin/`, `providers/claude/`, `providers/cursor/`, `gemini-extension.json`, and `agent.json`, and will be consolidated here in a follow-up step. The separate `team-telnyx/opencode-telnyx-auth` repo will also be absorbed as `plugins/opencode/`.
+- **`opencode/`** — OpenCode plugin, published as [`@telnyx/opencode`](https://www.npmjs.com/package/@telnyx/opencode). Adds Telnyx as a model provider with auth handling and a TUI for managing hosted models. Absorbed from the now-archived `team-telnyx/opencode-telnyx-auth` repo.
 
-See the repo root `README.md` for the full architecture.
+## Coming next
+
+The Claude Code and Cursor plugin payloads currently live at `providers/claude/plugin/` and `providers/cursor/plugin/` and will move to `plugins/claude-code/` and `plugins/cursor/` in a follow-up step. The root `.claude-plugin/marketplace.json` and `.cursor-plugin/marketplace.json` files stay at the repo root (they're consumed by `/plugin marketplace add team-telnyx/ai` and the Cursor marketplace) — only their `source:` fields will be rewired.
+
+Gemini CLI has no payload directory: its entire integration is the root `gemini-extension.json`, consumed by `gemini extensions install https://github.com/team-telnyx/ai`.
+
+See the repo root `README.md` for install instructions and the broader architecture.


### PR DESCRIPTION
## Summary
- Update `plugins/README.md` so it reflects current state, not the pre-merge plan.
- OpenCode landed in #157 (and follow-up fixes #161–164, currently published at 0.1.2). The README still talked about absorbing the external `opencode-telnyx-auth` repo as a future step — fixed.

## What changed
- List `opencode/` as current contents with a link to the npm package.
- Describe the remaining Claude Code / Cursor consolidation as the next step (payload move from `providers/{claude,cursor}/plugin/` → `plugins/{claude-code,cursor}/`, with the root `.claude-plugin/`/`.cursor-plugin/` `marketplace.json` files staying at root and only their `source:` fields rewired).
- Clarify that `gemini-extension.json` has no payload directory, so there is no `plugins/gemini-cli/` to create.

## Why now
Came up while cross-checking the architecture plan against `main` — the README was the only stale artifact pointing at out-of-date next steps.

## Test plan
- [ ] CI passes (README-only, no code changes)
- [ ] `plugins/README.md` renders cleanly on GitHub
- [ ] No broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)