### PR TITLE
docs: add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,148 @@
+# AGENTS.md
+
+Operating instructions for AI coding agents working **on** this repo, and for runtime agents **consuming** it.
+
+This file is a complement to `README.md` (human-facing) and `.github/CONTRIBUTING.md` (contribution flow). When in doubt, prefer the commands here.
+
+---
+
+## What this repo is
+
+The one-stop shop for AI agents and AI-first developers building with Telnyx. It contains agent toolkits (Python/TypeScript), an agent CLI, a unified plugin for Claude Code / Cursor / Gemini CLI / OpenCode, an MCP proxy, 235+ Agent Skills, and operational guides.
+
+---
+
+## Working on this repo
+
+### Setup
+
+This is an npm-based monorepo, but the workspaces are independent — install per-package, not at the root.
+
+```bash
+# Root tooling (only for `npm run test:guides*`)
+npm ci
+
+# Per-package
+cd cli && npm ci
+cd tools/typescript && npm ci
+cd tools/mcp && npm ci
+cd tools/python && pip install -e ".[dev]"
+```
+
+### Test / build / lint
+
+| Package          | Command                            |
+| ---------------- | ---------------------------------- |
+| `cli/`           | `cd cli && npm test`               |
+| `tools/python/`  | `cd tools/python && pytest`        |
+| `tools/typescript/` | `cd tools/typescript && npm test` |
+| `tools/mcp/`     | `cd tools/mcp && npm run build`    |
+| `guides/`        | `npm run test:guides` (from root)  |
+| Guides API tests | `npm run test:guides-api` (root)   |
+
+Run the relevant package's test suite before declaring a task done. Don't run all of them — pick the one you touched.
+
+### Where things live
+
+| Path                    | What it contains                                                          |
+| ----------------------- | ------------------------------------------------------------------------- |
+| `skills/`               | Canonical agent skills (SKILL.md files). 235+ skills covering messaging, voice, numbers, AI, IoT, WebRTC, Twilio migration. |
+| `providers/claude/`     | Claude Code plugin packaging — synced from `skills/` via `scripts/sync-skills.sh`. Don't edit by hand. |
+| `providers/cursor/`     | Cursor plugin packaging — synced from `skills/` via `scripts/sync-skills.sh`. Don't edit by hand. |
+| `plugins/opencode/`     | OpenCode plugin (auth + TUI for Telnyx-hosted models).                    |
+| `tools/python/`         | Python agent toolkit (PyPI: `telnyx-agent-toolkit`).                      |
+| `tools/typescript/`     | TypeScript agent toolkit (npm).                                           |
+| `tools/mcp/`            | MCP proxy server.                                                         |
+| `tools/ffl-cli/`        | Filling-from-life CLI tooling.                                            |
+| `cli/`                  | Agent CLI for provisioning Telnyx infrastructure.                         |
+| `inference/`            | Documentation for Telnyx-hosted inference.                                |
+| `guides/`               | Step-by-step operational guides.                                          |
+| `scripts/sync-skills.sh`| Syncs `skills/` → `providers/{claude,cursor}/plugin/skills/`.             |
+| `agent.json`            | Top-level agent manifest (capabilities, auth, endpoints).                 |
+| `.claude-plugin/`       | Claude Code marketplace metadata.                                         |
+| `.cursor-plugin/`       | Cursor marketplace metadata.                                              |
+| `gemini-extension.json` | Gemini CLI extension manifest.                                            |
+
+### Editing skills
+
+`skills/` is the canonical source. After editing any skill, run:
+
+```bash
+./scripts/sync-skills.sh
+```
+
+This propagates changes to `providers/claude/` and `providers/cursor/`. Commit the sync output alongside your skill edits — don't leave them out of sync.
+
+### Editing `agent.json`
+
+The capability list in `agent.json` is the source of truth for what Telnyx surfaces to runtime agents. When adding a capability, also add the corresponding skill under `skills/` and the guide under `guides/` referenced by the `guide` field.
+
+### Code style
+
+- TypeScript: ES2020+, strict mode, ESM where the package supports it.
+- Python: 3.10+, PEP 8, type hints required for public functions.
+- Markdown: GitHub-flavored. Use ATX headings (`#`, not underlines).
+- One change per PR — don't bundle skill edits with toolkit refactors.
+
+### Commit and PR conventions
+
+- Conventional Commits prefix in the title (`feat:`, `fix:`, `chore:`, `docs:`).
+- Sign commits (the maintainers' setup expects verified signatures).
+- One concern per PR. Keep skill regenerations (`scripts/sync-skills.sh`) in the same PR as the skill source change.
+- Reference the issue number in the PR description if one exists.
+
+### Don'ts
+
+- Don't edit files under `providers/claude/plugin/skills/` or `providers/cursor/plugin/skills/` directly — they are generated. Edit the source under `skills/` and run `./scripts/sync-skills.sh`.
+- Don't introduce a root-level test runner — each package has its own.
+- Don't commit credentials, API keys, or `.env` files. Use the patterns in existing `.env.example` files.
+- Don't `npm install` at the root and expect it to install workspace deps — each package has its own `package.json` and `node_modules/`.
+- Don't add new top-level directories without updating this file and `README.md`'s table of contents.
+
+---
+
+## Consuming this repo as a runtime agent
+
+If you are an AI agent **using** Telnyx (not modifying this repo), the entry points are:
+
+| You want to…                                              | Start here                                                              |
+| --------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Discover Telnyx capabilities                              | `/agent.json` (this repo) or `https://telnyx.com/agents/start`          |
+| Generate Telnyx code with a coding assistant              | Install the plugin: `team-telnyx/ai` marketplace (Claude / Cursor / Gemini / OpenCode) — see `README.md` |
+| Use Telnyx APIs from an agent framework (OpenAI Agents SDK, LangChain, CrewAI, Vercel AI SDK) | `tools/python/` or `tools/typescript/`                                   |
+| Talk to Telnyx via MCP                                    | `https://api.telnyx.com/v2/mcp` (Bearer auth) — proxy in `tools/mcp/`   |
+| Provision Telnyx infrastructure programmatically          | `cli/` — `npm install -g @telnyx/cli`                                   |
+| Get an API key as an agent                                | `https://telnyx.com/agent-signup.md` (PoW-based programmatic signup)   |
+
+### Auth (for runtime consumers)
+
+- **API keys**: Bearer token, `Authorization: Bearer <key>`. Get one via the portal or programmatically via `https://telnyx.com/agent-signup.md`.
+- **OAuth**: Metadata at `https://telnyx.com/.well-known/oauth-authorization-server`.
+- **MCP**: Bearer auth against `https://api.telnyx.com/v2/mcp`. Card at `https://telnyx.com/.well-known/mcp/server-card.json`.
+
+See `agent.json` (`auth` block) for the canonical auth contract.
+
+### Discovery surfaces
+
+| Surface                                          | URL                                                       |
+| ------------------------------------------------ | --------------------------------------------------------- |
+| Agent fast path (entry point)                    | `https://telnyx.com/agents/start`                         |
+| Agent manifest                                   | `https://telnyx.com/.well-known/agent-card.json`          |
+| Agent access (signup contract)                   | `https://telnyx.com/.well-known/agent-access.json`        |
+| Agent skills index                               | `https://telnyx.com/.well-known/agent-skills/index.json`  |
+| MCP server card                                  | `https://telnyx.com/.well-known/mcp/server-card.json`     |
+| OpenAPI spec                                     | `https://telnyx.com/.well-known/openapi.json`             |
+| llms.txt                                         | `https://telnyx.com/llms.txt`                             |
+| Capability index                                 | `https://telnyx.com/ai/capabilities.json`                 |
+| Pricing                                          | `https://telnyx.com/ai/pricing.json`                      |
+
+---
+
+## Reporting issues
+
+- **Bugs / feature requests**: open an issue.
+- **Security issues**: see `.github/SECURITY.md` — do not file public issues for vulnerabilities.
+
+---
+
+_Last reviewed: 2026-05-07_


### PR DESCRIPTION
## Summary

Adds a top-level `AGENTS.md` following the [agents.md](https://agents.md) convention. The file has two clearly-labeled sections:

- **Working on this repo** — setup, per-package test/build commands (`cli/`, `tools/python/`, `tools/typescript/`, `tools/mcp/`, root guides tests), where things live, code style, the canonical skills sync flow (`scripts/sync-skills.sh`), commit/PR conventions, and a Don'ts list (most importantly: don't hand-edit generated `providers/{claude,cursor}/plugin/skills/`).
- **Consuming this repo as a runtime agent** — entry points (`agent.json`, `https://telnyx.com/agents/start`, plugin install paths, toolkits, CLI, MCP), auth contract, and the discovery surfaces on telnyx.com.

## Why

Closes the **Agent platform configs** check from the Ora agent-readiness scan (Linear AIF-182). Ora's heuristic looks for `AGENTS.md` / `.cursorrules` at the root of a public repo associated with the domain. Although this repo already exposes rich agent infrastructure (`.cursor-plugin/`, `.claude-plugin/`, `agent.json`, `gemini-extension.json`, 235+ skills), the filename-based check scored 0/1 for the missing `AGENTS.md`.

## Test plan

- [ ] Render the file on GitHub and confirm headings, tables, and code blocks display correctly
- [ ] Rerun the [Ora scan](https://ora.run/score/telnyx.com) once merged and confirm "Agent platform configs" moves from 0/1 to 1/1