### PR TITLE
chore(release): bump agent package versions

### DIFF
--- a/.github/bin/check-release-environment
+++ b/.github/bin/check-release-environment
@@ -24,7 +24,8 @@ print(len(TOOL_DEFINITIONS))
 TS_COUNT=$(node -e "
 const fs = require('fs');
 const c = fs.readFileSync('tools/typescript/src/shared/constants.ts','utf8');
-const m = c.match(/^  [a-z_]+:\s*\{$/gm) || [];
+const definitions = c.slice(c.indexOf('export const TOOL_DEFINITIONS'));
+const m = definitions.match(/^  [a-z0-9_]+:\s*\{$/gm) || [];
 console.log(m.length);
 " 2>/dev/null || echo "?")
 

--- a/.github/bin/publish-npm
+++ b/.github/bin/publish-npm
@@ -40,6 +40,11 @@ else
   echo "Last published version: $LAST_VERSION"
 fi
 
+if [[ "$LAST_VERSION" == "$VERSION" ]]; then
+  echo "$PACKAGE_NAME@$VERSION is already published on npm; skipping publish."
+  exit 0
+fi
+
 # Determine tag (pre-release gets alpha/beta tag, stable gets latest)
 TAG="latest"
 if [[ "$VERSION" =~ -([a-zA-Z]+) ]]; then

--- a/.github/bin/publish-pypi
+++ b/.github/bin/publish-pypi
@@ -4,7 +4,7 @@
 
 set -eux
 
-cd "$(dirname "$0")/../tools/python"
+cd "$(dirname "$0")/../../tools/python"
 
 # Clean previous builds
 rm -rf dist

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@telnyx/agent-cli",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@telnyx/agent-cli",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telnyx/agent-cli",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Agent-friendly CLI for Telnyx API v2 — composite setup commands that reduce multi-step workflows to a single command",
   "type": "module",
   "bin": {
@@ -10,7 +10,8 @@
     "start": "tsx bin/telnyx-agent.ts",
     "test": "tsx --test tests/integration.test.ts tests/telnyx-cli-flags.test.ts tests/edge-handoff.test.ts",
     "typecheck": "tsc --noEmit",
-    "postinstall": "tsx scripts/postinstall.ts"
+    "postinstall": "tsx scripts/postinstall.ts",
+    "build": "npm run typecheck"
   },
   "dependencies": {
     "ethers": "^6.16.0",

--- a/cli/src/friction.ts
+++ b/cli/src/friction.ts
@@ -66,7 +66,7 @@ export class FrictionReporter {
         api_path: event.api_path,
         error_detail: event.error_message,
         sdk: "cli",
-        sdk_version: "0.1.0",
+        sdk_version: "0.3.0",
       },
     };
 

--- a/tools/python/pyproject.toml
+++ b/tools/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "telnyx-agent-toolkit"
-version = "0.1.0"
+version = "0.2.0"
 description = "Telnyx Agent Toolkit — tools for building AI agents with Telnyx APIs"
 readme = "README.md"
 license = "MIT"

--- a/tools/python/telnyx_agent_toolkit/__init__.py
+++ b/tools/python/telnyx_agent_toolkit/__init__.py
@@ -3,4 +3,4 @@
 from telnyx_agent_toolkit.configuration import TelnyxAgentToolkit, TelnyxConfig
 
 __all__ = ["TelnyxAgentToolkit", "TelnyxConfig"]
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/tools/python/telnyx_agent_toolkit/shared/friction.py
+++ b/tools/python/telnyx_agent_toolkit/shared/friction.py
@@ -73,7 +73,7 @@ class FrictionReporter:
                 "api_path": api_path,
                 "error_detail": error_message,
                 "sdk": "python",
-                "sdk_version": "0.1.0",
+                "sdk_version": "0.2.0",
             },
         }
 

--- a/tools/python/uv.lock
+++ b/tools/python/uv.lock
@@ -3087,7 +3087,7 @@ wheels = [
 
 [[package]]
 name = "telnyx-agent-toolkit"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/tools/typescript/package-lock.json
+++ b/tools/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@telnyx/agent-toolkit",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@telnyx/agent-toolkit",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/tools/typescript/package.json
+++ b/tools/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telnyx/agent-toolkit",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Telnyx Agent Toolkit for TypeScript — tools for OpenAI, Vercel AI SDK, and LangChain.js",
   "type": "module",
   "main": "./dist/index.js",

--- a/tools/typescript/src/shared/friction.ts
+++ b/tools/typescript/src/shared/friction.ts
@@ -65,7 +65,7 @@ export class FrictionReporter {
         api_path: event.api_path,
         error_detail: event.error_message,
         sdk: "typescript",
-        sdk_version: "0.1.0",
+        sdk_version: "0.2.0",
       },
     };
 


### PR DESCRIPTION
## Summary
- Bump the release versions for agent packages impacted by the recently merged CLI/SDK work.
- Add the missing CLI `build` script expected by `.github/bin/publish-npm` so the CLI publish path can run `npm run build` successfully.
- Fix release-doctor TypeScript tool counting so tool names containing digits (for example 10DLC tools) are counted under `TOOL_DEFINITIONS` and interface fields are not counted.

## Version bumps
- `@telnyx/agent-toolkit`: `0.1.0` → `0.2.0`
- `telnyx-agent-toolkit`: `0.1.0` → `0.2.0`
- `@telnyx/agent-cli`: `0.2.0` → `0.3.0`
- Left `@telnyx/mcp`, `@telnyx/opencode`, and `tools/ffl-cli` unchanged.

## Test plan
- `python3` version/package-lock consistency check for package manifests and lockfiles
- `bash ./.github/bin/check-release-environment`
- `npm ci && npm run build && npm test` in `cli`
- `npm ci && npm run build && npm test` in `tools/typescript`
- `uv run --python 3.11 --extra dev pytest` in `tools/python`
- `uv build --python 3.11` in `tools/python`
- `npm pack --dry-run` in `cli`
- `npm pack --dry-run` in `tools/typescript`
- `git diff --check`

Note: a first local `uv run pytest` attempt used the machine default CPython 3.14 and failed while building `pydantic-core` because its PyO3 dependency supports up to Python 3.13. Re-running with the project-supported Python 3.11 passed.

## References
- https://github.com/team-telnyx/ai/pull/169
- https://github.com/team-telnyx/ai/pull/168
- https://github.com/team-telnyx/ai/pull/145
