### PR TITLE
chore: add skill description audit and regression check

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Telnyx AI skills monorepo — SDKs, CLI, guides, and agent skills",
   "scripts": {
     "test:guides": "npx tsx --test tests/guides.test.ts",
-    "test:guides-api": "npx tsx --test tests/guides-api.test.ts"
+    "test:guides-api": "npx tsx --test tests/guides-api.test.ts",
+    "test:skill-descriptions": "npx tsx --test tests/skill-descriptions.test.ts"
   },
   "devDependencies": {
     "tsx": "^4.19.0"

--- a/scripts/check-skill-descriptions.sh
+++ b/scripts/check-skill-descriptions.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Validates that every canonical skill has a non-empty description in frontmatter.
+# Exit 1 if any skill is missing a description or has an empty one.
+#
+# Usage:
+#   ./scripts/check-skill-descriptions.sh [--json]
+#
+# --json: Output machine-readable JSON report instead of human-readable text.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SKILLS_SRC="$REPO_ROOT/skills"
+JSON_MODE=false
+
+if [[ "${1:-}" == "--json" ]]; then
+  JSON_MODE=true
+fi
+
+if [[ ! -d "$SKILLS_SRC" ]]; then
+  echo "ERROR: skills/ directory not found at $SKILLS_SRC" >&2
+  exit 1
+fi
+
+missing=()
+empty=()
+valid=()
+total=0
+
+for skill_dir in "$SKILLS_SRC"/*/; do
+  skill_name=$(basename "$skill_dir")
+  skill_file="$skill_dir/SKILL.md"
+
+  if [[ ! -f "$skill_file" ]]; then
+    continue
+  fi
+
+  total=$((total + 1))
+
+  # Extract the description line from YAML frontmatter
+  # Frontmatter is between --- delimiters
+  desc_line=$(awk '/^---$/{n++; next} n==1 && /^description:/{print; exit}' "$skill_file")
+
+  if [[ -z "$desc_line" ]]; then
+    missing+=("$skill_name")
+    continue
+  fi
+
+  # Extract value after "description:" and trim whitespace
+  desc_value=$(echo "$desc_line" | sed 's/^description:[[:space:]]*//' | sed 's/^"//' | sed 's/"$//')
+
+  if [[ -z "$desc_value" ]]; then
+    empty+=("$skill_name")
+    continue
+  fi
+
+  valid+=("$skill_name")
+done
+
+if $JSON_MODE; then
+  # Output JSON report
+  printf '{"total":%d,"valid":%d,"missing":%d,"empty":%d,"missing_list":[' "$total" "${#valid[@]}" "${#missing[@]}" "${#empty[@]}"
+  first=true
+  for s in "${missing[@]}"; do
+    $first || printf ','
+    printf '"%s"' "$s"
+    first=false
+  done
+  printf '],"empty_list":['
+  first=true
+  for s in "${empty[@]}"; do
+    $first || printf ','
+    printf '"%s"' "$s"
+    first=false
+  done
+  printf ']}\n'
+else
+  echo "Skill description audit: $total skills checked"
+  echo "  Valid:     ${#valid[@]}"
+  echo "  Missing:   ${#missing[@]}"
+  echo "  Empty:     ${#empty[@]}"
+
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    echo ""
+    echo "MISSING description frontmatter:"
+    for s in "${missing[@]}"; do
+      echo "  - $s"
+    done
+  fi
+
+  if [[ ${#empty[@]} -gt 0 ]]; then
+    echo ""
+    echo "EMPTY description frontmatter:"
+    for s in "${empty[@]}"; do
+      echo "  - $s"
+    done
+  fi
+fi
+
+if [[ ${#missing[@]} -gt 0 || ${#empty[@]} -gt 0 ]]; then
+  exit 1
+fi
+
+echo ""
+echo "All $total skills have non-empty descriptions. ✅"
+exit 0

--- a/tests/skill-descriptions.test.ts
+++ b/tests/skill-descriptions.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Validates that every canonical skill under skills/ has a non-empty
+ * description in YAML frontmatter. This is the regression check for
+ * AIF-194 / GitHub #112 — ensuring no skill ships without a description
+ * on agent/tool discovery surfaces.
+ *
+ * No API key needed — validates skill frontmatter structure only.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = typeof import.meta.dirname === "string"
+  ? import.meta.dirname
+  : dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..");
+const SKILLS_DIR = join(ROOT, "skills");
+
+/**
+ * Parse the YAML frontmatter from a SKILL.md file and extract the description.
+ * Returns null if no description found, empty string if description is present but empty.
+ */
+function extractDescription(content: string): string | null {
+  const lines = content.split("\n");
+  let inFrontmatter = false;
+  let frontmatterDelimiters = 0;
+
+  for (const line of lines) {
+    if (line.trim() === "---") {
+      frontmatterDelimiters++;
+      inFrontmatter = frontmatterDelimiters === 1;
+      if (frontmatterDelimiters === 2) break; // end of frontmatter
+      continue;
+    }
+
+    if (inFrontmatter && line.startsWith("description:")) {
+      const value = line.slice("description:".length).trim();
+      // Remove surrounding quotes if present
+      if ((value.startsWith('"') && value.endsWith('"')) ||
+          (value.startsWith("'") && value.endsWith("'"))) {
+        return value.slice(1, -1).trim();
+      }
+      return value;
+    }
+  }
+
+  return null; // No description key found
+}
+
+function getCanonicalSkills(): string[] {
+  if (!existsSync(SKILLS_DIR)) return [];
+  return readdirSync(SKILLS_DIR, { withFileTypes: true })
+    .filter(d => d.isDirectory())
+    .map(d => d.name)
+    .sort();
+}
+
+describe("Skill descriptions", () => {
+  it("every canonical skill should have a non-empty description in frontmatter", () => {
+    const skills = getCanonicalSkills();
+    assert.ok(skills.length > 0, "No canonical skills found — skills/ directory empty or missing");
+
+    const missing: string[] = [];
+    const empty: string[] = [];
+
+    for (const skillName of skills) {
+      const skillPath = join(SKILLS_DIR, skillName, "SKILL.md");
+      if (!existsSync(skillPath)) continue;
+
+      const content = readFileSync(skillPath, "utf-8");
+      const desc = extractDescription(content);
+
+      if (desc === null) {
+        missing.push(skillName);
+      } else if (desc.length === 0) {
+        empty.push(skillName);
+      }
+    }
+
+    const errors: string[] = [];
+    if (missing.length > 0) {
+      errors.push(`Missing description: ${missing.join(", ")}`);
+    }
+    if (empty.length > 0) {
+      errors.push(`Empty description: ${empty.join(", ")}`);
+    }
+
+    assert.strictEqual(errors.length, 0, errors.join("; "));
+  });
+
+  it("skill count should be stable (234 canonical skills)", () => {
+    const skills = getCanonicalSkills();
+    assert.ok(skills.length >= 234, `Expected at least 234 skills, found ${skills.length}`);
+  });
+});


### PR DESCRIPTION
## Summary

Add validation tooling to ensure every canonical skill under `skills/**/SKILL.md` has a non-empty `description` in YAML frontmatter. This prevents regressions like GitHub #112 where skills shipped without descriptions for agent/tool discovery surfaces.

**Current audit result:** 234/234 skills have non-empty descriptions ✅

## Changes

- **`scripts/check-skill-descriptions.sh`** — CLI audit script (human-readable text + `--json` for CI)
- **`tests/skill-descriptions.test.ts`** — Node.js test runner regression check
- **`package.json`** — Added `test:skill-descriptions` script

## Validation

```bash
# CLI audit
./scripts/check-skill-descriptions.sh

# Node.js test
npm run test:skill-descriptions
```

Both pass with 234/234 skills validated.

## Context

- Linear: [AIF-194](https://linear.app/telnyx/issue/AIF-194/afk-audit-agent-skill-descriptions-and-add-regression-check)
- GitHub: #112
- No skill source changes were needed — all 234 canonical skills already have descriptions. The regression-prevention check is the primary deliverable.

## AFK Bot Run

- Run ID: `AIF-194-2026-05-11T15-14-52-758Z-fe24cab8`
- Artifacts: `/data/work/aifde-afk-bot/runs/AIF-194/AIF-194-2026-05-11T15-14-52-758Z-fe24cab8/`
- Evaluator caveat: The automated evaluator blocked (`retry`) because the Hermes command runner did not produce git changes. Changes were implemented manually from the preserved worktree per operator override.

## Guardrails

- ✅ Draft PR only — no autonomous merge
- ✅ No credentials/secrets in artifacts or PR body
- ✅ No skill source edits needed (all descriptions already present)