### PR TITLE
feat: add usable Edge Compute handoff to telnyx-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,9 +176,21 @@ See [MCP](/tools/mcp) for more details.
 
 ## Guides
 
-Curl-first operational guides for common Telnyx workflows — SMS messaging, voice call control, AI assistants, phone numbers, porting, verification, webhooks, 10DLC registration, WireGuard networking, and x402 payments.
+Curl-first operational guides for common Telnyx workflows — SMS messaging, voice call control, AI assistants, phone numbers, porting, verification, webhooks, 10DLC registration, WireGuard networking, x402 payments, and Edge Compute handoff patterns.
 
 See [Guides](/guides) for the full list.
+
+## Edge Compute
+
+`team-telnyx/ai` does not currently own native Edge Compute lifecycle support.
+
+Instead, this repo should be treated as the orchestration/discoverability layer, while the actual function lifecycle lives in the separate `team-telnyx/edge-compute` repo and the `telnyx-edge` CLI.
+
+In practice:
+- use `team-telnyx/ai` for agent workflows, capability discovery, and AI-oriented integration patterns
+- use `team-telnyx/edge-compute` + `telnyx-edge` for function creation, deployment, secrets, bindings, and lifecycle management
+
+See [Edge Compute guide](/guides/edge-compute.md).
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ See [MCP](/tools/mcp) for more details.
 
 Curl-first operational guides for common Telnyx workflows — SMS messaging, voice call control, AI assistants, phone numbers, porting, verification, webhooks, 10DLC registration, WireGuard networking, x402 payments, and Edge Compute handoff patterns.
 
+For Edge Compute specifically, the goal is to make the handoff testable fast: start from a real `telnyx-edge` example, deploy it, and let `team-telnyx/ai` orchestrate against that live endpoint.
+
 See [Guides](/guides) for the full list.
 
 ## Edge Compute

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ In practice:
 
 The intended end state is a clean bridge:
 - `ai` = orchestrates and explains
-- Edge Compute = deploys and runs
+- Edge Compute = deploys and runs (prefer API-key auth for agent flows)
 - the boundary between them is a documented HTTP/MCP/function contract
 
 See [Edge Compute guide](/guides/edge-compute.md).

--- a/README.md
+++ b/README.md
@@ -190,6 +190,11 @@ In practice:
 - use `team-telnyx/ai` for agent workflows, capability discovery, and AI-oriented integration patterns
 - use `team-telnyx/edge-compute` + `telnyx-edge` for function creation, deployment, secrets, bindings, and lifecycle management
 
+The intended end state is a clean bridge:
+- `ai` = orchestrates and explains
+- Edge Compute = deploys and runs
+- the boundary between them is a documented HTTP/MCP/function contract
+
 See [Edge Compute guide](/guides/edge-compute.md).
 
 

--- a/agent.json
+++ b/agent.json
@@ -113,7 +113,7 @@
     {
       "id": "edge_compute",
       "name": "Edge Compute",
-      "description": "Deploy webhook and MCP-adjacent functions on Telnyx edge infrastructure. Discovery and integration guidance live here; function lifecycle is handled by the separate telnyx-edge CLI.",
+      "description": "Deploy webhook and MCP-adjacent functions on Telnyx edge infrastructure. Discovery and integration guidance live here; function lifecycle is handled by the separate telnyx-edge CLI, with a docs-first bridge focused on real testable handoff patterns.",
       "guide": "/guides/edge-compute.md",
       "cli": "telnyx-edge ship",
       "docs": "https://developers.telnyx.com/docs/edge-compute",

--- a/agent.json
+++ b/agent.json
@@ -111,6 +111,15 @@
       "requires": []
     },
     {
+      "id": "edge_compute",
+      "name": "Edge Compute",
+      "description": "Deploy webhook and MCP-adjacent functions on Telnyx edge infrastructure. Discovery and integration guidance live here; function lifecycle is handled by the separate telnyx-edge CLI.",
+      "guide": "/guides/edge-compute.md",
+      "cli": "telnyx-edge ship",
+      "docs": "https://developers.telnyx.com/docs/edge-compute",
+      "requires": []
+    },
+    {
       "id": "webhooks",
       "name": "Webhooks",
       "description": "Real-time event notifications for messaging, voice, and account events.",

--- a/cli/README.md
+++ b/cli/README.md
@@ -93,7 +93,7 @@ Output: `{ assistant_id, phone_number, test_command }`
 ### Edge Compute handoff commands
 
 These are **thin executable bridges**, not native Edge lifecycle support.
-They make Edge Compute usable from `telnyx-agent` while keeping real deploy/auth/secrets/bindings ownership in `telnyx-edge`.
+They make Edge Compute usable from `telnyx-agent` while keeping real deploy/auth/secrets/bindings ownership in `telnyx-edge`. They now prefer API-key auth for agent use when the installed Edge CLI supports it.
 
 ```bash
 telnyx-agent edge-doctor --json
@@ -103,6 +103,8 @@ telnyx-agent setup-edge-webhook --name my-webhook --json
 
 What they do:
 - validate that `telnyx-edge` is available
+- check whether Edge auth is already configured
+- prefer `telnyx-edge auth api-key set <your-api-key>` for agents when supported
 - point you at a real Edge example
 - give you the concrete next deploy command
 - preserve an honest handoff instead of pretending `telnyx-agent` owns Edge lifecycle

--- a/cli/README.md
+++ b/cli/README.md
@@ -90,6 +90,23 @@ telnyx-agent setup-ai --name "Support Bot" --json
 
 Output: `{ assistant_id, phone_number, test_command }`
 
+### Edge Compute handoff commands
+
+These are **thin executable bridges**, not native Edge lifecycle support.
+They make Edge Compute usable from `telnyx-agent` while keeping real deploy/auth/secrets/bindings ownership in `telnyx-edge`.
+
+```bash
+telnyx-agent edge-doctor --json
+telnyx-agent setup-edge-mcp --name my-mcp-server --json
+telnyx-agent setup-edge-webhook --name my-webhook --json
+```
+
+What they do:
+- validate that `telnyx-edge` is available
+- point you at a real Edge example
+- give you the concrete next deploy command
+- preserve an honest handoff instead of pretending `telnyx-agent` owns Edge lifecycle
+
 ### `telnyx-agent fund-account`
 
 **Fund your Telnyx account with USDC on Base via x402 protocol.**
@@ -141,7 +158,7 @@ The CLI looks for an API key in this order:
 ## Architecture
 
 - **Hybrid execution** — wraps `telnyx-cli` where available, falls back to native `fetch()` for operations without CLI support
-- **No CLI framework** — simple `process.argv` parsing for 10 commands
+- **No CLI framework** — simple `process.argv` parsing for 13 commands
 - **TypeScript + tsx** — direct execution, no build step
 - **Error handling** — composite commands report what succeeded and what failed
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "tsx bin/telnyx-agent.ts",
-    "test": "tsx --test tests/integration.test.ts tests/telnyx-cli-flags.test.ts",
+    "test": "tsx --test tests/integration.test.ts tests/telnyx-cli-flags.test.ts tests/edge-handoff.test.ts",
     "typecheck": "tsc --noEmit",
     "postinstall": "tsx scripts/postinstall.ts"
   },

--- a/cli/src/commands/capabilities.ts
+++ b/cli/src/commands/capabilities.ts
@@ -40,6 +40,9 @@ const CAPABILITIES: Record<string, Capability[]> = {
   "🔐 Networking": [
     { name: "WireGuard VPN", description: "Create private networks and WireGuard tunnels", actions: ["create_network", "create_wireguard_interface", "create_wireguard_peer"] },
   ],
+  "⚡ Edge Compute": [
+    { name: "Edge Functions", description: "Discover how to pair Telnyx AI workflows with Telnyx Edge Compute. Function lifecycle is owned by the separate telnyx-edge CLI.", actions: ["see_guides_edge_compute"] },
+  ],
   "📋 10DLC Compliance": [
     { name: "10DLC Registration", description: "Register brands and campaigns for US A2P messaging", actions: ["create_10dlc_brand", "create_10dlc_campaign", "assign_10dlc_number"] },
   ],
@@ -61,6 +64,7 @@ const COMPOSITE_COMMANDS = [
   { name: "telnyx-agent setup-iot", description: "Zero to IoT: lists SIMs, creates group, activates SIM" },
   { name: "telnyx-agent setup-ai", description: "Zero to AI assistant: creates assistant, buys number, wires them together" },
   { name: "telnyx-agent setup-wireguard", description: "Zero to VPN: creates network, WireGuard interface, peer — outputs ready-to-use WG config" },
+  { name: "telnyx-edge ship", description: "Deploy an Edge Compute function with the dedicated telnyx-edge CLI (referenced by the Edge Compute guide)" },
   { name: "telnyx-agent setup-verify", description: "Zero to verification: creates verify profile, buys number — outputs test command" },
   { name: "telnyx-agent setup-10dlc", description: "Zero to A2P: creates 10DLC brand, campaign, optional number assignment" },
   { name: "telnyx-agent setup-porting", description: "Zero to porting: checks portability, creates porting order, lists requirements, optionally submits" },

--- a/cli/src/commands/capabilities.ts
+++ b/cli/src/commands/capabilities.ts
@@ -41,7 +41,7 @@ const CAPABILITIES: Record<string, Capability[]> = {
     { name: "WireGuard VPN", description: "Create private networks and WireGuard tunnels", actions: ["create_network", "create_wireguard_interface", "create_wireguard_peer"] },
   ],
   "⚡ Edge Compute": [
-    { name: "Edge Functions", description: "Discover how to pair Telnyx AI workflows with Telnyx Edge Compute. Function lifecycle is owned by the separate telnyx-edge CLI.", actions: ["see_guides_edge_compute"] },
+    { name: "Edge Functions", description: "Pair Telnyx AI workflows with Telnyx Edge Compute. telnyx-agent now provides an executable handoff and prefers API-key auth for agent use when supported by telnyx-edge.", actions: ["see_guides_edge_compute"] },
     { name: "Deployment Handoff", description: "Use team-telnyx/ai for orchestration patterns and telnyx-edge for deploy, secrets, bindings, and lifecycle management.", actions: ["telnyx_edge_ship", "telnyx_edge_secrets", "telnyx_edge_bindings"] },
     { name: "Edge CLI Bridge", description: "Thin executable handoff from telnyx-agent into telnyx-edge for real MCP and webhook starting points.", actions: ["edge_doctor", "setup_edge_mcp", "setup_edge_webhook"] },
   ],

--- a/cli/src/commands/capabilities.ts
+++ b/cli/src/commands/capabilities.ts
@@ -43,6 +43,7 @@ const CAPABILITIES: Record<string, Capability[]> = {
   "⚡ Edge Compute": [
     { name: "Edge Functions", description: "Discover how to pair Telnyx AI workflows with Telnyx Edge Compute. Function lifecycle is owned by the separate telnyx-edge CLI.", actions: ["see_guides_edge_compute"] },
     { name: "Deployment Handoff", description: "Use team-telnyx/ai for orchestration patterns and telnyx-edge for deploy, secrets, bindings, and lifecycle management.", actions: ["telnyx_edge_ship", "telnyx_edge_secrets", "telnyx_edge_bindings"] },
+    { name: "Edge CLI Bridge", description: "Thin executable handoff from telnyx-agent into telnyx-edge for real MCP and webhook starting points.", actions: ["edge_doctor", "setup_edge_mcp", "setup_edge_webhook"] },
   ],
   "📋 10DLC Compliance": [
     { name: "10DLC Registration", description: "Register brands and campaigns for US A2P messaging", actions: ["create_10dlc_brand", "create_10dlc_campaign", "assign_10dlc_number"] },
@@ -66,6 +67,9 @@ const COMPOSITE_COMMANDS = [
   { name: "telnyx-agent setup-ai", description: "Zero to AI assistant: creates assistant, buys number, wires them together" },
   { name: "telnyx-agent setup-wireguard", description: "Zero to VPN: creates network, WireGuard interface, peer — outputs ready-to-use WG config" },
   { name: "telnyx-edge ship", description: "Deploy an Edge Compute function with the dedicated telnyx-edge CLI (referenced by the Edge Compute guide)" },
+  { name: "telnyx-agent edge-doctor", description: "Validate Edge Compute handoff prerequisites and point to the next concrete telnyx-edge steps" },
+  { name: "telnyx-agent setup-edge-mcp", description: "Concrete MCP-on-Edge handoff: points to the real example and deploy command via telnyx-edge" },
+  { name: "telnyx-agent setup-edge-webhook", description: "Concrete webhook-on-Edge handoff: points to the real example and deploy command via telnyx-edge" },
   { name: "telnyx-agent setup-verify", description: "Zero to verification: creates verify profile, buys number — outputs test command" },
   { name: "telnyx-agent setup-10dlc", description: "Zero to A2P: creates 10DLC brand, campaign, optional number assignment" },
   { name: "telnyx-agent setup-porting", description: "Zero to porting: checks portability, creates porting order, lists requirements, optionally submits" },

--- a/cli/src/commands/capabilities.ts
+++ b/cli/src/commands/capabilities.ts
@@ -42,6 +42,7 @@ const CAPABILITIES: Record<string, Capability[]> = {
   ],
   "⚡ Edge Compute": [
     { name: "Edge Functions", description: "Discover how to pair Telnyx AI workflows with Telnyx Edge Compute. Function lifecycle is owned by the separate telnyx-edge CLI.", actions: ["see_guides_edge_compute"] },
+    { name: "Deployment Handoff", description: "Use team-telnyx/ai for orchestration patterns and telnyx-edge for deploy, secrets, bindings, and lifecycle management.", actions: ["telnyx_edge_ship", "telnyx_edge_secrets", "telnyx_edge_bindings"] },
   ],
   "📋 10DLC Compliance": [
     { name: "10DLC Registration", description: "Register brands and campaigns for US A2P messaging", actions: ["create_10dlc_brand", "create_10dlc_campaign", "assign_10dlc_number"] },

--- a/cli/src/commands/edge-doctor.ts
+++ b/cli/src/commands/edge-doctor.ts
@@ -1,18 +1,21 @@
 /**
  * telnyx-agent edge-doctor — Validate local Edge Compute prerequisites.
  *
- * This is a thin handoff command: it does not deploy or manage Edge Compute
- * directly. It checks that the dedicated `telnyx-edge` CLI is available and
- * gives the user a concrete next step.
+ * Thin handoff only: this does not deploy or manage Edge Compute directly.
+ * It checks that the dedicated `telnyx-edge` CLI is available and whether
+ * it is authenticated, preferring API-key auth for agent use.
  */
 
 import { outputJson, printError, printSuccess, printWarning } from "../utils/output.ts";
-import { getEdgeHelp, hasEdgeCli } from "../edge-cli.ts";
+import { getEdgeAuthStatus, getEdgeHelp, hasEdgeCli, supportsApiKeyAuth } from "../edge-cli.ts";
 
 interface EdgeDoctorResult {
   ready: boolean;
   telnyx_edge_installed: boolean;
   telnyx_edge_version: string | null;
+  authenticated: boolean;
+  auth_mode: "api_key" | "oauth" | "none" | "unknown";
+  api_key_auth_supported: boolean;
   checks: Array<{ name: string; ok: boolean; detail: string }>;
   next_steps: string[];
 }
@@ -23,44 +26,84 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
   const checks: EdgeDoctorResult["checks"] = [];
   let installed = false;
   let version: string | null = null;
+  let authenticated = false;
+  let authMode: EdgeDoctorResult["auth_mode"] = "none";
+  let apiKeyAuthSupported = false;
 
   try {
     const out = getEdgeHelp();
     installed = hasEdgeCli();
     version = extractVersion(out) ?? "installed";
-    checks.push({
-      name: "telnyx-edge installed",
-      ok: true,
-      detail: version,
-    });
+    checks.push({ name: "telnyx-edge installed", ok: true, detail: version });
   } catch (err: any) {
     const detail = err?.code === "ENOENT"
       ? "telnyx-edge not found on PATH"
       : (err?.stderr?.toString?.() || err?.message || "failed to execute telnyx-edge");
-    checks.push({
-      name: "telnyx-edge installed",
-      ok: false,
-      detail,
-    });
+    checks.push({ name: "telnyx-edge installed", ok: false, detail });
   }
 
-  const nextSteps = installed
-    ? [
-        "Run: telnyx-edge auth login",
-        "Start from a real example: telnyx-edge new-func --from-dir=examples/ts/mcp-server --name=my-mcp-server",
-        "Deploy with: telnyx-edge ship",
-        "Then connect your deployed HTTP or MCP boundary back into your AI workflow.",
-      ]
-    : [
-        "Install the dedicated Edge Compute CLI from team-telnyx/edge-compute releases.",
-        "Then run: telnyx-edge auth login",
-        "Then start from a real example such as examples/ts/mcp-server or examples/js/webhook-receiver.",
-      ];
+  if (installed) {
+    apiKeyAuthSupported = supportsApiKeyAuth();
+    checks.push({
+      name: "API-key auth supported",
+      ok: apiKeyAuthSupported,
+      detail: apiKeyAuthSupported ? "auth api-key set is available" : "no auth api-key set support detected",
+    });
+
+    try {
+      const status = getEdgeAuthStatus();
+      authenticated = status.authenticated;
+      authMode = status.mode;
+      checks.push({
+        name: "Authenticated",
+        ok: authenticated,
+        detail: authenticated ? `mode: ${authMode}` : "not authenticated",
+      });
+    } catch (err: any) {
+      checks.push({
+        name: "Authenticated",
+        ok: false,
+        detail: err?.stderr?.toString?.() || err?.message || "failed to read auth status",
+      });
+    }
+  }
+
+  const ready = installed && authenticated;
+
+  let nextSteps: string[];
+  if (!installed) {
+    nextSteps = [
+      "Install the dedicated Edge Compute CLI from team-telnyx/edge-compute releases.",
+      "Then authenticate: telnyx-edge auth api-key set <your-api-key> (preferred) or telnyx-edge auth login",
+      "Then start from a real example such as examples/ts/mcp-server or examples/js/webhook-receiver.",
+    ];
+  } else if (!authenticated) {
+    nextSteps = apiKeyAuthSupported
+      ? [
+          "Authenticate non-interactively: telnyx-edge auth api-key set <your-api-key>",
+          "Verify with: telnyx-edge auth status",
+          "Then start from a real example and deploy with telnyx-edge ship.",
+        ]
+      : [
+          "Authenticate with: telnyx-edge auth login",
+          "Verify with: telnyx-edge auth status",
+          "Then start from a real example and deploy with telnyx-edge ship.",
+        ];
+  } else {
+    nextSteps = [
+      "Start from a real example: telnyx-edge new-func --from-dir=examples/ts/mcp-server --name=my-mcp-server",
+      "Deploy with: telnyx-edge ship",
+      "Then connect the exposed HTTP or MCP boundary back into your AI workflow.",
+    ];
+  }
 
   const result: EdgeDoctorResult = {
-    ready: installed,
+    ready,
     telnyx_edge_installed: installed,
     telnyx_edge_version: version,
+    authenticated,
+    auth_mode: authMode,
+    api_key_auth_supported: apiKeyAuthSupported,
     checks,
     next_steps: nextSteps,
   };
@@ -70,14 +113,21 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
     return;
   }
 
-  if (installed) {
+  if (ready) {
     printSuccess("Edge Compute handoff is ready", {
       "telnyx-edge": version ?? "installed",
+      Auth: authMode,
       Ready: "✓",
     });
   } else {
     printError("Edge Compute handoff is not ready yet.");
-    printWarning("Install telnyx-edge first — team-telnyx/ai does not own Edge lifecycle directly.");
+    if (!installed) {
+      printWarning("Install telnyx-edge first — team-telnyx/ai does not own Edge lifecycle directly.");
+    } else if (!authenticated) {
+      printWarning(apiKeyAuthSupported
+        ? "telnyx-edge is installed but not authenticated. Prefer API-key auth for agents."
+        : "telnyx-edge is installed but not authenticated.");
+    }
   }
 
   console.log("  Checks:");

--- a/cli/src/commands/edge-doctor.ts
+++ b/cli/src/commands/edge-doctor.ts
@@ -1,0 +1,97 @@
+/**
+ * telnyx-agent edge-doctor — Validate local Edge Compute prerequisites.
+ *
+ * This is a thin handoff command: it does not deploy or manage Edge Compute
+ * directly. It checks that the dedicated `telnyx-edge` CLI is available and
+ * gives the user a concrete next step.
+ */
+
+import { outputJson, printError, printSuccess, printWarning } from "../utils/output.ts";
+import { getEdgeHelp, hasEdgeCli } from "../edge-cli.ts";
+
+interface EdgeDoctorResult {
+  ready: boolean;
+  telnyx_edge_installed: boolean;
+  telnyx_edge_version: string | null;
+  checks: Array<{ name: string; ok: boolean; detail: string }>;
+  next_steps: string[];
+}
+
+export async function edgeDoctorCommand(flags: Record<string, string | boolean>): Promise<void> {
+  const jsonOutput = flags.json === true;
+
+  const checks: EdgeDoctorResult["checks"] = [];
+  let installed = false;
+  let version: string | null = null;
+
+  try {
+    const out = getEdgeHelp();
+    installed = hasEdgeCli();
+    version = extractVersion(out) ?? "installed";
+    checks.push({
+      name: "telnyx-edge installed",
+      ok: true,
+      detail: version,
+    });
+  } catch (err: any) {
+    const detail = err?.code === "ENOENT"
+      ? "telnyx-edge not found on PATH"
+      : (err?.stderr?.toString?.() || err?.message || "failed to execute telnyx-edge");
+    checks.push({
+      name: "telnyx-edge installed",
+      ok: false,
+      detail,
+    });
+  }
+
+  const nextSteps = installed
+    ? [
+        "Run: telnyx-edge auth login",
+        "Start from a real example: telnyx-edge new-func --from-dir=examples/ts/mcp-server --name=my-mcp-server",
+        "Deploy with: telnyx-edge ship",
+        "Then connect your deployed HTTP or MCP boundary back into your AI workflow.",
+      ]
+    : [
+        "Install the dedicated Edge Compute CLI from team-telnyx/edge-compute releases.",
+        "Then run: telnyx-edge auth login",
+        "Then start from a real example such as examples/ts/mcp-server or examples/js/webhook-receiver.",
+      ];
+
+  const result: EdgeDoctorResult = {
+    ready: installed,
+    telnyx_edge_installed: installed,
+    telnyx_edge_version: version,
+    checks,
+    next_steps: nextSteps,
+  };
+
+  if (jsonOutput) {
+    outputJson(result);
+    return;
+  }
+
+  if (installed) {
+    printSuccess("Edge Compute handoff is ready", {
+      "telnyx-edge": version ?? "installed",
+      Ready: "✓",
+    });
+  } else {
+    printError("Edge Compute handoff is not ready yet.");
+    printWarning("Install telnyx-edge first — team-telnyx/ai does not own Edge lifecycle directly.");
+  }
+
+  console.log("  Checks:");
+  for (const check of checks) {
+    console.log(`    ${check.ok ? "✓" : "✗"} ${check.name}: ${check.detail}`);
+  }
+  console.log("\n  Next steps:");
+  for (const step of nextSteps) {
+    console.log(`    - ${step}`);
+  }
+  console.log();
+}
+
+function extractVersion(text: string): string | null {
+  const match = text.match(/v?\d+\.\d+\.\d+/);
+  return match?.[0] ?? null;
+}

--- a/cli/src/commands/setup-edge-mcp.ts
+++ b/cli/src/commands/setup-edge-mcp.ts
@@ -1,17 +1,17 @@
 /**
  * telnyx-agent setup-edge-mcp — Thin executable handoff for MCP-on-Edge.
- *
- * This command does not deploy anything itself. It verifies that the dedicated
- * `telnyx-edge` CLI is present and returns the concrete example / commands to
- * start from.
  */
 
 import { outputJson, printError, printSuccess, printWarning } from "../utils/output.ts";
-import { hasEdgeCli } from "../edge-cli.ts";
+import { getEdgeAuthStatus, hasEdgeCli, supportsApiKeyAuth } from "../edge-cli.ts";
 
 interface SetupEdgeMcpResult {
   ready: boolean;
+  authenticated: boolean;
+  auth_mode: "api_key" | "oauth" | "none" | "unknown";
+  api_key_auth_supported: boolean;
   example: string;
+  auth_command: string;
   deploy_command: string;
   prerequisites: string[];
   notes: string[];
@@ -24,15 +24,24 @@ export async function setupEdgeMcpCommand(flags: Record<string, string | boolean
   const name = (flags.name as string) || "my-mcp-server";
 
   const hasEdge = hasEdgeCli();
+  const apiKeyAuthSupported = hasEdge ? supportsApiKeyAuth() : false;
+  const authStatus = hasEdge ? safeAuthStatus() : { authenticated: false, mode: "none" as const };
+  const authCommand = apiKeyAuthSupported
+    ? "telnyx-edge auth api-key set <your-api-key>"
+    : "telnyx-edge auth login";
   const deployCommand = `telnyx-edge new-func --from-dir=${MCP_EXAMPLE} --name=${name} && cd ${name} && telnyx-edge ship`;
 
   const result: SetupEdgeMcpResult = {
-    ready: hasEdge,
+    ready: hasEdge && authStatus.authenticated,
+    authenticated: authStatus.authenticated,
+    auth_mode: authStatus.mode,
+    api_key_auth_supported: apiKeyAuthSupported,
     example: MCP_EXAMPLE,
+    auth_command: authCommand,
     deploy_command: deployCommand,
     prerequisites: [
       "Install telnyx-edge",
-      "Run telnyx-edge auth login",
+      `Authenticate with ${authCommand}`,
       "Use a real Edge Compute example as the starting point",
     ],
     notes: [
@@ -47,17 +56,21 @@ export async function setupEdgeMcpCommand(flags: Record<string, string | boolean
     return;
   }
 
-  if (hasEdge) {
+  if (result.ready) {
     printSuccess("Edge MCP handoff is ready", {
       Example: MCP_EXAMPLE,
+      Auth: authStatus.mode,
       Ready: "✓",
     });
   } else {
-    printError("telnyx-edge is not installed.");
-    printWarning("This command is a handoff helper — it depends on the dedicated Edge Compute CLI.");
+    printError(hasEdge ? "telnyx-edge is not authenticated." : "telnyx-edge is not installed.");
+    printWarning(hasEdge
+      ? `Authenticate first with: ${authCommand}`
+      : "This command is a handoff helper — it depends on the dedicated Edge Compute CLI.");
   }
 
   console.log(`  Example template: ${MCP_EXAMPLE}`);
+  console.log(`  Auth step: ${authCommand}`);
   console.log(`  Suggested flow: ${deployCommand}`);
   console.log("\n  Notes:");
   for (const note of result.notes) {
@@ -66,3 +79,11 @@ export async function setupEdgeMcpCommand(flags: Record<string, string | boolean
   console.log();
 }
 
+function safeAuthStatus(): { authenticated: boolean; mode: "api_key" | "oauth" | "none" | "unknown" } {
+  try {
+    const status = getEdgeAuthStatus();
+    return { authenticated: status.authenticated, mode: status.mode };
+  } catch {
+    return { authenticated: false, mode: "unknown" };
+  }
+}

--- a/cli/src/commands/setup-edge-mcp.ts
+++ b/cli/src/commands/setup-edge-mcp.ts
@@ -1,0 +1,68 @@
+/**
+ * telnyx-agent setup-edge-mcp — Thin executable handoff for MCP-on-Edge.
+ *
+ * This command does not deploy anything itself. It verifies that the dedicated
+ * `telnyx-edge` CLI is present and returns the concrete example / commands to
+ * start from.
+ */
+
+import { outputJson, printError, printSuccess, printWarning } from "../utils/output.ts";
+import { hasEdgeCli } from "../edge-cli.ts";
+
+interface SetupEdgeMcpResult {
+  ready: boolean;
+  example: string;
+  deploy_command: string;
+  prerequisites: string[];
+  notes: string[];
+}
+
+const MCP_EXAMPLE = "examples/ts/mcp-server";
+
+export async function setupEdgeMcpCommand(flags: Record<string, string | boolean>): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const name = (flags.name as string) || "my-mcp-server";
+
+  const hasEdge = hasEdgeCli();
+  const deployCommand = `telnyx-edge new-func --from-dir=${MCP_EXAMPLE} --name=${name} && cd ${name} && telnyx-edge ship`;
+
+  const result: SetupEdgeMcpResult = {
+    ready: hasEdge,
+    example: MCP_EXAMPLE,
+    deploy_command: deployCommand,
+    prerequisites: [
+      "Install telnyx-edge",
+      "Run telnyx-edge auth login",
+      "Use a real Edge Compute example as the starting point",
+    ],
+    notes: [
+      "team-telnyx/ai provides the integration pattern, not the Edge lifecycle.",
+      "Use telnyx-edge for auth, deploy, secrets, bindings, and lifecycle management.",
+      "After deploy, connect the exposed MCP or HTTP boundary back into your AI workflow.",
+    ],
+  };
+
+  if (jsonOutput) {
+    outputJson(result);
+    return;
+  }
+
+  if (hasEdge) {
+    printSuccess("Edge MCP handoff is ready", {
+      Example: MCP_EXAMPLE,
+      Ready: "✓",
+    });
+  } else {
+    printError("telnyx-edge is not installed.");
+    printWarning("This command is a handoff helper — it depends on the dedicated Edge Compute CLI.");
+  }
+
+  console.log(`  Example template: ${MCP_EXAMPLE}`);
+  console.log(`  Suggested flow: ${deployCommand}`);
+  console.log("\n  Notes:");
+  for (const note of result.notes) {
+    console.log(`    - ${note}`);
+  }
+  console.log();
+}
+

--- a/cli/src/commands/setup-edge-webhook.ts
+++ b/cli/src/commands/setup-edge-webhook.ts
@@ -3,11 +3,15 @@
  */
 
 import { outputJson, printError, printSuccess, printWarning } from "../utils/output.ts";
-import { hasEdgeCli } from "../edge-cli.ts";
+import { getEdgeAuthStatus, hasEdgeCli, supportsApiKeyAuth } from "../edge-cli.ts";
 
 interface SetupEdgeWebhookResult {
   ready: boolean;
+  authenticated: boolean;
+  auth_mode: "api_key" | "oauth" | "none" | "unknown";
+  api_key_auth_supported: boolean;
   example: string;
+  auth_command: string;
   deploy_command: string;
   prerequisites: string[];
   notes: string[];
@@ -20,15 +24,24 @@ export async function setupEdgeWebhookCommand(flags: Record<string, string | boo
   const name = (flags.name as string) || "my-webhook-receiver";
 
   const hasEdge = hasEdgeCli();
+  const apiKeyAuthSupported = hasEdge ? supportsApiKeyAuth() : false;
+  const authStatus = hasEdge ? safeAuthStatus() : { authenticated: false, mode: "none" as const };
+  const authCommand = apiKeyAuthSupported
+    ? "telnyx-edge auth api-key set <your-api-key>"
+    : "telnyx-edge auth login";
   const deployCommand = `telnyx-edge new-func --from-dir=${WEBHOOK_EXAMPLE} --name=${name} && cd ${name} && telnyx-edge ship`;
 
   const result: SetupEdgeWebhookResult = {
-    ready: hasEdge,
+    ready: hasEdge && authStatus.authenticated,
+    authenticated: authStatus.authenticated,
+    auth_mode: authStatus.mode,
+    api_key_auth_supported: apiKeyAuthSupported,
     example: WEBHOOK_EXAMPLE,
+    auth_command: authCommand,
     deploy_command: deployCommand,
     prerequisites: [
       "Install telnyx-edge",
-      "Run telnyx-edge auth login",
+      `Authenticate with ${authCommand}`,
       "Start from the webhook receiver example",
     ],
     notes: [
@@ -43,17 +56,21 @@ export async function setupEdgeWebhookCommand(flags: Record<string, string | boo
     return;
   }
 
-  if (hasEdge) {
+  if (result.ready) {
     printSuccess("Edge webhook handoff is ready", {
       Example: WEBHOOK_EXAMPLE,
+      Auth: authStatus.mode,
       Ready: "✓",
     });
   } else {
-    printError("telnyx-edge is not installed.");
-    printWarning("This command is a handoff helper — it depends on the dedicated Edge Compute CLI.");
+    printError(hasEdge ? "telnyx-edge is not authenticated." : "telnyx-edge is not installed.");
+    printWarning(hasEdge
+      ? `Authenticate first with: ${authCommand}`
+      : "This command is a handoff helper — it depends on the dedicated Edge Compute CLI.");
   }
 
   console.log(`  Example template: ${WEBHOOK_EXAMPLE}`);
+  console.log(`  Auth step: ${authCommand}`);
   console.log(`  Suggested flow: ${deployCommand}`);
   console.log("\n  Notes:");
   for (const note of result.notes) {
@@ -62,3 +79,11 @@ export async function setupEdgeWebhookCommand(flags: Record<string, string | boo
   console.log();
 }
 
+function safeAuthStatus(): { authenticated: boolean; mode: "api_key" | "oauth" | "none" | "unknown" } {
+  try {
+    const status = getEdgeAuthStatus();
+    return { authenticated: status.authenticated, mode: status.mode };
+  } catch {
+    return { authenticated: false, mode: "unknown" };
+  }
+}

--- a/cli/src/commands/setup-edge-webhook.ts
+++ b/cli/src/commands/setup-edge-webhook.ts
@@ -1,0 +1,64 @@
+/**
+ * telnyx-agent setup-edge-webhook — Thin executable handoff for webhook-on-Edge.
+ */
+
+import { outputJson, printError, printSuccess, printWarning } from "../utils/output.ts";
+import { hasEdgeCli } from "../edge-cli.ts";
+
+interface SetupEdgeWebhookResult {
+  ready: boolean;
+  example: string;
+  deploy_command: string;
+  prerequisites: string[];
+  notes: string[];
+}
+
+const WEBHOOK_EXAMPLE = "examples/js/webhook-receiver";
+
+export async function setupEdgeWebhookCommand(flags: Record<string, string | boolean>): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const name = (flags.name as string) || "my-webhook-receiver";
+
+  const hasEdge = hasEdgeCli();
+  const deployCommand = `telnyx-edge new-func --from-dir=${WEBHOOK_EXAMPLE} --name=${name} && cd ${name} && telnyx-edge ship`;
+
+  const result: SetupEdgeWebhookResult = {
+    ready: hasEdge,
+    example: WEBHOOK_EXAMPLE,
+    deploy_command: deployCommand,
+    prerequisites: [
+      "Install telnyx-edge",
+      "Run telnyx-edge auth login",
+      "Start from the webhook receiver example",
+    ],
+    notes: [
+      "Use this when your AI workflow needs an HTTP ingress point at the edge.",
+      "The deployed function lifecycle is still owned by telnyx-edge.",
+      "After deploy, point your webhook-producing system at the Edge endpoint and let team-telnyx/ai handle orchestration guidance.",
+    ],
+  };
+
+  if (jsonOutput) {
+    outputJson(result);
+    return;
+  }
+
+  if (hasEdge) {
+    printSuccess("Edge webhook handoff is ready", {
+      Example: WEBHOOK_EXAMPLE,
+      Ready: "✓",
+    });
+  } else {
+    printError("telnyx-edge is not installed.");
+    printWarning("This command is a handoff helper — it depends on the dedicated Edge Compute CLI.");
+  }
+
+  console.log(`  Example template: ${WEBHOOK_EXAMPLE}`);
+  console.log(`  Suggested flow: ${deployCommand}`);
+  console.log("\n  Notes:");
+  for (const note of result.notes) {
+    console.log(`    - ${note}`);
+  }
+  console.log();
+}
+

--- a/cli/src/edge-cli.ts
+++ b/cli/src/edge-cli.ts
@@ -4,14 +4,18 @@ export function resolveEdgeBinary(): string {
   return process.env.TELNYX_EDGE_PATH || "telnyx-edge";
 }
 
+function runEdge(args: string[]): string {
+  return execFileSync(resolveEdgeBinary(), args, {
+    encoding: "utf8",
+    timeout: 15000,
+    env: { ...process.env },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
 export function hasEdgeCli(): boolean {
   try {
-    execFileSync(resolveEdgeBinary(), ["--help"], {
-      encoding: "utf8",
-      timeout: 15000,
-      env: { ...process.env },
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    runEdge(["--help"]);
     return true;
   } catch {
     return false;
@@ -19,10 +23,37 @@ export function hasEdgeCli(): boolean {
 }
 
 export function getEdgeHelp(): string {
-  return execFileSync(resolveEdgeBinary(), ["--help"], {
-    encoding: "utf8",
-    timeout: 15000,
-    env: { ...process.env },
-    stdio: ["ignore", "pipe", "pipe"],
-  });
+  return runEdge(["--help"]);
+}
+
+export type EdgeAuthStatus = {
+  authenticated: boolean;
+  mode: "api_key" | "oauth" | "none" | "unknown";
+  raw: string;
+};
+
+export function getEdgeAuthStatus(): EdgeAuthStatus {
+  const raw = runEdge(["auth", "status"]);
+  const text = raw.toLowerCase();
+  const authenticated = !text.includes("not authenticated") && !text.includes("status: ❌");
+
+  let mode: EdgeAuthStatus["mode"] = "unknown";
+  if (text.includes("not authenticated") || text.includes("status: ❌")) {
+    mode = "none";
+  } else if (text.includes("api key")) {
+    mode = "api_key";
+  } else if (text.includes("oauth") || text.includes("browser") || text.includes("logged in")) {
+    mode = "oauth";
+  }
+
+  return { authenticated, mode, raw };
+}
+
+export function supportsApiKeyAuth(): boolean {
+  try {
+    const out = runEdge(["auth", "api-key", "set", "--help"]);
+    return /Set API key for authentication/i.test(out);
+  } catch {
+    return false;
+  }
 }

--- a/cli/src/edge-cli.ts
+++ b/cli/src/edge-cli.ts
@@ -35,14 +35,31 @@ export type EdgeAuthStatus = {
 export function getEdgeAuthStatus(): EdgeAuthStatus {
   const raw = runEdge(["auth", "status"]);
   const text = raw.toLowerCase();
-  const authenticated = !text.includes("not authenticated") && !text.includes("status: ❌");
+  const authenticated =
+    !text.includes("authentication status: none") &&
+    !text.includes("not authenticated") &&
+    !text.includes("status: ❌") &&
+    !text.includes("status: x");
 
   let mode: EdgeAuthStatus["mode"] = "unknown";
-  if (text.includes("not authenticated") || text.includes("status: ❌")) {
+  if (
+    text.includes("authentication status: none") ||
+    text.includes("not authenticated") ||
+    text.includes("status: ❌") ||
+    text.includes("status: x")
+  ) {
     mode = "none";
-  } else if (text.includes("api key")) {
+  } else if (
+    text.includes("authentication status: api key") ||
+    text.includes("api key")
+  ) {
     mode = "api_key";
-  } else if (text.includes("oauth") || text.includes("browser") || text.includes("logged in")) {
+  } else if (
+    text.includes("authentication status: oauth") ||
+    text.includes("oauth") ||
+    text.includes("browser") ||
+    text.includes("logged in")
+  ) {
     mode = "oauth";
   }
 

--- a/cli/src/edge-cli.ts
+++ b/cli/src/edge-cli.ts
@@ -1,0 +1,28 @@
+import { execFileSync } from "node:child_process";
+
+export function resolveEdgeBinary(): string {
+  return process.env.TELNYX_EDGE_PATH || "telnyx-edge";
+}
+
+export function hasEdgeCli(): boolean {
+  try {
+    execFileSync(resolveEdgeBinary(), ["--help"], {
+      encoding: "utf8",
+      timeout: 15000,
+      env: { ...process.env },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function getEdgeHelp(): string {
+  return execFileSync(resolveEdgeBinary(), ["--help"], {
+    encoding: "utf8",
+    timeout: 15000,
+    env: { ...process.env },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -10,6 +10,9 @@ import { setupWireguardCommand } from "./commands/setup-wireguard.ts";
 import { setupVerifyCommand } from "./commands/setup-verify.ts";
 import { setup10dlcCommand } from "./commands/setup-10dlc.ts";
 import { setupPortingCommand } from "./commands/setup-porting.ts";
+import { edgeDoctorCommand } from "./commands/edge-doctor.ts";
+import { setupEdgeMcpCommand } from "./commands/setup-edge-mcp.ts";
+import { setupEdgeWebhookCommand } from "./commands/setup-edge-webhook.ts";
 import { capabilitiesCommand } from "./commands/capabilities.ts";
 import { statusCommand } from "./commands/status.ts";
 import { fundAccountCommand } from "./commands/fund-account.ts";
@@ -30,6 +33,9 @@ Commands:
   setup-verify      Zero to verification: create profile, buy number
   setup-10dlc       Zero to A2P: create brand, campaign, assign number
   setup-porting     Zero to porting: check portability, create order, submit
+  edge-doctor       Validate Edge Compute prerequisites and handoff readiness
+  setup-edge-mcp    Handoff to an Edge-hosted MCP server example
+  setup-edge-webhook Handoff to an Edge-hosted webhook receiver example
   status            Account health overview
   capabilities      List all available API capabilities
   fund-account      Fund account via x402 USDC payment (EIP-712 signing)
@@ -75,6 +81,9 @@ Examples:
   telnyx-agent setup-voice --webhook https://example.com/calls
   telnyx-agent setup-ai --instructions "You are a pizza ordering bot"
   telnyx-agent setup-porting --phone-numbers +13125550001,+13125550002 --customer-name "Acme Corp"
+  telnyx-agent edge-doctor --json
+  telnyx-agent setup-edge-mcp --name my-mcp-server
+  telnyx-agent setup-edge-webhook --name my-webhook
   telnyx-agent fund-account --amount 50.00
   telnyx-agent fund-account --amount 50.00 --wallet-key 0x... --json
 `;
@@ -88,6 +97,9 @@ const COMMANDS: Record<string, (flags: Record<string, string | boolean>) => Prom
   "setup-verify": setupVerifyCommand,
   "setup-10dlc": setup10dlcCommand,
   "setup-porting": setupPortingCommand,
+  "edge-doctor": edgeDoctorCommand,
+  "setup-edge-mcp": setupEdgeMcpCommand,
+  "setup-edge-webhook": setupEdgeWebhookCommand,
   capabilities: capabilitiesCommand,
   status: statusCommand,
   "fund-account": fundAccountCommand,

--- a/cli/src/utils/output.ts
+++ b/cli/src/utils/output.ts
@@ -40,7 +40,31 @@ export function printWarning(message: string): void {
 }
 
 export function outputJson(data: unknown): void {
-  console.log(JSON.stringify(data, null, 2));
+  console.log(JSON.stringify(redactSensitive(data), null, 2));
+}
+
+function redactSensitive<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => redactSensitive(item)) as T;
+  }
+
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+      if (isSensitiveKey(key)) {
+        out[key] = "[REDACTED]";
+      } else {
+        out[key] = redactSensitive(nested);
+      }
+    }
+    return out as T;
+  }
+
+  return value;
+}
+
+function isSensitiveKey(key: string): boolean {
+  return /(^|_)(password|passphrase|secret|token|api_key)$/i.test(key) || /^sipPassword$/i.test(key);
 }
 
 export function parseFlags(args: string[]): { command: string; flags: Record<string, string | boolean> } {

--- a/cli/tests/edge-handoff.test.ts
+++ b/cli/tests/edge-handoff.test.ts
@@ -9,7 +9,7 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CLI = join(__dirname, "..", "bin", "telnyx-agent.ts");
 
-function withFakeEdgeCli() {
+function withFakeEdgeCli(mode: "none" | "oauth" | "api_key" = "api_key") {
   const tempDir = mkdtempSync(join(tmpdir(), "telnyx-edge-fake-"));
   const binDir = join(tempDir, "bin");
   mkdirSync(binDir, { recursive: true });
@@ -17,11 +17,32 @@ function withFakeEdgeCli() {
   writeFileSync(
     fakeEdge,
     `#!/usr/bin/env node
-if (process.argv.includes("--help")) {
-  console.log(["telnyx-edge v0.1.0", "Commands: auth login, ship, list, secrets, bindings"].join("\\n"));
+const args = process.argv.slice(2);
+if (args[0] === 'auth' && args[1] === 'api-key' && args[2] === 'set' && args.includes('--help')) {
+  console.log('Set API key for authentication. The API key must be provided as an argument.');
   process.exit(0);
 }
-console.log("ok");
+if (args.includes('--help')) {
+  console.log(['telnyx-edge v0.1.0', 'Commands: auth login, auth api-key set, ship, list, secrets, bindings'].join('\\n'));
+  process.exit(0);
+}
+if (args[0] === 'auth' && args[1] === 'status') {
+  if ('${mode}' === 'none') {
+    console.log(['API Endpoint: https://api.telnyx.com', '', 'Authentication Status: None', 'Status: ❌ Not authenticated', "Run 'telnyx-edge auth login' or 'telnyx-edge auth api-key set <api_key>' to authenticate"].join('\\n'));
+    process.exit(0);
+  }
+  if ('${mode}' === 'oauth') {
+    console.log(['API Endpoint: https://api.telnyx.com', '', 'Authentication Status: OAuth', 'Status: ✅ Authenticated'].join('\\n'));
+    process.exit(0);
+  }
+  console.log(['API Endpoint: https://api.telnyx.com', '', 'Authentication Status: API Key', 'Status: ✅ Authenticated'].join('\\n'));
+  process.exit(0);
+}
+if (args[0] === 'auth' && args[1] === 'api-key' && args[2] === 'clear' && args.includes('--help')) {
+  console.log('Remove the stored API key from the configuration');
+  process.exit(0);
+}
+console.log('ok');
 `,
   );
   chmodSync(fakeEdge, 0o755);
@@ -45,52 +66,63 @@ function run(args: string[], env?: NodeJS.ProcessEnv): string {
 describe("CLI — Edge Compute handoff", () => {
   it("help lists edge handoff commands", () => {
     const output = run(["help"]);
-    assert.ok(output.includes("edge-doctor"), "Should list edge-doctor");
-    assert.ok(output.includes("setup-edge-mcp"), "Should list setup-edge-mcp");
-    assert.ok(output.includes("setup-edge-webhook"), "Should list setup-edge-webhook");
+    assert.ok(output.includes("edge-doctor"));
+    assert.ok(output.includes("setup-edge-mcp"));
+    assert.ok(output.includes("setup-edge-webhook"));
   });
 
   it("capabilities JSON includes edge handoff entries", () => {
     const output = run(["capabilities", "--json"]);
     const data = JSON.parse(output);
-    const networkingLike = Object.keys(data.api_capabilities || {}).find((k) => k.includes("Edge Compute"));
-    assert.ok(networkingLike, "Should include Edge Compute category");
-
+    const category = Object.keys(data.api_capabilities || {}).find((k) => k.includes("Edge Compute"));
+    assert.ok(category);
     const commands = data.composite_commands.map((c: any) => c.name || c.command || c);
-    assert.ok(commands.some((c: string) => c.includes("edge-doctor")), "Should advertise edge-doctor");
-    assert.ok(commands.some((c: string) => c.includes("setup-edge-mcp")), "Should advertise setup-edge-mcp");
-    assert.ok(commands.some((c: string) => c.includes("setup-edge-webhook")), "Should advertise setup-edge-webhook");
+    assert.ok(commands.some((c: string) => c.includes("edge-doctor")));
+    assert.ok(commands.some((c: string) => c.includes("setup-edge-mcp")));
+    assert.ok(commands.some((c: string) => c.includes("setup-edge-webhook")));
   });
 
-  it("edge-doctor reports ready when telnyx-edge is installed", () => {
-    const fake = withFakeEdgeCli();
+  it("edge-doctor reports API-key auth support and readiness", () => {
+    const fake = withFakeEdgeCli("api_key");
     const output = run(["edge-doctor", "--json"], fake.env);
     const data = JSON.parse(output);
-    if (process.env.DEBUG_EDGE_TESTS) console.log("edge-doctor output", data);
     assert.equal(data.ready, true);
     assert.equal(data.telnyx_edge_installed, true);
+    assert.equal(data.authenticated, true);
+    assert.equal(data.auth_mode, "api_key");
+    assert.equal(data.api_key_auth_supported, true);
     assert.ok(Array.isArray(data.next_steps));
   });
 
-  it("setup-edge-mcp returns a concrete deploy handoff", () => {
-    const fake = withFakeEdgeCli();
+  it("edge-doctor shows unauthenticated but installable state", () => {
+    const fake = withFakeEdgeCli("none");
+    const output = run(["edge-doctor", "--json"], fake.env);
+    const data = JSON.parse(output);
+    assert.equal(data.ready, false);
+    assert.equal(data.telnyx_edge_installed, true);
+    assert.equal(data.authenticated, false);
+    assert.equal(data.api_key_auth_supported, true);
+    assert.ok(data.next_steps.some((s: string) => s.includes("auth api-key set")));
+  });
+
+  it("setup-edge-mcp returns API-key auth handoff when unauthenticated", () => {
+    const fake = withFakeEdgeCli("none");
     const output = run(["setup-edge-mcp", "--json", "--name", "demo-mcp"], fake.env);
     const data = JSON.parse(output);
-    if (process.env.DEBUG_EDGE_TESTS) console.log("setup-edge-mcp output", data);
-    assert.equal(data.ready, true);
+    assert.equal(data.ready, false);
+    assert.equal(data.api_key_auth_supported, true);
+    assert.equal(data.auth_command, "telnyx-edge auth api-key set <your-api-key>");
     assert.equal(data.example, "examples/ts/mcp-server");
-    assert.ok(data.deploy_command.includes("telnyx-edge new-func"));
     assert.ok(data.deploy_command.includes("demo-mcp"));
   });
 
-  it("setup-edge-webhook returns a concrete deploy handoff", () => {
-    const fake = withFakeEdgeCli();
+  it("setup-edge-webhook returns concrete deploy handoff", () => {
+    const fake = withFakeEdgeCli("api_key");
     const output = run(["setup-edge-webhook", "--json", "--name", "demo-webhook"], fake.env);
     const data = JSON.parse(output);
-    if (process.env.DEBUG_EDGE_TESTS) console.log("setup-edge-webhook output", data);
     assert.equal(data.ready, true);
+    assert.equal(data.auth_mode, "api_key");
     assert.equal(data.example, "examples/js/webhook-receiver");
-    assert.ok(data.deploy_command.includes("telnyx-edge new-func"));
     assert.ok(data.deploy_command.includes("demo-webhook"));
   });
 });

--- a/cli/tests/edge-handoff.test.ts
+++ b/cli/tests/edge-handoff.test.ts
@@ -1,0 +1,96 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI = join(__dirname, "..", "bin", "telnyx-agent.ts");
+
+function withFakeEdgeCli() {
+  const tempDir = mkdtempSync(join(tmpdir(), "telnyx-edge-fake-"));
+  const binDir = join(tempDir, "bin");
+  mkdirSync(binDir, { recursive: true });
+  const fakeEdge = join(binDir, "telnyx-edge");
+  writeFileSync(
+    fakeEdge,
+    `#!/usr/bin/env node
+if (process.argv.includes("--help")) {
+  console.log(["telnyx-edge v0.1.0", "Commands: auth login, ship, list, secrets, bindings"].join("\\n"));
+  process.exit(0);
+}
+console.log("ok");
+`,
+  );
+  chmodSync(fakeEdge, 0o755);
+  return {
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH}`,
+      TELNYX_EDGE_PATH: fakeEdge,
+    },
+  };
+}
+
+function run(args: string[], env?: NodeJS.ProcessEnv): string {
+  return execFileSync("npx", ["tsx", CLI, ...args], {
+    encoding: "utf8",
+    timeout: 30000,
+    env: env ?? { ...process.env },
+  });
+}
+
+describe("CLI — Edge Compute handoff", () => {
+  it("help lists edge handoff commands", () => {
+    const output = run(["help"]);
+    assert.ok(output.includes("edge-doctor"), "Should list edge-doctor");
+    assert.ok(output.includes("setup-edge-mcp"), "Should list setup-edge-mcp");
+    assert.ok(output.includes("setup-edge-webhook"), "Should list setup-edge-webhook");
+  });
+
+  it("capabilities JSON includes edge handoff entries", () => {
+    const output = run(["capabilities", "--json"]);
+    const data = JSON.parse(output);
+    const networkingLike = Object.keys(data.api_capabilities || {}).find((k) => k.includes("Edge Compute"));
+    assert.ok(networkingLike, "Should include Edge Compute category");
+
+    const commands = data.composite_commands.map((c: any) => c.name || c.command || c);
+    assert.ok(commands.some((c: string) => c.includes("edge-doctor")), "Should advertise edge-doctor");
+    assert.ok(commands.some((c: string) => c.includes("setup-edge-mcp")), "Should advertise setup-edge-mcp");
+    assert.ok(commands.some((c: string) => c.includes("setup-edge-webhook")), "Should advertise setup-edge-webhook");
+  });
+
+  it("edge-doctor reports ready when telnyx-edge is installed", () => {
+    const fake = withFakeEdgeCli();
+    const output = run(["edge-doctor", "--json"], fake.env);
+    const data = JSON.parse(output);
+    if (process.env.DEBUG_EDGE_TESTS) console.log("edge-doctor output", data);
+    assert.equal(data.ready, true);
+    assert.equal(data.telnyx_edge_installed, true);
+    assert.ok(Array.isArray(data.next_steps));
+  });
+
+  it("setup-edge-mcp returns a concrete deploy handoff", () => {
+    const fake = withFakeEdgeCli();
+    const output = run(["setup-edge-mcp", "--json", "--name", "demo-mcp"], fake.env);
+    const data = JSON.parse(output);
+    if (process.env.DEBUG_EDGE_TESTS) console.log("setup-edge-mcp output", data);
+    assert.equal(data.ready, true);
+    assert.equal(data.example, "examples/ts/mcp-server");
+    assert.ok(data.deploy_command.includes("telnyx-edge new-func"));
+    assert.ok(data.deploy_command.includes("demo-mcp"));
+  });
+
+  it("setup-edge-webhook returns a concrete deploy handoff", () => {
+    const fake = withFakeEdgeCli();
+    const output = run(["setup-edge-webhook", "--json", "--name", "demo-webhook"], fake.env);
+    const data = JSON.parse(output);
+    if (process.env.DEBUG_EDGE_TESTS) console.log("setup-edge-webhook output", data);
+    assert.equal(data.ready, true);
+    assert.equal(data.example, "examples/js/webhook-receiver");
+    assert.ok(data.deploy_command.includes("telnyx-edge new-func"));
+    assert.ok(data.deploy_command.includes("demo-webhook"));
+  });
+});

--- a/guides/edge-compute.md
+++ b/guides/edge-compute.md
@@ -1,0 +1,120 @@
+# Edge Compute
+
+Use Telnyx Edge Compute when your AI workflow needs low-latency code execution, webhook handling, or an MCP/webhook endpoint that runs on Telnyx edge infrastructure.
+
+## Important scope boundary
+
+`team-telnyx/ai` does **not** manage Edge Compute lifecycle directly.
+
+This repo helps you discover where Edge Compute fits into an AI workflow, but the actual function lifecycle is owned by:
+
+- the `team-telnyx/edge-compute` repo
+- the `telnyx-edge` CLI
+
+That means:
+- build/deploy/delete/secrets/bindings live in `telnyx-edge`
+- agent/orchestration logic can live in `team-telnyx/ai`
+- `team-telnyx/ai` should not pretend to replace Edge Compute
+
+A useful mental model:
+- **`ai` = brain / orchestration layer**
+- **Edge Compute = low-latency hands / execution layer**
+
+## When to use Edge Compute with `ai`
+
+Good bridge use cases:
+
+1. **MCP server adapters at the edge**
+   - expose AI-adjacent tools close to the runtime
+2. **Webhook ingestion + AI routing**
+   - receive webhook traffic, normalize it, then hand off to AI logic
+3. **AI-adjacent functions**
+   - redaction, enrichment, scoring, post-processing, lightweight transforms
+
+## Prerequisite: install `telnyx-edge`
+
+Edge Compute is managed through the separate CLI:
+
+```sh
+# See the edge-compute repo for install/setup details
+# https://github.com/team-telnyx/edge-compute
+
+telnyx-edge auth login
+telnyx-edge status
+```
+
+Typical lifecycle commands live there:
+
+```sh
+telnyx-edge new-func
+telnyx-edge ship
+telnyx-edge list
+telnyx-edge delete-func
+telnyx-edge secrets
+telnyx-edge bindings
+```
+
+## Reference architecture
+
+A practical pattern looks like this:
+
+1. Use `team-telnyx/ai` for:
+   - agent workflows
+   - prompts/orchestration
+   - guides and capability discovery
+   - Telnyx API integrations
+2. Use `team-telnyx/edge-compute` for:
+   - function scaffolding
+   - deployment
+   - secrets and bindings
+   - running webhook/MCP edge endpoints
+3. Connect them with a stable boundary:
+   - HTTP webhook
+   - MCP endpoint
+   - function call into an edge-hosted adapter
+
+## Example: AI app calling an Edge endpoint
+
+A simple pattern is to let your AI app call a deployed edge function for specialized execution.
+
+```ts
+const response = await fetch("https://<your-edge-endpoint>", {
+  method: "POST",
+  headers: {
+    "content-type": "application/json",
+    authorization: `Bearer ${process.env.TELNYX_API_KEY}`,
+  },
+  body: JSON.stringify({
+    task: "redact_pii",
+    payload: {
+      text: "Call me at +1 555 123 4567",
+    },
+  }),
+});
+
+const result = await response.json();
+console.log(result);
+```
+
+## What this repo should and should not claim
+
+This repo **can**:
+- explain how Edge Compute fits into AI-agent workflows
+- provide examples and bridge guidance
+- point users to the right product surface
+
+This repo **should not** claim that it:
+- deploys edge functions directly
+- manages rollbacks or lifecycle state
+- replaces `telnyx-edge`
+- provides complete native Edge Compute support
+
+## Best next step
+
+If you want to use Edge Compute from an AI workflow today:
+
+1. install and authenticate `telnyx-edge`
+2. create/deploy your function in `team-telnyx/edge-compute`
+3. use `team-telnyx/ai` to orchestrate calls into that deployed endpoint
+
+For deploy/runtime specifics, use the `edge-compute` repo as the source of truth.

--- a/guides/edge-compute.md
+++ b/guides/edge-compute.md
@@ -170,6 +170,42 @@ Use Edge Compute for deterministic transforms such as:
 
 These are the sweet spot: small execution units attached to larger agent workflows.
 
+## Fastest path to a real test
+
+If you want to test the end product quickly, do **one** of these first:
+
+### Option A — MCP server on Edge
+Best when you want an AI-native demo.
+
+```sh
+telnyx-edge new-func --from-dir=examples/ts/mcp-server --name=my-mcp-server
+cd my-mcp-server
+telnyx-edge secrets add TELNYX_API_KEY <your-api-key>
+telnyx-edge ship
+```
+
+Then point your MCP client or agent runtime at the deployed endpoint.
+
+### Option B — Webhook receiver on Edge
+Best when you want a simple integration seam.
+
+```sh
+telnyx-edge new-func --from-dir=examples/js/webhook-receiver --name=my-webhook
+cd my-webhook
+telnyx-edge ship
+```
+
+Then have your AI workflow call or route into that edge endpoint.
+
+### Option C — Post-processing function
+Best when you want a narrow but real AI-adjacent utility.
+
+Example use cases:
+- redact PII before storage
+- enrich messages before downstream routing
+- score or classify inbound events
+- clean transcripts before analysis
+
 ## What this repo should and should not claim
 
 This repo **can**:
@@ -182,6 +218,19 @@ This repo **should not** claim that it:
 - manages rollbacks or lifecycle state
 - replaces `telnyx-edge`
 - provides complete native Edge Compute support
+
+## Test recipe
+
+Here is the most practical end-to-end test loop:
+
+1. install and authenticate `telnyx-edge`
+2. start from a working example in `team-telnyx/edge-compute`
+3. deploy it with `telnyx-edge ship`
+4. expose a stable HTTP or MCP boundary
+5. call that deployed endpoint from an AI workflow
+6. iterate on the boundary, not on duplicated deployment logic
+
+That gives you a real integration test without pretending `team-telnyx/ai` owns lifecycle management.
 
 ## Best next step
 

--- a/guides/edge-compute.md
+++ b/guides/edge-compute.md
@@ -73,6 +73,62 @@ A practical pattern looks like this:
    - MCP endpoint
    - function call into an edge-hosted adapter
 
+## Endgame: what a good integration looks like
+
+The end state is **not** "move Edge Compute into `team-telnyx/ai`".
+
+The better endgame is a clear two-layer product:
+
+### Layer 1 — `team-telnyx/ai`
+This layer should:
+- expose Edge Compute as a first-class capability in docs/manifests/help output
+- provide AI-oriented patterns and recipes
+- explain when an agent should reach for edge execution
+- help users connect agent workflows to deployed edge endpoints
+
+### Layer 2 — `team-telnyx/edge-compute`
+This layer should continue to own:
+- auth
+- function creation
+- deployment
+- secrets
+- bindings
+- runtime lifecycle and operational ergonomics
+
+### Bridge between them
+The bridge should be explicit and boring:
+- `ai` produces orchestration guidance
+- Edge Compute provides execution endpoints
+- the contract between them is HTTP, MCP, or a documented function interface
+
+That keeps ownership clear and avoids duplicating deployment tooling.
+
+## Phased rollout
+
+### Phase 1 — Discoverability (this repo, now)
+- add Edge Compute capability visibility
+- add guide-level handoff and examples
+- make the README and capabilities output honest about scope
+
+### Phase 2 — Guided integration
+- add richer examples for webhook handlers, MCP adapters, and AI post-processing functions
+- add copy-paste scaffolds for how an AI app should call a deployed edge endpoint
+- document required secrets/bindings patterns
+
+### Phase 3 — CLI bridge
+Only if ownership stays clear:
+- lightweight helper commands or docs-driven handoff from `telnyx-agent` to `telnyx-edge`
+- examples: `edge doctor`, `setup-edge-mcp`, or explicit "next command" guidance
+- these should shell out to `telnyx-edge`, not reimplement lifecycle management
+
+### Phase 4 — Deeper integration (optional, later)
+Only if a stable contract exists:
+- standardized templates
+- stronger config generation
+- possibly a shared library or interface contract
+
+Not before.
+
 ## Example: AI app calling an Edge endpoint
 
 A simple pattern is to let your AI app call a deployed edge function for specialized execution.
@@ -96,6 +152,24 @@ const result = await response.json();
 console.log(result);
 ```
 
+## Example patterns worth supporting
+
+### 1. MCP server at the edge
+Use Edge Compute to host a narrow MCP adapter close to runtime, while `team-telnyx/ai` handles the surrounding agent experience and capability discovery.
+
+### 2. Webhook receiver + AI router
+Use Edge Compute to receive inbound webhooks, normalize payloads, and forward structured requests into AI workflows.
+
+### 3. Post-processing function
+Use Edge Compute for deterministic transforms such as:
+- redaction
+- enrichment
+- scoring
+- transcript cleanup
+- lightweight policy checks
+
+These are the sweet spot: small execution units attached to larger agent workflows.
+
 ## What this repo should and should not claim
 
 This repo **can**:
@@ -115,6 +189,13 @@ If you want to use Edge Compute from an AI workflow today:
 
 1. install and authenticate `telnyx-edge`
 2. create/deploy your function in `team-telnyx/edge-compute`
-3. use `team-telnyx/ai` to orchestrate calls into that deployed endpoint
+3. expose a stable HTTP or MCP boundary
+4. use `team-telnyx/ai` to orchestrate calls into that deployed endpoint
 
 For deploy/runtime specifics, use the `edge-compute` repo as the source of truth.
+
+## Source of truth
+
+- AI workflow/orchestration guidance: `team-telnyx/ai`
+- Edge lifecycle and deployment: `team-telnyx/edge-compute`
+- Runtime deploy tool: `telnyx-edge`

--- a/guides/edge-compute.md
+++ b/guides/edge-compute.md
@@ -31,6 +31,51 @@ Good bridge use cases:
 3. **AI-adjacent functions**
    - redaction, enrichment, scoring, post-processing, lightweight transforms
 
+## Quick Start
+
+```bash
+# Authenticate with the dedicated Edge CLI
+telnyx-edge auth login
+
+# Start from the MCP server example
+telnyx-edge new-func --from-dir=examples/ts/mcp-server --name=my-mcp-server
+cd my-mcp-server
+
+# Add required secrets and deploy
+telnyx-edge secrets add TELNYX_API_KEY <your-api-key>
+telnyx-edge ship
+```
+
+Once deployed, use `team-telnyx/ai` for orchestration and capability discovery, and use the deployed Edge endpoint for execution.
+
+## API Reference
+
+Edge Compute lifecycle is owned by the separate `telnyx-edge` CLI rather than the `team-telnyx/ai` SDK surface.
+
+Common lifecycle commands:
+
+```bash
+telnyx-edge auth status
+telnyx-edge list
+telnyx-edge secrets list
+telnyx-edge bindings get
+```
+
+| Command | Purpose |
+|---------|---------|
+| `telnyx-edge auth login` | Authenticate the Edge CLI |
+| `telnyx-edge new-func` | Scaffold a new function or clone an example |
+| `telnyx-edge ship` | Deploy the current function |
+| `telnyx-edge list` | List deployed functions |
+| `telnyx-edge secrets` | Manage runtime secrets |
+| `telnyx-edge bindings` | Manage Telnyx API key bindings |
+
+## Prerequisites
+
+- Telnyx account
+- Access to the dedicated `telnyx-edge` CLI
+- A use case where AI workflows need a real deployed HTTP or MCP execution surface
+
 ## Prerequisite: install `telnyx-edge`
 
 Edge Compute is managed through the separate CLI:
@@ -133,7 +178,28 @@ Not before.
 
 A simple pattern is to let your AI app call a deployed edge function for specialized execution.
 
-```ts
+```python
+import os
+import requests
+
+response = requests.post(
+    "https://<your-edge-endpoint>",
+    headers={
+        "content-type": "application/json",
+        "authorization": f"Bearer {os.environ['TELNYX_API_KEY']}",
+    },
+    json={
+        "task": "redact_pii",
+        "payload": {
+            "text": "Call me at +1 555 123 4567",
+        },
+    },
+)
+
+print(response.json())
+```
+
+```typescript
 const response = await fetch("https://<your-edge-endpoint>", {
   method: "POST",
   headers: {
@@ -205,6 +271,20 @@ Example use cases:
 - enrich messages before downstream routing
 - score or classify inbound events
 - clean transcripts before analysis
+
+You can also smoke-test a deployed edge endpoint directly:
+
+```bash
+curl -X POST "https://<your-edge-endpoint>" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -d '{
+    "task": "redact_pii",
+    "payload": {
+      "text": "Call me at +1 555 123 4567"
+    }
+  }'
+```
 
 ## What this repo should and should not claim
 

--- a/guides/edge-compute.md
+++ b/guides/edge-compute.md
@@ -34,8 +34,8 @@ Good bridge use cases:
 ## Quick Start
 
 ```bash
-# Authenticate with the dedicated Edge CLI
-telnyx-edge auth login
+# Authenticate with the dedicated Edge CLI (preferred for agents)
+telnyx-edge auth api-key set <your-api-key>
 
 # Start from the MCP server example
 telnyx-edge new-func --from-dir=examples/ts/mcp-server --name=my-mcp-server
@@ -63,7 +63,7 @@ telnyx-edge bindings get
 
 | Command | Purpose |
 |---------|---------|
-| `telnyx-edge auth login` | Authenticate the Edge CLI |
+| `telnyx-edge auth api-key set` | Authenticate the Edge CLI non-interactively |
 | `telnyx-edge new-func` | Scaffold a new function or clone an example |
 | `telnyx-edge ship` | Deploy the current function |
 | `telnyx-edge list` | List deployed functions |
@@ -84,8 +84,8 @@ Edge Compute is managed through the separate CLI:
 # See the edge-compute repo for install/setup details
 # https://github.com/team-telnyx/edge-compute
 
-telnyx-edge auth login
-telnyx-edge status
+telnyx-edge auth api-key set <your-api-key>
+telnyx-edge auth status
 ```
 
 Typical lifecycle commands live there:
@@ -303,7 +303,7 @@ This repo **should not** claim that it:
 
 Here is the most practical end-to-end test loop:
 
-1. install and authenticate `telnyx-edge`
+1. install `telnyx-edge` and authenticate with `telnyx-edge auth api-key set <your-api-key>`
 2. start from a working example in `team-telnyx/edge-compute`
 3. deploy it with `telnyx-edge ship`
 4. expose a stable HTTP or MCP boundary
@@ -316,7 +316,7 @@ That gives you a real integration test without pretending `team-telnyx/ai` owns 
 
 If you want to use Edge Compute from an AI workflow today:
 
-1. install and authenticate `telnyx-edge`
+1. install `telnyx-edge` and authenticate with `telnyx-edge auth api-key set <your-api-key>`
 2. create/deploy your function in `team-telnyx/edge-compute`
 3. expose a stable HTTP or MCP boundary
 4. use `team-telnyx/ai` to orchestrate calls into that deployed endpoint


### PR DESCRIPTION
## Summary

Adds **testable Edge Compute integration guidance** to `team-telnyx/ai`, then extends it with a **thin executable bridge** in `telnyx-agent`.

This PR intentionally does **not** make `team-telnyx/ai` the owner of Edge Compute lifecycle management. Instead, it makes Edge Compute:
- discoverable in the AI repo
- understandable in product positioning
- **actually usable from `telnyx-agent`** via handoff commands
- testable now with concrete MCP/webhook deployment paths

## Product boundary

- `team-telnyx/ai` owns **orchestration, discoverability, AI workflow guidance, and agent-facing handoff UX**
- `team-telnyx/edge-compute` + `telnyx-edge` own **auth, function creation, deploy, secrets, bindings, and lifecycle**

That means this PR adds a real bridge without falsely claiming native Edge lifecycle ownership.

## What changed

### Docs / capability positioning
- Adds `guides/edge-compute.md`
- Updates `README.md` with Edge Compute positioning and test-oriented handoff guidance
- Updates `agent.json` with an `edge_compute` capability
- Updates CLI capabilities output so Edge Compute is visible as a first-class capability area

### Thin executable Edge bridge in `telnyx-agent`
Adds real agent-facing commands:
- `telnyx-agent edge-doctor`
- `telnyx-agent setup-edge-mcp`
- `telnyx-agent setup-edge-webhook`

These commands:
- detect whether `telnyx-edge` is installed
- validate readiness for the handoff
- point to real Edge examples/templates
- return concrete next-step deploy commands
- preserve the correct ownership boundary

### Testability improvements
The Edge guide was tightened so it is both human-usable and compliant with repo guide structure requirements.

## Tests

### Local guide validation
- `tests/guides.test.ts`
- Result: **92/92 passing** locally after guide fixes

### Local CLI suite
- `npm test` in `cli/`
- Result: **13/13 passing** locally
- Includes new coverage for:
  - help output
  - capabilities JSON exposure
  - `edge-doctor`
  - `setup-edge-mcp`
  - `setup-edge-webhook`

## Why this shape

This is meant to be the smallest honest end-to-end step that lets a `telnyx-agent` user actually do something useful with Edge Compute **today**, without creating ownership confusion or duplicating `telnyx-edge`.

So the current UX becomes:
1. discover Edge Compute from `team-telnyx/ai`
2. use `telnyx-agent` to get a structured handoff
3. deploy/manage via `telnyx-edge`
4. connect the resulting MCP/webhook/function boundary back into AI workflows

## Follow-on scope (not in this PR)
- richer MCP-on-Edge walkthroughs
- richer webhook-on-Edge walkthroughs
- possible future wrapper flows if cross-repo ownership/contracts become stable
