### PR TITLE
chore: bump @telnyx/opencode to 0.1.3

### DIFF
--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -4,9 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-05-19
+
 ### Fixed
 
 - Fixed README install instructions to use `opencode plugin @telnyx/opencode` (there is no `install` subcommand)
+- Added `limit.output` (with 16384 fallback) to model config — fixes `config.get: Missing key` crash on opencode 1.14.44+ when `max_output_length` is null in the Telnyx API response
 
 ## [0.1.2] - 2026-04-24
 

--- a/plugins/opencode/package-lock.json
+++ b/plugins/opencode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@telnyx/opencode",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@telnyx/opencode",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@opencode-ai/plugin": "^1.2.27"
@@ -487,7 +487,6 @@
       "version": "0.17.3",
       "resolved": "https://registry.npmjs.org/@dimforge/rapier2d-simd-compat/-/rapier2d-simd-compat-0.17.3.tgz",
       "integrity": "sha512-bijvwWz6NHsNj5e5i1vtd3dU2pDhthSaTUZSh14DUGGKJfw8eMnlWZsxwHBxB/a3AXVNDjL9abuHw1k9FGR+jg==",
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true
     },
@@ -1718,7 +1717,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1732,7 +1730,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1746,7 +1743,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1760,7 +1756,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1774,7 +1769,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1788,7 +1782,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2198,7 +2191,6 @@
       "version": "0.1.69",
       "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.69.tgz",
       "integrity": "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true
     },
@@ -2446,7 +2438,6 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/bun-webgpu/-/bun-webgpu-0.1.5.tgz",
       "integrity": "sha512-91/K6S5whZKX7CWAm9AylhyKrLGRz6BUiiPiM/kXadSnD4rffljCD/q9cNFftm5YXhx4MvLqw33yEilxogJvwA==",
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -2466,7 +2457,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2480,7 +2470,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2494,7 +2483,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2508,7 +2496,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3637,7 +3624,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/planck/-/planck-1.5.0.tgz",
       "integrity": "sha512-dlvqJE+FscZgrGUXJ5ybd0o5bvZ5XXyZNbm08xGsXp9WjXeAyWSFT6n9s/1PQcUBo4546fDXA5RMA4wbDyZw6g==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -3982,6 +3968,17 @@
         "node": ">= 12"
       }
     },
+    "node_modules/stage-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stage-js/-/stage-js-1.0.2.tgz",
+      "integrity": "sha512-EWTRBYlg7Qv9wGUao99/PfRe3KaiQqWmgSvTOXvaWnu1Jk/q/vV8yJVu6bi/3EqDZeMVnCPAjheba6OFc5k1GQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=24.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -4073,7 +4070,6 @@
       "version": "0.177.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.177.0.tgz",
       "integrity": "sha512-EiXv5/qWAaGI+Vz2A+JfavwYCMdGjxVsrn3oBwllUoqYeaBO75J63ZfyaQKoiLrqNHoTlUc6PFgMXnS0kI45zg==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telnyx/opencode",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Telnyx auth and provider plugin for OpenCode",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Bumps version to trigger npm publish.

## Fixes included (already in main)

1. **`limit.output` missing** — All Telnyx models return `max_output_length: null`. Published v0.1.2 only sets `limit: { context }`, causing `config.get: Missing key` crash on startup. Fixed with 16384 fallback.
2. **README install command** — Corrected in #188.

## Changes
- `plugins/opencode/package.json`: 0.1.2 → 0.1.3
- `plugins/opencode/package-lock.json`: updated
- `plugins/opencode/CHANGELOG.md`: 0.1.3 release notes