### PR TITLE
docs: add Cursor / Claude / Windsurf agent rules

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,92 @@
+# CLAUDE.md — team-telnyx/ai
+
+Project rules for Claude Code (and other Claude-family coding agents)
+working in this repo. The canonical source of truth is `AGENTS.md` at
+the repo root — keep this file in sync with it.
+
+## What this repo is
+
+Telnyx AI — agent toolkits (Python, TypeScript), agent CLI, plugins for
+Claude Code / Cursor / Gemini CLI / OpenCode, an MCP proxy, 235+ Agent
+Skills, and operational guides.
+
+## Hard rules (must follow)
+
+- **Generated files** under `providers/claude/plugin/skills/` and
+  `providers/cursor/plugin/skills/` are produced by
+  `./scripts/sync-skills.sh` from `skills/`. **Never hand-edit them.**
+  Edit the source under `skills/` and run the sync script.
+- **Per-package installs**: each package owns its own `package.json` /
+  `node_modules`. Don't run `npm install` at the repo root and don't
+  introduce a root-level test runner.
+- **No secrets in commits**: never add `.env` files, API keys, or
+  credentials. Use the existing `.env.example` patterns.
+- **Conventional Commits**: title prefix required (`feat:`, `fix:`,
+  `chore:`, `docs:`).
+- **Signed commits**: maintainer setup expects verified signatures.
+
+## Setup
+
+Per-package, not root:
+
+```bash
+cd cli && npm ci
+cd tools/typescript && npm ci
+cd tools/mcp && npm ci
+cd tools/python && pip install -e ".[dev]"
+```
+
+Root-level: `npm ci` covers only the guides test scripts.
+
+## Testing
+
+Run only the package you touched.
+
+| Package | Command |
+| --- | --- |
+| `cli/` | `cd cli && npm test` |
+| `tools/python/` | `cd tools/python && pytest` |
+| `tools/typescript/` | `cd tools/typescript && npm test` |
+| `tools/mcp/` | `cd tools/mcp && npm run build` |
+| `guides/` | `npm run test:guides` (root) |
+| Guides API | `npm run test:guides-api` (root) |
+
+## Editing agent skills
+
+Skills are written as `SKILL.md` files under `skills/<skill-name>/`.
+After editing any skill, run:
+
+```bash
+./scripts/sync-skills.sh
+```
+
+Commit the sync output alongside the skill change — don't leave them
+out of sync. CI will catch drift.
+
+## Code style
+
+- TypeScript: ES2020+, strict mode, ESM where supported.
+- Python: 3.10+, PEP 8, type hints on public functions.
+- Markdown: GitHub-flavored, ATX headings only.
+- One concern per PR — skill regen + skill source go together; toolkit
+  refactors stay separate.
+
+## Where things live
+
+- `skills/` — canonical SKILL.md files (the source of truth)
+- `providers/{claude,cursor}/` — generated plugin packaging (don't edit)
+- `plugins/opencode/` — OpenCode plugin (auth + TUI for Telnyx-hosted models)
+- `tools/python/` — Python agent toolkit (PyPI)
+- `tools/typescript/` — TypeScript agent toolkit (npm)
+- `tools/mcp/` — MCP proxy server
+- `tools/ffl-cli/` — Filling-from-life CLI
+- `cli/` — agent CLI for provisioning Telnyx infrastructure
+- `inference/` — Telnyx inference docs
+- `guides/` — operational guides
+- `agent.json` — top-level agent manifest
+- `.claude-plugin/` — Claude Code marketplace metadata
+- `.cursor-plugin/` — Cursor marketplace metadata
+- `gemini-extension.json` — Gemini CLI extension manifest
+
+For runtime-agent (consumer) guidance, see `AGENTS.md` §"Consuming this
+repo as a runtime agent".

--- a/.cursor/rules/main.mdc
+++ b/.cursor/rules/main.mdc
@@ -1,0 +1,64 @@
+---
+description: Project-wide rules for Cursor agents working on team-telnyx/ai. Loaded by Cursor for every request.
+alwaysApply: true
+---
+
+# team-telnyx/ai — Cursor agent rules
+
+The canonical source of truth is `AGENTS.md` at the repo root. This MDC
+file holds the rules Cursor's agent must always have in context. Keep
+in sync with `AGENTS.md` and `.cursorrules` when changing project-wide
+guidance.
+
+## Hard rules (don't break these)
+
+- **Generated files**: never hand-edit under
+  `providers/claude/plugin/skills/` or `providers/cursor/plugin/skills/`.
+  Edit the source under `skills/` and run `./scripts/sync-skills.sh`.
+- **Per-package install/test**: `npm ci` and tests run from each
+  package's directory, not the repo root. Don't introduce a root-level
+  test runner.
+- **Secrets**: never commit credentials, API keys, or `.env` files.
+- **Conventional Commits**: title prefix required (`feat:`, `fix:`,
+  `chore:`, `docs:`). Commits must be signed.
+
+## Where things live
+
+- `skills/` — canonical SKILL.md files (235+ skills).
+- `providers/{claude,cursor}/` — synced from `skills/`. Generated.
+- `plugins/opencode/` — OpenCode plugin source.
+- `tools/{python,typescript,mcp,ffl-cli}/` — agent toolkits.
+- `cli/` — agent CLI source.
+- `inference/` — Telnyx-hosted inference docs.
+- `guides/` — operational guides.
+- `agent.json` — top-level agent manifest (capabilities, auth, endpoints).
+
+## Per-package commands
+
+| Package | Test/build |
+| --- | --- |
+| `cli/` | `cd cli && npm test` |
+| `tools/python/` | `cd tools/python && pytest` |
+| `tools/typescript/` | `cd tools/typescript && npm test` |
+| `tools/mcp/` | `cd tools/mcp && npm run build` |
+| `guides/` | `npm run test:guides` (root) |
+
+## Editing skills
+
+After touching anything under `skills/`, run:
+
+```bash
+./scripts/sync-skills.sh
+```
+
+Commit the sync output in the same PR as the skill source change.
+
+## Style
+
+- TypeScript: ES2020+, strict mode, ESM where the package supports it.
+- Python: 3.10+, PEP 8, type hints on public functions.
+- Markdown: GitHub-flavored, ATX headings.
+- One concern per PR.
+
+For runtime-agent (consumer) guidance, see `AGENTS.md` §"Consuming this
+repo as a runtime agent".

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,48 @@
+# Cursor rules — team-telnyx/ai
+
+Operating instructions for the Cursor agent working in this repo.
+This file is the legacy single-file convention. The MDC equivalent
+lives at `.cursor/rules/main.mdc`. The canonical source of truth
+for everything below is `AGENTS.md` at the repo root — keep these
+rules in sync with it when changing project-wide guidance.
+
+## What this repo is
+Telnyx AI — agent toolkits, plugins for Claude Code / Cursor / Gemini /
+OpenCode, an MCP proxy, 235+ agent skills, and operational guides.
+The skills under `skills/` are the source of truth; they are synced to
+`providers/{claude,cursor}/plugin/skills/` via `scripts/sync-skills.sh`.
+
+## Hard rules (don't break these)
+- **Don't hand-edit** files under `providers/claude/plugin/skills/` or
+  `providers/cursor/plugin/skills/` — they are generated. Edit the
+  source under `skills/` and run `./scripts/sync-skills.sh`.
+- **Don't run `npm install` at the repo root.** Each package has its
+  own `package.json` and `node_modules/`. Install per-package:
+  `cd cli && npm ci`, `cd tools/typescript && npm ci`, etc.
+- **Don't introduce a root-level test runner.** Each package owns its
+  own tests. Run only the package you touched.
+- **Don't commit credentials, API keys, or `.env` files.** Use the
+  patterns in existing `.env.example` files.
+
+## Per-package commands
+- `cli/`: `cd cli && npm test`
+- `tools/python/`: `cd tools/python && pytest`
+- `tools/typescript/`: `cd tools/typescript && npm test`
+- `tools/mcp/`: `cd tools/mcp && npm run build`
+- `guides/`: `npm run test:guides` from repo root
+- Guides API tests: `npm run test:guides-api` from repo root
+
+## Code style
+- TypeScript: ES2020+, strict mode, ESM where the package supports it.
+- Python: 3.10+, PEP 8, type hints required for public functions.
+- Markdown: GitHub-flavored. ATX headings (`#`), no underline headings.
+- One concern per PR. Keep skill regenerations in the same PR as the
+  skill source change (run `./scripts/sync-skills.sh` and commit both).
+
+## Commits and PRs
+- Conventional Commits prefix in the title (`feat:`, `fix:`, `chore:`,
+  `docs:`).
+- Sign commits — the maintainers' setup expects verified signatures.
+- Reference the issue number in the PR description if one exists.
+
+For everything not covered here, read `AGENTS.md`.

--- a/.windsurf/rules.md
+++ b/.windsurf/rules.md
@@ -1,0 +1,56 @@
+# Windsurf rules — team-telnyx/ai
+
+Operating rules for the Windsurf agent (Cascade) working in this repo.
+The canonical source of truth is `AGENTS.md` at the repo root — keep
+this file in sync.
+
+## Hard rules (must follow)
+
+- **Generated files** under `providers/{claude,cursor}/plugin/skills/`
+  are produced by `./scripts/sync-skills.sh` from `skills/`. Never
+  hand-edit. Edit the source under `skills/` and run the sync script.
+- **Per-package installs**: each package owns its own `package.json` /
+  `node_modules`. Don't run `npm install` at the repo root and don't
+  introduce a root-level test runner.
+- **No secrets in commits**: no `.env`, no API keys, no credentials.
+  Use existing `.env.example` patterns.
+- **Conventional Commits** title prefix (`feat:`, `fix:`, `chore:`,
+  `docs:`). Commits must be signed.
+
+## Setup
+
+Per package, not root:
+
+```bash
+cd cli && npm ci
+cd tools/typescript && npm ci
+cd tools/mcp && npm ci
+cd tools/python && pip install -e ".[dev]"
+```
+
+## Testing
+
+Run only the package you touched.
+
+| Package | Command |
+| --- | --- |
+| `cli/` | `cd cli && npm test` |
+| `tools/python/` | `cd tools/python && pytest` |
+| `tools/typescript/` | `cd tools/typescript && npm test` |
+| `tools/mcp/` | `cd tools/mcp && npm run build` |
+| `guides/` | `npm run test:guides` (root) |
+
+## Skills workflow
+
+Skills live as `SKILL.md` under `skills/<name>/`. After any edit, run
+`./scripts/sync-skills.sh` and commit the output alongside the source.
+
+## Code style
+
+- TypeScript ES2020+, strict, ESM where supported
+- Python 3.10+, PEP 8, type hints on public functions
+- Markdown: GFM with ATX headings
+- One concern per PR
+
+For runtime-agent (consumer) guidance, see `AGENTS.md` §"Consuming this
+repo as a runtime agent".


### PR DESCRIPTION
## Summary

Follow-up to #174 (AGENTS.md). Ora's **\"Agent platform configs\"** check (Discovery, currently 0/1 → +1 pt) specifically searches GitHub for \`.claude/\`, \`.cursor/\`, \`.windsurf/\` directories and \`.cursorrules\` files — not just \`AGENTS.md\`.

Even though AGENTS.md is the canonical source of truth and shipped in #174, the per-tool conventional locations are what the agent platforms themselves load:

- **Cursor** reads \`.cursorrules\` (legacy) and \`.cursor/rules/*.mdc\` (modern)
- **Claude Code** reads \`.claude/CLAUDE.md\` (project rules)
- **Windsurf Cascade** reads \`.windsurf/rules.md\`

This PR adds those four conventional surfaces.

## Changes

| File | Purpose |
| --- | --- |
| \`.cursorrules\` | Legacy single-file Cursor convention |
| \`.cursor/rules/main.mdc\` | Modern Cursor MDC format with \`alwaysApply: true\` so it loads on every request |
| \`.claude/CLAUDE.md\` | Claude Code project rules |
| \`.windsurf/rules.md\` | Windsurf Cascade rules |

Each replicates the small set of project-wide hard rules (don't hand-edit generated \`providers/*/plugin/skills/\`, per-package installs, no secrets, Conventional Commits + signed commits) so the agent has them in context regardless of which platform loads them. Anything beyond those rules points the reader at \`AGENTS.md\` to keep a single source of truth.

## Why duplicate vs. just symlink?

Symlinks don't work for tooling that reads the literal file path (`.cursorrules` vs `AGENTS.md`). Duplicating the small project-wide rules is intentional — the duplication is **bounded** (the cross-cutting hard rules) and points at \`AGENTS.md\` for everything else. Drift risk is small because the duplicated rules rarely change.

## Score impact

Targets **+1 Ora pt** (\"Agent platform configs\" 0/1 → 1/1). Ora's heuristic literally greps the repo for these filenames; once they exist, the check should flip on the next rescan after Ora's per-check cache refreshes.

## Risk

Trivial — four new files in conventional dot-directories. No existing file changed.

## Test plan

- [x] \`AGENTS.md\` already lives at the repo root (#174 merged)
- [x] All four new files written
- [x] Each file points at \`AGENTS.md\` as the canonical source of truth
- [ ] After merge, rerun the [Ora scan](https://ora.run/score/telnyx.com) and confirm \"Agent platform configs\" flips from 0/1 to 1/1