### PR TITLE
fix: add limit.output to TUI providerModels (opencode plugin 0.1.4)

### DIFF
--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.4] - 2026-05-19
+
+### Fixed
+
+- Added `limit.output` (16384 fallback) to TUI `providerModels()` — fixes `/telnyx` model toggles not appearing in `/models`
+
 ## [0.1.3] - 2026-05-19
 
 ### Fixed

--- a/plugins/opencode/package-lock.json
+++ b/plugins/opencode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@telnyx/opencode",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@telnyx/opencode",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "@opencode-ai/plugin": "^1.2.27"

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telnyx/opencode",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Telnyx auth and provider plugin for OpenCode",
   "license": "MIT",
   "type": "module",

--- a/plugins/opencode/src/tui.tsx
+++ b/plugins/opencode/src/tui.tsx
@@ -82,7 +82,7 @@ function providerModels(models: Array<{ id: string; name: string; context: numbe
       if (!enabled.has(model.id)) return []
       const entry: Record<string, unknown> = {
         name: model.name,
-        limit: { context: model.context },
+        limit: { context: model.context, output: 16384 },
       }
       if (model.vision) {
         entry.attachment = true


### PR DESCRIPTION
## Problem

The TUI `/telnyx` command's `providerModels()` function builds model configs with `limit: { context }` but no `output` field. OpenCode's config validator requires `limit.output`, so toggling models via `/telnyx` silently fails — they never appear in `/models`.

Same bug as fixed in v0.1.3 for the server plugin, but the TUI code path was missed.

## Fix

Added `output: 16384` fallback to `providerModels()` in `tui.tsx` (line 85), matching the server plugin's existing fix.

## Changes

- `plugins/opencode/src/tui.tsx` — added `output: 16384` to limit in providerModels()
- `plugins/opencode/CHANGELOG.md` — v0.1.4 entry
- `plugins/opencode/package.json` — bumped to 0.1.4
- `plugins/opencode/package-lock.json` — updated