### PR TITLE
fix: add limit.output to model config for opencode 1.14.44+ schema

### DIFF
--- a/plugins/opencode/src/index.ts
+++ b/plugins/opencode/src/index.ts
@@ -53,12 +53,13 @@ function modelConfig(model: JsonObject): [string, JsonObject] | undefined {
 
   const shortId = id.includes("/") ? id.split("/").pop() ?? id : id
   const vision = model.is_vision_supported === true
+  const output = typeof model.max_output_length === "number" ? model.max_output_length : 16384
 
   return [
     id,
     {
       name: shortId,
-      limit: { context },
+      limit: { context, output },
       ...(vision
         ? {
             attachment: true,


### PR DESCRIPTION
## Problem

opencode 1.14.44+ added schema validation requiring `limit.output` on every model config. The Telnyx plugin was only returning `limit: { context }`, causing:

```
HttpApiSchemaError: Missing key at ["provider"]["telnyx"]["models"][...]["limit"]["output"]
```

This manifests as `400: (empty response body)` on startup, making opencode completely unusable with the Telnyx plugin enabled.

Related upstream issue: anomalyco/opencode#25790

## Fix

- Read `max_output_length` from the Telnyx API response if available
- Fallback to `16384` (safe default for most text generation models)
- Every model now returns `limit: { context, output }` which satisfies the new schema

## Testing

- Typecheck passes (`tsc --noEmit`)
- Build succeeds (`npm run build`)
- The `chat.params` hook that sets `maxOutputTokens = undefined` for Telnyx models is unchanged

## Workaround (without this fix)

Run `opencode --pure` to skip external plugins.