### PR TITLE
docs: fix opencode plugin install command in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,11 @@ Empowers coding agents to generate correct, production-ready code without relyin
 Install the Telnyx plugin for [OpenCode](https://opencode.ai) to add Telnyx as a model provider with automatic auth and a TUI for managing hosted models.
 
 ```sh
-npm install @telnyx/opencode
-```
+# Local (current project only)
+opencode plugin @telnyx/opencode
 
-Then add it to your `opencode.json`:
-
-```jsonc
-{
-  "plugin": ["@telnyx/opencode"]
-}
+# Global (all projects)
+opencode plugin -g @telnyx/opencode
 ```
 
 See [`plugins/opencode/README.md`](/plugins/opencode/README.md) for full setup and configuration.

--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -4,15 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed README install instructions to use `opencode plugin @telnyx/opencode` (there is no `install` subcommand)
+
 ## [0.1.2] - 2026-04-24
 
 ### Added
 
-- Added `oc-plugin` field declaring both server and TUI targets for `opencode plugin install` compatibility
+- Added `oc-plugin` field declaring both server and TUI targets for `opencode plugin` compatibility
 
 ### Fixed
 
-- Fixed README install instructions to use `opencode plugin install` (the standard method that auto-configures both `opencode.json` and `tui.json`)
+- Fixed README install instructions to use `opencode plugin` (the standard method that auto-configures both `opencode.json` and `tui.json`)
 
 ## [0.1.1] - 2026-04-24
 

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -5,7 +5,7 @@
 ## Install
 
 ```bash
-opencode plugin install @telnyx/opencode
+opencode plugin @telnyx/opencode
 ```
 
 This auto-detects both the server and TUI targets and adds the plugin to `opencode.json` (server) and `tui.json` (TUI) automatically.
@@ -13,7 +13,7 @@ This auto-detects both the server and TUI targets and adds the plugin to `openco
 For global install (all projects):
 
 ```bash
-opencode plugin install -g @telnyx/opencode
+opencode plugin -g @telnyx/opencode
 ```
 
 ## What it does
@@ -175,7 +175,7 @@ Some smaller models cannot fit OpenCode's full tool list and system prompt into 
 
 ### `/telnyx` does not appear
 
-The TUI plugin requires a `tui.json` entry. Run `opencode plugin install @telnyx/opencode` which configures both `opencode.json` and `tui.json` automatically. If you added the plugin manually to `opencode.json`, you also need `tui.json`:
+The TUI plugin requires a `tui.json` entry. Run `opencode plugin @telnyx/opencode` which configures both `opencode.json` and `tui.json` automatically. If you added the plugin manually to `opencode.json`, you also need `tui.json`:
 
 ```json
 {


### PR DESCRIPTION
## What was wrong

The READMEs documented the OpenCode plugin install command as:

```
opencode plugin install @telnyx/opencode
```

But the correct command is:

```
opencode plugin @telnyx/opencode
```

The `install` subcommand doesn't exist — it was being parsed as the module name, causing the CLI to print help text instead of actually installing the plugin.

## What was changed

- **`plugins/opencode/README.md`**: Fixed all 3 instances of the incorrect command (`opencode plugin install` → `opencode plugin`) in the Install section and Troubleshooting section.
- **`README.md`**: Replaced the old `npm install` + manual `opencode.json` config block with the correct CLI commands, now showing both local and global install options:
  ```sh
  # Local (current project only)
  opencode plugin @telnyx/opencode

  # Global (all projects)
  opencode plugin -g @telnyx/opencode
  ```

## Notes

- `plugins/opencode/CHANGELOG.md` contains historical references to the old command in the v0.1.2 entry. These are left as-is since changelogs are immutable historical records.