### PR TITLE
feat: port MCP Apps into ai repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ npm ci
 cd cli && npm ci
 cd tools/typescript && npm ci
 cd tools/mcp && npm ci
+cd tools/mcp-apps && npm ci
 cd tools/python && pip install -e ".[dev]"
 ```
 
@@ -37,6 +38,7 @@ cd tools/python && pip install -e ".[dev]"
 | `tools/python/`  | `cd tools/python && pytest`        |
 | `tools/typescript/` | `cd tools/typescript && npm test` |
 | `tools/mcp/`     | `cd tools/mcp && npm run build`    |
+| `tools/mcp-apps/`| `cd tools/mcp-apps && npm run typecheck && npm run build && npm test` |
 | `guides/`        | `npm run test:guides` (from root)  |
 | Guides API tests | `npm run test:guides-api` (root)   |
 
@@ -52,7 +54,8 @@ Run the relevant package's test suite before declaring a task done. Don't run al
 | `plugins/opencode/`     | OpenCode plugin (auth + TUI for Telnyx-hosted models).                    |
 | `tools/python/`         | Python agent toolkit (PyPI: `telnyx-agent-toolkit`).                      |
 | `tools/typescript/`     | TypeScript agent toolkit (npm).                                           |
-| `tools/mcp/`            | MCP proxy server.                                                         |
+| `tools/mcp/`            | MCP proxy server for the generic Telnyx API MCP endpoint.                |
+| `tools/mcp-apps/`       | Focused app-layer MCP servers with MCP Apps UI resources.                |
 | `tools/ffl-cli/`        | Filling-from-life CLI tooling.                                            |
 | `cli/`                  | Agent CLI for provisioning Telnyx infrastructure.                         |
 | `inference/`            | Documentation for Telnyx-hosted inference.                                |

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This repo is the one-stop shop for AI Agents and AI-first developers building wi
   
 - [Agent CLI](#agent-cli) - provision and build on Telnyx infrastructure in a single command.
 
+- [Model Context Protocol (MCP)](#model-context-protocol-mcp) - use Telnyx's generic API MCP proxy or app-layer MCP Apps.
+
 - [Guides](#guides) - step-by-step tutorials for common workflows
  
 
@@ -168,7 +170,19 @@ To run a local Telnyx MCP server using npx:
 npx -y @telnyx/mcp --api-key=YOUR_TELNYX_API_KEY
 ```
 
-See [MCP](/tools/mcp) for more details.
+See [MCP](/tools/mcp) for more details about the generic API MCP proxy.
+
+### MCP Apps
+
+[`tools/mcp-apps`](/tools/mcp-apps) contains app-layer MCP servers with MCP Apps UI resources for focused Telnyx workflows. These are separate from the generic `@telnyx/mcp` proxy above.
+
+Current apps:
+
+- Number Intelligence (`tools/mcp-apps/apps/number-intelligence`)
+- Usage & Cost Explorer (`tools/mcp-apps/apps/usage-cost-explorer`)
+- Voice Monitor (`tools/mcp-apps/apps/voice-monitor`)
+
+From `tools/mcp-apps`, use `npm install`, `npm run typecheck`, `npm run build`, and `npm test`.
 
 ## Guides
 

--- a/tools/mcp-apps/.gitignore
+++ b/tools/mcp-apps/.gitignore
@@ -1,0 +1,20 @@
+# Dependencies
+node_modules/
+.venv/
+
+# Build output
+dist/
+build/
+coverage/
+
+# Local env / secrets
+.env
+.env.*
+!.env.example
+*.pem
+*.key
+
+# OS/editor
+.DS_Store
+.idea/
+.vscode/

--- a/tools/mcp-apps/README.md
+++ b/tools/mcp-apps/README.md
@@ -1,0 +1,57 @@
+# Telnyx MCP Apps
+
+Telnyx MCP Apps are app-layer MCP servers with focused tools and MCP Apps UI resources for specific Telnyx workflows. They live under `tools/mcp-apps` in the `team-telnyx/ai` monorepo.
+
+These apps are separate from [`tools/mcp`](../mcp), which is the generic `@telnyx/mcp` stdio proxy to the hosted Telnyx API MCP endpoint at `https://api.telnyx.com/v2/mcp`.
+
+## Apps
+
+- [`apps/number-intelligence`](apps/number-intelligence) — phone-number analysis using Telnyx Number Lookup and read-first readiness signals.
+- [`apps/usage-cost-explorer`](apps/usage-cost-explorer) — balance, usage reports, billing groups, and guarded billing controls.
+- [`apps/voice-monitor`](apps/voice-monitor) — read-only active-call monitoring, call timelines, call status, and recording discovery.
+
+## Repository layout
+
+```text
+tools/mcp-apps/
+  apps/
+    number-intelligence/
+    usage-cost-explorer/
+    voice-monitor/
+  package.json
+  tsconfig.json
+```
+
+The root package is an npm workspace package with `apps/*` workspaces. Each app is a private package with its own source, tests, and README.
+
+## Setup
+
+From `tools/mcp-apps`:
+
+```sh
+npm install
+```
+
+Each app reads `TELNYX_API_KEY` from the environment when making live Telnyx API calls. Local `.env` files are supported by the app servers and `.env.example` files are included in each app directory.
+
+## Checks
+
+From `tools/mcp-apps`:
+
+```sh
+npm run typecheck
+npm run build
+npm test
+```
+
+Run an individual app with npm workspaces, for example:
+
+```sh
+npm run dev --workspace @telnyx-mcp-apps/number-intelligence
+npm run dev --workspace @telnyx-mcp-apps/usage-cost-explorer
+npm run dev --workspace @telnyx-mcp-apps/voice-monitor
+```
+
+## MCP Apps surface
+
+Each app exposes a stdio MCP server using `@modelcontextprotocol/sdk` and registers MCP Apps metadata/UI resources using `@modelcontextprotocol/ext-apps`. See the app READMEs for tool names, environment variables, and safety behavior.

--- a/tools/mcp-apps/apps/README.md
+++ b/tools/mcp-apps/apps/README.md
@@ -1,0 +1,7 @@
+# Apps
+
+Implemented app directories:
+
+- [`number-intelligence`](number-intelligence) — phone-number analysis with TypeScript/Vitest tests, MCP tools, and an MCP Apps UI resource.
+- [`usage-cost-explorer`](usage-cost-explorer) — balance, Usage Reports beta, billing groups, guarded billing-control tools, TypeScript/Vitest tests, and an MCP Apps UI resource.
+- [`voice-monitor`](voice-monitor) — read-only active-call monitoring, call timelines, call status lookup, recording discovery, TypeScript/Vitest tests, and an MCP Apps UI resource.

--- a/tools/mcp-apps/apps/number-intelligence/.env.example
+++ b/tools/mcp-apps/apps/number-intelligence/.env.example
@@ -1,0 +1,4 @@
+TELNYX_API_KEY=replace-with-readonly-key
+TELNYX_API_BASE_URL=https://api.telnyx.com
+# Default for include_raw on tool calls; per-call include_raw arg always wins.
+NUMBER_INTELLIGENCE_INCLUDE_RAW=false

--- a/tools/mcp-apps/apps/number-intelligence/README.md
+++ b/tools/mcp-apps/apps/number-intelligence/README.md
@@ -1,0 +1,154 @@
+# Number Intelligence
+
+Read-first Telnyx [MCP App](https://modelcontextprotocol.io/extensions/apps/overview) for explaining what is known about a phone number and what a user should do next.
+
+Current scope:
+
+- carrier and line type from Telnyx Number Lookup;
+- caller-name/ownership hint when returned by Number Lookup;
+- inferred messaging and voice capability from line type;
+- optional signals for ownership, portability, messaging configuration, voice configuration, and cached reputation;
+- stable recommended actions with IDs and tool hints;
+- interactive HTML UI resource for an MCP App-capable host to render in-chat.
+
+## Safety defaults
+
+- **Read-first behavior.** The default live Telnyx calls are read-only. Portability is opt-in because it uses an eligibility-check POST that does not create a port order.
+- **No mutating Telnyx setup calls.** No ordering numbers, no profile updates, no port creation, no sends.
+- **No fresh billed reputation lookup by default.** Reputation requests force `fresh=false`.
+- **No secrets in tests.** Tests use injected `fetch`/client stubs and do not require a real Telnyx API key.
+- **Default outputs are redacted.** `input.phone_number`, `normalized`, and `display` values use redacted phone-number strings; exact numbers are used only internally for lookup requests.
+- **Raw responses are opt-in and redacted.** `include_raw` defaults to `false`; when enabled, raw values pass through phone-number redaction.
+- **Avoid logging full numbers/secrets.** The client does not log requests or Authorization headers.
+
+## APIs used
+
+| Source | Behavior |
+| --- | --- |
+| Telnyx Number Lookup | Live read-only lookup: `GET /v2/number_lookup/{phone_number}?type=carrier&type=caller-name`. Always used. |
+| Owned-number config | Safe default live source: `GET /v2/phone_numbers?filter[phone_number]=...` to determine account ownership and missing assignment hints. |
+| Messaging readiness | Safe default live source: `GET /v2/phone_numbers/messaging` plus `GET /v2/messaging_profiles/{id}` when attached. The app does not surface sensitive profile secrets. |
+| Voice readiness | Safe default live source: `GET /v2/phone_numbers/voice` plus `GET /v2/connections/{id}` when attached. |
+| Portability | Opt-in live source: `POST /v2/portability_checks` as an eligibility-only/read-first check. It does not create a port order. |
+| Reputation | Opt-in cached-only live source: `GET /v2/reputation/numbers/{phone_number}?fresh=false`. |
+
+## Environment
+
+```bash
+TELNYX_API_KEY=replac...-key
+TELNYX_API_BASE_URL=https://api.telnyx.com   # optional
+NUMBER_INTELLIGENCE_INCLUDE_RAW=false        # optional; overridden per-call by include_raw
+```
+
+A `.env` file in this directory is auto-loaded when the server is run directly (`npm run dev` / `npm start`). The test suite does not read `.env`.
+
+## Commands
+
+From `tools/mcp-apps`:
+
+```bash
+npm install
+npm test --workspace @telnyx-mcp-apps/number-intelligence
+npm run typecheck --workspace @telnyx-mcp-apps/number-intelligence
+npm run build --workspace @telnyx-mcp-apps/number-intelligence
+npm run dev --workspace @telnyx-mcp-apps/number-intelligence
+```
+
+## MCP Apps surface
+
+The server is built on the official `@modelcontextprotocol/sdk` and registers MCP Apps metadata via `@modelcontextprotocol/ext-apps/server`. It runs over stdio.
+
+- tool: `number_intelligence_analyze`
+  - `phone_number` string, required
+  - `include_raw` boolean, optional (defaults to `NUMBER_INTELLIGENCE_INCLUDE_RAW` env, else `false`)
+  - `sources` string array, optional. Supported values: `lookup`, `owned`, `portability`, `messaging`, `voice`, `reputation`.
+  - omitted `sources` uses safe defaults: `owned`, `messaging`, `voice` plus the always-on Number Lookup.
+  - `portability` is opt-in because it uses an eligibility-check POST.
+  - `reputation` is opt-in and cached-only; requests force `fresh=false`.
+  - tool description carries `_meta.ui.resourceUri = "ui://number-intelligence/index.html"`
+  - tool result includes `structuredContent` with the full analysis object so MCP App hosts can hand it to the UI
+- tool: `number_intelligence_batch_analyze`
+  - `numbers` as newline/CSV text or an array of strings
+  - conservative max batch size: 25
+  - runs sequentially, redacts per-number output, and returns aggregate health/action counts
+- resource: `ui://number-intelligence/index.html` (mimeType `text/html;profile=mcp-app`)
+
+If `TELNYX_API_KEY` is missing, tool calls return a safe error result instead of attempting a live lookup.
+
+## Example output shape
+
+```json
+{
+  "input": { "phone_number": "+1312******23" },
+  "normalized": {
+    "e164": "+1312******23",
+    "e164_validated": false,
+    "national_format": "+1312******23"
+  },
+  "display": { "redacted": "+1312******23", "label": "+1312******23" },
+  "summary": {
+    "type": "mobile",
+    "carrier": "Example Wireless",
+    "country": "US",
+    "ownership": "Example Support",
+    "portability": "unknown",
+    "messaging": "likely_supported",
+    "voice": "likely_supported",
+    "reputation": "unknown"
+  },
+  "health": { "status": "good", "score": 90, "rationale": "Available read-only signals do not show a blocker." },
+  "signals": [
+    { "id": "lookup.carrier", "label": "Carrier lookup", "status": "info", "detail": "Carrier Example Wireless; type mobile." }
+  ],
+  "recommended_actions": [
+    { "id": "confirm_messaging_profile", "label": "Confirm messaging profile before sending", "tool_hint": "messaging_readiness_check" }
+  ],
+  "sources": [
+    { "id": "telnyx.number_lookup", "label": "Telnyx Number Lookup", "status": "consulted" }
+  ]
+}
+```
+
+`normalized.e164_validated` is always `false`: phone normalization is intentionally lightweight (`e164-ish`) and is not a real E.164 validator.
+
+## Running it live
+
+`TELNYX_API_KEY` must be a real, read-only Telnyx API key. Pick one of:
+
+**1. Raw stdio one-shot.**
+
+```bash
+export TELNYX_API_KEY=***
+npm run build --workspace @telnyx-mcp-apps/number-intelligence
+(
+  printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"cli","version":"0"}}}'
+  printf '%s\n' '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+  printf '%s\n' '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"number_intelligence_analyze","arguments":{"phone_number":"+1XXXXXXXXXX","include_raw":true}}}'
+) | node apps/number-intelligence/dist/server.js
+```
+
+**2. MCP Inspector (interactive).**
+
+```bash
+TELNYX_API_KEY=*** npx @modelcontextprotocol/inspector node "$PWD/apps/number-intelligence/dist/server.js"
+```
+
+Open the printed URL, hit Connect, then call `number_intelligence_analyze`.
+
+**3. Attach to Claude Code / Claude Desktop.**
+
+```bash
+claude mcp add number-intelligence \
+  --env TELNYX_API_KEY=*** \
+  -- node "$PWD/apps/number-intelligence/dist/server.js"
+```
+
+A host that supports the MCP Apps extension can resolve the tool's `_meta.ui.resourceUri` and render the UI in-chat.
+
+## Known limits
+
+- 10DLC campaign assignment, toll-free verification details, porting-order history, and type-specific SIP/FQDN/UAC connection details are not queried.
+- Portability is opt-in because it is a read-first POST, even though it does not create a port order.
+- Cached reputation is opt-in and always uses `fresh=false`; fresh/billed reputation lookups are not exposed.
+- `normalized.e164` is best-effort, not validated (see `normalized.e164_validated`).
+- The UI resource consumes `structuredContent` and attempts common host bridge names for re-analysis; host-specific MCP Apps client integration can vary.

--- a/tools/mcp-apps/apps/number-intelligence/package.json
+++ b/tools/mcp-apps/apps/number-intelligence/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@telnyx-mcp-apps/number-intelligence",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Read-first Telnyx MCP app for phone number intelligence.",
+  "main": "dist/server.js",
+  "scripts": {
+    "test": "vitest run",
+    "dev": "tsx src/server.ts",
+    "start": "node dist/server.js",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "build": "tsc -p tsconfig.json"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/team-telnyx/ai",
+    "directory": "tools/mcp-apps/apps/number-intelligence"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/ext-apps": "^1.7.2",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "dotenv": "^17.4.2"
+  }
+}

--- a/tools/mcp-apps/apps/number-intelligence/src/server.ts
+++ b/tools/mcp-apps/apps/number-intelligence/src/server.ts
@@ -1,0 +1,194 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  RESOURCE_MIME_TYPE,
+  registerAppResource,
+  registerAppTool
+} from "@modelcontextprotocol/ext-apps/server";
+import { z } from "zod";
+
+import { analyzeBatchNumbers, analyzeNumber } from "./service.js";
+import { TelnyxReadOnlyClient } from "./telnyxClient.js";
+import type { AnalyzeNumberDeps, NumberIntelligenceSourceId } from "./types.js";
+import { NUMBER_INTELLIGENCE_UI_HTML } from "./ui.js";
+
+const TOOL_NAME = "number_intelligence_analyze";
+const BATCH_TOOL_NAME = "number_intelligence_batch_analyze";
+const UI_RESOURCE_URI = "ui://number-intelligence/index.html";
+const SOURCE_IDS = ["lookup", "owned", "portability", "messaging", "voice", "reputation"] as const;
+const DEFAULT_SAFE_SOURCES: NumberIntelligenceSourceId[] = ["owned", "messaging", "voice"];
+const MAX_BATCH_SIZE = 25;
+
+export function createServer(): McpServer {
+  const server = new McpServer({
+    name: "telnyx-number-intelligence",
+    version: "0.2.0"
+  });
+
+  const envIncludeRawDefault = process.env.NUMBER_INTELLIGENCE_INCLUDE_RAW === "true";
+
+  registerAppTool(
+    server,
+    TOOL_NAME,
+    {
+      title: "Analyze phone number",
+      description:
+        "Read-first Number Intelligence summary using Telnyx Number Lookup plus safe owned-number, messaging, and voice enrichment by default. Portability and cached reputation are opt-in; reputation is always fresh=false.",
+      inputSchema: {
+        phone_number: z.string().min(1).describe("Phone number to analyze. E.164 is preferred."),
+        include_raw: z
+          .boolean()
+          .optional()
+          .describe("Include redacted raw Telnyx Number Lookup response. Overrides NUMBER_INTELLIGENCE_INCLUDE_RAW."),
+        sources: z
+          .array(z.enum(SOURCE_IDS))
+          .optional()
+          .describe(
+            "Optional source selection. Omit for safe defaults: owned, messaging, voice. Add portability for eligibility POST or reputation for cached fresh=false reputation."
+          )
+      },
+      _meta: { ui: { resourceUri: UI_RESOURCE_URI } }
+    },
+    async ({ phone_number, include_raw, sources }) => {
+      const deps = createLiveDeps();
+      if (!deps) {
+        return missingApiKeyResult();
+      }
+
+      const result = await analyzeNumber(
+        {
+          phone_number,
+          include_raw: include_raw ?? envIncludeRawDefault,
+          sources
+        },
+        deps
+      );
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        structuredContent: result as unknown as Record<string, unknown>
+      };
+    }
+  );
+
+  registerAppTool(
+    server,
+    BATCH_TOOL_NAME,
+    {
+      title: "Batch analyze phone numbers",
+      description:
+        "Read-first batch Number Intelligence for pasted CSV/newline input. Runs sequentially, caps batch size, redacts outputs, and never performs mutating Telnyx calls.",
+      inputSchema: {
+        numbers: z
+          .union([z.string().min(1), z.array(z.string().min(1))])
+          .describe("Phone numbers as pasted CSV/newline text or an array of strings. First CSV column is used."),
+        include_raw: z
+          .boolean()
+          .optional()
+          .describe("Include redacted raw Number Lookup responses for each result. Defaults to false/env setting."),
+        sources: z
+          .array(z.enum(SOURCE_IDS))
+          .optional()
+          .describe("Optional source selection. Omit for safe defaults: owned, messaging, voice.")
+      },
+      _meta: { ui: { resourceUri: UI_RESOURCE_URI } }
+    },
+    async ({ numbers, include_raw, sources }) => {
+      const deps = createLiveDeps();
+      if (!deps) {
+        return missingApiKeyResult();
+      }
+
+      try {
+        const result = await analyzeBatchNumbers(
+          {
+            numbers,
+            include_raw: include_raw ?? envIncludeRawDefault,
+            sources
+          },
+          deps,
+          { maxBatchSize: MAX_BATCH_SIZE }
+        );
+
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          structuredContent: result as unknown as Record<string, unknown>
+        };
+      } catch (error) {
+        const batchError = error instanceof Error ? error : new Error(String(error));
+        return {
+          isError: true,
+          content: [{ type: "text", text: batchError.message }]
+        };
+      }
+    }
+  );
+
+  registerAppResource(
+    server,
+    "Number Intelligence UI",
+    UI_RESOURCE_URI,
+    {
+      description:
+        "Interactive summary for phone-number analysis: carrier, line type, ownership/configuration readiness, cached reputation, batch aggregates, and recommended actions."
+    },
+    async () => ({
+      contents: [
+        {
+          uri: UI_RESOURCE_URI,
+          mimeType: RESOURCE_MIME_TYPE,
+          text: NUMBER_INTELLIGENCE_UI_HTML
+        }
+      ]
+    })
+  );
+
+  return server;
+}
+
+function createLiveDeps(): AnalyzeNumberDeps | undefined {
+  const apiKey = process.env.TELNYX_API_KEY;
+  if (!apiKey) {
+    return undefined;
+  }
+
+  const client = new TelnyxReadOnlyClient({
+    apiKey,
+    baseUrl: process.env.TELNYX_API_BASE_URL
+  });
+
+  return {
+    lookupClient: client,
+    sources: {
+      owned: client,
+      portability: client,
+      messaging: client,
+      voice: client,
+      reputation: client
+    },
+    defaultSources: DEFAULT_SAFE_SOURCES
+  };
+}
+
+function missingApiKeyResult(): { isError: true; content: Array<{ type: "text"; text: string }> } {
+  return {
+    isError: true,
+    content: [
+      {
+        type: "text",
+        text: "TELNYX_API_KEY is not set. Provide a read-only Telnyx API key to run live Number Intelligence."
+      }
+    ]
+  };
+}
+
+async function main(): Promise<void> {
+  await import("dotenv/config");
+  const server = createServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main();
+}

--- a/tools/mcp-apps/apps/number-intelligence/src/service.ts
+++ b/tools/mcp-apps/apps/number-intelligence/src/service.ts
@@ -1,0 +1,715 @@
+import type {
+  AnalyzeNumberDeps,
+  AnalyzeNumberInput,
+  BatchAnalyzeInput,
+  BatchAnalyzeOptions,
+  HealthStatus,
+  NumberIntelligenceBatchResult,
+  NumberIntelligenceResult,
+  NumberIntelligenceSignal,
+  NumberIntelligenceSource,
+  NumberIntelligenceSourceId,
+  OptionalSignals,
+  RecommendedAction,
+  TelnyxNumberLookupResponse
+} from "./types.js";
+
+const UNKNOWN = "unknown";
+const DEFAULT_LIVE_SOURCES: NumberIntelligenceSourceId[] = ["owned", "messaging", "voice"];
+const ALL_ENRICHMENT_SOURCES: Exclude<NumberIntelligenceSourceId, "lookup">[] = [
+  "owned",
+  "portability",
+  "messaging",
+  "voice",
+  "reputation"
+];
+const DEFAULT_MAX_BATCH_SIZE = 25;
+
+export async function analyzeNumber(
+  input: AnalyzeNumberInput,
+  deps: AnalyzeNumberDeps
+): Promise<NumberIntelligenceResult> {
+  const normalized = normalizePhoneNumber(input.phone_number);
+  const signals: NumberIntelligenceSignal[] = [];
+  const sources: NumberIntelligenceSource[] = [];
+  const recommendedActions = new Map<string, RecommendedAction>();
+
+  let lookup: TelnyxNumberLookupResponse | undefined;
+  let lookupError: Error | undefined;
+
+  try {
+    lookup = await deps.lookupClient.lookupNumber(normalized);
+    sources.push({
+      id: "telnyx.number_lookup",
+      label: "Telnyx Number Lookup",
+      status: "consulted",
+      detail: "GET /v2/number_lookup/{phone_number}?type=carrier&type=caller-name"
+    });
+  } catch (error) {
+    lookupError = error instanceof Error ? error : new Error(String(error));
+    sources.push({
+      id: "telnyx.number_lookup",
+      label: "Telnyx Number Lookup",
+      status: "error",
+      detail: redactString(lookupError.message, normalized)
+    });
+  }
+
+  const data = lookup?.data;
+  const carrierName = stringOrUnknown(data?.carrier?.name);
+  const carrierType = normalizeCarrierType(data?.carrier?.type);
+  const country = stringOrUnknown(data?.country_code);
+  const callerName = data?.caller_name?.caller_name ?? undefined;
+  const optional: OptionalSignals = { ...(deps.optionalSignals ?? {}) };
+
+  await collectSourceSignals(input, deps, normalized, optional, sources, signals);
+
+  if (lookupError) {
+    signals.push({
+      id: "lookup.error",
+      label: "Lookup unavailable",
+      status: "warning",
+      detail: "Telnyx Number Lookup could not be completed. Retry or verify the number format.",
+      value: lookupError.name
+    });
+    recommendedActions.set("retry_lookup", {
+      id: "retry_lookup",
+      label: "Retry number lookup",
+      rationale: "The primary lookup failed, so carrier, caller name, and capability signals may be incomplete.",
+      tool_hint: "number_intelligence_analyze"
+    });
+  } else if (carrierName !== UNKNOWN || carrierType !== UNKNOWN) {
+    signals.push({
+      id: "lookup.carrier",
+      label: "Carrier lookup",
+      status: "info",
+      detail: `Carrier ${carrierName}; type ${carrierType}.`,
+      value: carrierName
+    });
+  } else {
+    signals.push({
+      id: "lookup.carrier",
+      label: "Carrier lookup",
+      status: "warning",
+      detail: "Carrier details were not returned by Number Lookup.",
+      value: UNKNOWN
+    });
+  }
+
+  if (callerName) {
+    signals.push({
+      id: "lookup.caller_name",
+      label: "Caller name",
+      status: "info",
+      detail: `Caller name returned as ${callerName}.`,
+      value: callerName
+    });
+  } else if (!lookupError) {
+    signals.push({
+      id: "lookup.caller_name",
+      label: "Caller name",
+      status: "warning",
+      detail: "Caller-name data was not available for this lookup.",
+      value: UNKNOWN
+    });
+  }
+
+  const messagingCapability = inferMessagingCapability(carrierType, optional.messaging);
+  const voiceCapability = inferVoiceCapability(carrierType, optional.voice);
+  const portability = summarizePortability(optional.portability);
+  const ownership = summarizeOwnership(optional.ownership, callerName);
+  const reputation = summarizeReputation(optional.reputation);
+
+  addCapabilitySignals(signals, optional, carrierType, messagingCapability, voiceCapability, recommendedActions);
+  addOptionalSourceStatuses(sources, optional, input, deps);
+
+  if (optional.portability) {
+    if (optional.portability.portable === false || optional.portability.status === "not_portable") {
+      signals.push({
+        id: "portability.status",
+        label: "Portability",
+        status: "action_required",
+        detail: optional.portability.reason ?? "The number is currently marked not portable.",
+        value: false
+      });
+      recommendedActions.set("review_portability_block", {
+        id: "review_portability_block",
+        label: "Review portability blocker",
+        rationale: optional.portability.reason ?? "Resolve the reported portability issue before starting any port workflow.",
+        href: "https://portal.telnyx.com/#/porting",
+        tool_hint: "portability_check"
+      });
+    } else if (optional.portability.portable === true || optional.portability.status === "portable") {
+      signals.push({
+        id: "portability.status",
+        label: "Portability",
+        status: "info",
+        detail: optional.portability.reason ?? "The number appears portable based on supplied signals.",
+        value: true
+      });
+    }
+  }
+
+  if (optional.messaging) {
+    if (optional.messaging.configured === false) {
+      signals.push({
+        id: "messaging.configuration",
+        label: "Messaging configuration",
+        status: "action_required",
+        detail: optional.messaging.reason ?? "Messaging is not configured for this number.",
+        value: false
+      });
+      recommendedActions.set("attach_messaging_profile", {
+        id: "attach_messaging_profile",
+        label: "Attach or fix messaging profile",
+        rationale: optional.messaging.reason ?? "A messaging-capable number needs an active messaging profile before send/receive traffic.",
+        href: "https://portal.telnyx.com/#/app/messaging/profiles",
+        tool_hint: "messaging_readiness_check"
+      });
+    } else if (optional.messaging.configured === true) {
+      signals.push({
+        id: "messaging.configuration",
+        label: "Messaging configuration",
+        status: "info",
+        detail: optional.messaging.reason ?? "Messaging configuration signal is healthy.",
+        value: optional.messaging.profileId ?? true
+      });
+    }
+  }
+
+  if (optional.reputation?.status === "bad") {
+    signals.push({
+      id: "reputation.cached",
+      label: "Reputation",
+      status: "action_required",
+      detail: optional.reputation.reason ?? "Cached reputation signal is bad.",
+      value: "bad"
+    });
+    recommendedActions.set("investigate_reputation", {
+      id: "investigate_reputation",
+      label: "Investigate reputation before use",
+      rationale: "Bad reputation can reduce deliverability or increase answer-rate risk.",
+      tool_hint: "cached_reputation_review"
+    });
+  } else if (optional.reputation?.status === "warning") {
+    signals.push({
+      id: "reputation.cached",
+      label: "Reputation",
+      status: "warning",
+      detail: optional.reputation.reason ?? "Cached reputation signal needs review.",
+      value: "warning"
+    });
+  }
+
+  if (messagingCapability === "likely_supported") {
+    recommendedActions.set("confirm_messaging_profile", {
+      id: "confirm_messaging_profile",
+      label: "Confirm messaging profile before sending",
+      rationale: "Carrier type suggests messaging may be supported; confirm the messaging readiness source or profile configuration before production sends.",
+      href: "https://portal.telnyx.com/#/app/messaging/profiles",
+      tool_hint: "messaging_readiness_check"
+    });
+  }
+
+  if (carrierType === "mobile") {
+    recommendedActions.set("verify_compliance_use_case", {
+      id: "verify_compliance_use_case",
+      label: "Verify messaging compliance/use case",
+      rationale: "Mobile destinations can require campaign/use-case compliance before production messaging.",
+      tool_hint: "compliance_review"
+    });
+  }
+
+  if (recommendedActions.size === 0 && !lookupError) {
+    recommendedActions.set("monitor_before_launch", {
+      id: "monitor_before_launch",
+      label: "Monitor this number before production use",
+      rationale: "No blocking issue was found from available read-only signals; review readiness checks before launch."
+    });
+  }
+
+  const health = scoreHealth(signals, Boolean(lookupError));
+  const normalizedFromLookup = data?.phone_number ? normalizePhoneNumber(data.phone_number) : normalized;
+  const redactedInput = redactPhoneNumber(input.phone_number);
+  const redactedNormalized = redactPhoneNumber(normalizedFromLookup);
+  const redactedNationalFormat = data?.national_format ? redactString(data.national_format, normalizedFromLookup) : undefined;
+  const displayLabel =
+    redactedNationalFormat && redactedNationalFormat !== redactedNormalized
+      ? `${redactedNationalFormat} (${redactedNormalized})`
+      : redactedNormalized;
+
+  return {
+    input: { phone_number: redactedInput },
+    normalized: {
+      e164: redactedNormalized,
+      e164_validated: false,
+      ...(redactedNationalFormat ? { national_format: redactedNationalFormat } : {})
+    },
+    display: {
+      redacted: redactedNormalized,
+      label: displayLabel
+    },
+    summary: {
+      type: carrierType,
+      carrier: carrierName,
+      country,
+      ownership,
+      portability,
+      messaging: messagingCapability,
+      voice: voiceCapability,
+      reputation
+    },
+    health,
+    signals,
+    recommended_actions: Array.from(recommendedActions.values()),
+    sources,
+    ...(input.include_raw && lookup ? { raw: { telnyx_number_lookup: redactRaw(lookup, normalized) } } : {})
+  };
+}
+
+export async function analyzeBatchNumbers(
+  input: BatchAnalyzeInput,
+  deps: AnalyzeNumberDeps,
+  options: BatchAnalyzeOptions = {}
+): Promise<NumberIntelligenceBatchResult> {
+  const numbers = parseBatchNumbers(input.numbers);
+  const maxBatchSize = options.maxBatchSize ?? DEFAULT_MAX_BATCH_SIZE;
+
+  if (numbers.length === 0) {
+    throw new Error("Batch analysis requires at least one phone number.");
+  }
+  if (numbers.length > maxBatchSize) {
+    throw new Error(`Batch analysis accepts at most ${maxBatchSize} numbers per request.`);
+  }
+
+  const results: NumberIntelligenceResult[] = [];
+  for (const phoneNumber of numbers) {
+    results.push(
+      await analyzeNumber(
+        { phone_number: phoneNumber, include_raw: input.include_raw, sources: input.sources },
+        deps
+      )
+    );
+  }
+
+  const health_status_counts: Record<HealthStatus, number> = { good: 0, warning: 0, bad: 0, unknown: 0 };
+  let action_required_count = 0;
+  for (const result of results) {
+    health_status_counts[result.health.status] += 1;
+    action_required_count += result.signals.filter((signal) => signal.status === "action_required").length;
+  }
+
+  return {
+    total: results.length,
+    aggregate: { health_status_counts, action_required_count },
+    results
+  };
+}
+
+export function normalizePhoneNumber(phoneNumber: string): string {
+  const trimmed = phoneNumber.trim();
+  const digits = trimmed.replace(/\D/g, "");
+
+  if (trimmed.startsWith("+") && digits.length > 0) {
+    return `+${digits}`;
+  }
+
+  if (digits.length === 10) {
+    return `+1${digits}`;
+  }
+
+  if (digits.length > 0) {
+    return `+${digits}`;
+  }
+
+  return trimmed;
+}
+
+export function redactPhoneNumber(phoneNumber: string): string {
+  const normalized = normalizePhoneNumber(phoneNumber);
+  const digits = normalized.replace(/\D/g, "");
+
+  if (digits.length < 4) {
+    return "[redacted-number]";
+  }
+
+  const visiblePrefix = digits.slice(0, Math.min(4, digits.length - 2));
+  const visibleSuffix = digits.slice(-2);
+  const stars = "*".repeat(6);
+  return `+${visiblePrefix}${stars}${visibleSuffix}`;
+}
+
+function stringOrUnknown(value: unknown): string {
+  return typeof value === "string" && value.trim().length > 0 ? value : UNKNOWN;
+}
+
+function normalizeCarrierType(value: unknown): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return UNKNOWN;
+  }
+
+  return value.toLowerCase().replace(/\s+/g, "_");
+}
+
+function inferMessagingCapability(carrierType: string, messaging?: OptionalSignals["messaging"]): string {
+  if (messaging?.configured === false) {
+    return "misconfigured";
+  }
+  if (messaging?.configured === true) {
+    return "ready";
+  }
+  if (messaging?.capable === false) {
+    return "not_supported";
+  }
+  if (["mobile", "voip", "fixed_or_mobile", "toll_free"].includes(carrierType)) {
+    return "likely_supported";
+  }
+  if (["landline", "fixed_line", "premium_rate"].includes(carrierType)) {
+    return "unlikely_supported";
+  }
+  return UNKNOWN;
+}
+
+function inferVoiceCapability(carrierType: string, voice?: OptionalSignals["voice"]): string {
+  if (voice?.configured === false) {
+    return "misconfigured";
+  }
+  if (voice?.configured === true) {
+    return "ready";
+  }
+  if (carrierType === UNKNOWN) {
+    return UNKNOWN;
+  }
+  return "likely_supported";
+}
+
+function summarizePortability(portability?: OptionalSignals["portability"]): string {
+  if (!portability) {
+    return UNKNOWN;
+  }
+  if (portability.portable === false || portability.status === "not_portable") {
+    return "not_portable";
+  }
+  if (portability.portable === true || portability.status === "portable") {
+    return "portable";
+  }
+  return UNKNOWN;
+}
+
+function summarizeOwnership(ownership?: OptionalSignals["ownership"], callerName?: string): string {
+  if (ownership?.owned === true) {
+    return "owned";
+  }
+  if (ownership?.owned === false) {
+    return "not_owned";
+  }
+  if (callerName) {
+    return callerName;
+  }
+  return UNKNOWN;
+}
+
+function summarizeReputation(reputation?: OptionalSignals["reputation"]): string {
+  return reputation?.status ?? UNKNOWN;
+}
+
+async function collectSourceSignals(
+  input: AnalyzeNumberInput,
+  deps: AnalyzeNumberDeps,
+  normalized: string,
+  optional: OptionalSignals,
+  sources: NumberIntelligenceSource[],
+  signals: NumberIntelligenceSignal[]
+): Promise<void> {
+  const requested = requestedEnrichmentSources(input, deps);
+
+  await collectSingleSource("owned", requested, sources, signals, normalized, async () => {
+    const signal = await deps.sources?.owned?.getOwnedNumber?.(normalized);
+    if (signal) optional.ownership = signal;
+  });
+
+  await collectSingleSource("portability", requested, sources, signals, normalized, async () => {
+    const signal = await deps.sources?.portability?.checkPortability?.(normalized);
+    if (signal) optional.portability = signal;
+  });
+
+  await collectSingleSource("messaging", requested, sources, signals, normalized, async () => {
+    const signal = await deps.sources?.messaging?.checkMessagingReadiness?.(normalized);
+    if (signal) optional.messaging = signal;
+  });
+
+  await collectSingleSource("voice", requested, sources, signals, normalized, async () => {
+    const signal = await deps.sources?.voice?.checkVoiceReadiness?.(normalized);
+    if (signal) optional.voice = signal;
+  });
+
+  await collectSingleSource("reputation", requested, sources, signals, normalized, async () => {
+    const signal = await deps.sources?.reputation?.getCachedReputation?.(normalized);
+    if (signal) optional.reputation = signal;
+  });
+}
+
+async function collectSingleSource(
+  sourceId: Exclude<NumberIntelligenceSourceId, "lookup">,
+  requested: Exclude<NumberIntelligenceSourceId, "lookup">[],
+  sources: NumberIntelligenceSource[],
+  signals: NumberIntelligenceSignal[],
+  normalized: string,
+  run: () => Promise<void>
+): Promise<void> {
+  if (!requested.includes(sourceId)) {
+    return;
+  }
+
+  try {
+    await run();
+    sources.push({
+      id: sourceStatusId(sourceId),
+      label: sourceLabel(sourceId),
+      status: "consulted",
+      detail: sourceConsultedDetail(sourceId)
+    });
+  } catch (error) {
+    const sourceError = error instanceof Error ? error : new Error(String(error));
+    sources.push({
+      id: sourceStatusId(sourceId),
+      label: sourceLabel(sourceId),
+      status: "error",
+      detail: redactString(sourceError.message, normalized)
+    });
+    signals.push({
+      id: `source.${sourceStatusId(sourceId)}.error`,
+      label: `${sourceLabel(sourceId)} unavailable`,
+      status: "warning",
+      detail: `${sourceLabel(sourceId)} could not be completed; analysis continues with available sources.`,
+      value: sourceError.name
+    });
+  }
+}
+
+function requestedEnrichmentSources(
+  input: AnalyzeNumberInput,
+  deps: AnalyzeNumberDeps
+): Exclude<NumberIntelligenceSourceId, "lookup">[] {
+  const selected = input.sources ?? deps.defaultSources ?? (deps.sources ? DEFAULT_LIVE_SOURCES : []);
+  const unique = new Set<Exclude<NumberIntelligenceSourceId, "lookup">>();
+  for (const sourceId of selected) {
+    if (sourceId !== "lookup" && ALL_ENRICHMENT_SOURCES.includes(sourceId)) {
+      unique.add(sourceId);
+    }
+  }
+  return Array.from(unique);
+}
+
+function sourceStatusId(sourceId: Exclude<NumberIntelligenceSourceId, "lookup">): string {
+  return sourceId === "owned" ? "telnyx.owned_numbers" : `telnyx.${sourceId}`;
+}
+
+function sourceLabel(sourceId: Exclude<NumberIntelligenceSourceId, "lookup">): string {
+  switch (sourceId) {
+    case "owned":
+      return "Telnyx owned-number configuration";
+    case "portability":
+      return "Telnyx portability check";
+    case "messaging":
+      return "Telnyx messaging readiness";
+    case "voice":
+      return "Telnyx voice readiness";
+    case "reputation":
+      return "Telnyx cached reputation";
+  }
+}
+
+function sourceConsultedDetail(sourceId: Exclude<NumberIntelligenceSourceId, "lookup">): string {
+  switch (sourceId) {
+    case "owned":
+      return "GET /v2/phone_numbers?filter[phone_number]=...";
+    case "portability":
+      return "POST /v2/portability_checks (eligibility only; no port order is created).";
+    case "messaging":
+      return "GET /v2/phone_numbers/messaging and GET /v2/messaging_profiles/{id} when attached.";
+    case "voice":
+      return "GET /v2/phone_numbers/voice and GET /v2/connections/{id} when attached.";
+    case "reputation":
+      return "GET /v2/reputation/numbers/{phone_number}?fresh=false (cached only).";
+  }
+}
+
+function parseBatchNumbers(numbers: string | string[]): string[] {
+  const rawRows = Array.isArray(numbers) ? numbers : numbers.split(/\r?\n/);
+  const parsed: string[] = [];
+
+  for (const row of rawRows) {
+    const trimmed = row.trim();
+    if (!trimmed) continue;
+    const lower = trimmed.toLowerCase();
+    if (["phone_number", "phone", "number"].includes(lower)) continue;
+
+    const firstCsvCell = splitCsvRow(trimmed)[0]?.trim();
+    if (!firstCsvCell) continue;
+    if (["phone_number", "phone", "number"].includes(firstCsvCell.toLowerCase())) continue;
+    parsed.push(firstCsvCell);
+  }
+
+  return Array.from(new Set(parsed));
+}
+
+function splitCsvRow(row: string): string[] {
+  const cells: string[] = [];
+  let current = "";
+  let inQuotes = false;
+  for (let index = 0; index < row.length; index += 1) {
+    const char = row[index];
+    if (char === '"') {
+      inQuotes = !inQuotes;
+      continue;
+    }
+    if (char === "," && !inQuotes) {
+      cells.push(current);
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  cells.push(current);
+  return cells;
+}
+
+function addCapabilitySignals(
+  signals: NumberIntelligenceSignal[],
+  optional: OptionalSignals,
+  carrierType: string,
+  messagingCapability: string,
+  voiceCapability: string,
+  recommendedActions: Map<string, RecommendedAction>
+): void {
+  if (messagingCapability === "likely_supported" || messagingCapability === "ready") {
+    signals.push({
+      id: "messaging.capability",
+      label: "Messaging capability",
+      status: "info",
+      detail: `Carrier type ${carrierType} suggests messaging is ${messagingCapability.replace("_", " ")}.`,
+      value: messagingCapability
+    });
+  } else if (messagingCapability === "unlikely_supported" || messagingCapability === "not_supported") {
+    signals.push({
+      id: "messaging.capability",
+      label: "Messaging capability",
+      status: "warning",
+      detail: `Carrier type ${carrierType} may not support messaging reliably.`,
+      value: messagingCapability
+    });
+    recommendedActions.set("confirm_sms_capability", {
+      id: "confirm_sms_capability",
+      label: "Confirm SMS capability before use",
+      rationale: "The line type does not clearly support messaging.",
+      tool_hint: "messaging_readiness_check"
+    });
+  }
+
+  if (voiceCapability === "misconfigured") {
+    signals.push({
+      id: "voice.configuration",
+      label: "Voice configuration",
+      status: "action_required",
+      detail: optional.voice?.reason ?? "Voice is not configured for this number.",
+      value: false
+    });
+    recommendedActions.set("fix_voice_configuration", {
+      id: "fix_voice_configuration",
+      label: "Fix voice configuration",
+      rationale: optional.voice?.reason ?? "Voice traffic may fail until configuration is corrected.",
+      tool_hint: "voice_readiness_check"
+    });
+  }
+}
+
+function addOptionalSourceStatuses(
+  sources: NumberIntelligenceSource[],
+  optional: OptionalSignals,
+  input: AnalyzeNumberInput,
+  deps: AnalyzeNumberDeps
+): void {
+  const requested = requestedEnrichmentSources(input, deps);
+  for (const sourceId of ALL_ENRICHMENT_SOURCES) {
+    const id = sourceStatusId(sourceId);
+    if (sources.some((source) => source.id === id)) {
+      continue;
+    }
+    const hasOptionalSignal = sourceId === "owned" ? Boolean(optional.ownership) : Boolean(optional[sourceId]);
+    sources.push({
+      id,
+      label: sourceLabel(sourceId),
+      status: hasOptionalSignal ? "consulted" : "unavailable",
+      detail: hasOptionalSignal
+        ? "Supplied by injected optional signal."
+        : requested.includes(sourceId)
+          ? "Requested, but no source client is configured."
+          : sourceId === "reputation"
+            ? "Not queried by default; cached reputation is opt-in and always uses fresh=false."
+            : "Not requested for this analysis."
+    });
+  }
+}
+
+function scoreHealth(signals: NumberIntelligenceSignal[], lookupFailed: boolean): NumberIntelligenceResult["health"] {
+  if (lookupFailed) {
+    return {
+      status: "unknown",
+      score: 0,
+      rationale: "Primary lookup failed; available intelligence is incomplete."
+    };
+  }
+
+  const actionRequired = signals.filter((signal) => signal.status === "action_required").length;
+  const warnings = signals.filter((signal) => signal.status === "warning").length;
+
+  let score = 90 - warnings * 12 - actionRequired * 30;
+  score = Math.max(0, Math.min(100, score));
+
+  let status: HealthStatus = "good";
+  if (actionRequired > 0) {
+    status = actionRequired >= 2 ? "bad" : "warning";
+  } else if (warnings > 0) {
+    status = "warning";
+  }
+
+  return {
+    status,
+    score,
+    rationale:
+      status === "good"
+        ? "Available read-only signals do not show a blocker."
+        : `${actionRequired} action-required signal(s), ${warnings} warning signal(s).`
+  };
+}
+
+function redactRaw(value: unknown, normalized: string): unknown {
+  if (typeof value === "string") {
+    return redactString(value, normalized);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => redactRaw(item, normalized));
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [key, redactRaw(nestedValue, normalized)])
+    );
+  }
+  return value;
+}
+
+function redactString(value: string, normalized: string): string {
+  let redacted = value.split(normalized).join(redactPhoneNumber(normalized));
+  const compactNormalized = normalized.replace(/\D/g, "");
+  if (compactNormalized.length >= 7) {
+    redacted = redacted.split(compactNormalized).join(redactPhoneNumber(normalized));
+  }
+
+  const digits = redacted.replace(/\D/g, "");
+  if (digits.length >= 7 && /(?:\(?\+?\d[\d\s().-]{6,}\d\)?)/.test(redacted)) {
+    return redacted.replace(/\(?\+?\d[\d\s().-]{6,}\d\)?/g, (match) => redactPhoneNumber(match));
+  }
+
+  return redacted;
+}

--- a/tools/mcp-apps/apps/number-intelligence/src/telnyxClient.ts
+++ b/tools/mcp-apps/apps/number-intelligence/src/telnyxClient.ts
@@ -1,0 +1,329 @@
+import type {
+  MessagingSignalInput,
+  OwnershipSignalInput,
+  PortabilitySignalInput,
+  ReputationSignalInput,
+  TelnyxClientOptions,
+  TelnyxNumberLookupResponse,
+  VoiceSignalInput
+} from "./types.js";
+
+export class TelnyxNumberLookupError extends Error {
+  readonly status: number;
+  readonly details: unknown;
+
+  constructor(message: string, status: number, details: unknown) {
+    super(message);
+    this.name = "TelnyxNumberLookupError";
+    this.status = status;
+    this.details = details;
+  }
+}
+
+class TelnyxBaseClient {
+  protected readonly apiKey: string;
+  protected readonly baseUrl: string;
+  protected readonly fetchImpl: typeof fetch;
+
+  constructor(options: TelnyxClientOptions) {
+    if (!options.apiKey) {
+      throw new Error("Telnyx API key is required for live number intelligence");
+    }
+
+    this.apiKey = options.apiKey;
+    this.baseUrl = (options.baseUrl ?? "https://api.telnyx.com").replace(/\/+$/, "");
+    this.fetchImpl = options.fetch ?? globalThis.fetch;
+
+    if (!this.fetchImpl) {
+      throw new Error("A fetch implementation is required");
+    }
+  }
+
+  protected url(path: string): URL {
+    return new URL(`${this.baseUrl}${path}`);
+  }
+
+  protected async request<T>(url: URL, init: RequestInit = {}): Promise<T> {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.apiKey}`,
+      Accept: "application/json",
+      ...(init.body ? { "Content-Type": "application/json" } : {}),
+      ...(init.headers as Record<string, string> | undefined)
+    };
+
+    const response = await this.fetchImpl(url.toString(), {
+      ...init,
+      headers
+    });
+
+    const body = await parseJson(response);
+
+    if (!response.ok) {
+      throw new TelnyxNumberLookupError(
+        extractTelnyxErrorMessage(body) ?? `Telnyx request failed with status ${response.status}`,
+        response.status,
+        body
+      );
+    }
+
+    return body as T;
+  }
+}
+
+export class TelnyxNumberLookupClient extends TelnyxBaseClient {
+  async lookupNumber(phoneNumber: string): Promise<TelnyxNumberLookupResponse> {
+    const url = this.url(`/v2/number_lookup/${encodeURIComponent(normalizeE164ish(phoneNumber))}`);
+    url.searchParams.append("type", "carrier");
+    url.searchParams.append("type", "caller-name");
+
+    return this.request<TelnyxNumberLookupResponse>(url, { method: "GET" });
+  }
+}
+
+export class TelnyxReadOnlyClient extends TelnyxNumberLookupClient {
+  async getOwnedNumber(phoneNumber: string): Promise<OwnershipSignalInput> {
+    const url = this.url("/v2/phone_numbers");
+    url.searchParams.set("filter[phone_number]", digitsOnly(phoneNumber));
+    url.searchParams.set("page[size]", "1");
+    url.searchParams.set("page[number]", "1");
+    url.searchParams.set("handle_messaging_profile_error", "true");
+
+    const body = await this.request<TelnyxListResponse<Record<string, unknown>>>(url, { method: "GET" });
+    const record = firstRecord(body);
+    if (!record) {
+      return { owned: false, reason: "No owned Telnyx phone-number inventory record was found." };
+    }
+
+    const missing: string[] = [];
+    if (!stringField(record, "messaging_profile_id")) missing.push("messaging profile");
+    if (!stringField(record, "connection_id")) missing.push("voice connection");
+
+    return {
+      owned: true,
+      numberId: stringField(record, "id"),
+      reason: missing.length > 0 ? `Owned number found; missing ${missing.join(" and ")}.` : "Owned number found with messaging and voice assignments."
+    };
+  }
+
+  async checkPortability(phoneNumber: string): Promise<PortabilitySignalInput> {
+    const normalized = normalizeE164ish(phoneNumber);
+    const url = this.url("/v2/portability_checks");
+    const body = await this.request<TelnyxListResponse<Record<string, unknown>>>(url, {
+      method: "POST",
+      body: JSON.stringify({ phone_numbers: [normalized] })
+    });
+    const record = firstRecord(body);
+    if (!record) {
+      return { status: "unknown", reason: "Portability check returned no result for the number." };
+    }
+
+    const portable = booleanField(record, "portable");
+    const reason = stringField(record, "not_portable_reason") ?? stringField(record, "reason");
+    return {
+      portable,
+      status: portable === true ? "portable" : portable === false ? "not_portable" : "unknown",
+      reason: reason ?? (portable === true ? "Telnyx portability check returned portable." : "Telnyx portability check returned no explicit reason.")
+    };
+  }
+
+  async checkMessagingReadiness(phoneNumber: string): Promise<MessagingSignalInput> {
+    const normalized = normalizeE164ish(phoneNumber);
+    const url = this.url("/v2/phone_numbers/messaging");
+    url.searchParams.set("filter[phone_number]", normalized);
+    url.searchParams.set("page[size]", "1");
+    url.searchParams.set("page[number]", "1");
+
+    const body = await this.request<TelnyxListResponse<Record<string, unknown>>>(url, { method: "GET" });
+    const record = firstRecord(body);
+    if (!record) {
+      return { configured: false, capable: false, reason: "No Telnyx messaging settings record was found for this number." };
+    }
+
+    const profileId = stringField(record, "messaging_profile_id");
+    const capable = messagingCapable(record);
+    if (!profileId) {
+      return { configured: false, capable, reason: "Messaging settings exist but no messaging profile is attached." };
+    }
+
+    const profileUrl = this.url(`/v2/messaging_profiles/${encodeURIComponent(profileId)}`);
+    const profileBody = await this.request<TelnyxSingleResponse<Record<string, unknown>>>(profileUrl, { method: "GET" });
+    const profile = singleRecord(profileBody);
+    const enabled = booleanField(profile, "enabled");
+    const healthReason = messagingHealthReason(record);
+
+    if (enabled === false) {
+      return { configured: false, capable, profileId, reason: "Messaging profile is attached but disabled." };
+    }
+
+    return {
+      configured: true,
+      capable,
+      profileId,
+      reason: healthReason ?? "Messaging profile is attached and enabled."
+    };
+  }
+
+  async checkVoiceReadiness(phoneNumber: string): Promise<VoiceSignalInput> {
+    const url = this.url("/v2/phone_numbers/voice");
+    url.searchParams.set("filter[phone_number]", digitsOnly(phoneNumber));
+    url.searchParams.set("page[size]", "1");
+    url.searchParams.set("page[number]", "1");
+
+    const body = await this.request<TelnyxListResponse<Record<string, unknown>>>(url, { method: "GET" });
+    const record = firstRecord(body);
+    if (!record) {
+      return { configured: false, reason: "No Telnyx voice settings record was found for this number." };
+    }
+
+    const connectionId = stringField(record, "connection_id");
+    if (!connectionId) {
+      return { configured: false, reason: "Voice settings exist but no connection is assigned." };
+    }
+
+    const connectionUrl = this.url(`/v2/connections/${encodeURIComponent(connectionId)}`);
+    const connectionBody = await this.request<TelnyxSingleResponse<Record<string, unknown>>>(connectionUrl, { method: "GET" });
+    const connection = singleRecord(connectionBody);
+    const active = booleanField(connection, "active");
+
+    if (active === false) {
+      return { configured: false, connectionId, reason: "Voice connection is assigned but inactive." };
+    }
+
+    return { configured: true, connectionId, reason: "Active voice connection is assigned." };
+  }
+
+  async getCachedReputation(phoneNumber: string): Promise<ReputationSignalInput> {
+    const url = this.url(`/v2/reputation/numbers/${encodeURIComponent(normalizeE164ish(phoneNumber))}`);
+    url.searchParams.set("fresh", "false");
+
+    try {
+      const body = await this.request<TelnyxSingleResponse<Record<string, unknown>>>(url, { method: "GET" });
+      const record = singleRecord(body);
+      const reputation = objectField(record, "reputation_data");
+      if (!reputation) {
+        return { status: "unknown", reason: "Cached reputation endpoint returned no reputation data." };
+      }
+
+      const spamRisk = stringField(reputation, "spam_risk")?.toLowerCase();
+      const maturityScore = numberField(reputation, "maturity_score");
+      if (spamRisk === "high" || spamRisk === "very_high") {
+        return { status: "bad", reason: "Cached Telnyx reputation spam risk is high." };
+      }
+      if (spamRisk === "medium" || spamRisk === "moderate" || (typeof maturityScore === "number" && maturityScore < 50)) {
+        return { status: "warning", reason: "Cached Telnyx reputation should be reviewed before production use." };
+      }
+      if (spamRisk === "low" || (typeof maturityScore === "number" && maturityScore >= 80)) {
+        return { status: "good", reason: "Cached Telnyx reputation does not show elevated risk." };
+      }
+      return { status: "unknown", reason: "Cached Telnyx reputation exists but could not be scored." };
+    } catch (error) {
+      if (error instanceof TelnyxNumberLookupError && error.status === 404) {
+        return { status: "unknown", reason: "No cached Telnyx reputation record was found; no fresh lookup was requested." };
+      }
+      throw error;
+    }
+  }
+}
+
+interface TelnyxListResponse<T> {
+  data?: T[];
+}
+
+interface TelnyxSingleResponse<T> {
+  data?: T;
+}
+
+async function parseJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return { text };
+  }
+}
+
+function extractTelnyxErrorMessage(body: unknown): string | undefined {
+  if (!body || typeof body !== "object") {
+    return undefined;
+  }
+
+  const errors = (body as { errors?: unknown }).errors;
+  if (!Array.isArray(errors) || errors.length === 0) {
+    return undefined;
+  }
+
+  const first = errors[0];
+  if (!first || typeof first !== "object") {
+    return undefined;
+  }
+
+  const title = (first as { title?: unknown }).title;
+  const detail = (first as { detail?: unknown }).detail;
+  return [title, detail].filter((value): value is string => typeof value === "string" && value.length > 0).join(": ");
+}
+
+function normalizeE164ish(phoneNumber: string): string {
+  const trimmed = phoneNumber.trim();
+  const digits = digitsOnly(trimmed);
+  if (trimmed.startsWith("+") && digits.length > 0) return `+${digits}`;
+  if (digits.length === 10) return `+1${digits}`;
+  if (digits.length > 0) return `+${digits}`;
+  return trimmed;
+}
+
+function digitsOnly(phoneNumber: string): string {
+  return phoneNumber.replace(/\D/g, "");
+}
+
+function firstRecord<T>(body: TelnyxListResponse<T>): T | undefined {
+  return Array.isArray(body.data) ? body.data[0] : undefined;
+}
+
+function singleRecord<T extends Record<string, unknown>>(body: TelnyxSingleResponse<T>): T {
+  return body.data ?? ({} as T);
+}
+
+function stringField(record: Record<string, unknown> | undefined, field: string): string | undefined {
+  const value = record?.[field];
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function booleanField(record: Record<string, unknown> | undefined, field: string): boolean | undefined {
+  const value = record?.[field];
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function numberField(record: Record<string, unknown> | undefined, field: string): number | undefined {
+  const value = record?.[field];
+  return typeof value === "number" ? value : undefined;
+}
+
+function objectField(record: Record<string, unknown> | undefined, field: string): Record<string, unknown> | undefined {
+  const value = record?.[field];
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
+}
+
+function messagingCapable(record: Record<string, unknown>): boolean | undefined {
+  const products = record.eligible_messaging_products;
+  if (Array.isArray(products)) return products.length > 0;
+  const features = objectField(record, "features");
+  if (!features) return undefined;
+  return Boolean(features.sms || features.mms);
+}
+
+function messagingHealthReason(record: Record<string, unknown>): string | undefined {
+  const health = objectField(record, "health");
+  const spamRatio = numberField(health, "spam_ratio");
+  const successRatio = numberField(health, "success_ratio");
+  if (typeof spamRatio === "number" && spamRatio >= 0.1) {
+    return "Messaging profile is enabled, but spam ratio is elevated in cached health data.";
+  }
+  if (typeof successRatio === "number" && successRatio < 0.8) {
+    return "Messaging profile is enabled, but success ratio is low in cached health data.";
+  }
+  return undefined;
+}

--- a/tools/mcp-apps/apps/number-intelligence/src/types.ts
+++ b/tools/mcp-apps/apps/number-intelligence/src/types.ts
@@ -1,0 +1,186 @@
+export type SignalStatus = "info" | "warning" | "action_required";
+export type SourceStatus = "consulted" | "unavailable" | "error";
+export type HealthStatus = "good" | "warning" | "bad" | "unknown";
+
+export interface AnalyzeNumberInput {
+  phone_number: string;
+  include_raw?: boolean;
+  sources?: NumberIntelligenceSourceId[];
+}
+
+export type NumberIntelligenceSourceId = "lookup" | "owned" | "portability" | "messaging" | "voice" | "reputation";
+
+export interface TelnyxCarrierInfo {
+  name?: string | null;
+  type?: string | null;
+  mobile_country_code?: string | null;
+  mobile_network_code?: string | null;
+  error_code?: string | null;
+}
+
+export interface TelnyxCallerNameInfo {
+  caller_name?: string | null;
+  error_code?: string | null;
+}
+
+export interface TelnyxNumberLookupData {
+  phone_number?: string | null;
+  national_format?: string | null;
+  country_code?: string | null;
+  carrier?: TelnyxCarrierInfo | null;
+  caller_name?: TelnyxCallerNameInfo | null;
+  [key: string]: unknown;
+}
+
+export interface TelnyxNumberLookupResponse {
+  data: TelnyxNumberLookupData;
+  [key: string]: unknown;
+}
+
+export interface NumberLookupClient {
+  lookupNumber(phoneNumber: string): Promise<TelnyxNumberLookupResponse>;
+}
+
+export interface TelnyxClientOptions {
+  apiKey: string;
+  baseUrl?: string;
+  fetch?: typeof fetch;
+}
+
+export interface PortabilitySignalInput {
+  portable?: boolean;
+  reason?: string;
+  status?: "portable" | "not_portable" | "unknown";
+}
+
+export interface MessagingSignalInput {
+  configured?: boolean;
+  reason?: string;
+  profileId?: string;
+  capable?: boolean;
+}
+
+export interface OwnershipSignalInput {
+  owned?: boolean;
+  numberId?: string;
+  reason?: string;
+}
+
+export interface ReputationSignalInput {
+  status?: "good" | "warning" | "bad" | "unknown";
+  reason?: string;
+}
+
+export interface VoiceSignalInput {
+  configured?: boolean;
+  reason?: string;
+  connectionId?: string;
+}
+
+export interface OptionalSignals {
+  portability?: PortabilitySignalInput;
+  messaging?: MessagingSignalInput;
+  ownership?: OwnershipSignalInput;
+  reputation?: ReputationSignalInput;
+  voice?: VoiceSignalInput;
+}
+
+export interface AnalyzeNumberDeps {
+  lookupClient: NumberLookupClient;
+  optionalSignals?: OptionalSignals;
+  sources?: NumberIntelligenceSourceClients;
+  defaultSources?: NumberIntelligenceSourceId[];
+}
+
+export interface NumberIntelligenceSignal {
+  id: string;
+  label: string;
+  status: SignalStatus;
+  detail: string;
+  value?: string | boolean | number | null;
+}
+
+export interface RecommendedAction {
+  id: string;
+  label: string;
+  rationale: string;
+  href?: string;
+  tool_hint?: string;
+}
+
+export interface NumberIntelligenceSource {
+  id: string;
+  label: string;
+  status: SourceStatus;
+  detail?: string;
+}
+
+export interface NumberIntelligenceSummary {
+  type: string;
+  carrier: string;
+  country: string;
+  ownership: string;
+  portability: string;
+  messaging: string;
+  voice: string;
+  reputation: string;
+}
+
+export interface NumberIntelligenceResult {
+  input: { phone_number: string };
+  normalized: { e164: string; e164_validated: boolean; national_format?: string };
+  display: { redacted: string; label: string };
+  summary: NumberIntelligenceSummary;
+  health: { status: HealthStatus; score: number; rationale: string };
+  signals: NumberIntelligenceSignal[];
+  recommended_actions: RecommendedAction[];
+  sources: NumberIntelligenceSource[];
+  raw?: Record<string, unknown>;
+}
+
+export interface OwnedNumberSource {
+  getOwnedNumber?(phoneNumber: string): Promise<OwnershipSignalInput>;
+}
+
+export interface PortingSource {
+  checkPortability?(phoneNumber: string): Promise<PortabilitySignalInput>;
+}
+
+export interface MessagingReadinessSource {
+  checkMessagingReadiness?(phoneNumber: string): Promise<MessagingSignalInput>;
+}
+
+export interface ReputationSource {
+  getCachedReputation?(phoneNumber: string): Promise<ReputationSignalInput>;
+}
+
+export interface VoiceReadinessSource {
+  checkVoiceReadiness?(phoneNumber: string): Promise<VoiceSignalInput>;
+}
+
+export interface NumberIntelligenceSourceClients {
+  owned?: OwnedNumberSource;
+  portability?: PortingSource;
+  messaging?: MessagingReadinessSource;
+  voice?: VoiceReadinessSource;
+  reputation?: ReputationSource;
+}
+
+export interface BatchAnalyzeInput {
+  numbers: string | string[];
+  include_raw?: boolean;
+  sources?: NumberIntelligenceSourceId[];
+}
+
+export interface BatchAnalyzeOptions {
+  maxBatchSize?: number;
+}
+
+export interface NumberIntelligenceBatchResult {
+  total: number;
+  aggregate: {
+    health_status_counts: Record<HealthStatus, number>;
+    action_required_count: number;
+  };
+  results: NumberIntelligenceResult[];
+}

--- a/tools/mcp-apps/apps/number-intelligence/src/ui.ts
+++ b/tools/mcp-apps/apps/number-intelligence/src/ui.ts
@@ -1,0 +1,496 @@
+export const NUMBER_INTELLIGENCE_UI_HTML = String.raw`<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Telnyx Number Intelligence</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg: #f7f8fb;
+        --panel: #ffffff;
+        --panel-soft: #eef3f7;
+        --text: #111827;
+        --muted: #5b6472;
+        --line: #d7dde6;
+        --accent: #00a3a3;
+        --accent-strong: #057474;
+        --good: #16803c;
+        --warn: #a46000;
+        --bad: #b42318;
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #09111f;
+          --panel: #101928;
+          --panel-soft: #142237;
+          --text: #f8fafc;
+          --muted: #aab7c7;
+          --line: #27364b;
+          --accent: #2dd4bf;
+          --accent-strong: #5eead4;
+          --good: #4ade80;
+          --warn: #fbbf24;
+          --bad: #f87171;
+        }
+      }
+
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--bg); color: var(--text); }
+      main { width: min(1120px, 100%); margin: 0 auto; padding: 22px; }
+      header { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 18px; }
+      h1 { margin: 0; font-size: 30px; line-height: 1.1; font-weight: 760; }
+      h2 { margin: 0 0 12px; font-size: 15px; line-height: 1.25; }
+      p { margin: 0; color: var(--muted); line-height: 1.5; }
+      button, input { font: inherit; }
+      button {
+        min-height: 42px;
+        border: 0;
+        border-radius: 8px;
+        padding: 0 14px;
+        background: var(--accent);
+        color: #042f2e;
+        font-weight: 760;
+        cursor: pointer;
+      }
+      button:disabled { cursor: progress; opacity: .7; }
+      input {
+        min-width: 0;
+        min-height: 42px;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 0 12px;
+        background: var(--panel);
+        color: var(--text);
+      }
+      .eyebrow { color: var(--accent-strong); font-size: 12px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+      .toolbar { display: grid; grid-template-columns: minmax(180px, 1fr) auto; gap: 10px; margin: 18px 0 12px; }
+      .source-options { display: flex; flex-wrap: wrap; gap: 10px; margin: 0 0 18px; }
+      .checkbox { display: inline-flex; align-items: center; gap: 7px; color: var(--muted); font-size: 13px; }
+      .grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; }
+      .card, .panel {
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: var(--panel);
+        box-shadow: 0 1px 2px rgba(15, 23, 42, .06);
+      }
+      .card { min-height: 104px; padding: 14px; }
+      .panel { padding: 16px; }
+      .label { color: var(--muted); font-size: 12px; font-weight: 700; letter-spacing: .04em; text-transform: uppercase; }
+      .value { margin-top: 8px; font-size: 20px; font-weight: 760; overflow-wrap: anywhere; }
+      .meta { margin-top: 6px; color: var(--muted); font-size: 13px; overflow-wrap: anywhere; }
+      .status-good, .status-info, .status-likely_supported { color: var(--good); }
+      .status-warning, .status-unlikely_supported { color: var(--warn); }
+      .status-bad, .status-error, .status-action_required { color: var(--bad); }
+      .status-unknown { color: var(--muted); }
+      .columns { display: grid; grid-template-columns: 1.15fr .85fr; gap: 12px; margin-top: 12px; }
+      .list { display: grid; gap: 10px; margin: 0; padding: 0; list-style: none; }
+      .row { display: grid; gap: 3px; padding: 10px; border-radius: 8px; background: var(--panel-soft); }
+      .row-title { font-weight: 720; }
+      .row-detail { color: var(--muted); line-height: 1.45; }
+      .pill-row { display: flex; flex-wrap: wrap; gap: 8px; justify-content: flex-end; }
+      .pill { border: 1px solid var(--line); border-radius: 999px; padding: 6px 9px; color: var(--muted); font-size: 12px; background: var(--panel); }
+      .tabs { display: flex; flex-wrap: wrap; gap: 8px; margin: 14px 0 12px; }
+      .tab { min-height: 36px; border: 1px solid var(--line); background: var(--panel); color: var(--muted); border-radius: 999px; }
+      .tab[aria-selected="true"] { background: var(--accent); border-color: var(--accent); color: #042f2e; }
+      .empty { padding: 28px 16px; text-align: center; border: 1px dashed var(--line); border-radius: 8px; background: var(--panel); }
+      .error { margin-top: 12px; color: var(--bad); font-weight: 650; }
+      .table-wrap { overflow-x: auto; }
+      table { width: 100%; border-collapse: collapse; }
+      th, td { padding: 9px; border-bottom: 1px solid var(--line); text-align: left; vertical-align: top; }
+      th { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: .04em; }
+      pre { overflow: auto; max-height: 300px; margin: 0; padding: 12px; border-radius: 8px; background: var(--panel-soft); color: var(--text); }
+      .hidden { display: none; }
+
+      @media (max-width: 820px) {
+        main { padding: 16px; }
+        header, .columns { grid-template-columns: 1fr; display: grid; }
+        .pill-row { justify-content: flex-start; }
+        .grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+        .toolbar { grid-template-columns: 1fr; }
+      }
+
+      @media (max-width: 460px) {
+        .grid { grid-template-columns: 1fr; }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <div>
+          <div class="eyebrow">Telnyx MCP App</div>
+          <h1>Number Intelligence</h1>
+          <p>Carrier, line type, ownership/configuration readiness, cached reputation, and next actions.</p>
+        </div>
+        <div class="pill-row">
+          <span class="pill" id="bridgeStatus">Host bridge: initializing</span>
+          <span class="pill" id="modeStatus">Single number</span>
+        </div>
+      </header>
+
+      <form class="toolbar" id="analyzeForm">
+        <input id="phoneInput" name="phone" autocomplete="tel" aria-label="Phone number" placeholder="+13125550123" />
+        <button id="analyzeButton" type="submit">Analyze</button>
+      </form>
+
+      <div class="source-options" aria-label="Source options">
+        <label class="checkbox"><input type="checkbox" value="owned" checked /> owned</label>
+        <label class="checkbox"><input type="checkbox" value="messaging" checked /> messaging</label>
+        <label class="checkbox"><input type="checkbox" value="voice" checked /> voice</label>
+        <label class="checkbox"><input type="checkbox" value="portability" /> portability</label>
+        <label class="checkbox"><input type="checkbox" value="reputation" /> cached reputation</label>
+      </div>
+
+      <div class="error hidden" id="error"></div>
+
+      <section id="emptyState" class="empty">
+        <h2>Waiting for a number analysis</h2>
+        <p>Run <strong>number_intelligence_analyze</strong> or <strong>number_intelligence_batch_analyze</strong> from your MCP host.</p>
+      </section>
+
+      <section id="resultView" class="hidden">
+        <section class="grid" aria-label="Summary">
+          <article class="card">
+            <div class="label">Health</div>
+            <div class="value" id="healthValue">Unknown</div>
+            <div class="meta" id="healthMeta"></div>
+          </article>
+          <article class="card">
+            <div class="label">Number</div>
+            <div class="value" id="numberValue">redacted</div>
+            <div class="meta" id="countryValue"></div>
+          </article>
+          <article class="card">
+            <div class="label">Carrier / Type</div>
+            <div class="value" id="carrierValue">Unknown</div>
+            <div class="meta" id="ownershipValue"></div>
+          </article>
+          <article class="card">
+            <div class="label">Messaging / Voice</div>
+            <div class="value" id="messagingValue">Unknown</div>
+            <div class="meta" id="voiceValue"></div>
+          </article>
+        </section>
+
+        <div class="tabs" role="tablist">
+          <button class="tab" data-tab="signalsPanel" aria-selected="true" type="button">Signals</button>
+          <button class="tab" data-tab="actionsPanel" aria-selected="false" type="button">Actions</button>
+          <button class="tab" data-tab="sourcesPanel" aria-selected="false" type="button">Sources</button>
+          <button class="tab" data-tab="batchPanel" aria-selected="false" type="button">Batch</button>
+          <button class="tab" data-tab="jsonPanel" aria-selected="false" type="button">JSON</button>
+        </div>
+
+        <section class="columns" id="singlePanels">
+          <article class="panel" id="signalsPanel">
+            <h2>Signals</h2>
+            <ul class="list" id="signalsList"></ul>
+          </article>
+          <article class="panel hidden" id="actionsPanel">
+            <h2>Recommended Actions</h2>
+            <ul class="list" id="actionsList"></ul>
+          </article>
+          <article class="panel hidden" id="sourcesPanel">
+            <h2>Sources</h2>
+            <ul class="list" id="sourcesList"></ul>
+          </article>
+          <article class="panel hidden" id="batchPanel">
+            <h2>Batch</h2>
+            <div id="batchContent"></div>
+          </article>
+          <article class="panel hidden" id="jsonPanel">
+            <h2>JSON</h2>
+            <pre id="jsonPre"></pre>
+          </article>
+        </section>
+      </section>
+    </main>
+
+    <script>
+      const TOOL_NAME = "number_intelligence_analyze";
+      const PROTOCOL_VERSION = "2026-01-26";
+      let nextId = 1;
+      const pending = new Map();
+      let initialized = false;
+      let currentResult;
+
+      const els = {
+        form: document.getElementById("analyzeForm"),
+        button: document.getElementById("analyzeButton"),
+        phone: document.getElementById("phoneInput"),
+        error: document.getElementById("error"),
+        empty: document.getElementById("emptyState"),
+        result: document.getElementById("resultView"),
+        bridgeStatus: document.getElementById("bridgeStatus"),
+        modeStatus: document.getElementById("modeStatus"),
+        healthValue: document.getElementById("healthValue"),
+        healthMeta: document.getElementById("healthMeta"),
+        numberValue: document.getElementById("numberValue"),
+        countryValue: document.getElementById("countryValue"),
+        carrierValue: document.getElementById("carrierValue"),
+        ownershipValue: document.getElementById("ownershipValue"),
+        messagingValue: document.getElementById("messagingValue"),
+        voiceValue: document.getElementById("voiceValue"),
+        signalsList: document.getElementById("signalsList"),
+        actionsList: document.getElementById("actionsList"),
+        sourcesList: document.getElementById("sourcesList"),
+        batchContent: document.getElementById("batchContent"),
+        jsonPre: document.getElementById("jsonPre")
+      };
+
+      function send(message) {
+        window.parent.postMessage(message, "*");
+      }
+
+      function request(method, params) {
+        const id = nextId++;
+        send({ jsonrpc: "2.0", id, method, params });
+        return new Promise((resolve, reject) => {
+          pending.set(id, { resolve, reject });
+          window.setTimeout(() => {
+            if (!pending.has(id)) return;
+            pending.delete(id);
+            reject(new Error(method + " timed out"));
+          }, 30000);
+        });
+      }
+
+      function notify(method, params) {
+        send({ jsonrpc: "2.0", method, params });
+      }
+
+      function resize() {
+        notify("ui/notifications/size-changed", {
+          width: Math.ceil(window.innerWidth),
+          height: Math.ceil(document.documentElement.getBoundingClientRect().height)
+        });
+      }
+
+      function text(value, fallback = "unknown") {
+        return value === undefined || value === null || value === "" ? fallback : String(value);
+      }
+
+      function title(value) {
+        return text(value).replaceAll("_", " ");
+      }
+
+      function safeClass(value) {
+        return "status-" + text(value, "unknown").replace(/[^a-z0-9_]/gi, "_");
+      }
+
+      function setError(message) {
+        els.error.textContent = message || "";
+        els.error.classList.toggle("hidden", !message);
+        resize();
+      }
+
+      function selectedSources() {
+        return Array.from(document.querySelectorAll(".source-options input:checked")).map((box) => box.value);
+      }
+
+      function renderList(container, rows, emptyText, detailKeys = ["detail", "rationale", "tool_hint"]) {
+        container.replaceChildren();
+        if (!rows || rows.length === 0) {
+          const li = document.createElement("li");
+          li.className = "row";
+          li.textContent = emptyText;
+          container.append(li);
+          return;
+        }
+
+        for (const row of rows) {
+          const li = document.createElement("li");
+          li.className = "row";
+          const heading = document.createElement("div");
+          heading.className = "row-title " + safeClass(row.status);
+          heading.textContent = row.label || row.id || "Item";
+          const detail = document.createElement("div");
+          detail.className = "row-detail";
+          detail.textContent = detailKeys.map((key) => row[key]).find(Boolean) || "";
+          li.append(heading, detail);
+          container.append(li);
+        }
+      }
+
+      function renderResult(result) {
+        currentResult = result;
+        const isBatch = Array.isArray(result.results);
+        const first = isBatch ? result.results[0] : result;
+        const summary = first?.summary || {};
+        const health = first?.health || {};
+        els.empty.classList.add("hidden");
+        els.result.classList.remove("hidden");
+        els.modeStatus.textContent = isBatch ? "Batch: " + text(result.total, result.results.length) + " numbers" : "Single number";
+
+        if (first?.normalized?.e164 || first?.display?.redacted) {
+          els.phone.value = first.normalized?.e164 || first.display?.redacted || "";
+        }
+
+        els.healthValue.textContent = title(health.status) + (health.score !== undefined ? " · " + health.score : "");
+        els.healthValue.className = "value " + safeClass(health.status);
+        els.healthMeta.textContent = text(health.rationale, "");
+        els.numberValue.textContent = text(first?.display?.label || first?.display?.redacted || first?.input?.phone_number, "redacted");
+        els.countryValue.textContent = "Country: " + text(summary.country);
+        els.carrierValue.textContent = text(summary.carrier) + " · " + title(summary.type);
+        els.ownershipValue.textContent = "Ownership: " + text(summary.ownership);
+        els.messagingValue.textContent = title(summary.messaging);
+        els.messagingValue.className = "value " + safeClass(summary.messaging);
+        els.voiceValue.textContent = "Voice: " + title(summary.voice) + " · Reputation: " + title(summary.reputation);
+
+        renderList(els.signalsList, first?.signals, "No signals returned.");
+        renderList(els.actionsList, first?.recommended_actions, "No recommended actions.", ["rationale", "tool_hint", "detail"]);
+        renderList(els.sourcesList, first?.sources, "No sources returned.");
+        renderBatch(result);
+        els.jsonPre.textContent = JSON.stringify(result, null, 2);
+        resize();
+      }
+
+      function renderBatch(result) {
+        els.batchContent.replaceChildren();
+        if (!Array.isArray(result.results)) {
+          const p = document.createElement("p");
+          p.className = "meta";
+          p.textContent = "Batch aggregate appears after calling number_intelligence_batch_analyze.";
+          els.batchContent.append(p);
+          return;
+        }
+
+        const counts = result.aggregate?.health_status_counts || {};
+        const summary = document.createElement("p");
+        summary.className = "meta";
+        summary.textContent = "Total: " + result.total + "; action-required signals: " + text(result.aggregate?.action_required_count, 0) + "; good/warning/bad/unknown: " + [counts.good || 0, counts.warning || 0, counts.bad || 0, counts.unknown || 0].join("/");
+
+        const wrap = document.createElement("div");
+        wrap.className = "table-wrap";
+        const table = document.createElement("table");
+        table.innerHTML = "<thead><tr><th>Number</th><th>Health</th><th>Messaging</th><th>Voice</th></tr></thead>";
+        const tbody = document.createElement("tbody");
+        for (const row of result.results) {
+          const tr = document.createElement("tr");
+          const values = [
+            row.display?.label || row.display?.redacted || "redacted",
+            row.health?.status || "unknown",
+            row.summary?.messaging || "unknown",
+            row.summary?.voice || "unknown"
+          ];
+          for (const value of values) {
+            const td = document.createElement("td");
+            td.textContent = value;
+            if (value === values[1]) td.className = safeClass(value);
+            tr.append(td);
+          }
+          tbody.append(tr);
+        }
+        table.append(tbody);
+        wrap.append(table);
+        els.batchContent.append(summary, wrap);
+      }
+
+      function extractResult(result) {
+        if (result?.structuredContent) return result.structuredContent;
+        const textBlock = result?.content?.find?.((block) => block.type === "text");
+        if (!textBlock?.text) return undefined;
+        try {
+          return JSON.parse(textBlock.text);
+        } catch {
+          return undefined;
+        }
+      }
+
+      async function analyze(phoneNumber) {
+        if (!initialized) {
+          setError("The host has not initialized the MCP App bridge yet.");
+          return;
+        }
+
+        els.button.disabled = true;
+        els.button.textContent = "Analyzing";
+        setError("");
+        try {
+          const result = await request("tools/call", {
+            name: TOOL_NAME,
+            arguments: { phone_number: phoneNumber, include_raw: false, sources: selectedSources() }
+          });
+          const payload = extractResult(result);
+          if (!payload) throw new Error("Tool returned no structured analysis.");
+          renderResult(payload);
+        } catch (error) {
+          setError(error instanceof Error ? error.message : "Analysis failed.");
+        } finally {
+          els.button.disabled = false;
+          els.button.textContent = "Analyze";
+        }
+      }
+
+      function showPanel(panelId) {
+        for (const tab of document.querySelectorAll(".tab")) {
+          tab.setAttribute("aria-selected", String(tab.dataset.tab === panelId));
+        }
+        for (const panel of ["signalsPanel", "actionsPanel", "sourcesPanel", "batchPanel", "jsonPanel"]) {
+          document.getElementById(panel).classList.toggle("hidden", panel !== panelId);
+        }
+        resize();
+      }
+
+      window.addEventListener("message", (event) => {
+        if (event.source !== window.parent) return;
+        const message = event.data;
+        if (!message || message.jsonrpc !== "2.0") return;
+
+        if (message.id !== undefined && pending.has(message.id)) {
+          const handlers = pending.get(message.id);
+          pending.delete(message.id);
+          if (message.error) handlers.reject(new Error(message.error.message || "Request failed"));
+          else handlers.resolve(message.result);
+          return;
+        }
+
+        if (message.method === "ui/notifications/tool-input") {
+          const args = message.params?.arguments || {};
+          if (args.phone_number) els.phone.value = args.phone_number;
+        }
+
+        if (message.method === "ui/notifications/tool-result") {
+          const payload = extractResult(message.params);
+          if (payload) renderResult(payload);
+        }
+      });
+
+      els.form.addEventListener("submit", (event) => {
+        event.preventDefault();
+        const phoneNumber = els.phone.value.trim();
+        if (!phoneNumber) {
+          setError("Enter a phone number to analyze.");
+          return;
+        }
+        analyze(phoneNumber);
+      });
+
+      for (const tab of document.querySelectorAll(".tab")) {
+        tab.addEventListener("click", () => showPanel(tab.dataset.tab));
+      }
+
+      window.addEventListener("resize", resize);
+
+      request("ui/initialize", {
+        appInfo: { name: "telnyx-number-intelligence-ui", version: "0.2.0" },
+        appCapabilities: {},
+        protocolVersion: PROTOCOL_VERSION
+      })
+        .then(() => {
+          initialized = true;
+          els.bridgeStatus.textContent = "Host bridge: connected";
+          notify("ui/notifications/initialized", {});
+          resize();
+        })
+        .catch((error) => {
+          els.bridgeStatus.textContent = "Host bridge: unavailable";
+          setError("MCP App bridge failed to initialize: " + error.message);
+        });
+
+      if (currentResult) renderResult(currentResult);
+    </script>
+  </body>
+</html>`;

--- a/tools/mcp-apps/apps/number-intelligence/test/phase2.test.ts
+++ b/tools/mcp-apps/apps/number-intelligence/test/phase2.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+
+import { analyzeBatchNumbers, analyzeNumber } from "../src/service.js";
+import { TelnyxReadOnlyClient } from "../src/telnyxClient.js";
+import type { NumberLookupClient, TelnyxNumberLookupResponse } from "../src/types.js";
+
+const lookupResponse: TelnyxNumberLookupResponse = {
+  data: {
+    phone_number: "+13125550123",
+    national_format: "(312) 555-0123",
+    country_code: "US",
+    carrier: { name: "Example Wireless", type: "mobile" },
+    caller_name: { caller_name: "Example Support" }
+  }
+};
+
+function lookupClient(response: TelnyxNumberLookupResponse = lookupResponse): NumberLookupClient {
+  return {
+    async lookupNumber() {
+      return response;
+    }
+  };
+}
+
+describe("phase 2 read-only Telnyx source client", () => {
+  it("constructs owned, portability, messaging, voice, and cached reputation requests safely", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchImpl: typeof fetch = async (url, init) => {
+      calls.push({ url: String(url), init });
+      const requestUrl = String(url);
+      if (requestUrl.includes("/phone_numbers/messaging")) {
+        return json({ data: [{ id: "pnm_1", messaging_profile_id: "mp_1", features: { sms: { domestic: true } }, health: { success_ratio: 0.99, spam_ratio: 0.01 } }] });
+      }
+      if (requestUrl.includes("/messaging_profiles/mp_1")) {
+        return json({ data: { id: "mp_1", name: "Production", enabled: true, v1_secret: "must-not-surface" } });
+      }
+      if (requestUrl.includes("/phone_numbers/voice")) {
+        return json({ data: [{ id: "pnv_1", connection_id: "conn_1" }] });
+      }
+      if (requestUrl.includes("/connections/conn_1")) {
+        return json({ data: { id: "conn_1", active: true, connection_name: "Voice app" } });
+      }
+      if (requestUrl.includes("/reputation/numbers/")) {
+        return json({ data: { reputation_data: { spam_risk: "low", maturity_score: 94 } } });
+      }
+      if (requestUrl.includes("/portability_checks")) {
+        expect(init?.method).toBe("POST");
+        expect(init?.body).toBe(JSON.stringify({ phone_numbers: ["+13125550123"] }));
+        return json({ data: [{ phone_number: "+13125550123", portable: true, fast_portable: true }] });
+      }
+      return json({ data: [{ id: "pn_1", phone_number: "+13125550123", status: "active", messaging_profile_id: "mp_1", connection_id: "conn_1" }] });
+    };
+
+    const client = new TelnyxReadOnlyClient({ apiKey: "test_secret_key", baseUrl: "https://api.telnyx.test", fetch: fetchImpl });
+
+    await client.getOwnedNumber("+1 (312) 555-0123");
+    await client.checkPortability("+1 (312) 555-0123");
+    await client.checkMessagingReadiness("+1 (312) 555-0123");
+    await client.checkVoiceReadiness("+1 (312) 555-0123");
+    const reputation = await client.getCachedReputation("+1 (312) 555-0123");
+
+    expect(calls.map((call) => call.url)).toEqual([
+      "https://api.telnyx.test/v2/phone_numbers?filter%5Bphone_number%5D=13125550123&page%5Bsize%5D=1&page%5Bnumber%5D=1&handle_messaging_profile_error=true",
+      "https://api.telnyx.test/v2/portability_checks",
+      "https://api.telnyx.test/v2/phone_numbers/messaging?filter%5Bphone_number%5D=%2B13125550123&page%5Bsize%5D=1&page%5Bnumber%5D=1",
+      "https://api.telnyx.test/v2/messaging_profiles/mp_1",
+      "https://api.telnyx.test/v2/phone_numbers/voice?filter%5Bphone_number%5D=13125550123&page%5Bsize%5D=1&page%5Bnumber%5D=1",
+      "https://api.telnyx.test/v2/connections/conn_1",
+      "https://api.telnyx.test/v2/reputation/numbers/%2B13125550123?fresh=false"
+    ]);
+    expect(calls.every((call) => (call.init?.headers as Record<string, string>).Authorization === "Bearer test_secret_key")).toBe(true);
+    expect(calls.map((call) => call.url).join("\n")).toContain("fresh=false");
+    expect(calls.map((call) => call.url).join("\n")).not.toContain("fresh=true");
+    expect(JSON.stringify(reputation)).not.toContain("must-not-surface");
+  });
+});
+
+describe("phase 2 source integration", () => {
+  it("consults requested read-only sources and maps them into summaries, signals, and actions", async () => {
+    const result = await analyzeNumber(
+      { phone_number: "+1 (312) 555-0123", sources: ["owned", "portability", "messaging", "voice", "reputation"] },
+      {
+        lookupClient: lookupClient(),
+        sources: {
+          owned: { async getOwnedNumber() { return { owned: true, numberId: "pn_1", reason: "Owned number found." }; } },
+          portability: { async checkPortability() { return { portable: false, status: "not_portable", reason: "Carrier rejected portability." }; } },
+          messaging: { async checkMessagingReadiness() { return { configured: false, capable: true, reason: "No messaging profile is attached." }; } },
+          voice: { async checkVoiceReadiness() { return { configured: true, reason: "Active connection assigned." }; } },
+          reputation: { async getCachedReputation() { return { status: "bad", reason: "Cached spam risk is high." }; } }
+        }
+      }
+    );
+
+    expect(result.summary).toMatchObject({
+      ownership: "owned",
+      portability: "not_portable",
+      messaging: "misconfigured",
+      voice: "ready",
+      reputation: "bad"
+    });
+    expect(result.health.status).toBe("bad");
+    expect(result.sources).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "telnyx.owned_numbers", status: "consulted" }),
+        expect.objectContaining({ id: "telnyx.portability", status: "consulted" }),
+        expect.objectContaining({ id: "telnyx.messaging", status: "consulted" }),
+        expect.objectContaining({ id: "telnyx.voice", status: "consulted" }),
+        expect.objectContaining({ id: "telnyx.reputation", status: "consulted" })
+      ])
+    );
+    expect(result.signals).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "portability.status", status: "action_required" }),
+        expect.objectContaining({ id: "messaging.configuration", status: "action_required" }),
+        expect.objectContaining({ id: "reputation.cached", status: "action_required" })
+      ])
+    );
+    expect(result.recommended_actions.map((action) => action.id)).toEqual(
+      expect.arrayContaining(["review_portability_block", "attach_messaging_profile", "investigate_reputation"])
+    );
+  });
+
+  it("continues analysis when a source errors and redacts phone numbers in source details", async () => {
+    const result = await analyzeNumber(
+      { phone_number: "+1 (312) 555-0123", sources: ["messaging", "voice"] },
+      {
+        lookupClient: lookupClient(),
+        sources: {
+          messaging: { async checkMessagingReadiness() { throw new Error("Telnyx failed for +13125550123"); } },
+          voice: { async checkVoiceReadiness() { return { configured: true, reason: "Active connection assigned." }; } }
+        }
+      }
+    );
+
+    expect(result.summary.voice).toBe("ready");
+    expect(result.sources).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "telnyx.messaging", status: "error", detail: expect.stringContaining("+1312******23") }),
+        expect.objectContaining({ id: "telnyx.voice", status: "consulted" })
+      ])
+    );
+    expect(result.signals).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: "source.telnyx.messaging.error", status: "warning" })])
+    );
+    expect(JSON.stringify(result)).not.toContain("+13125550123");
+  });
+});
+
+describe("phase 2 batch analysis", () => {
+  it("parses pasted CSV/newline input, redacts results, and aggregates health/action counts", async () => {
+    const result = await analyzeBatchNumbers(
+      { numbers: "phone_number\n+1 (312) 555-0123\n+1 (415) 555-2671\n", sources: ["owned"] },
+      {
+        lookupClient: lookupClient(),
+        sources: { owned: { async getOwnedNumber() { return { owned: true, reason: "Owned number found." }; } } }
+      },
+      { maxBatchSize: 5 }
+    );
+
+    expect(result.total).toBe(2);
+    expect(result.aggregate.health_status_counts.good).toBe(2);
+    expect(result.aggregate.action_required_count).toBe(0);
+    expect(result.results).toHaveLength(2);
+    expect(JSON.stringify(result)).not.toContain("+13125550123");
+    expect(JSON.stringify(result)).not.toContain("+14155552671");
+  });
+
+  it("enforces a conservative max batch size before making lookups", async () => {
+    let lookupCalls = 0;
+    await expect(
+      analyzeBatchNumbers(
+        { numbers: ["+13125550123", "+14155552671", "+12125550199"] },
+        { lookupClient: { async lookupNumber() { lookupCalls += 1; return lookupResponse; } } },
+        { maxBatchSize: 2 }
+      )
+    ).rejects.toThrow("at most 2 numbers");
+    expect(lookupCalls).toBe(0);
+  });
+});
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+}

--- a/tools/mcp-apps/apps/number-intelligence/test/service.test.ts
+++ b/tools/mcp-apps/apps/number-intelligence/test/service.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+import { analyzeNumber } from "../src/service.js";
+import type { NumberLookupClient, TelnyxNumberLookupResponse } from "../src/types.js";
+
+const lookupResponse: TelnyxNumberLookupResponse = {
+  data: {
+    phone_number: "+13125550123",
+    national_format: "(312) 555-0123",
+    country_code: "US",
+    carrier: {
+      name: "Verizon Wireless",
+      type: "mobile",
+      mobile_country_code: "311",
+      mobile_network_code: "480"
+    },
+    caller_name: {
+      caller_name: "ACME Support",
+      error_code: null
+    }
+  }
+};
+
+function lookupClient(response: TelnyxNumberLookupResponse): NumberLookupClient {
+  return {
+    async lookupNumber() {
+      return response;
+    }
+  };
+}
+
+describe("analyzeNumber", () => {
+  it("summarizes a normal lookup and returns stable recommendations", async () => {
+    const result = await analyzeNumber(
+      { phone_number: "+1 (312) 555-0123" },
+      { lookupClient: lookupClient(lookupResponse) }
+    );
+
+    expect(result.input.phone_number).toBe("+1312******23");
+    expect(result.normalized.e164).toBe("+1312******23");
+    expect(result.normalized.e164_validated).toBe(false);
+    expect(result.normalized.national_format).toBe("+1312******23");
+    expect(result.display.redacted).toBe("+1312******23");
+    expect(result.display.label).toBe("+1312******23");
+    expect(result.summary).toMatchObject({
+      type: "mobile",
+      carrier: "Verizon Wireless",
+      country: "US",
+      ownership: "ACME Support",
+      messaging: "likely_supported",
+      voice: "likely_supported",
+      reputation: "unknown"
+    });
+    expect(result.health.status).toBe("good");
+    expect(result.signals).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "lookup.carrier", status: "info" }),
+        expect.objectContaining({ id: "messaging.capability", status: "info" })
+      ])
+    );
+    expect(result.recommended_actions.map((action) => action.id)).toContain("confirm_messaging_profile");
+    expect(result.sources).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "telnyx.number_lookup", status: "consulted" })
+      ])
+    );
+    expect(result.raw).toBeUndefined();
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("+1 (312) 555-0123");
+    expect(serialized).not.toContain("+13125550123");
+    expect(serialized).not.toContain("(312) 555-0123");
+  });
+
+  it("adds action-required signals for non-portable and messaging-misconfigured optional inputs", async () => {
+    const result = await analyzeNumber(
+      { phone_number: "+13125550123" },
+      {
+        lookupClient: lookupClient(lookupResponse),
+        optionalSignals: {
+          portability: { portable: false, reason: "Current provider blocks porting" },
+          messaging: { configured: false, reason: "No messaging profile is attached" },
+          ownership: { owned: true, numberId: "123" }
+        }
+      }
+    );
+
+    expect(result.summary.portability).toBe("not_portable");
+    expect(result.summary.messaging).toBe("misconfigured");
+    expect(result.summary.ownership).toBe("owned");
+    expect(result.health.status).toBe("bad");
+    expect(result.signals).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "portability.status", status: "action_required" }),
+        expect.objectContaining({ id: "messaging.configuration", status: "action_required" })
+      ])
+    );
+    expect(result.recommended_actions.map((action) => action.id)).toEqual(
+      expect.arrayContaining(["review_portability_block", "attach_messaging_profile"])
+    );
+  });
+
+  it("still reports voice misconfiguration when messaging is also misconfigured", async () => {
+    const result = await analyzeNumber(
+      { phone_number: "+13125550123" },
+      {
+        lookupClient: lookupClient(lookupResponse),
+        optionalSignals: {
+          messaging: { configured: false, reason: "No messaging profile is attached" },
+          voice: { configured: false, reason: "No connection assigned" }
+        }
+      }
+    );
+
+    expect(result.signals).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "messaging.configuration", status: "action_required" }),
+        expect.objectContaining({ id: "voice.configuration", status: "action_required" })
+      ])
+    );
+    expect(result.recommended_actions.map((action) => action.id)).toEqual(
+      expect.arrayContaining(["attach_messaging_profile", "fix_voice_configuration"])
+    );
+    expect(result.summary.voice).toBe("misconfigured");
+  });
+
+  it("gracefully handles lookup errors and keeps the result useful", async () => {
+    const result = await analyzeNumber(
+      { phone_number: "+14155550199" },
+      {
+        lookupClient: {
+          async lookupNumber() {
+            throw Object.assign(new Error("Telnyx rejected lookup"), { status: 422 });
+          }
+        }
+      }
+    );
+
+    expect(result.normalized.e164).toBe("+1415******99");
+    expect(result.normalized.e164_validated).toBe(false);
+    expect(result.summary.carrier).toBe("unknown");
+    expect(result.health.status).toBe("unknown");
+    expect(result.sources).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "telnyx.number_lookup", status: "error" })
+      ])
+    );
+    expect(result.signals).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "lookup.error", status: "warning" })
+      ])
+    );
+    expect(result.recommended_actions.map((action) => action.id)).toContain("retry_lookup");
+  });
+
+  it("omits raw by default and includes only redacted raw when explicitly requested", async () => {
+    const withoutRaw = await analyzeNumber(
+      { phone_number: "+14155552671" },
+      {
+        lookupClient: lookupClient({
+          data: {
+            ...lookupResponse.data,
+            phone_number: "+14155552671",
+            national_format: "(415) 555-2671"
+          }
+        })
+      }
+    );
+
+    expect(withoutRaw.raw).toBeUndefined();
+    expect(withoutRaw.display.redacted).toBe("+1415******71");
+
+    const withRaw = await analyzeNumber(
+      { phone_number: "+14155552671", include_raw: true },
+      {
+        lookupClient: lookupClient({
+          data: {
+            ...lookupResponse.data,
+            phone_number: "+14155552671",
+            national_format: "(415) 555-2671"
+          }
+        })
+      }
+    );
+
+    expect(withRaw.raw?.telnyx_number_lookup).toBeDefined();
+    expect(JSON.stringify(withRaw.raw)).toContain("+1415******71");
+    expect(JSON.stringify(withRaw.raw)).not.toContain("+14155552671");
+  });
+});

--- a/tools/mcp-apps/apps/number-intelligence/test/telnyxClient.test.ts
+++ b/tools/mcp-apps/apps/number-intelligence/test/telnyxClient.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { TelnyxNumberLookupClient } from "../src/telnyxClient.js";
+
+describe("TelnyxNumberLookupClient", () => {
+  it("constructs a read-only number lookup request with injected fetch", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchImpl: typeof fetch = async (url, init) => {
+      calls.push({ url: String(url), init });
+      return new Response(JSON.stringify({ data: { phone_number: "+13125550123" } }), {
+        status: 200,
+        headers: { "content-type": "application/json" }
+      });
+    };
+
+    const client = new TelnyxNumberLookupClient({
+      apiKey: "test_secret_key",
+      baseUrl: "https://api.telnyx.test",
+      fetch: fetchImpl
+    });
+
+    const result = await client.lookupNumber("+13125550123");
+
+    expect(result.data.phone_number).toBe("+13125550123");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe(
+      "https://api.telnyx.test/v2/number_lookup/%2B13125550123?type=carrier&type=caller-name"
+    );
+    expect(calls[0]?.init?.method).toBe("GET");
+    expect((calls[0]?.init?.headers as Record<string, string>).Authorization).toBe("Bearer test_secret_key");
+  });
+
+  it("surfaces Telnyx error details without logging the authorization header", async () => {
+    const consoleMessages: string[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => consoleMessages.push(args.join(" "));
+    try {
+      const fetchImpl: typeof fetch = async () =>
+        new Response(JSON.stringify({ errors: [{ title: "Invalid number" }] }), {
+          status: 422,
+          headers: { "content-type": "application/json" }
+        });
+
+      const client = new TelnyxNumberLookupClient({ apiKey: "test_secret_key", fetch: fetchImpl });
+
+      await expect(client.lookupNumber("+1 312 555 0123")).rejects.toMatchObject({
+        status: 422,
+        message: expect.stringContaining("Invalid number")
+      });
+      expect(consoleMessages.join("\n")).not.toContain("test_secret_key");
+      expect(consoleMessages.join("\n")).not.toContain("Authorization");
+    } finally {
+      console.error = originalError;
+    }
+  });
+});

--- a/tools/mcp-apps/apps/number-intelligence/tsconfig.json
+++ b/tools/mcp-apps/apps/number-intelligence/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "**/*.test.ts"]
+}

--- a/tools/mcp-apps/apps/number-intelligence/vitest.config.ts
+++ b/tools/mcp-apps/apps/number-intelligence/vitest.config.ts
@@ -1,0 +1,10 @@
+/// <reference types="vitest" />
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+    clearMocks: true
+  }
+});

--- a/tools/mcp-apps/apps/usage-cost-explorer/.env.example
+++ b/tools/mcp-apps/apps/usage-cost-explorer/.env.example
@@ -1,0 +1,7 @@
+TELNYX_API_KEY=
+TELNYX_API_BASE_URL=https://api.telnyx.com/v2
+
+# Conservative app guardrails for guarded auto-recharge updates.
+# These are Usage & Billing Explorer app caps, not Telnyx API policy.
+USAGE_COST_EXPLORER_MAX_AUTO_RECHARGE_THRESHOLD=5000
+USAGE_COST_EXPLORER_MAX_AUTO_RECHARGE_AMOUNT=5000

--- a/tools/mcp-apps/apps/usage-cost-explorer/README.md
+++ b/tools/mcp-apps/apps/usage-cost-explorer/README.md
@@ -1,0 +1,69 @@
+# Telnyx Usage & Billing Explorer
+
+Read-first MCP app for Telnyx balance, usage, billing groups, and guarded billing controls.
+
+## Scope
+
+Read tools:
+
+- `billing_get_balance` — `GET /balance`
+- `billing_get_auto_recharge_preferences` — `GET /payment/auto_recharge_prefs`
+- `billing_list_billing_groups` — `GET /billing_groups`
+- `billing_get_billing_group` — `GET /billing_groups/{id}`
+- `billing_usage_report_options` — `GET /usage_reports/options` (**Usage Reports is beta**)
+- `billing_query_usage` — `GET /usage_reports` (**Usage Reports is beta**)
+
+Guarded mutation tools:
+
+- `billing_preview_auto_recharge_update` — fetches current prefs and returns a before/after diff plus stateless confirmation token; no mutation.
+- `billing_update_auto_recharge_preferences` — requires the preview token, refetches current prefs, enforces app guardrail caps, then patches only if the token still matches.
+- `billing_preview_stored_payment_transaction` — validates a top-up amount and returns a stateless confirmation token; no mutation.
+- `billing_create_stored_payment_transaction` — requires the preview token, then posts `POST /payment/stored_payment_transactions` using the account's saved payment method.
+- `billing_preview_billing_group_update` — fetches current group and returns a before/after diff plus stateless confirmation token; no mutation.
+- `billing_update_billing_group` — requires the preview token and refetches current group before patching.
+- `billing_create_billing_group` — requires `confirm=true` and a non-empty name.
+
+## Safety guardrails
+
+- Stored payment top-ups require a saved payment method in the Telnyx portal and a preview confirmation token. New payment-method collection, invoice payment, card/bank management, and x402 operations are not exposed.
+- Live tools require `TELNYX_API_KEY`; missing keys return a safe MCP tool error without making network calls.
+- API keys, authorization headers, payment-like numbers, tokens, and secrets are redacted from Telnyx errors.
+- Operational identifiers such as `billing_group_id` are intentionally preserved so users can make follow-up calls.
+- Auto-recharge caps default to `5000` for threshold and recharge amounts. Override with:
+  - `USAGE_COST_EXPLORER_MAX_AUTO_RECHARGE_THRESHOLD`
+  - `USAGE_COST_EXPLORER_MAX_AUTO_RECHARGE_AMOUNT`
+- Stored payment top-up caps default to `5000`. Override with:
+  - `USAGE_COST_EXPLORER_MAX_STORED_PAYMENT_AMOUNT`
+
+These caps are app guardrails, not Telnyx API policy.
+
+## Usage Reports beta defaults
+
+`billing_query_usage` requires exactly one `product`, at least one `dimensions[]`, and at least one `metrics[]`. It defaults to:
+
+- `format=json`
+- `managed_accounts=false`
+- `page_number=1`
+- capped `page_size`
+
+When explicit `start_date` and `end_date` are provided, this app limits the range to 31 days. Use either explicit dates or `date_range`, not both.
+
+## Development
+
+From `tools/mcp-apps`:
+
+```bash
+npm install
+npm test --workspace @telnyx-mcp-apps/usage-cost-explorer
+npm run typecheck --workspace @telnyx-mcp-apps/usage-cost-explorer
+npm run build --workspace @telnyx-mcp-apps/usage-cost-explorer
+```
+
+Run locally:
+
+```bash
+cp apps/usage-cost-explorer/.env.example apps/usage-cost-explorer/.env
+npm run dev --workspace @telnyx-mcp-apps/usage-cost-explorer
+```
+
+The UI resource is registered at `ui://usage-cost-explorer/index.html`.

--- a/tools/mcp-apps/apps/usage-cost-explorer/package.json
+++ b/tools/mcp-apps/apps/usage-cost-explorer/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@telnyx-mcp-apps/usage-cost-explorer",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Read-first Telnyx MCP app for usage and billing exploration with guarded billing controls.",
+  "main": "dist/server.js",
+  "scripts": {
+    "test": "vitest run",
+    "dev": "tsx src/server.ts",
+    "start": "node dist/server.js",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "build": "tsc -p tsconfig.json"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/team-telnyx/ai",
+    "directory": "tools/mcp-apps/apps/usage-cost-explorer"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/ext-apps": "^1.7.2",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "dotenv": "^17.4.2"
+  }
+}

--- a/tools/mcp-apps/apps/usage-cost-explorer/src/server.ts
+++ b/tools/mcp-apps/apps/usage-cost-explorer/src/server.ts
@@ -1,0 +1,422 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  RESOURCE_MIME_TYPE,
+  registerAppResource,
+  registerAppTool
+} from "@modelcontextprotocol/ext-apps/server";
+import { z } from "zod";
+
+import { createBillingService, DEFAULT_AUTO_RECHARGE_POLICY, DEFAULT_MAX_PAGE_SIZE } from "./service.js";
+import { TelnyxBillingClient, sanitizeBillingValue, sanitizeError } from "./telnyxClient.js";
+import type { BillingService } from "./service.js";
+import { AUTO_RECHARGE_SETUP_UI_HTML, STORED_PAYMENT_TOP_UP_UI_HTML, USAGE_COST_EXPLORER_UI_HTML } from "./ui.js";
+
+const UI_RESOURCE_URI = "ui://usage-cost-explorer/index.html";
+const AUTO_RECHARGE_RESOURCE_URI = "ui://usage-cost-explorer/auto-recharge.html";
+const STORED_PAYMENT_RESOURCE_URI = "ui://usage-cost-explorer/stored-payment-top-up.html";
+const READ_ONLY_ANNOTATIONS = { readOnlyHint: true, destructiveHint: false, openWorldHint: true };
+const SIDE_EFFECT_ANNOTATIONS = { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true };
+
+const pagingSchema = {
+  page_number: z.number().int().positive().optional().describe("1-based page number. Defaults to 1."),
+  page_size: z.number().int().positive().optional().describe(`Page size. Defaults conservatively and is capped at ${DEFAULT_MAX_PAGE_SIZE}.`)
+};
+
+const autoRechargeAmountPattern = /^(?:\d+|\d+\.\d+|\.\d+)$/;
+const nonBlankStringSchema = z.string().trim().min(1);
+const amountSchema = z.union([
+  nonBlankStringSchema.regex(autoRechargeAmountPattern, "Auto-recharge amounts must be non-negative numeric strings or numbers."),
+  z.number().finite().nonnegative()
+]);
+const autoRechargePatchSchema = {
+  threshold_amount: amountSchema.optional().describe("Auto-recharge threshold amount. Guarded by app cap."),
+  recharge_amount: amountSchema.optional().describe("Auto-recharge amount. Guarded by app cap."),
+  enabled: z.boolean().optional().describe("Whether auto recharge is enabled."),
+  invoice_enabled: z.boolean().optional().describe("Whether invoice-backed preference is enabled."),
+  preference: z.enum(["credit_paypal", "ach"]).optional().describe("Telnyx auto-recharge preference value.")
+};
+const storedPaymentSchema = {
+  amount: z.string().trim().regex(/^\d+\.\d{2}$/, 'Amount must include dollars and cents, for example "25.00".')
+};
+
+export function createServer(): McpServer {
+  const server = new McpServer({
+    name: "telnyx-usage-cost-explorer",
+    version: "0.1.0"
+  });
+
+  registerReadTool(
+    server,
+    "billing_overview",
+    "Open billing dashboard",
+    "Open a single Telnyx billing dashboard with current balance, usage controls, billing groups, and guarded auto-recharge settings.",
+    {},
+    async (service) => {
+      const [balance, auto_recharge, billing_groups, usage_options] = await Promise.all([
+        safeDashboardRead("balance", () => service.getBalance()),
+        safeDashboardRead("auto_recharge", () => service.getAutoRechargePreferences()),
+        safeDashboardRead("billing_groups", () => service.listBillingGroups({ pageNumber: 1, pageSize: 100 })),
+        safeDashboardRead("usage_options", () => service.usageReportOptions())
+      ]);
+      return {
+        balance: balance.data,
+        auto_recharge: auto_recharge.data,
+        billing_groups: billing_groups.data,
+        usage_options: usage_options.data,
+        warnings: [balance, auto_recharge, billing_groups, usage_options].flatMap((result) => result.warning ? [result.warning] : [])
+      };
+    },
+    READ_ONLY_ANNOTATIONS,
+    UI_RESOURCE_URI
+  );
+
+  registerReadTool(
+    server,
+    "billing_auto_recharge_setup",
+    "Set up auto recharge",
+    "Open a focused app for enabling auto recharge with threshold, recharge amount, and preference so low-credit users can unblock service without direct MCP payments.",
+    {},
+    async (service) => {
+      const [balance, auto_recharge] = await Promise.all([
+        safeDashboardRead("balance", () => service.getBalance()),
+        safeDashboardRead("auto_recharge", () => service.getAutoRechargePreferences())
+      ]);
+      return {
+        balance: balance.data,
+        auto_recharge: auto_recharge.data,
+        warnings: [balance, auto_recharge].flatMap((result) => result.warning ? [result.warning] : [])
+      };
+    },
+    READ_ONLY_ANNOTATIONS,
+    AUTO_RECHARGE_RESOURCE_URI
+  );
+
+  registerReadTool(
+    server,
+    "billing_stored_payment_top_up",
+    "Top up with stored payment",
+    "Open a focused app for charging a saved portal payment method through a guarded stored-payment transaction.",
+    {},
+    async (service) => ({ balance: await service.getBalance() }),
+    READ_ONLY_ANNOTATIONS,
+    STORED_PAYMENT_RESOURCE_URI
+  );
+
+  registerReadTool(server, "billing_get_balance", "Get account balance", "Read account balance details from GET /balance.", {}, async (service) =>
+    service.getBalance()
+  );
+
+  registerReadTool(
+    server,
+    "billing_get_auto_recharge_preferences",
+    "Get auto-recharge preferences",
+    "Read auto-recharge preferences from GET /payment/auto_recharge_prefs. This does not mutate billing settings.",
+    {},
+    async (service) => service.getAutoRechargePreferences()
+  );
+
+  registerReadTool(
+    server,
+    "billing_list_billing_groups",
+    "List billing groups",
+    "List billing groups from GET /billing_groups. Billing group IDs are preserved for follow-up calls.",
+    pagingSchema,
+    async (service, input) => service.listBillingGroups({ pageNumber: input.page_number, pageSize: input.page_size })
+  );
+
+  registerReadTool(
+    server,
+    "billing_get_billing_group",
+    "Get billing group",
+    "Fetch one billing group by ID from GET /billing_groups/{id}.",
+    { id: z.string().min(1).describe("Billing group ID, e.g. bg_...") },
+    async (service, input) => service.getBillingGroup(input.id)
+  );
+
+  registerReadTool(
+    server,
+    "billing_usage_report_options",
+    "Discover Usage Reports options (beta)",
+    "Discover available products, dimensions, and metrics from GET /usage_reports/options. Usage Reports is beta.",
+    { product: z.string().min(1).optional().describe("Optional product to narrow option discovery.") },
+    async (service, input) => service.usageReportOptions({ product: input.product })
+  );
+
+  registerReadTool(
+    server,
+    "billing_query_usage",
+    "Query Usage Reports (beta)",
+    "Query the Telnyx Usage Reports beta endpoint. Requires one product plus dimensions[] and metrics[]. Defaults format=json, managed_accounts=false, caps page size, and limits explicit start/end ranges to 31 days.",
+    {
+      product: z.string().min(1).describe("Usage Reports beta product."),
+      dimensions: z.array(z.string().min(1)).min(1).describe("Required Usage Reports dimensions."),
+      metrics: z.array(z.string().min(1)).min(1).describe("Required Usage Reports metrics."),
+      start_date: z.string().min(1).optional().describe("Optional YYYY-MM-DD start date; use with end_date, max 31 days."),
+      end_date: z.string().min(1).optional().describe("Optional YYYY-MM-DD end date; use with start_date, max 31 days."),
+      date_range: z.string().min(1).optional().describe("Optional Telnyx date_range shortcut. Do not combine with explicit dates."),
+      filters: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()])).optional().describe("Optional Usage Reports filters."),
+      sort: z.array(z.string().min(1)).optional().describe("Optional sort entries, e.g. -cost."),
+      format: z.enum(["json", "csv"]).optional().describe("Response format; defaults to json."),
+      managed_accounts: z.boolean().optional().describe("Defaults to false."),
+      ...pagingSchema
+    },
+    async (service, input) => service.queryUsage(input)
+  );
+
+  registerReadTool(
+    server,
+    "billing_preview_auto_recharge_update",
+    "Preview auto-recharge update",
+    "Preview a financial side-effect update to PATCH /payment/auto_recharge_prefs. No mutation occurs; returns a diff and confirmation token.",
+    autoRechargePatchSchema,
+    async (service, input) => service.previewAutoRechargeUpdate(input)
+  );
+
+  registerReadTool(
+    server,
+    "billing_update_auto_recharge_preferences",
+    "Confirm auto-recharge update",
+    "Guarded financial side-effect: validates the confirmation token from billing_preview_auto_recharge_update, enforces conservative app caps, refetches current preferences, then PATCHes.",
+    {
+      ...autoRechargePatchSchema,
+      confirmation_token: z.string().min(1).describe("Token returned by billing_preview_auto_recharge_update for the same requested after-state.")
+    },
+    async (service, input) => service.updateAutoRechargePreferences(input),
+    SIDE_EFFECT_ANNOTATIONS
+  );
+
+  registerReadTool(
+    server,
+    "billing_preview_stored_payment_transaction",
+    "Preview stored payment top-up",
+    "Preview a financial side-effect transaction to POST /payment/stored_payment_transactions. No mutation occurs; returns a confirmation token.",
+    storedPaymentSchema,
+    async (service, input) => service.previewStoredPaymentTransaction(input)
+  );
+
+  registerReadTool(
+    server,
+    "billing_create_stored_payment_transaction",
+    "Confirm stored payment top-up",
+    "Guarded financial side-effect: validates the confirmation token from billing_preview_stored_payment_transaction, then POSTs /payment/stored_payment_transactions using the saved payment method on the account.",
+    {
+      ...storedPaymentSchema,
+      confirmation_token: z.string().min(1).describe("Token returned by billing_preview_stored_payment_transaction for the same amount.")
+    },
+    async (service, input) => service.createStoredPaymentTransaction(input),
+    SIDE_EFFECT_ANNOTATIONS
+  );
+
+  registerReadTool(
+    server,
+    "billing_preview_billing_group_update",
+    "Preview billing group update",
+    "Preview a billing group rename from PATCH /billing_groups/{id}. No mutation occurs; returns a diff and confirmation token.",
+    {
+      id: z.string().min(1).describe("Billing group ID."),
+      name: z.string().min(1).describe("New billing group name.")
+    },
+    async (service, input) => service.previewBillingGroupUpdate(input)
+  );
+
+  registerReadTool(
+    server,
+    "billing_update_billing_group",
+    "Confirm billing group update",
+    "Guarded billing group update: validates the token from billing_preview_billing_group_update, refetches current group, then PATCHes /billing_groups/{id}.",
+    {
+      id: z.string().min(1).describe("Billing group ID."),
+      name: z.string().min(1).describe("New billing group name."),
+      confirmation_token: z.string().min(1).describe("Token returned by billing_preview_billing_group_update.")
+    },
+    async (service, input) => service.updateBillingGroup(input),
+    SIDE_EFFECT_ANNOTATIONS
+  );
+
+  registerReadTool(
+    server,
+    "billing_create_billing_group",
+    "Create billing group",
+    "Create a billing group with POST /billing_groups. Requires confirm=true and a non-empty name. This app does not expose direct payments or payment-method management.",
+    {
+      name: z.string().min(1).describe("New billing group name."),
+      confirm: z.boolean().describe("Must be true to create the billing group.")
+    },
+    async (service, input) => service.createBillingGroup(input),
+    SIDE_EFFECT_ANNOTATIONS
+  );
+
+  registerAppResource(
+    server,
+    "Billing Dashboard UI",
+    UI_RESOURCE_URI,
+    {
+      description:
+        "Interactive billing dashboard for balance, usage, billing groups, and guarded auto-recharge settings."
+    },
+    async () => ({
+      contents: [
+        {
+          uri: UI_RESOURCE_URI,
+          mimeType: RESOURCE_MIME_TYPE,
+          text: USAGE_COST_EXPLORER_UI_HTML
+        }
+      ]
+    })
+  );
+
+  registerAppResource(
+    server,
+    "Auto Recharge Setup UI",
+    AUTO_RECHARGE_RESOURCE_URI,
+    {
+      description: "Focused auto-recharge setup UI for unblocking low-credit Telnyx accounts without direct MCP payments."
+    },
+    async () => ({
+      contents: [
+        {
+          uri: AUTO_RECHARGE_RESOURCE_URI,
+          mimeType: RESOURCE_MIME_TYPE,
+          text: AUTO_RECHARGE_SETUP_UI_HTML
+        }
+      ]
+    })
+  );
+
+  registerAppResource(
+    server,
+    "Stored Payment Top Up UI",
+    STORED_PAYMENT_RESOURCE_URI,
+    {
+      description: "Focused stored-payment top-up UI for charging a saved portal payment method after explicit confirmation."
+    },
+    async () => ({
+      contents: [
+        {
+          uri: STORED_PAYMENT_RESOURCE_URI,
+          mimeType: RESOURCE_MIME_TYPE,
+          text: STORED_PAYMENT_TOP_UP_UI_HTML
+        }
+      ]
+    })
+  );
+
+  return server;
+}
+
+type ToolShape = Record<string, z.ZodTypeAny>;
+type ToolInput<T extends ToolShape> = { [K in keyof T]: z.infer<T[K]> };
+
+function registerReadTool<T extends ToolShape>(
+  server: McpServer,
+  name: string,
+  title: string,
+  description: string,
+  inputSchema: T,
+  run: (service: BillingService, input: ToolInput<T>) => Promise<unknown>,
+  annotations: Record<string, boolean> = READ_ONLY_ANNOTATIONS,
+  uiResourceUri?: string
+): void {
+  // The ext-apps wrapper preserves MCP SDK callback typing, but this small
+  // helper needs to accept many different zod input shapes. Keep the public
+  // schema strongly typed at call sites and narrow the implementation boundary
+  // here rather than duplicating the same live-service/error boilerplate for
+  // every billing tool.
+  (registerAppTool as unknown as (...args: unknown[]) => void)(
+    server,
+    name,
+    {
+      title,
+      description,
+      inputSchema,
+      annotations,
+      _meta: { ui: uiResourceUri ? { resourceUri: uiResourceUri } : { visibility: ["app"] } }
+    },
+    async (input: ToolInput<T>) => {
+      const service = createLiveService();
+      if (!service) return missingApiKeyResult();
+      try {
+        const result = await run(service, input);
+        return toolResult(result);
+      } catch (error) {
+        return safeToolError(error);
+      }
+    }
+  );
+}
+
+async function safeDashboardRead(name: string, read: () => Promise<unknown>): Promise<{ data?: unknown; warning?: { source: string; message: string } }> {
+  try {
+    return { data: await read() };
+  } catch (error) {
+    return { warning: { source: name, message: sanitizeError(error).message } };
+  }
+}
+
+function createLiveService(): BillingService | undefined {
+  const apiKey = process.env.TELNYX_API_KEY;
+  if (!apiKey) return undefined;
+  const client = new TelnyxBillingClient({
+    apiKey,
+    baseUrl: process.env.TELNYX_API_BASE_URL
+  });
+  return createBillingService(client, {
+    autoRechargePolicy: {
+      maxThresholdAmount: envNumber("USAGE_COST_EXPLORER_MAX_AUTO_RECHARGE_THRESHOLD", DEFAULT_AUTO_RECHARGE_POLICY.maxThresholdAmount),
+      maxRechargeAmount: envNumber("USAGE_COST_EXPLORER_MAX_AUTO_RECHARGE_AMOUNT", DEFAULT_AUTO_RECHARGE_POLICY.maxRechargeAmount),
+      version: DEFAULT_AUTO_RECHARGE_POLICY.version
+    },
+    maxStoredPaymentAmount: envNumber("USAGE_COST_EXPLORER_MAX_STORED_PAYMENT_AMOUNT", 5000)
+  });
+}
+
+function envNumber(name: string, fallback: number): number {
+  const value = process.env[name];
+  if (!value) return fallback;
+  const number = Number(value);
+  return Number.isFinite(number) && number >= 0 ? number : fallback;
+}
+
+function toolResult(result: unknown): { content: Array<{ type: "text"; text: string }>; structuredContent: Record<string, unknown> } {
+  const structuredContent = asStructuredContent(sanitizeBillingValue(result));
+  return {
+    content: [{ type: "text", text: JSON.stringify(structuredContent, null, 2) }],
+    structuredContent
+  };
+}
+
+function asStructuredContent(result: unknown): Record<string, unknown> {
+  if (result && typeof result === "object" && !Array.isArray(result)) return result as Record<string, unknown>;
+  return { result };
+}
+
+function missingApiKeyResult(): { isError: true; content: Array<{ type: "text"; text: string }> } {
+  return {
+    isError: true,
+    content: [
+      {
+        type: "text",
+        text: "TELNYX_API_KEY is not set. Provide a Telnyx API key with least-privilege billing/usage access to run live Usage & Billing Explorer tools."
+      }
+    ]
+  };
+}
+
+function safeToolError(error: unknown): { isError: true; content: Array<{ type: "text"; text: string }> } {
+  return {
+    isError: true,
+    content: [{ type: "text", text: sanitizeError(error).message }]
+  };
+}
+
+async function main(): Promise<void> {
+  await import("dotenv/config");
+  const server = createServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main();
+}

--- a/tools/mcp-apps/apps/usage-cost-explorer/src/service.ts
+++ b/tools/mcp-apps/apps/usage-cost-explorer/src/service.ts
@@ -1,0 +1,416 @@
+import { createHash } from "node:crypto";
+
+import type {
+  AutoRechargePolicy,
+  AutoRechargeUpdatePayload,
+  BillingGroupUpdatePayload,
+  BillingServiceClient,
+  DiffEntry,
+  MutationPreview,
+  PageInput,
+  StoredPaymentTransactionPayload,
+  TelnyxEnvelope,
+  UsageQueryInput,
+  UsageQueryRequest
+} from "./types.js";
+import { TelnyxBillingError } from "./telnyxClient.js";
+
+export const DEFAULT_MAX_PAGE_SIZE = 1000;
+export const DEFAULT_AUTO_RECHARGE_POLICY: Required<AutoRechargePolicy> = {
+  maxThresholdAmount: 5000,
+  maxRechargeAmount: 5000,
+  version: "usage-cost-explorer-policy-v1"
+};
+
+const AUTO_RECHARGE_ACTION = "billing.update_auto_recharge_preferences";
+const STORED_PAYMENT_ACTION = "billing.create_stored_payment_transaction";
+const BILLING_GROUP_UPDATE_ACTION = "billing.update_billing_group";
+const MUTABLE_AUTO_RECHARGE_FIELDS = ["threshold_amount", "recharge_amount", "enabled", "invoice_enabled", "preference"] as const;
+const AUTO_RECHARGE_AMOUNT_PATTERN = /^(?:\d+|\d+\.\d+|\.\d+)$/;
+const STORED_PAYMENT_AMOUNT_PATTERN = /^\d+\.\d{2}$/;
+const DEFAULT_MAX_STORED_PAYMENT_AMOUNT = 5000;
+const DEFAULT_AUTO_RECHARGE_STATE = {
+  enabled: false,
+  invoice_enabled: false,
+  preference: "credit_paypal"
+} satisfies Record<string, unknown>;
+
+export interface BillingServiceOptions {
+  maxPageSize?: number;
+  maxStoredPaymentAmount?: number;
+  autoRechargePolicy?: Partial<AutoRechargePolicy>;
+}
+
+export function createBillingService(client: BillingServiceClient, options: BillingServiceOptions = {}) {
+  const maxPageSize = options.maxPageSize ?? DEFAULT_MAX_PAGE_SIZE;
+  const maxStoredPaymentAmount = options.maxStoredPaymentAmount ?? DEFAULT_MAX_STORED_PAYMENT_AMOUNT;
+  const autoRechargePolicy: Required<AutoRechargePolicy> = {
+    ...DEFAULT_AUTO_RECHARGE_POLICY,
+    ...options.autoRechargePolicy,
+    version: options.autoRechargePolicy?.version ?? DEFAULT_AUTO_RECHARGE_POLICY.version
+  };
+
+  return {
+    async getBalance() {
+      return client.getBalance();
+    },
+
+    async getAutoRechargePreferences() {
+      return client.getAutoRechargePreferences();
+    },
+
+    async listBillingGroups(input: PageInput = {}) {
+      return client.listBillingGroups({
+        pageNumber: normalizePositiveInt(input.pageNumber, 1),
+        pageSize: capPageSize(input.pageSize, maxPageSize)
+      });
+    },
+
+    async getBillingGroup(id: string) {
+      assertNonEmpty(id, "billing_group_id is required");
+      return client.getBillingGroup(id.trim());
+    },
+
+    async usageReportOptions(input: { product?: string } = {}) {
+      return client.getUsageReportOptions({ product: normalizeOptionalString(input.product) });
+    },
+
+    async queryUsage(input: UsageQueryRequest) {
+      const normalized = normalizeUsageQuery(input, maxPageSize);
+      return client.queryUsageReport(normalized);
+    },
+
+    async previewAutoRechargeUpdate(input: AutoRechargeUpdatePayload): Promise<MutationPreview> {
+      const patch = normalizeAutoRechargePatch(input);
+      enforceAutoRechargePatchPolicy(patch, autoRechargePolicy);
+      const before = await getAutoRechargeState(client);
+      const after = { ...before, ...patch };
+      enforceAutoRechargeAfterStatePolicy(after, autoRechargePolicy);
+      return buildPreview(AUTO_RECHARGE_ACTION, true, before, after, autoRechargePolicy.version);
+    },
+
+    async updateAutoRechargePreferences(input: AutoRechargeUpdatePayload & { confirmation_token: string }): Promise<TelnyxEnvelope> {
+      const { confirmation_token, ...rest } = input;
+      assertNonEmpty(confirmation_token, "A confirmation token from billing_preview_auto_recharge_update is required.");
+      const patch = normalizeAutoRechargePatch(rest);
+      enforceAutoRechargePatchPolicy(patch, autoRechargePolicy);
+      const before = await getAutoRechargeState(client);
+      const after = { ...before, ...patch };
+      enforceAutoRechargeAfterStatePolicy(after, autoRechargePolicy);
+      const expected = confirmationToken(AUTO_RECHARGE_ACTION, before, after, autoRechargePolicy.version);
+      if (confirmation_token !== expected) {
+        throw new Error("Invalid confirmation token. Run billing_preview_auto_recharge_update again against the current preferences.");
+      }
+      return client.updateAutoRechargePreferences(patch);
+    },
+
+    async previewStoredPaymentTransaction(input: StoredPaymentTransactionPayload): Promise<MutationPreview> {
+      const amount = normalizeStoredPaymentAmount(input.amount, maxStoredPaymentAmount);
+      return buildPreview(
+        STORED_PAYMENT_ACTION,
+        true,
+        { transaction: "not_created" },
+        { amount, transaction_processing_type: "stored_payment" },
+        autoRechargePolicy.version
+      );
+    },
+
+    async createStoredPaymentTransaction(input: StoredPaymentTransactionPayload & { confirmation_token: string }): Promise<TelnyxEnvelope> {
+      assertNonEmpty(input.confirmation_token, "A confirmation token from billing_preview_stored_payment_transaction is required.");
+      const amount = normalizeStoredPaymentAmount(input.amount, maxStoredPaymentAmount);
+      const before = { transaction: "not_created" };
+      const after = { amount, transaction_processing_type: "stored_payment" };
+      const expected = confirmationToken(STORED_PAYMENT_ACTION, before, after, autoRechargePolicy.version);
+      if (input.confirmation_token !== expected) {
+        throw new Error("Invalid confirmation token. Run billing_preview_stored_payment_transaction again for this amount.");
+      }
+      return client.createStoredPaymentTransaction({ amount });
+    },
+
+    async previewBillingGroupUpdate(input: { id: string; name: string }): Promise<MutationPreview> {
+      const id = normalizeRequiredString(input.id, "billing_group_id is required");
+      const patch = normalizeBillingGroupPatch({ name: input.name });
+      const current = recordFromEnvelope(await client.getBillingGroup(id));
+      const before = pickBillingGroupState(current);
+      const after = { ...before, ...patch };
+      return buildPreview(BILLING_GROUP_UPDATE_ACTION, false, before, after, autoRechargePolicy.version);
+    },
+
+    async updateBillingGroup(input: { id: string; name: string; confirmation_token: string }): Promise<TelnyxEnvelope> {
+      const id = normalizeRequiredString(input.id, "billing_group_id is required");
+      assertNonEmpty(input.confirmation_token, "A confirmation token from billing_preview_billing_group_update is required.");
+      const patch = normalizeBillingGroupPatch({ name: input.name });
+      const current = recordFromEnvelope(await client.getBillingGroup(id));
+      const before = pickBillingGroupState(current);
+      const after = { ...before, ...patch };
+      const expected = confirmationToken(BILLING_GROUP_UPDATE_ACTION, before, after, autoRechargePolicy.version);
+      if (input.confirmation_token !== expected) {
+        throw new Error("Invalid confirmation token. Run billing_preview_billing_group_update again against the current billing group.");
+      }
+      return client.updateBillingGroup(id, patch);
+    },
+
+    async createBillingGroup(input: { name: string; confirm?: boolean }): Promise<TelnyxEnvelope> {
+      if (input.confirm !== true) {
+        throw new Error("billing_create_billing_group requires confirm=true because it creates a billing resource.");
+      }
+      const name = normalizeRequiredString(input.name, "Billing group name is required.");
+      return client.createBillingGroup({ name });
+    }
+  };
+}
+
+export type BillingService = ReturnType<typeof createBillingService>;
+
+async function getAutoRechargeState(client: BillingServiceClient): Promise<Record<string, unknown>> {
+  try {
+    return pickAutoRechargeState(recordFromEnvelope(await client.getAutoRechargePreferences()));
+  } catch (error) {
+    if (isMissingAutoRechargePreferences(error)) return { ...DEFAULT_AUTO_RECHARGE_STATE };
+    throw error;
+  }
+}
+
+function isMissingAutoRechargePreferences(error: unknown): boolean {
+  return error instanceof TelnyxBillingError && error.status === 404;
+}
+
+export function normalizeUsageQuery(input: UsageQueryRequest, maxPageSize = DEFAULT_MAX_PAGE_SIZE): UsageQueryInput {
+  const product = normalizeRequiredString(input.product, "Usage report product is required.");
+  const dimensions = normalizeStringArray(input.dimensions, "Usage report requires at least one dimension.");
+  const metrics = normalizeStringArray(input.metrics, "Usage report requires at least one metric.");
+  const hasDateRange = Boolean(normalizeOptionalString(input.date_range));
+  const hasExplicitDate = Boolean(normalizeOptionalString(input.start_date) || normalizeOptionalString(input.end_date));
+
+  if (hasDateRange && hasExplicitDate) {
+    throw new Error("Use either date_range or start_date/end_date, not both.");
+  }
+  if (hasExplicitDate) {
+    if (!input.start_date || !input.end_date) {
+      throw new Error("Both start_date and end_date are required when using explicit dates.");
+    }
+    enforceMaxDateRange(input.start_date, input.end_date, 31);
+  }
+
+  return {
+    product,
+    dimensions,
+    metrics,
+    startDate: normalizeOptionalString(input.start_date),
+    endDate: normalizeOptionalString(input.end_date),
+    dateRange: normalizeOptionalString(input.date_range),
+    filters: input.filters,
+    sort: input.sort && input.sort.length > 0 ? normalizeStringArray(input.sort, "sort entries must be non-empty strings") : undefined,
+    format: input.format ?? "json",
+    managedAccounts: input.managed_accounts ?? false,
+    pageNumber: normalizePositiveInt(input.page_number, 1),
+    pageSize: capPageSize(input.page_size, maxPageSize)
+  };
+}
+
+function enforceMaxDateRange(startDate: string, endDate: string, maxDays: number): void {
+  const start = parseStrictIsoDate(startDate, "start_date");
+  const end = parseStrictIsoDate(endDate, "end_date");
+  if (end < start) {
+    throw new Error("end_date must be on or after start_date.");
+  }
+  const days = (end.getTime() - start.getTime()) / 86_400_000;
+  if (days > maxDays) {
+    throw new Error(`Usage Reports beta queries with explicit start_date/end_date are capped at ${maxDays} days by this app.`);
+  }
+}
+
+function parseStrictIsoDate(value: string, fieldName: string): Date {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) {
+    throw new Error(`${fieldName} must be a valid ISO date string (YYYY-MM-DD).`);
+  }
+  const [, yearText, monthText, dayText] = match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if (date.getUTCFullYear() !== year || date.getUTCMonth() !== month - 1 || date.getUTCDate() !== day) {
+    throw new Error(`${fieldName} must be a valid ISO date string (YYYY-MM-DD).`);
+  }
+  return date;
+}
+
+function normalizeAutoRechargePatch(input: AutoRechargeUpdatePayload): AutoRechargeUpdatePayload {
+  const patch: AutoRechargeUpdatePayload = {};
+  for (const field of MUTABLE_AUTO_RECHARGE_FIELDS) {
+    const value = input[field];
+    if (value !== undefined) {
+      (patch as Record<string, unknown>)[field] = typeof value === "string" ? normalizeAutoRechargeStringField(value, field) : value;
+    }
+  }
+  if (Object.keys(patch).length === 0) {
+    throw new Error("At least one auto-recharge preference field is required.");
+  }
+  return patch;
+}
+
+function normalizeAutoRechargeStringField(value: string, field: (typeof MUTABLE_AUTO_RECHARGE_FIELDS)[number]): string {
+  const normalized = value.trim();
+  if (normalized.length === 0) {
+    throw new Error(`${field} must not be blank.`);
+  }
+  return normalized;
+}
+
+function enforceAutoRechargePatchPolicy(patch: AutoRechargeUpdatePayload, policy: Required<AutoRechargePolicy>): void {
+  enforceAutoRechargeAmountPolicy(patch as Record<string, unknown>, policy);
+}
+
+function enforceAutoRechargeAfterStatePolicy(after: Record<string, unknown>, policy: Required<AutoRechargePolicy>): void {
+  if (after.enabled === true) {
+    enforceAutoRechargeAmountPolicy(after, policy);
+  }
+}
+
+function enforceAutoRechargeAmountPolicy(values: Record<string, unknown>, policy: Required<AutoRechargePolicy>): void {
+  const threshold = amountValue(values.threshold_amount);
+  if (threshold !== undefined && threshold > policy.maxThresholdAmount) {
+    throw new Error(`threshold_amount exceeds app guardrail max of ${policy.maxThresholdAmount}. This is an app guardrail, not a Telnyx API policy.`);
+  }
+  const recharge = amountValue(values.recharge_amount);
+  if (recharge !== undefined && recharge > policy.maxRechargeAmount) {
+    throw new Error(`recharge_amount exceeds app guardrail max of ${policy.maxRechargeAmount}. This is an app guardrail, not a Telnyx API policy.`);
+  }
+}
+
+function amountValue(value: unknown): number | undefined {
+  if (value === undefined) return undefined;
+  let amount: number;
+  if (typeof value === "string") {
+    const normalized = value.trim();
+    if (!AUTO_RECHARGE_AMOUNT_PATTERN.test(normalized)) {
+      throw new Error("Auto-recharge amounts must be non-negative numeric strings or numbers.");
+    }
+    amount = Number(normalized);
+  } else if (typeof value === "number") {
+    amount = value;
+  } else {
+    throw new Error("Auto-recharge amounts must be non-negative numeric strings or numbers.");
+  }
+  if (!Number.isFinite(amount) || amount < 0) {
+    throw new Error("Auto-recharge amounts must be non-negative numeric strings or numbers.");
+  }
+  return amount;
+}
+
+function normalizeStoredPaymentAmount(value: string, maxAmount: number): string {
+  const amount = normalizeRequiredString(value, "Stored payment amount is required.");
+  if (!STORED_PAYMENT_AMOUNT_PATTERN.test(amount)) {
+    throw new Error('Stored payment amount must include dollars and cents, for example "25.00".');
+  }
+  const numericAmount = Number(amount);
+  if (!Number.isFinite(numericAmount) || numericAmount <= 0) {
+    throw new Error("Stored payment amount must be greater than 0.");
+  }
+  if (numericAmount > maxAmount) {
+    throw new Error(`Stored payment amount exceeds app guardrail max of ${maxAmount}. This is an app guardrail, not a Telnyx API policy.`);
+  }
+  return amount;
+}
+
+function normalizeBillingGroupPatch(input: BillingGroupUpdatePayload): BillingGroupUpdatePayload {
+  const name = normalizeRequiredString(input.name, "Billing group name is required.");
+  return { name };
+}
+
+function buildPreview(
+  action: string,
+  financialSideEffect: boolean,
+  before: Record<string, unknown>,
+  after: Record<string, unknown>,
+  policyVersion: string
+): MutationPreview {
+  return {
+    action,
+    financial_side_effect: financialSideEffect,
+    policy_version: policyVersion,
+    before,
+    after,
+    diff: diff(before, after),
+    confirmation_token: confirmationToken(action, before, after, policyVersion),
+    expires: "stateless-token-valid-while-resource-unchanged",
+    instructions: "Review the diff, then pass confirmation_token with the same requested fields to the update tool."
+  };
+}
+
+function confirmationToken(action: string, before: Record<string, unknown>, after: Record<string, unknown>, policyVersion: string): string {
+  return createHash("sha256").update(stableJson({ action, before, after, policyVersion })).digest("hex");
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, nested]) => `${JSON.stringify(key)}:${stableJson(nested)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function diff(before: Record<string, unknown>, after: Record<string, unknown>): DiffEntry[] {
+  const fields = new Set([...Object.keys(before), ...Object.keys(after)]);
+  return [...fields]
+    .sort()
+    .filter((field) => stableJson(before[field]) !== stableJson(after[field]))
+    .map((field) => ({ field, before: before[field], after: after[field] }));
+}
+
+function recordFromEnvelope(envelope: TelnyxEnvelope): Record<string, unknown> {
+  const data = envelope.data;
+  return data && typeof data === "object" && !Array.isArray(data) ? (data as Record<string, unknown>) : {};
+}
+
+function pickAutoRechargeState(current: Record<string, unknown>): Record<string, unknown> {
+  const state: Record<string, unknown> = {};
+  for (const key of ["id", "record_type", ...MUTABLE_AUTO_RECHARGE_FIELDS]) {
+    if (current[key] !== undefined) state[key] = current[key];
+  }
+  return state;
+}
+
+function pickBillingGroupState(current: Record<string, unknown>): Record<string, unknown> {
+  return {
+    ...(current.id !== undefined ? { id: current.id } : {}),
+    ...(current.record_type !== undefined ? { record_type: current.record_type } : {}),
+    ...(current.name !== undefined ? { name: current.name } : {})
+  };
+}
+
+function normalizeStringArray(values: string[] | undefined, message: string): string[] {
+  const normalized = (values ?? []).map((value) => value.trim()).filter((value) => value.length > 0);
+  if (normalized.length === 0) throw new Error(message);
+  return [...new Set(normalized)];
+}
+
+function normalizeRequiredString(value: string | undefined, message: string): string {
+  const normalized = normalizeOptionalString(value);
+  if (!normalized) throw new Error(message);
+  return normalized;
+}
+
+function normalizeOptionalString(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized && normalized.length > 0 ? normalized : undefined;
+}
+
+function assertNonEmpty(value: string | undefined, message: string): void {
+  if (!value || value.trim().length === 0) throw new Error(message);
+}
+
+function normalizePositiveInt(value: number | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  const normalized = Math.trunc(value);
+  return normalized > 0 ? normalized : fallback;
+}
+
+function capPageSize(value: number | undefined, maxPageSize: number): number {
+  const normalized = normalizePositiveInt(value, Math.min(100, maxPageSize));
+  return Math.min(normalized, maxPageSize);
+}

--- a/tools/mcp-apps/apps/usage-cost-explorer/src/telnyxClient.ts
+++ b/tools/mcp-apps/apps/usage-cost-explorer/src/telnyxClient.ts
@@ -1,0 +1,204 @@
+import type {
+  AutoRechargePreferencesData,
+  AutoRechargeUpdatePayload,
+  BillingGroupCreatePayload,
+  BillingGroupData,
+  BillingGroupUpdatePayload,
+  BalanceData,
+  PageInput,
+  StoredPaymentTransactionData,
+  StoredPaymentTransactionPayload,
+  TelnyxClientOptions,
+  TelnyxEnvelope,
+  UsageQueryInput,
+  UsageReportOptionsInput
+} from "./types.js";
+
+const DEFAULT_BASE_URL = "https://api.telnyx.com/v2";
+
+export class TelnyxBillingError extends Error {
+  readonly status: number;
+  readonly details: unknown;
+
+  constructor(message: string, status: number, details: unknown) {
+    super(message);
+    this.name = "TelnyxBillingError";
+    this.status = status;
+    this.details = details;
+  }
+}
+
+export class TelnyxBillingClient {
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: TelnyxClientOptions) {
+    if (!options.apiKey) {
+      throw new Error("Telnyx API key is required for live Usage & Billing Explorer calls");
+    }
+    this.apiKey = options.apiKey;
+    this.baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
+    this.fetchImpl = options.fetch ?? globalThis.fetch;
+    if (!this.fetchImpl) {
+      throw new Error("A fetch implementation is required");
+    }
+  }
+
+  async getBalance(): Promise<TelnyxEnvelope<BalanceData>> {
+    return this.request(this.url("/balance"), { method: "GET" });
+  }
+
+  async getAutoRechargePreferences(): Promise<TelnyxEnvelope<AutoRechargePreferencesData>> {
+    return this.request(this.url("/payment/auto_recharge_prefs"), { method: "GET" });
+  }
+
+  async updateAutoRechargePreferences(payload: AutoRechargeUpdatePayload): Promise<TelnyxEnvelope<AutoRechargePreferencesData>> {
+    return this.request(this.url("/payment/auto_recharge_prefs"), {
+      method: "PATCH",
+      body: JSON.stringify(payload)
+    });
+  }
+
+  async createStoredPaymentTransaction(payload: StoredPaymentTransactionPayload): Promise<TelnyxEnvelope<StoredPaymentTransactionData>> {
+    return this.request(this.url("/payment/stored_payment_transactions"), {
+      method: "POST",
+      body: JSON.stringify(payload)
+    });
+  }
+
+  async listBillingGroups(input: PageInput = {}): Promise<TelnyxEnvelope<BillingGroupData[]>> {
+    const url = this.url("/billing_groups");
+    if (input.pageNumber !== undefined) url.searchParams.set("page[number]", String(input.pageNumber));
+    if (input.pageSize !== undefined) url.searchParams.set("page[size]", String(input.pageSize));
+    return this.request(url, { method: "GET" });
+  }
+
+  async createBillingGroup(payload: BillingGroupCreatePayload): Promise<TelnyxEnvelope<BillingGroupData>> {
+    return this.request(this.url("/billing_groups"), { method: "POST", body: JSON.stringify(payload) });
+  }
+
+  async getBillingGroup(id: string): Promise<TelnyxEnvelope<BillingGroupData>> {
+    return this.request(this.url(`/billing_groups/${encodeURIComponent(id)}`), { method: "GET" });
+  }
+
+  async updateBillingGroup(id: string, payload: BillingGroupUpdatePayload): Promise<TelnyxEnvelope<BillingGroupData>> {
+    return this.request(this.url(`/billing_groups/${encodeURIComponent(id)}`), {
+      method: "PATCH",
+      body: JSON.stringify(payload)
+    });
+  }
+
+  async getUsageReportOptions(input: UsageReportOptionsInput = {}): Promise<TelnyxEnvelope> {
+    const url = this.url("/usage_reports/options");
+    if (input.product) url.searchParams.set("product", input.product);
+    return this.request(url, { method: "GET" });
+  }
+
+  async queryUsageReport(input: UsageQueryInput): Promise<TelnyxEnvelope> {
+    const url = this.url("/usage_reports");
+    url.searchParams.set("product", input.product);
+    url.searchParams.set("dimensions", input.dimensions.join(","));
+    url.searchParams.set("metrics", input.metrics.join(","));
+    if (input.startDate) url.searchParams.set("start_date", input.startDate);
+    if (input.endDate) url.searchParams.set("end_date", input.endDate);
+    if (input.dateRange) url.searchParams.set("date_range", input.dateRange);
+    if (input.filters) {
+      for (const [key, value] of Object.entries(input.filters)) {
+        url.searchParams.append(`filter[${key}]`, String(value));
+      }
+    }
+    if (input.sort) {
+      url.searchParams.set("sort", input.sort.join(","));
+    }
+    url.searchParams.set("format", input.format);
+    url.searchParams.set("page[number]", String(input.pageNumber));
+    url.searchParams.set("page[size]", String(input.pageSize));
+    url.searchParams.set("managed_accounts", String(input.managedAccounts));
+    return this.request(url, { method: "GET" });
+  }
+
+  private url(path: string): URL {
+    return new URL(`${this.baseUrl}${path}`);
+  }
+
+  private async request<T>(url: URL, init: RequestInit): Promise<T> {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.apiKey}`,
+      Accept: "application/json",
+      ...(init.body ? { "Content-Type": "application/json" } : {}),
+      ...(init.headers as Record<string, string> | undefined)
+    };
+
+    const response = await this.fetchImpl(url.toString(), { ...init, headers });
+    const body = await parseJson(response);
+
+    if (!response.ok) {
+      const sanitizedDetails = sanitizeBillingValue(body);
+      const message = sanitizeMessage(extractTelnyxErrorMessage(sanitizedDetails) ?? `Telnyx request failed with status ${response.status}`);
+      throw new TelnyxBillingError(message, response.status, sanitizedDetails);
+    }
+
+    return body as T;
+  }
+}
+
+export function sanitizeError(error: unknown): Error {
+  const source = error instanceof Error ? error : new Error(String(error));
+  const sanitized = new Error(sanitizeMessage(source.message));
+  sanitized.name = source.name;
+  return sanitized;
+}
+
+async function parseJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return {};
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return { text };
+  }
+}
+
+function extractTelnyxErrorMessage(body: unknown): string | undefined {
+  if (!body || typeof body !== "object") return undefined;
+  const errors = (body as { errors?: unknown }).errors;
+  if (!Array.isArray(errors) || errors.length === 0) return undefined;
+  const first = errors[0];
+  if (!first || typeof first !== "object") return undefined;
+  const title = (first as { title?: unknown }).title;
+  const detail = (first as { detail?: unknown }).detail;
+  return [title, detail].filter((value): value is string => typeof value === "string" && value.length > 0).join(": ");
+}
+
+export function sanitizeBillingValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sanitizeBillingValue);
+  if (value && typeof value === "object") {
+    const output: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(value)) {
+      if (isSafeAppTokenKey(key)) output[key] = sanitizeBillingValue(nested);
+      else if (isSecretKey(key)) output[key] = "[redacted-secret]";
+      else output[key] = sanitizeBillingValue(nested);
+    }
+    return output;
+  }
+  if (typeof value === "string") return sanitizeMessage(value);
+  return value;
+}
+
+function isSafeAppTokenKey(key: string): boolean {
+  return key === "confirmation_token";
+}
+
+function isSecretKey(key: string): boolean {
+  return /(^|_)(auth|authorization|api_?key|secret|token|password|card|bank|payment_method|paypal|ach|x402)($|_)/i.test(key);
+}
+
+function sanitizeMessage(message: string): string {
+  return message
+    .replace(/Authorization\s*:\s*Bearer\s+[^\s;,)]+/gi, "Authorization: Bearer [redacted-secret]")
+    .replace(/Bearer\s+[^\s;,)]+/gi, "Bearer [redacted-secret]")
+    .replace(/\b(?:sk|pk|key|api)[_-]?(?:live|test|secret)?_[A-Za-z0-9_\-]{6,}\b/gi, "[redacted-secret]")
+    .replace(/\b(?:api[_-]?key|secret|token|password)\s*(?:[=:]|\s)\s*[^\s;,)]+/gi, (match) => `${match.split(/[=:\s]/)[0]}=[redacted-secret]`)
+    .replace(/\b(?:\d[ -]*?){13,19}\b/g, "[redacted-payment]");
+}

--- a/tools/mcp-apps/apps/usage-cost-explorer/src/types.ts
+++ b/tools/mcp-apps/apps/usage-cost-explorer/src/types.ts
@@ -1,0 +1,149 @@
+export interface TelnyxClientOptions {
+  apiKey: string;
+  baseUrl?: string;
+  fetch?: typeof fetch;
+}
+
+export interface TelnyxEnvelope<T = unknown> {
+  data?: T;
+  meta?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export interface BalanceData {
+  record_type?: string;
+  pending?: string | number;
+  balance?: string | number;
+  credit_limit?: string | number;
+  available_credit?: string | number;
+  currency?: string;
+  [key: string]: unknown;
+}
+
+export interface AutoRechargePreferencesData {
+  id?: string;
+  record_type?: "auto_recharge_pref" | string;
+  threshold_amount?: string | number;
+  recharge_amount?: string | number;
+  enabled?: boolean;
+  invoice_enabled?: boolean;
+  preference?: string;
+  [key: string]: unknown;
+}
+
+export interface AutoRechargeUpdatePayload {
+  threshold_amount?: string | number;
+  recharge_amount?: string | number;
+  enabled?: boolean;
+  invoice_enabled?: boolean;
+  preference?: string;
+}
+
+export interface StoredPaymentTransactionPayload {
+  amount: string;
+}
+
+export interface StoredPaymentTransactionData {
+  id?: string;
+  record_type?: "transaction" | string;
+  amount_cents?: number;
+  processor_status?: string;
+  amount_currency?: string;
+  created_at?: string;
+  auto_recharge?: boolean;
+  transaction_processing_type?: "stored_payment" | string;
+  [key: string]: unknown;
+}
+
+export interface BillingGroupData {
+  id?: string;
+  record_type?: "billing_group" | string;
+  name?: string;
+  [key: string]: unknown;
+}
+
+export interface BillingGroupCreatePayload {
+  name: string;
+}
+
+export interface BillingGroupUpdatePayload {
+  name?: string;
+}
+
+export interface PageInput {
+  pageNumber?: number;
+  pageSize?: number;
+}
+
+export interface UsageReportOptionsInput {
+  product?: string;
+}
+
+export type UsageReportFormat = "json" | "csv";
+
+export interface UsageQueryInput {
+  product: string;
+  dimensions: string[];
+  metrics: string[];
+  startDate?: string;
+  endDate?: string;
+  dateRange?: string;
+  filters?: Record<string, string | number | boolean>;
+  sort?: string[];
+  format: UsageReportFormat;
+  managedAccounts: boolean;
+  pageNumber: number;
+  pageSize: number;
+}
+
+export interface UsageQueryRequest {
+  product: string;
+  dimensions: string[];
+  metrics: string[];
+  start_date?: string;
+  end_date?: string;
+  date_range?: string;
+  filters?: Record<string, string | number | boolean>;
+  sort?: string[];
+  format?: UsageReportFormat;
+  managed_accounts?: boolean;
+  page_number?: number;
+  page_size?: number;
+}
+
+export interface BillingServiceClient {
+  getBalance(): Promise<TelnyxEnvelope<BalanceData>>;
+  getAutoRechargePreferences(): Promise<TelnyxEnvelope<AutoRechargePreferencesData>>;
+  updateAutoRechargePreferences(payload: AutoRechargeUpdatePayload): Promise<TelnyxEnvelope<AutoRechargePreferencesData>>;
+  createStoredPaymentTransaction(payload: StoredPaymentTransactionPayload): Promise<TelnyxEnvelope<StoredPaymentTransactionData>>;
+  listBillingGroups(input?: PageInput): Promise<TelnyxEnvelope<BillingGroupData[]>>;
+  createBillingGroup(payload: BillingGroupCreatePayload): Promise<TelnyxEnvelope<BillingGroupData>>;
+  getBillingGroup(id: string): Promise<TelnyxEnvelope<BillingGroupData>>;
+  updateBillingGroup(id: string, payload: BillingGroupUpdatePayload): Promise<TelnyxEnvelope<BillingGroupData>>;
+  getUsageReportOptions(input?: UsageReportOptionsInput): Promise<TelnyxEnvelope>;
+  queryUsageReport(input: UsageQueryInput): Promise<TelnyxEnvelope>;
+}
+
+export interface AutoRechargePolicy {
+  maxThresholdAmount: number;
+  maxRechargeAmount: number;
+  version?: string;
+}
+
+export interface DiffEntry {
+  field: string;
+  before: unknown;
+  after: unknown;
+}
+
+export interface MutationPreview {
+  action: string;
+  financial_side_effect: boolean;
+  policy_version: string;
+  before: Record<string, unknown>;
+  after: Record<string, unknown>;
+  diff: DiffEntry[];
+  confirmation_token: string;
+  expires: string;
+  instructions: string;
+}

--- a/tools/mcp-apps/apps/usage-cost-explorer/src/ui.ts
+++ b/tools/mcp-apps/apps/usage-cost-explorer/src/ui.ts
@@ -1,0 +1,843 @@
+export const USAGE_COST_EXPLORER_UI_HTML = String.raw`<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Telnyx Billing Dashboard</title>
+    <style>
+      :root { color-scheme: light dark; --bg: #f6f8fb; --panel: #fff; --soft: #eef3f7; --text: #111827; --muted: #5b6472; --line: #d7dde6; --accent: #00a3a3; --accent-strong: #057474; --good: #16803c; --warn: #a46000; --bad: #b42318; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      @media (prefers-color-scheme: dark) { :root { --bg: #09111f; --panel: #101928; --soft: #142237; --text: #f8fafc; --muted: #aab7c7; --line: #27364b; --accent: #2dd4bf; --accent-strong: #5eead4; --good: #4ade80; --warn: #fbbf24; --bad: #f87171; } }
+      * { box-sizing: border-box; } body { margin: 0; background: var(--bg); color: var(--text); } main { width: min(1180px, 100%); margin: 0 auto; padding: 22px; } header { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; margin-bottom: 16px; } h1 { margin: 0; font-size: 30px; line-height: 1.1; } h2 { margin: 0; font-size: 15px; line-height: 1.25; } h3 { margin: 0; font-size: 13px; color: var(--muted); font-weight: 760; text-transform: uppercase; letter-spacing: .04em; } p { margin: 0; color: var(--muted); line-height: 1.5; } button, input, select { font: inherit; } button { min-height: 40px; border: 0; border-radius: 8px; padding: 0 13px; background: var(--accent); color: #042f2e; font-weight: 760; cursor: pointer; } button.secondary { border: 1px solid var(--line); background: var(--panel); color: var(--text); } button.danger { background: var(--bad); color: #fff; } button:disabled { cursor: progress; opacity: .65; } input, select { min-width: 0; min-height: 40px; border: 1px solid var(--line); border-radius: 8px; padding: 0 10px; background: var(--panel); color: var(--text); } label { display: grid; gap: 6px; color: var(--muted); font-size: 12px; font-weight: 720; }
+      .eyebrow { color: var(--accent-strong); font-size: 12px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; } .pill-row { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 8px; } .pill { border: 1px solid var(--line); border-radius: 999px; padding: 6px 9px; color: var(--muted); background: var(--panel); font-size: 12px; } .grid { display: grid; gap: 10px; } .summary { grid-template-columns: repeat(4, minmax(0, 1fr)); } .main-grid { grid-template-columns: minmax(0, 1.45fr) minmax(330px, .8fr); margin-top: 12px; } .card, .panel { border: 1px solid var(--line); border-radius: 8px; background: var(--panel); box-shadow: 0 1px 2px rgba(15,23,42,.06); } .card { min-height: 104px; padding: 14px; } .panel { padding: 16px; } .panel-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 12px; } .value { margin-top: 8px; font-size: 22px; font-weight: 780; overflow-wrap: anywhere; } .meta { margin-top: 6px; color: var(--muted); font-size: 13px; overflow-wrap: anywhere; } .good { color: var(--good); } .warn { color: var(--warn); } .bad { color: var(--bad); } .toolbar { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)) auto; gap: 10px; margin-bottom: 12px; } .chart { width: 100%; height: 260px; border: 1px solid var(--line); border-radius: 8px; background: var(--soft); } .table-wrap { overflow-x: auto; } table { width: 100%; border-collapse: collapse; } th, td { padding: 9px; border-bottom: 1px solid var(--line); text-align: left; vertical-align: top; } th { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: .04em; } .stack { display: grid; gap: 12px; } .form-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; } .switch { display: flex; align-items: center; justify-content: space-between; gap: 10px; min-height: 40px; padding: 9px 10px; border: 1px solid var(--line); border-radius: 8px; } .switch input { min-height: auto; } .actions { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 10px; } .preview { display: grid; gap: 8px; margin-top: 12px; padding: 12px; border: 1px solid var(--line); border-radius: 8px; background: var(--soft); } .diff { display: grid; grid-template-columns: minmax(80px, .7fr) 1fr 1fr; gap: 8px; font-size: 13px; } .empty { padding: 24px 16px; text-align: center; border: 1px dashed var(--line); border-radius: 8px; background: var(--panel); } .error { margin-bottom: 12px; color: var(--bad); font-weight: 650; } .hidden { display: none; }
+      @media (max-width: 960px) { header, .main-grid { grid-template-columns: 1fr; display: grid; } .pill-row { justify-content: flex-start; } .summary { grid-template-columns: repeat(2, minmax(0, 1fr)); } .toolbar { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+      @media (max-width: 560px) { main { padding: 16px; } .summary, .toolbar, .form-grid { grid-template-columns: 1fr; } }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <div>
+          <div class="eyebrow">Telnyx MCP App</div>
+          <h1>Billing Dashboard</h1>
+          <p>Current balance, usage, billing groups, and guarded auto-recharge settings in one workspace.</p>
+        </div>
+        <div class="pill-row">
+          <span class="pill" id="bridgeStatus">Host bridge: initializing</span>
+          <span class="pill warn">Usage Reports beta</span>
+          <span class="pill">No direct payments</span>
+        </div>
+      </header>
+
+      <div class="error hidden" id="error"></div>
+
+      <section class="grid summary" aria-label="Billing summary">
+        <article class="card"><h3>Balance</h3><div class="value" id="balanceValue">Loading</div><div class="meta" id="balanceMeta">available credit</div></article>
+        <article class="card"><h3>Credit Limit</h3><div class="value" id="creditValue">Loading</div><div class="meta" id="creditMeta">pending and frozen</div></article>
+        <article class="card"><h3>Auto Recharge</h3><div class="value" id="autoValue">Loading</div><div class="meta" id="autoMeta">threshold / amount</div></article>
+        <article class="card"><h3>Billing Groups</h3><div class="value" id="groupsValue">Loading</div><div class="meta">IDs preserved for follow-up work</div></article>
+      </section>
+
+      <section class="grid main-grid">
+        <div class="stack">
+          <article class="panel">
+            <div class="panel-head">
+              <div><h2>Usage</h2><p class="meta">Select discovered report options, then refresh the chart.</p></div>
+              <button class="secondary" id="refreshButton" type="button">Refresh</button>
+            </div>
+            <form class="toolbar" id="usageForm">
+              <label>Product<select id="productSelect"></select></label>
+              <label>Dimension<select id="dimensionSelect"></select></label>
+              <label>Metric<select id="metricSelect"></select></label>
+              <label>Range<select id="rangeSelect"><option value="last_7_days">Last 7 days</option><option value="last_30_days">Last 30 days</option><option value="today">Today</option><option value="yesterday">Yesterday</option></select></label>
+              <button type="submit">Run</button>
+            </form>
+            <svg class="chart" id="usageChart" role="img" aria-label="Usage chart"></svg>
+            <div class="meta" id="usageMeta">Waiting for usage data.</div>
+          </article>
+
+          <article class="panel">
+            <div class="panel-head"><h2>Billing Groups</h2><button class="secondary" id="reloadGroupsButton" type="button">Reload</button></div>
+            <div class="table-wrap"><table><thead><tr><th>Name</th><th>ID</th><th>Type</th></tr></thead><tbody id="groupsBody"></tbody></table></div>
+          </article>
+        </div>
+
+        <div class="stack">
+          <article class="panel">
+            <div class="panel-head"><h2>Auto Recharge</h2><button class="secondary" id="reloadAutoButton" type="button">Reload</button></div>
+            <form id="autoForm" class="stack">
+              <div class="switch"><span>Enabled</span><input id="enabledInput" type="checkbox" /></div>
+              <div class="switch"><span>Invoice enabled</span><input id="invoiceInput" type="checkbox" /></div>
+              <div class="form-grid">
+                <label>Threshold amount<input id="thresholdInput" inputmode="decimal" /></label>
+                <label>Recharge amount<input id="rechargeInput" inputmode="decimal" /></label>
+              </div>
+              <label>Payment method<select id="preferenceSelect"><option value="credit_paypal">Card or PayPal</option><option value="ach">Bank transfer (ACH)</option></select><span class="meta" id="preferenceHelp">Uses the saved card or PayPal payment method.</span></label>
+              <div class="actions">
+                <button type="submit">Preview change</button>
+                <button class="secondary" id="resetAutoButton" type="button">Reset</button>
+              </div>
+            </form>
+            <section id="previewBox" class="preview hidden">
+              <h3>Preview</h3>
+              <div id="diffList"></div>
+              <div class="actions">
+                <button id="confirmAutoButton" type="button">Confirm update</button>
+                <button class="secondary" id="cancelPreviewButton" type="button">Cancel</button>
+              </div>
+            </section>
+          </article>
+
+          <article class="panel">
+            <h2>Raw Data</h2>
+            <pre id="jsonPre">{}</pre>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <script>
+      const PROTOCOL_VERSION = "2026-01-26";
+      let nextId = 1;
+      const pending = new Map();
+      const state = { initialized: false, overview: {}, autoPatch: null, confirmationToken: null };
+
+      const els = {
+        bridgeStatus: document.getElementById("bridgeStatus"), error: document.getElementById("error"),
+        balanceValue: document.getElementById("balanceValue"), balanceMeta: document.getElementById("balanceMeta"),
+        creditValue: document.getElementById("creditValue"), creditMeta: document.getElementById("creditMeta"),
+        autoValue: document.getElementById("autoValue"), autoMeta: document.getElementById("autoMeta"),
+        groupsValue: document.getElementById("groupsValue"), groupsBody: document.getElementById("groupsBody"),
+        productSelect: document.getElementById("productSelect"), dimensionSelect: document.getElementById("dimensionSelect"),
+        metricSelect: document.getElementById("metricSelect"), rangeSelect: document.getElementById("rangeSelect"),
+        usageChart: document.getElementById("usageChart"), usageMeta: document.getElementById("usageMeta"),
+        usageForm: document.getElementById("usageForm"), refreshButton: document.getElementById("refreshButton"),
+        enabledInput: document.getElementById("enabledInput"), invoiceInput: document.getElementById("invoiceInput"),
+        thresholdInput: document.getElementById("thresholdInput"), rechargeInput: document.getElementById("rechargeInput"),
+        preferenceSelect: document.getElementById("preferenceSelect"), autoForm: document.getElementById("autoForm"),
+        reloadAutoButton: document.getElementById("reloadAutoButton"), reloadGroupsButton: document.getElementById("reloadGroupsButton"),
+        resetAutoButton: document.getElementById("resetAutoButton"), previewBox: document.getElementById("previewBox"),
+        diffList: document.getElementById("diffList"), confirmAutoButton: document.getElementById("confirmAutoButton"),
+        cancelPreviewButton: document.getElementById("cancelPreviewButton"), jsonPre: document.getElementById("jsonPre")
+      };
+
+      function send(message) { window.parent.postMessage(message, "*"); }
+      function notify(method, params) { send({ jsonrpc: "2.0", method, params }); }
+      let resizePending = false;
+      function resize() {
+        if (resizePending) return;
+        resizePending = true;
+        requestAnimationFrame(() => {
+          resizePending = false;
+          const root = document.documentElement;
+          const previousHeight = root.style.height;
+          root.style.height = "max-content";
+          const height = Math.ceil(root.getBoundingClientRect().height);
+          root.style.height = previousHeight;
+          notify("ui/notifications/size-changed", { width: Math.ceil(root.scrollWidth || window.innerWidth), height });
+        });
+      }
+      function request(method, params) {
+        const id = nextId++;
+        send({ jsonrpc: "2.0", id, method, params });
+        return new Promise((resolve, reject) => {
+          pending.set(id, { resolve, reject });
+          window.setTimeout(() => {
+            if (!pending.has(id)) return;
+            pending.delete(id);
+            reject(new Error(method + " timed out"));
+          }, 30000);
+        });
+      }
+      async function callTool(name, args = {}) { return extractResult(await request("tools/call", { name, arguments: args })); }
+      function extractResult(result) {
+        if (result?.isError) {
+          const textBlock = result?.content?.find?.((block) => block.type === "text");
+          throw new Error(textBlock?.text || "Tool request failed.");
+        }
+        if (result?.structuredContent) return result.structuredContent;
+        const textBlock = result?.content?.find?.((block) => block.type === "text");
+        if (!textBlock?.text) return result;
+        try { return JSON.parse(textBlock.text); } catch { return result; }
+      }
+      function setError(message) { els.error.textContent = message || ""; els.error.classList.toggle("hidden", !message); resize(); }
+      function dataOf(envelope) { return envelope?.data ?? envelope; }
+      function asArray(value) { return Array.isArray(value) ? value : value ? [value] : []; }
+      function fmtMoney(value, currency) { return value === undefined || value === null || value === "" ? "-" : (currency ? value + " " + currency : String(value)); }
+      function unique(values) { return [...new Set(values.filter((value) => typeof value === "string" && value.trim()))]; }
+      function optionValues(options, keys, fallback) {
+        const data = dataOf(options) || {};
+        if (Array.isArray(data)) return fallback;
+        for (const key of keys) {
+          const value = data[key];
+          if (Array.isArray(value)) return unique(value.map((item) => typeof item === "string" ? item : item?.name || item?.id || item?.value));
+          if (value && typeof value === "object") return unique(Object.keys(value));
+        }
+        return fallback;
+      }
+      function fillSelect(select, values, preferred) {
+        const current = select.value;
+        select.replaceChildren();
+        for (const value of unique(values)) select.append(new Option(value, value));
+        select.value = values.includes(current) ? current : values.includes(preferred) ? preferred : values[0] || "";
+      }
+      function renderOverview(overview) {
+        state.overview = { ...state.overview, ...overview };
+        const balance = dataOf(state.overview.balance);
+        const auto = dataOf(state.overview.auto_recharge);
+        const groups = asArray(dataOf(state.overview.billing_groups));
+        const currency = balance?.currency;
+        els.balanceValue.textContent = fmtMoney(balance?.balance, currency);
+        els.balanceMeta.textContent = "available " + fmtMoney(balance?.available_credit, currency);
+        els.creditValue.textContent = fmtMoney(balance?.credit_limit, currency);
+        els.creditMeta.textContent = "pending " + fmtMoney(balance?.pending, currency) + "; frozen " + fmtMoney(balance?.frozen, currency);
+        renderAuto(auto);
+        renderGroups(groups);
+        renderOptions(state.overview.usage_options);
+        if (state.overview.warnings?.length) {
+          els.usageMeta.textContent = state.overview.warnings.map((warning) => warning.source + ": " + warning.message).join("; ");
+        }
+        els.jsonPre.textContent = JSON.stringify(state.overview, null, 2);
+        resize();
+      }
+      function renderAuto(auto) {
+        els.autoValue.textContent = auto ? (auto.enabled ? "Enabled" : "Disabled") : "-";
+        els.autoValue.className = "value " + (auto?.enabled ? "good" : "warn");
+        els.autoMeta.textContent = auto ? "threshold " + fmtMoney(auto.threshold_amount) + "; recharge " + fmtMoney(auto.recharge_amount) : "threshold / amount";
+        if (!auto) return;
+        els.enabledInput.checked = Boolean(auto.enabled);
+        els.invoiceInput.checked = Boolean(auto.invoice_enabled);
+        els.thresholdInput.value = auto.threshold_amount ?? "";
+        els.rechargeInput.value = auto.recharge_amount ?? "";
+        if (auto.preference && !Array.from(els.preferenceSelect.options).some((option) => option.value === auto.preference)) {
+          els.preferenceSelect.append(new Option(auto.preference, auto.preference));
+        }
+        els.preferenceSelect.value = auto.preference || els.preferenceSelect.value;
+        renderPreferenceHelp();
+      }
+      function renderGroups(groups) {
+        els.groupsValue.textContent = String(groups.length);
+        els.groupsBody.replaceChildren();
+        if (!groups.length) {
+          const tr = document.createElement("tr");
+          const td = document.createElement("td");
+          td.colSpan = 3;
+          td.textContent = "No billing groups returned.";
+          tr.append(td);
+          els.groupsBody.append(tr);
+          return;
+        }
+        for (const group of groups) {
+          const tr = document.createElement("tr");
+          for (const value of [group.name || "Unnamed", group.id || "-", group.record_type || "billing_group"]) {
+            const td = document.createElement("td");
+            td.textContent = value;
+            tr.append(td);
+          }
+          els.groupsBody.append(tr);
+        }
+      }
+      function renderOptions(options) {
+        const rows = asArray(dataOf(options));
+        const products = rows.length ? unique(rows.map((row) => row.product)) : optionValues(options, ["products", "product"], ["messaging"]);
+        fillSelect(els.productSelect, products, "messaging");
+        renderProductOptions();
+      }
+      function renderProductOptions() {
+        const rows = asArray(dataOf(state.overview.usage_options));
+        const row = rows.find((item) => item?.product === els.productSelect.value) || rows[0];
+        const recordTypes = asArray(row?.record_types);
+        const dimensions = unique([...(row?.product_dimensions || []), ...recordTypes.flatMap((record) => record.product_dimensions || [])]);
+        const metrics = unique([...(row?.product_metrics || []), ...recordTypes.flatMap((record) => record.product_metrics || [])]);
+        fillSelect(els.dimensionSelect, dimensions.length ? dimensions : ["date"], "date");
+        fillSelect(els.metricSelect, metrics.length ? metrics : ["cost"], "cost");
+      }
+      function renderUsage(result) {
+        const rows = asArray(dataOf(result));
+        const metric = els.metricSelect.value;
+        const dimension = els.dimensionSelect.value;
+        const points = rows.map((row, index) => ({ label: String(row?.[dimension] ?? row?.date ?? row?.period ?? index + 1), value: Number(row?.[metric] ?? row?.cost ?? row?.count ?? 0) })).filter((point) => Number.isFinite(point.value));
+        drawChart(points);
+        els.usageMeta.textContent = points.length ? points.length + " rows; metric " + metric + " by " + dimension + "." : "No usage rows returned for this query.";
+        state.overview.usage = result;
+        els.jsonPre.textContent = JSON.stringify(state.overview, null, 2);
+        resize();
+      }
+      function drawChart(points) {
+        const svg = els.usageChart;
+        const width = 760, height = 260, pad = 34;
+        svg.setAttribute("viewBox", "0 0 " + width + " " + height);
+        svg.replaceChildren();
+        const max = Math.max(1, ...points.map((point) => point.value));
+        const barWidth = points.length ? Math.max(8, (width - pad * 2) / points.length - 6) : 0;
+        const axis = document.createElementNS("http://www.w3.org/2000/svg", "path");
+        axis.setAttribute("d", "M" + pad + " " + (height - pad) + "H" + (width - pad) + "M" + pad + " " + pad + "V" + (height - pad));
+        axis.setAttribute("stroke", "var(--line)");
+        axis.setAttribute("fill", "none");
+        svg.append(axis);
+        if (!points.length) {
+          const text = document.createElementNS("http://www.w3.org/2000/svg", "text");
+          text.setAttribute("x", String(width / 2)); text.setAttribute("y", String(height / 2)); text.setAttribute("text-anchor", "middle"); text.setAttribute("fill", "var(--muted)");
+          text.textContent = "No usage data";
+          svg.append(text);
+          return;
+        }
+        points.slice(0, 40).forEach((point, index) => {
+          const x = pad + index * ((width - pad * 2) / Math.min(points.length, 40)) + 3;
+          const h = Math.max(2, (point.value / max) * (height - pad * 2));
+          const rect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+          rect.setAttribute("x", String(x)); rect.setAttribute("y", String(height - pad - h)); rect.setAttribute("width", String(barWidth)); rect.setAttribute("height", String(h)); rect.setAttribute("rx", "3"); rect.setAttribute("fill", "var(--accent)");
+          const title = document.createElementNS("http://www.w3.org/2000/svg", "title");
+          title.textContent = point.label + ": " + point.value;
+          rect.append(title);
+          svg.append(rect);
+        });
+      }
+      function patchFromForm() {
+        return {
+          enabled: els.enabledInput.checked,
+          invoice_enabled: els.invoiceInput.checked,
+          threshold_amount: els.thresholdInput.value.trim(),
+          recharge_amount: els.rechargeInput.value.trim(),
+          preference: els.preferenceSelect.value
+        };
+      }
+      function renderPreferenceHelp() {
+        const descriptions = {
+          credit_paypal: "Uses the saved card or PayPal payment method.",
+          ach: "Uses a linked US bank account through ACH."
+        };
+        const help = document.getElementById("preferenceHelp");
+        if (help) help.textContent = descriptions[els.preferenceSelect.value] || "";
+      }
+      function renderPreview(preview, patch) {
+        state.autoPatch = patch;
+        state.confirmationToken = preview.confirmation_token;
+        els.previewBox.classList.remove("hidden");
+        els.diffList.replaceChildren();
+        for (const item of preview.diff || []) {
+          const row = document.createElement("div");
+          row.className = "diff";
+          row.replaceChildren(textNode(item.field), textNode(String(item.before ?? "-")), textNode(String(item.after ?? "-")));
+          els.diffList.append(row);
+        }
+        if (!preview.diff?.length) els.diffList.textContent = "No field changes detected.";
+        resize();
+      }
+      function textNode(value) { const div = document.createElement("div"); div.textContent = value; return div; }
+      async function loadOverview() {
+        setError("");
+        const overview = await callTool("billing_overview");
+        renderOverview(overview);
+      }
+      async function loadUsage() {
+        const product = els.productSelect.value;
+        const dimension = els.dimensionSelect.value;
+        const metric = els.metricSelect.value;
+        if (!product || !dimension || !metric) return;
+        try {
+          renderUsage(await callTool("billing_query_usage", { product, dimensions: [dimension], metrics: [metric], date_range: els.rangeSelect.value, page_size: 100 }));
+        } catch (error) {
+          drawChart([]);
+          els.usageMeta.textContent = error.message || "Usage query failed.";
+          resize();
+        }
+      }
+
+      window.addEventListener("message", (event) => {
+        if (event.source !== window.parent) return;
+        const message = event.data;
+        if (!message || message.jsonrpc !== "2.0") return;
+        if (message.id !== undefined && pending.has(message.id)) {
+          const handlers = pending.get(message.id);
+          pending.delete(message.id);
+          if (message.error) handlers.reject(new Error(message.error.message || "Request failed"));
+          else handlers.resolve(message.result);
+          return;
+        }
+        if (message.method === "ui/notifications/tool-result") {
+          const payload = extractResult(message.params);
+          if (payload?.balance || payload?.auto_recharge || payload?.billing_groups) renderOverview(payload);
+        }
+      });
+
+      els.refreshButton.addEventListener("click", () => loadOverview().then(loadUsage).catch((error) => setError(error.message || "Refresh failed.")));
+      els.reloadGroupsButton.addEventListener("click", async () => {
+        try { renderOverview({ billing_groups: await callTool("billing_list_billing_groups", { page_size: 100 }) }); } catch (error) { setError(error.message || "Could not load billing groups."); }
+      });
+      els.reloadAutoButton.addEventListener("click", async () => {
+        try { renderOverview({ auto_recharge: await callTool("billing_get_auto_recharge_preferences") }); } catch (error) { setError(error.message || "Could not load auto recharge."); }
+      });
+      els.resetAutoButton.addEventListener("click", () => renderAuto(dataOf(state.overview.auto_recharge)));
+      els.cancelPreviewButton.addEventListener("click", () => { state.autoPatch = null; state.confirmationToken = null; els.previewBox.classList.add("hidden"); resize(); });
+      els.usageForm.addEventListener("submit", (event) => {
+        event.preventDefault();
+        loadUsage().catch((error) => setError(error.message || "Usage query failed."));
+      });
+      els.productSelect.addEventListener("change", renderProductOptions);
+      els.preferenceSelect.addEventListener("change", renderPreferenceHelp);
+      els.autoForm.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        try {
+          const patch = patchFromForm();
+          renderPreview(await callTool("billing_preview_auto_recharge_update", patch), patch);
+        } catch (error) { setError(error.message || "Preview failed."); }
+      });
+      els.confirmAutoButton.addEventListener("click", async () => {
+        if (!state.autoPatch || !state.confirmationToken) return;
+        try {
+          const result = await callTool("billing_update_auto_recharge_preferences", { ...state.autoPatch, confirmation_token: state.confirmationToken });
+          els.previewBox.classList.add("hidden");
+          state.autoPatch = null; state.confirmationToken = null;
+          renderOverview({ auto_recharge: result });
+        } catch (error) { setError(error.message || "Update failed."); }
+      });
+      window.addEventListener("resize", resize);
+      new ResizeObserver(resize).observe(document.documentElement);
+      new ResizeObserver(resize).observe(document.body);
+
+      request("ui/initialize", { appInfo: { name: "telnyx-billing-dashboard-ui", version: "0.2.0" }, appCapabilities: {}, protocolVersion: PROTOCOL_VERSION })
+        .then(async () => {
+          state.initialized = true;
+          els.bridgeStatus.textContent = "Host bridge: connected";
+          notify("ui/notifications/initialized", {});
+          await loadOverview();
+          renderPreferenceHelp();
+          await loadUsage();
+        })
+        .catch((error) => {
+          els.bridgeStatus.textContent = "Host bridge: unavailable";
+          setError("MCP App bridge failed to initialize: " + error.message);
+          renderOptions();
+          drawChart([]);
+        });
+    </script>
+  </body>
+</html>`;
+
+export const STORED_PAYMENT_TOP_UP_UI_HTML = String.raw`<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Telnyx Stored Payment Top Up</title>
+    <style>
+      :root { color-scheme: light dark; --bg: #f6f8fb; --panel: #fff; --soft: #eef3f7; --text: #111827; --muted: #5b6472; --line: #d7dde6; --accent: #00a3a3; --accent-strong: #057474; --good: #16803c; --warn: #a46000; --bad: #b42318; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      @media (prefers-color-scheme: dark) { :root { --bg: #09111f; --panel: #101928; --soft: #142237; --text: #f8fafc; --muted: #aab7c7; --line: #27364b; --accent: #2dd4bf; --accent-strong: #5eead4; --good: #4ade80; --warn: #fbbf24; --bad: #f87171; } }
+      * { box-sizing: border-box; } body { margin: 0; background: var(--bg); color: var(--text); } main { width: min(720px, 100%); margin: 0 auto; padding: 22px; } h1 { margin: 0; font-size: 30px; line-height: 1.1; } h2 { margin: 0; font-size: 16px; } h3 { margin: 0; color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: .04em; } p { margin: 0; color: var(--muted); line-height: 1.5; } button, input { font: inherit; } button { min-height: 42px; border: 0; border-radius: 8px; padding: 0 14px; background: var(--accent); color: #042f2e; font-weight: 760; cursor: pointer; } button.secondary { border: 1px solid var(--line); background: var(--panel); color: var(--text); } button:disabled { cursor: progress; opacity: .65; } input { min-width: 0; min-height: 42px; border: 1px solid var(--line); border-radius: 8px; padding: 0 11px; background: var(--panel); color: var(--text); } label { display: grid; gap: 6px; color: var(--muted); font-size: 12px; font-weight: 720; }
+      header { display: grid; gap: 10px; margin-bottom: 14px; } .eyebrow { color: var(--accent-strong); font-size: 12px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; } .pill-row { display: flex; flex-wrap: wrap; gap: 8px; } .pill { border: 1px solid var(--line); border-radius: 999px; padding: 6px 9px; color: var(--muted); background: var(--panel); font-size: 12px; } .card, .panel { border: 1px solid var(--line); border-radius: 8px; background: var(--panel); box-shadow: 0 1px 2px rgba(15,23,42,.06); } .card { padding: 14px; } .panel { padding: 16px; margin-top: 12px; } .summary { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; } .value { margin-top: 7px; font-size: 24px; font-weight: 780; overflow-wrap: anywhere; } .meta { margin-top: 6px; color: var(--muted); font-size: 13px; overflow-wrap: anywhere; } .stack { display: grid; gap: 12px; } .actions { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 10px; } .preview { display: grid; gap: 8px; margin-top: 12px; padding: 12px; border: 1px solid var(--line); border-radius: 8px; background: var(--soft); } .notice { padding: 12px; border-radius: 8px; background: var(--soft); color: var(--muted); } .error { margin-top: 12px; color: var(--bad); font-weight: 650; } .success { color: var(--good); } .hidden { display: none; }
+      @media (max-width: 560px) { main { padding: 16px; } .summary { grid-template-columns: 1fr; } }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <div class="eyebrow">Telnyx Billing</div>
+        <h1>Top Up Balance</h1>
+        <p>Charge a saved payment method from the Telnyx portal to add credit to this account. The payment is previewed first and only submitted after confirmation.</p>
+        <div class="pill-row">
+          <span class="pill" id="bridgeStatus">Host bridge: initializing</span>
+          <span class="pill">Saved payment method</span>
+          <span class="pill">Preview required</span>
+        </div>
+      </header>
+
+      <section class="summary">
+        <article class="card"><h3>Balance</h3><div class="value" id="balanceValue">Loading</div><div class="meta" id="balanceMeta">available credit</div></article>
+        <article class="card"><h3>Pending</h3><div class="value" id="pendingValue">Loading</div><div class="meta">current pending balance activity</div></article>
+      </section>
+
+      <section class="panel">
+        <div class="notice">This creates a stored payment transaction using the payment method already saved in the Telnyx portal.</div>
+        <form id="topUpForm" class="stack">
+          <label>Top-up amount<input id="amountInput" inputmode="decimal" value="25.00" /></label>
+          <div class="actions">
+            <button id="previewButton" type="submit">Preview payment</button>
+            <button class="secondary" id="reloadButton" type="button">Reload balance</button>
+          </div>
+        </form>
+        <div class="notice hidden" id="status"></div>
+        <div class="error hidden" id="error"></div>
+      </section>
+
+      <section id="previewBox" class="preview hidden">
+        <h2>Confirm Stored Payment</h2>
+        <p id="previewText"></p>
+        <div class="actions">
+          <button id="confirmButton" type="button">Submit payment</button>
+          <button class="secondary" id="cancelButton" type="button">Cancel</button>
+        </div>
+      </section>
+
+      <section id="resultBox" class="preview hidden">
+        <h2>Payment Submitted</h2>
+        <div id="resultText" class="success"></div>
+      </section>
+    </main>
+    <script>
+      const PROTOCOL_VERSION = "2026-01-26";
+      let nextId = 1;
+      const pending = new Map();
+      const state = { amount: null, token: null };
+      const els = {
+        bridgeStatus: document.getElementById("bridgeStatus"), error: document.getElementById("error"), status: document.getElementById("status"),
+        balanceValue: document.getElementById("balanceValue"), balanceMeta: document.getElementById("balanceMeta"), pendingValue: document.getElementById("pendingValue"),
+        amountInput: document.getElementById("amountInput"), topUpForm: document.getElementById("topUpForm"), previewButton: document.getElementById("previewButton"),
+        reloadButton: document.getElementById("reloadButton"), previewBox: document.getElementById("previewBox"), previewText: document.getElementById("previewText"),
+        confirmButton: document.getElementById("confirmButton"), cancelButton: document.getElementById("cancelButton"), resultBox: document.getElementById("resultBox"), resultText: document.getElementById("resultText")
+      };
+      function send(message) { window.parent.postMessage(message, "*"); }
+      function notify(method, params) { send({ jsonrpc: "2.0", method, params }); }
+      let resizePending = false;
+      function resize() {
+        if (resizePending) return;
+        resizePending = true;
+        requestAnimationFrame(() => {
+          resizePending = false;
+          const root = document.documentElement;
+          const previousHeight = root.style.height;
+          root.style.height = "max-content";
+          const height = Math.ceil(root.getBoundingClientRect().height);
+          root.style.height = previousHeight;
+          notify("ui/notifications/size-changed", { width: Math.ceil(root.scrollWidth || window.innerWidth), height });
+        });
+      }
+      function request(method, params) {
+        const id = nextId++;
+        send({ jsonrpc: "2.0", id, method, params });
+        return new Promise((resolve, reject) => {
+          pending.set(id, { resolve, reject });
+          window.setTimeout(() => {
+            if (!pending.has(id)) return;
+            pending.delete(id);
+            reject(new Error(method + " timed out"));
+          }, 30000);
+        });
+      }
+      async function callTool(name, args = {}) { return extractResult(await request("tools/call", { name, arguments: args })); }
+      function extractResult(result) {
+        if (result?.isError) {
+          const textBlock = result?.content?.find?.((block) => block.type === "text");
+          throw new Error(textBlock?.text || "Tool request failed.");
+        }
+        if (result?.structuredContent) return result.structuredContent;
+        const textBlock = result?.content?.find?.((block) => block.type === "text");
+        if (!textBlock?.text) return result;
+        try { return JSON.parse(textBlock.text); } catch { return result; }
+      }
+      function dataOf(envelope) { return envelope?.data ?? envelope; }
+      function fmtMoney(value, currency) { return value === undefined || value === null || value === "" ? "-" : (currency ? value + " " + currency : String(value)); }
+      function setError(message) { els.error.textContent = message || ""; els.error.classList.toggle("hidden", !message); resize(); }
+      function setStatus(message) { els.status.textContent = message || ""; els.status.classList.toggle("hidden", !message); resize(); }
+      function renderBalance(payload) {
+        const balance = dataOf(payload?.balance);
+        const currency = balance?.currency;
+        els.balanceValue.textContent = fmtMoney(balance?.balance, currency);
+        els.balanceMeta.textContent = "available " + fmtMoney(balance?.available_credit, currency);
+        els.pendingValue.textContent = fmtMoney(balance?.pending, currency);
+        resize();
+      }
+      async function loadState() { renderBalance(await callTool("billing_stored_payment_top_up")); }
+      window.addEventListener("message", (event) => {
+        if (event.source !== window.parent) return;
+        const message = event.data;
+        if (!message || message.jsonrpc !== "2.0") return;
+        if (message.id !== undefined && pending.has(message.id)) {
+          const handlers = pending.get(message.id);
+          pending.delete(message.id);
+          if (message.error) handlers.reject(new Error(message.error.message || "Request failed"));
+          else handlers.resolve(message.result);
+        }
+      });
+      els.topUpForm.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        setError(""); setStatus("Creating payment preview..."); els.resultBox.classList.add("hidden");
+        els.previewButton.disabled = true;
+        const previousText = els.previewButton.textContent;
+        els.previewButton.textContent = "Previewing";
+        try {
+          const amount = els.amountInput.value.trim();
+          const preview = await callTool("billing_preview_stored_payment_transaction", { amount });
+          state.amount = amount; state.token = preview.confirmation_token;
+          els.previewText.textContent = "Submit a stored payment transaction for " + amount + "?";
+          els.previewBox.classList.remove("hidden");
+          setStatus("Preview ready. Confirm to submit the payment.");
+        } catch (error) { setStatus(""); setError(error.message || "Preview failed."); }
+        finally { els.previewButton.disabled = false; els.previewButton.textContent = previousText; }
+      });
+      els.confirmButton.addEventListener("click", async () => {
+        if (!state.amount || !state.token) return;
+        setError(""); setStatus("Submitting payment...");
+        els.confirmButton.disabled = true;
+        const previousText = els.confirmButton.textContent;
+        els.confirmButton.textContent = "Submitting";
+        try {
+          const result = await callTool("billing_create_stored_payment_transaction", { amount: state.amount, confirmation_token: state.token });
+          const transaction = dataOf(result);
+          state.amount = null; state.token = null;
+          els.previewBox.classList.add("hidden");
+          els.resultBox.classList.remove("hidden");
+          els.resultText.textContent = "Transaction " + (transaction?.id || "submitted") + " is " + (transaction?.processor_status || "submitted") + ".";
+          setStatus("Stored payment transaction submitted.");
+          await loadState().catch(() => {});
+        } catch (error) { setStatus(""); setError(error.message || "Payment failed."); }
+        finally { els.confirmButton.disabled = false; els.confirmButton.textContent = previousText; }
+      });
+      els.cancelButton.addEventListener("click", () => { state.amount = null; state.token = null; els.previewBox.classList.add("hidden"); setStatus(""); resize(); });
+      els.reloadButton.addEventListener("click", () => { setStatus("Reloading balance..."); loadState().then(() => setStatus("Balance reloaded.")).catch((error) => setError(error.message || "Reload failed.")); });
+      window.addEventListener("resize", resize);
+      new ResizeObserver(resize).observe(document.documentElement);
+      new ResizeObserver(resize).observe(document.body);
+      request("ui/initialize", { appInfo: { name: "telnyx-stored-payment-top-up-ui", version: "0.1.0" }, appCapabilities: {}, protocolVersion: PROTOCOL_VERSION })
+        .then(async () => {
+          els.bridgeStatus.textContent = "Host bridge: connected";
+          notify("ui/notifications/initialized", {});
+          await loadState();
+        })
+        .catch((error) => {
+          els.bridgeStatus.textContent = "Host bridge: unavailable";
+          setError("MCP App bridge failed to initialize: " + error.message);
+        });
+    </script>
+  </body>
+</html>`;
+
+export const AUTO_RECHARGE_SETUP_UI_HTML = String.raw`<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Telnyx Auto Recharge Setup</title>
+    <style>
+      :root { color-scheme: light dark; --bg: #f6f8fb; --panel: #fff; --soft: #eef3f7; --text: #111827; --muted: #5b6472; --line: #d7dde6; --accent: #00a3a3; --accent-strong: #057474; --good: #16803c; --warn: #a46000; --bad: #b42318; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      @media (prefers-color-scheme: dark) { :root { --bg: #09111f; --panel: #101928; --soft: #142237; --text: #f8fafc; --muted: #aab7c7; --line: #27364b; --accent: #2dd4bf; --accent-strong: #5eead4; --good: #4ade80; --warn: #fbbf24; --bad: #f87171; } }
+      * { box-sizing: border-box; } body { margin: 0; background: var(--bg); color: var(--text); } main { width: min(760px, 100%); margin: 0 auto; padding: 22px; } h1 { margin: 0; font-size: 30px; line-height: 1.1; } h2 { margin: 0; font-size: 16px; } h3 { margin: 0; color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: .04em; } p { margin: 0; color: var(--muted); line-height: 1.5; } button, input, select { font: inherit; } button { min-height: 42px; border: 0; border-radius: 8px; padding: 0 14px; background: var(--accent); color: #042f2e; font-weight: 760; cursor: pointer; } button.secondary { border: 1px solid var(--line); background: var(--panel); color: var(--text); } button:disabled { cursor: progress; opacity: .65; } input, select { min-width: 0; min-height: 42px; border: 1px solid var(--line); border-radius: 8px; padding: 0 11px; background: var(--panel); color: var(--text); } label { display: grid; gap: 6px; color: var(--muted); font-size: 12px; font-weight: 720; }
+      header { display: grid; gap: 10px; margin-bottom: 14px; } .eyebrow { color: var(--accent-strong); font-size: 12px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; } .pill-row { display: flex; flex-wrap: wrap; gap: 8px; } .pill { border: 1px solid var(--line); border-radius: 999px; padding: 6px 9px; color: var(--muted); background: var(--panel); font-size: 12px; } .card, .panel { border: 1px solid var(--line); border-radius: 8px; background: var(--panel); box-shadow: 0 1px 2px rgba(15,23,42,.06); } .card { padding: 14px; } .panel { padding: 16px; margin-top: 12px; } .summary { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; } .value { margin-top: 7px; font-size: 24px; font-weight: 780; overflow-wrap: anywhere; } .meta { margin-top: 6px; color: var(--muted); font-size: 13px; overflow-wrap: anywhere; } .good { color: var(--good); } .warn { color: var(--warn); } .bad { color: var(--bad); } .stack { display: grid; gap: 12px; } .form-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; } .switch { display: flex; align-items: center; justify-content: space-between; gap: 10px; min-height: 42px; padding: 9px 10px; border: 1px solid var(--line); border-radius: 8px; } .switch input { min-height: auto; } .actions { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 10px; } .preview { display: grid; gap: 8px; margin-top: 12px; padding: 12px; border: 1px solid var(--line); border-radius: 8px; background: var(--soft); } .diff { display: grid; grid-template-columns: minmax(92px, .7fr) 1fr 1fr; gap: 8px; font-size: 13px; } .notice { padding: 12px; border-radius: 8px; background: var(--soft); color: var(--muted); } .error { margin-top: 12px; color: var(--bad); font-weight: 650; } .hidden { display: none; }
+      @media (max-width: 560px) { main { padding: 16px; } .summary, .form-grid { grid-template-columns: 1fr; } }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <div class="eyebrow">Telnyx Billing</div>
+        <h1>Set Up Auto Recharge</h1>
+        <p>Enable automatic balance top-ups so service can continue when account credit runs low. This does not collect a payment in the MCP app.</p>
+        <div class="pill-row">
+          <span class="pill" id="bridgeStatus">Host bridge: initializing</span>
+          <span class="pill">Preview required</span>
+          <span class="pill">No direct payments</span>
+        </div>
+      </header>
+
+      <section class="summary">
+        <article class="card"><h3>Balance</h3><div class="value" id="balanceValue">Loading</div><div class="meta" id="balanceMeta">available credit</div></article>
+        <article class="card"><h3>Current Auto Recharge</h3><div class="value" id="autoValue">Loading</div><div class="meta" id="autoMeta">threshold / amount</div></article>
+      </section>
+
+      <section class="panel">
+        <div class="notice">Set a threshold that should trigger a top-up, then choose the recharge amount. Changes are previewed first and only applied after confirmation.</div>
+        <form id="autoForm" class="stack">
+          <div class="switch"><span>Enable auto recharge</span><input id="enabledInput" type="checkbox" checked /></div>
+          <div class="switch"><span>Invoice-backed billing</span><input id="invoiceInput" type="checkbox" /></div>
+          <div class="form-grid">
+            <label>Threshold amount<input id="thresholdInput" inputmode="decimal" value="10.00" /></label>
+            <label>Recharge amount<input id="rechargeInput" inputmode="decimal" value="25.00" /></label>
+          </div>
+          <label>Payment method<select id="preferenceSelect"><option value="credit_paypal">Card or PayPal</option><option value="ach">Bank transfer (ACH)</option></select><span class="meta" id="preferenceHelp">Uses the saved card or PayPal payment method.</span></label>
+          <div class="actions">
+            <button id="previewButton" type="submit">Preview setup</button>
+            <button class="secondary" id="reloadButton" type="button">Reload current state</button>
+          </div>
+        </form>
+        <div class="notice hidden" id="status"></div>
+        <div class="error hidden" id="error"></div>
+      </section>
+
+      <section id="previewBox" class="preview hidden">
+        <h2>Confirm Auto Recharge</h2>
+        <div id="diffList"></div>
+        <div class="actions">
+          <button id="confirmButton" type="button">Enable auto recharge</button>
+          <button class="secondary" id="cancelButton" type="button">Cancel</button>
+        </div>
+      </section>
+    </main>
+    <script>
+      const PROTOCOL_VERSION = "2026-01-26";
+      let nextId = 1;
+      const pending = new Map();
+      const state = { patch: null, token: null };
+      const els = {
+        bridgeStatus: document.getElementById("bridgeStatus"), error: document.getElementById("error"),
+        status: document.getElementById("status"),
+        balanceValue: document.getElementById("balanceValue"), balanceMeta: document.getElementById("balanceMeta"),
+        autoValue: document.getElementById("autoValue"), autoMeta: document.getElementById("autoMeta"),
+        enabledInput: document.getElementById("enabledInput"), invoiceInput: document.getElementById("invoiceInput"),
+        thresholdInput: document.getElementById("thresholdInput"), rechargeInput: document.getElementById("rechargeInput"),
+        preferenceSelect: document.getElementById("preferenceSelect"), autoForm: document.getElementById("autoForm"),
+        reloadButton: document.getElementById("reloadButton"), previewBox: document.getElementById("previewBox"),
+        diffList: document.getElementById("diffList"), confirmButton: document.getElementById("confirmButton"),
+        cancelButton: document.getElementById("cancelButton"), previewButton: document.getElementById("previewButton")
+      };
+      function send(message) { window.parent.postMessage(message, "*"); }
+      function notify(method, params) { send({ jsonrpc: "2.0", method, params }); }
+      let resizePending = false;
+      function resize() {
+        if (resizePending) return;
+        resizePending = true;
+        requestAnimationFrame(() => {
+          resizePending = false;
+          const root = document.documentElement;
+          const previousHeight = root.style.height;
+          root.style.height = "max-content";
+          const height = Math.ceil(root.getBoundingClientRect().height);
+          root.style.height = previousHeight;
+          notify("ui/notifications/size-changed", { width: Math.ceil(root.scrollWidth || window.innerWidth), height });
+        });
+      }
+      function request(method, params) {
+        const id = nextId++;
+        send({ jsonrpc: "2.0", id, method, params });
+        return new Promise((resolve, reject) => {
+          pending.set(id, { resolve, reject });
+          window.setTimeout(() => {
+            if (!pending.has(id)) return;
+            pending.delete(id);
+            reject(new Error(method + " timed out"));
+          }, 30000);
+        });
+      }
+      async function callTool(name, args = {}) { return extractResult(await request("tools/call", { name, arguments: args })); }
+      function extractResult(result) {
+        if (result?.isError) {
+          const textBlock = result?.content?.find?.((block) => block.type === "text");
+          throw new Error(textBlock?.text || "Tool request failed.");
+        }
+        if (result?.structuredContent) return result.structuredContent;
+        const textBlock = result?.content?.find?.((block) => block.type === "text");
+        if (!textBlock?.text) return result;
+        try { return JSON.parse(textBlock.text); } catch { return result; }
+      }
+      function dataOf(envelope) { return envelope?.data ?? envelope; }
+      function fmtMoney(value, currency) { return value === undefined || value === null || value === "" ? "-" : (currency ? value + " " + currency : String(value)); }
+      function setError(message) { els.error.textContent = message || ""; els.error.classList.toggle("hidden", !message); resize(); }
+      function setStatus(message) { els.status.textContent = message || ""; els.status.classList.toggle("hidden", !message); resize(); }
+      function renderState(payload) {
+        const balance = dataOf(payload?.balance);
+        const auto = dataOf(payload?.auto_recharge);
+        const currency = balance?.currency;
+        els.balanceValue.textContent = fmtMoney(balance?.balance, currency);
+        els.balanceMeta.textContent = "available " + fmtMoney(balance?.available_credit, currency);
+        els.autoValue.textContent = auto ? (auto.enabled ? "Enabled" : "Disabled") : "-";
+        els.autoValue.className = "value " + (auto?.enabled ? "good" : "warn");
+        els.autoMeta.textContent = auto ? "threshold " + fmtMoney(auto.threshold_amount) + "; recharge " + fmtMoney(auto.recharge_amount) : "not configured or unavailable";
+        if (auto) {
+          els.enabledInput.checked = auto.enabled !== false;
+          els.invoiceInput.checked = Boolean(auto.invoice_enabled);
+          els.thresholdInput.value = auto.threshold_amount ?? els.thresholdInput.value;
+          els.rechargeInput.value = auto.recharge_amount ?? els.rechargeInput.value;
+          if (auto.preference && !Array.from(els.preferenceSelect.options).some((option) => option.value === auto.preference)) {
+            els.preferenceSelect.append(new Option(auto.preference, auto.preference));
+          }
+          els.preferenceSelect.value = auto.preference || els.preferenceSelect.value;
+          renderPreferenceHelp();
+        }
+        if (payload?.warnings?.length) setError(payload.warnings.map((warning) => warning.source + ": " + warning.message).join("; "));
+        else setError("");
+        resize();
+      }
+      function patchFromForm() {
+        return {
+          enabled: els.enabledInput.checked,
+          invoice_enabled: els.invoiceInput.checked,
+          threshold_amount: els.thresholdInput.value.trim(),
+          recharge_amount: els.rechargeInput.value.trim(),
+          preference: els.preferenceSelect.value
+        };
+      }
+      function renderPreferenceHelp() {
+        const descriptions = {
+          credit_paypal: "Uses the saved card or PayPal payment method.",
+          ach: "Uses a linked US bank account through ACH."
+        };
+        els.preferenceHelp ??= document.getElementById("preferenceHelp");
+        if (els.preferenceHelp) els.preferenceHelp.textContent = descriptions[els.preferenceSelect.value] || "";
+      }
+      function textNode(value) { const div = document.createElement("div"); div.textContent = value; return div; }
+      function renderPreview(preview, patch) {
+        state.patch = patch;
+        state.token = preview.confirmation_token;
+        els.previewBox.classList.remove("hidden");
+        setStatus("Preview ready. Review the changes below, then confirm to update Telnyx.");
+        els.diffList.replaceChildren();
+        for (const item of preview.diff || []) {
+          const row = document.createElement("div");
+          row.className = "diff";
+          row.replaceChildren(textNode(item.field), textNode(String(item.before ?? "-")), textNode(String(item.after ?? "-")));
+          els.diffList.append(row);
+        }
+        if (!preview.diff?.length) els.diffList.textContent = "No field changes detected.";
+        resize();
+      }
+      async function loadState() {
+        renderState(await callTool("billing_auto_recharge_setup"));
+      }
+      window.addEventListener("message", (event) => {
+        if (event.source !== window.parent) return;
+        const message = event.data;
+        if (!message || message.jsonrpc !== "2.0") return;
+        if (message.id !== undefined && pending.has(message.id)) {
+          const handlers = pending.get(message.id);
+          pending.delete(message.id);
+          if (message.error) handlers.reject(new Error(message.error.message || "Request failed"));
+          else handlers.resolve(message.result);
+        }
+      });
+      els.autoForm.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        setError("");
+        setStatus("Creating preview...");
+        els.previewButton.disabled = true;
+        const previousText = els.previewButton.textContent;
+        els.previewButton.textContent = "Previewing";
+        try {
+          const patch = patchFromForm();
+          renderPreview(await callTool("billing_preview_auto_recharge_update", patch), patch);
+        } catch (error) { setStatus(""); setError(error.message || "Preview failed."); }
+        finally { els.previewButton.disabled = false; els.previewButton.textContent = previousText; }
+      });
+      els.confirmButton.addEventListener("click", async () => {
+        if (!state.patch || !state.token) return;
+        setError("");
+        setStatus("Updating auto recharge...");
+        els.confirmButton.disabled = true;
+        const previousText = els.confirmButton.textContent;
+        els.confirmButton.textContent = "Updating";
+        try {
+          const auto_recharge = await callTool("billing_update_auto_recharge_preferences", { ...state.patch, confirmation_token: state.token });
+          state.patch = null; state.token = null;
+          els.previewBox.classList.add("hidden");
+          renderState({ auto_recharge });
+          setStatus("Auto recharge update sent.");
+        } catch (error) { setStatus(""); setError(error.message || "Update failed."); }
+        finally { els.confirmButton.disabled = false; els.confirmButton.textContent = previousText; }
+      });
+      els.cancelButton.addEventListener("click", () => { state.patch = null; state.token = null; els.previewBox.classList.add("hidden"); setStatus(""); resize(); });
+      els.reloadButton.addEventListener("click", () => { setStatus("Reloading current state..."); loadState().then(() => setStatus("Current state reloaded.")).catch((error) => setError(error.message || "Reload failed.")); });
+      els.preferenceSelect.addEventListener("change", renderPreferenceHelp);
+      window.addEventListener("resize", resize);
+      new ResizeObserver(resize).observe(document.documentElement);
+      new ResizeObserver(resize).observe(document.body);
+      request("ui/initialize", { appInfo: { name: "telnyx-auto-recharge-setup-ui", version: "0.1.0" }, appCapabilities: {}, protocolVersion: PROTOCOL_VERSION })
+        .then(async () => {
+          els.bridgeStatus.textContent = "Host bridge: connected";
+          notify("ui/notifications/initialized", {});
+          await loadState();
+          renderPreferenceHelp();
+        })
+        .catch((error) => {
+          els.bridgeStatus.textContent = "Host bridge: unavailable";
+          setError("MCP App bridge failed to initialize: " + error.message);
+        });
+    </script>
+  </body>
+</html>`;

--- a/tools/mcp-apps/apps/usage-cost-explorer/test/mutationSafety.test.ts
+++ b/tools/mcp-apps/apps/usage-cost-explorer/test/mutationSafety.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+
+import { createBillingService, DEFAULT_AUTO_RECHARGE_POLICY } from "../src/service.js";
+import { TelnyxBillingError } from "../src/telnyxClient.js";
+import type { BillingServiceClient } from "../src/types.js";
+
+function mutationClient(): { client: BillingServiceClient; calls: string[]; state: { auto: Record<string, unknown>; group: Record<string, unknown> } } {
+  const calls: string[] = [];
+  const state: { auto: Record<string, unknown>; group: Record<string, unknown> } = {
+    auto: { id: "arp_1", record_type: "auto_recharge_pref", threshold_amount: "10.00", recharge_amount: "25.00", enabled: true, invoice_enabled: false, preference: "credit_paypal" },
+    group: { id: "bg_keep_for_followup", record_type: "billing_group", name: "Default" }
+  };
+  const client: BillingServiceClient = {
+    async getBalance() { return { data: {} }; },
+    async getAutoRechargePreferences() { calls.push("get-auto"); return { data: { ...state.auto } }; },
+    async updateAutoRechargePreferences(payload) { calls.push("patch-auto"); state.auto = { ...state.auto, ...payload }; return { data: { ...state.auto } }; },
+    async createStoredPaymentTransaction(payload) { calls.push("post-stored-payment"); return { data: { id: "txn_1", record_type: "transaction", amount_cents: Math.round(Number(payload.amount) * 100), processor_status: "submitted_for_settlement", amount_currency: "USD", auto_recharge: false, transaction_processing_type: "stored_payment" } }; },
+    async listBillingGroups() { return { data: [] }; },
+    async createBillingGroup(payload) { calls.push("post-group"); return { data: { id: "bg_new", record_type: "billing_group", name: payload.name } }; },
+    async getBillingGroup(id) { calls.push(`get-group:${id}`); return { data: { ...state.group, id } }; },
+    async updateBillingGroup(id, payload) { calls.push(`patch-group:${id}`); state.group = { ...state.group, id, ...payload }; return { data: { ...state.group } }; },
+    async getUsageReportOptions() { return { data: {} }; },
+    async queryUsageReport() { return { data: [] }; }
+  };
+  return { client, calls, state };
+}
+
+describe("guarded auto-recharge updates", () => {
+  it("previews a before/after diff and token without mutating", async () => {
+    const { client, calls } = mutationClient();
+    const service = createBillingService(client);
+
+    const preview = await service.previewAutoRechargeUpdate({ threshold_amount: "20.00", recharge_amount: "50.00", enabled: true });
+
+    expect(preview.action).toBe("billing.update_auto_recharge_preferences");
+    expect(preview.financial_side_effect).toBe(true);
+    expect(preview.diff).toEqual(
+      expect.arrayContaining([
+        { field: "threshold_amount", before: "10.00", after: "20.00" },
+        { field: "recharge_amount", before: "25.00", after: "50.00" }
+      ])
+    );
+    expect(preview.confirmation_token).toMatch(/^[a-f0-9]{64}$/);
+    expect(calls).toEqual(["get-auto"]);
+  });
+
+  it("requires a valid preview token and patches only after the current state still matches", async () => {
+    const { client, calls } = mutationClient();
+    const service = createBillingService(client);
+    const update = { threshold_amount: "20.00", recharge_amount: "50.00", enabled: false };
+    const preview = await service.previewAutoRechargeUpdate(update);
+
+    await expect(service.updateAutoRechargePreferences({ ...update, confirmation_token: "bad-token" })).rejects.toThrow("confirmation token");
+    const result = await service.updateAutoRechargePreferences({ ...update, confirmation_token: preview.confirmation_token });
+
+    expect(result.data).toMatchObject({ threshold_amount: "20.00", recharge_amount: "50.00", enabled: false });
+    expect(calls).toEqual(["get-auto", "get-auto", "get-auto", "patch-auto"]);
+  });
+
+  it("rejects amounts above conservative app guardrail caps before patching", async () => {
+    const { client, calls } = mutationClient();
+    const service = createBillingService(client, { autoRechargePolicy: { maxThresholdAmount: 100, maxRechargeAmount: 200 } });
+
+    await expect(service.previewAutoRechargeUpdate({ threshold_amount: "101.00" })).rejects.toThrow("threshold_amount exceeds app guardrail");
+    await expect(service.previewAutoRechargeUpdate({ recharge_amount: String(DEFAULT_AUTO_RECHARGE_POLICY.maxRechargeAmount + 1) })).rejects.toThrow("recharge_amount exceeds app guardrail");
+    expect(calls).toEqual([]);
+  });
+
+  it("rejects blank auto-recharge string fields before previewing or patching", async () => {
+    const { client, calls } = mutationClient();
+    const service = createBillingService(client);
+    const blankInputs = [
+      { input: { threshold_amount: "   " }, message: "threshold_amount must not be blank" },
+      { input: { recharge_amount: "\t\n" }, message: "recharge_amount must not be blank" },
+      { input: { preference: "   " }, message: "preference must not be blank" }
+    ] as const;
+
+    for (const { input, message } of blankInputs) {
+      await expect(service.previewAutoRechargeUpdate(input)).rejects.toThrow(message);
+      await expect(service.updateAutoRechargePreferences({ ...input, confirmation_token: "token" })).rejects.toThrow(message);
+    }
+    expect(calls).toEqual([]);
+  });
+
+  it("rejects non-numeric amount strings before fetching current preferences", async () => {
+    const { client, calls } = mutationClient();
+    const service = createBillingService(client);
+
+    await expect(service.previewAutoRechargeUpdate({ threshold_amount: "not-a-number" })).rejects.toThrow("Auto-recharge amounts");
+    await expect(service.previewAutoRechargeUpdate({ recharge_amount: "NaN" })).rejects.toThrow("Auto-recharge amounts");
+    await expect(service.updateAutoRechargePreferences({ threshold_amount: "Infinity", confirmation_token: "token" })).rejects.toThrow("Auto-recharge amounts");
+    expect(calls).toEqual([]);
+  });
+
+  it("rejects enabling auto-recharge when existing amounts exceed caps", async () => {
+    const { client, state, calls } = mutationClient();
+    state.auto = { ...state.auto, enabled: false, threshold_amount: "10.00", recharge_amount: "100000.00" };
+    const service = createBillingService(client, { autoRechargePolicy: { maxThresholdAmount: 5000, maxRechargeAmount: 5000 } });
+
+    await expect(service.previewAutoRechargeUpdate({ enabled: true })).rejects.toThrow("recharge_amount exceeds app guardrail");
+    expect(calls).toEqual(["get-auto"]);
+  });
+
+  it("treats missing auto-recharge preferences as an unconfigured setup state", async () => {
+    const { client, calls, state } = mutationClient();
+    client.getAutoRechargePreferences = async () => {
+      calls.push("get-auto");
+      throw new TelnyxBillingError("Resource not found: The requested resource or URL could not be found.", 404, {});
+    };
+    client.updateAutoRechargePreferences = async (payload) => {
+      calls.push("patch-auto");
+      state.auto = { ...payload };
+      return { data: { ...state.auto } };
+    };
+    const service = createBillingService(client);
+    const update = { enabled: true, invoice_enabled: false, threshold_amount: "10.00", recharge_amount: "25.00", preference: "credit_paypal" };
+
+    const preview = await service.previewAutoRechargeUpdate(update);
+    const result = await service.updateAutoRechargePreferences({ ...update, confirmation_token: preview.confirmation_token });
+
+    expect(preview.before).toEqual({ enabled: false, invoice_enabled: false, preference: "credit_paypal" });
+    expect(preview.diff).toEqual(
+      expect.arrayContaining([
+        { field: "enabled", before: false, after: true },
+        { field: "threshold_amount", before: undefined, after: "10.00" },
+        { field: "recharge_amount", before: undefined, after: "25.00" }
+      ])
+    );
+    expect(result.data).toMatchObject(update);
+    expect(calls).toEqual(["get-auto", "get-auto", "patch-auto"]);
+  });
+
+  it("still surfaces non-404 auto-recharge lookup failures", async () => {
+    const { client } = mutationClient();
+    client.getAutoRechargePreferences = async () => {
+      throw new TelnyxBillingError("Telnyx request failed with status 500", 500, {});
+    };
+    const service = createBillingService(client);
+
+    await expect(service.previewAutoRechargeUpdate({ enabled: true })).rejects.toThrow("status 500");
+  });
+
+  it("previews and confirms stored payment transactions with amount-specific tokens", async () => {
+    const { client, calls } = mutationClient();
+    const service = createBillingService(client);
+    const preview = await service.previewStoredPaymentTransaction({ amount: "25.00" });
+
+    expect(preview.action).toBe("billing.create_stored_payment_transaction");
+    expect(preview.financial_side_effect).toBe(true);
+    expect(preview.after).toMatchObject({ amount: "25.00", transaction_processing_type: "stored_payment" });
+    await expect(service.createStoredPaymentTransaction({ amount: "30.00", confirmation_token: preview.confirmation_token })).rejects.toThrow("confirmation token");
+
+    const result = await service.createStoredPaymentTransaction({ amount: "25.00", confirmation_token: preview.confirmation_token });
+
+    expect(result.data).toMatchObject({ amount_cents: 2500, transaction_processing_type: "stored_payment" });
+    expect(calls).toEqual(["post-stored-payment"]);
+  });
+
+  it("rejects invalid stored payment amounts before posting", async () => {
+    const { client, calls } = mutationClient();
+    const service = createBillingService(client, { maxStoredPaymentAmount: 50 });
+
+    await expect(service.previewStoredPaymentTransaction({ amount: "25" })).rejects.toThrow("dollars and cents");
+    await expect(service.previewStoredPaymentTransaction({ amount: "0.00" })).rejects.toThrow("greater than 0");
+    await expect(service.previewStoredPaymentTransaction({ amount: "50.01" })).rejects.toThrow("guardrail max");
+    await expect(service.createStoredPaymentTransaction({ amount: "10.00", confirmation_token: "bad-token" })).rejects.toThrow("confirmation token");
+    expect(calls).toEqual([]);
+  });
+});
+
+describe("guarded billing group mutations", () => {
+  it("previews and confirms billing group rename tokens", async () => {
+    const { client, calls } = mutationClient();
+    const service = createBillingService(client);
+
+    const preview = await service.previewBillingGroupUpdate({ id: "bg_keep_for_followup", name: "Production" });
+    const result = await service.updateBillingGroup({ id: "bg_keep_for_followup", name: "Production", confirmation_token: preview.confirmation_token });
+
+    expect(preview.financial_side_effect).toBe(false);
+    expect(preview.diff).toEqual([{ field: "name", before: "Default", after: "Production" }]);
+    expect(result.data).toMatchObject({ id: "bg_keep_for_followup", name: "Production" });
+    expect(calls).toEqual(["get-group:bg_keep_for_followup", "get-group:bg_keep_for_followup", "patch-group:bg_keep_for_followup"]);
+  });
+
+  it("invalidates billing group tokens when current resource has changed", async () => {
+    const { client, state } = mutationClient();
+    const service = createBillingService(client);
+    const preview = await service.previewBillingGroupUpdate({ id: "bg_keep_for_followup", name: "Production" });
+    state.group.name = "Changed elsewhere";
+
+    await expect(service.updateBillingGroup({ id: "bg_keep_for_followup", name: "Production", confirmation_token: preview.confirmation_token })).rejects.toThrow("confirmation token");
+  });
+
+  it("requires explicit confirm=true and a valid name for billing group creation", async () => {
+    const { client, calls } = mutationClient();
+    const service = createBillingService(client);
+
+    await expect(service.createBillingGroup({ name: "New group", confirm: false })).rejects.toThrow("confirm=true");
+    await expect(service.createBillingGroup({ name: "   ", confirm: true })).rejects.toThrow("name is required");
+    const result = await service.createBillingGroup({ name: "New group", confirm: true });
+
+    expect(result.data).toMatchObject({ id: "bg_new", name: "New group" });
+    expect(calls).toEqual(["post-group"]);
+  });
+});

--- a/tools/mcp-apps/apps/usage-cost-explorer/test/service.test.ts
+++ b/tools/mcp-apps/apps/usage-cost-explorer/test/service.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createBillingService,
+  DEFAULT_MAX_PAGE_SIZE,
+  DEFAULT_AUTO_RECHARGE_POLICY
+} from "../src/service.js";
+import type { BillingServiceClient, UsageQueryInput } from "../src/types.js";
+
+function fakeClient(overrides: Partial<BillingServiceClient> = {}): BillingServiceClient {
+  return {
+    async getBalance() {
+      return { data: { record_type: "balance", pending: "0.00", balance: "25.00", credit_limit: "100.00", available_credit: "75.00", currency: "USD" } };
+    },
+    async getAutoRechargePreferences() {
+      return { data: { id: "arp_1", record_type: "auto_recharge_pref", threshold_amount: "10.00", recharge_amount: "25.00", enabled: true, invoice_enabled: false, preference: "credit_paypal" } };
+    },
+    async updateAutoRechargePreferences(payload) {
+      return { data: { id: "arp_1", record_type: "auto_recharge_pref", threshold_amount: payload.threshold_amount ?? "10.00", recharge_amount: payload.recharge_amount ?? "25.00", enabled: payload.enabled ?? true, invoice_enabled: payload.invoice_enabled ?? false, preference: payload.preference ?? "credit_paypal" } };
+    },
+    async createStoredPaymentTransaction(payload) {
+      return { data: { id: "txn_1", record_type: "transaction", amount_cents: Math.round(Number(payload.amount) * 100), processor_status: "submitted_for_settlement", amount_currency: "USD", auto_recharge: false, transaction_processing_type: "stored_payment" } };
+    },
+    async listBillingGroups() {
+      return { data: [{ id: "bg_1", record_type: "billing_group", name: "Default" }] };
+    },
+    async createBillingGroup(payload) {
+      return { data: { id: "bg_new", record_type: "billing_group", name: payload.name } };
+    },
+    async getBillingGroup(id) {
+      return { data: { id, record_type: "billing_group", name: "Default" } };
+    },
+    async updateBillingGroup(id, payload) {
+      return { data: { id, record_type: "billing_group", name: payload.name ?? "Default" } };
+    },
+    async getUsageReportOptions() {
+      return { data: { products: ["messaging"], dimensions: ["country"], metrics: ["cost"] } };
+    },
+    async queryUsageReport(input) {
+      return { data: [{ product: input.product, cost: "1.23" }], meta: { page_number: input.pageNumber, page_size: input.pageSize } };
+    },
+    ...overrides
+  };
+}
+
+describe("BillingService read tools", () => {
+  it("returns pass-through balance and billing group data with structured metadata", async () => {
+    const service = createBillingService(fakeClient());
+
+    await expect(service.getBalance()).resolves.toMatchObject({ data: { currency: "USD", balance: "25.00" } });
+    await expect(service.listBillingGroups({ pageNumber: 1, pageSize: 10 })).resolves.toMatchObject({ data: [{ id: "bg_1" }] });
+  });
+});
+
+describe("BillingService usage report validation", () => {
+  it("normalizes defaults and caps page size before querying the beta Usage Reports endpoint", async () => {
+    const calls: UsageQueryInput[] = [];
+    const service = createBillingService(
+      fakeClient({
+        async queryUsageReport(input) {
+          calls.push(input);
+          return { data: [] };
+        }
+      })
+    );
+
+    await service.queryUsage({ product: "messaging", dimensions: ["country"], metrics: ["cost"], date_range: "last_7_days", page_size: 5000 });
+
+    expect(calls).toEqual([
+      {
+        product: "messaging",
+        dimensions: ["country"],
+        metrics: ["cost"],
+        dateRange: "last_7_days",
+        filters: undefined,
+        sort: undefined,
+        format: "json",
+        managedAccounts: false,
+        pageNumber: 1,
+        pageSize: DEFAULT_MAX_PAGE_SIZE
+      }
+    ]);
+  });
+
+  it("requires product, dimensions, and metrics", async () => {
+    const service = createBillingService(fakeClient());
+
+    await expect(service.queryUsage({ product: "", dimensions: ["country"], metrics: ["cost"] })).rejects.toThrow("product is required");
+    await expect(service.queryUsage({ product: "messaging", dimensions: [], metrics: ["cost"] })).rejects.toThrow("at least one dimension");
+    await expect(service.queryUsage({ product: "messaging", dimensions: ["country"], metrics: [] })).rejects.toThrow("at least one metric");
+  });
+
+  it("enforces a max 31-day explicit start/end date range", async () => {
+    const service = createBillingService(fakeClient());
+
+    await expect(
+      service.queryUsage({
+        product: "messaging",
+        dimensions: ["country"],
+        metrics: ["cost"],
+        start_date: "2026-05-01",
+        end_date: "2026-06-02"
+      })
+    ).rejects.toThrow("31 days");
+  });
+
+  it("rejects invalid calendar dates instead of letting Date.parse normalize them", async () => {
+    const service = createBillingService(fakeClient());
+
+    await expect(
+      service.queryUsage({
+        product: "messaging",
+        dimensions: ["country"],
+        metrics: ["cost"],
+        start_date: "2026-02-31",
+        end_date: "2026-03-01"
+      })
+    ).rejects.toThrow("start_date must be a valid ISO date string");
+  });
+
+  it("rejects a query that mixes date_range with explicit dates", async () => {
+    const service = createBillingService(fakeClient());
+
+    await expect(
+      service.queryUsage({ product: "messaging", dimensions: ["country"], metrics: ["cost"], date_range: "last_7_days", start_date: "2026-05-01" })
+    ).rejects.toThrow("Use either date_range or start_date/end_date");
+  });
+});

--- a/tools/mcp-apps/apps/usage-cost-explorer/test/telnyxClient.test.ts
+++ b/tools/mcp-apps/apps/usage-cost-explorer/test/telnyxClient.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+
+import { TelnyxBillingClient, TelnyxBillingError, sanitizeError } from "../src/telnyxClient.js";
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+}
+
+describe("TelnyxBillingClient", () => {
+  it("constructs balance, auto-recharge, and stored payment requests against the /v2 default base URL", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchImpl: typeof fetch = async (url, init) => {
+      calls.push({ url: String(url), init });
+      if (String(url).endsWith("/balance")) return json({ data: { record_type: "balance", balance: "42.00", currency: "USD" } });
+      if (String(url).endsWith("/stored_payment_transactions")) return json({ data: { id: "txn_1", record_type: "transaction", amount_cents: 2500 } });
+      return json({ data: { id: "arp_1", record_type: "auto_recharge_pref", enabled: true } });
+    };
+    const client = new TelnyxBillingClient({ apiKey: "fixture_credential", fetch: fetchImpl });
+
+    await client.getBalance();
+    await client.getAutoRechargePreferences();
+    await client.createStoredPaymentTransaction({ amount: "25.00" });
+
+    expect(calls.map((call) => call.url)).toEqual([
+      "https://api.telnyx.com/v2/balance",
+      "https://api.telnyx.com/v2/payment/auto_recharge_prefs",
+      "https://api.telnyx.com/v2/payment/stored_payment_transactions"
+    ]);
+    expect(calls.map((call) => call.init?.method)).toEqual(["GET", "GET", "POST"]);
+    expect(calls[2]?.init?.body).toBe(JSON.stringify({ amount: "25.00" }));
+    expect(calls.every((call) => (call.init?.headers as Record<string, string>).Authorization === "Bearer fixture_credential")).toBe(true);
+  });
+
+  it("constructs billing group CRUD requests without redacting billing_group_id", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchImpl: typeof fetch = async (url, init) => {
+      calls.push({ url: String(url), init });
+      return json({ data: { id: "bg_keep_for_followup", record_type: "billing_group", name: "Ops" } });
+    };
+    const client = new TelnyxBillingClient({ apiKey: "fixture_credential", baseUrl: "https://api.telnyx.test/v2", fetch: fetchImpl });
+
+    await client.listBillingGroups({ pageNumber: 2, pageSize: 25 });
+    await client.createBillingGroup({ name: "Ops" });
+    await client.getBillingGroup("bg_keep_for_followup");
+    await client.updateBillingGroup("bg_keep_for_followup", { name: "Ops renamed" });
+
+    expect(calls.map((call) => call.url)).toEqual([
+      "https://api.telnyx.test/v2/billing_groups?page%5Bnumber%5D=2&page%5Bsize%5D=25",
+      "https://api.telnyx.test/v2/billing_groups",
+      "https://api.telnyx.test/v2/billing_groups/bg_keep_for_followup",
+      "https://api.telnyx.test/v2/billing_groups/bg_keep_for_followup"
+    ]);
+    expect(calls[1]?.init?.method).toBe("POST");
+    expect(calls[1]?.init?.body).toBe(JSON.stringify({ name: "Ops" }));
+    expect(calls[3]?.init?.method).toBe("PATCH");
+    expect(calls[3]?.init?.body).toBe(JSON.stringify({ name: "Ops renamed" }));
+  });
+
+  it("constructs usage report option and query requests with arrays, filters, sort, and managed account defaults", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchImpl: typeof fetch = async (url, init) => {
+      calls.push({ url: String(url), init });
+      return json({ data: [] });
+    };
+    const client = new TelnyxBillingClient({ apiKey: "fixture_credential", baseUrl: "https://api.telnyx.test/v2/", fetch: fetchImpl });
+
+    await client.getUsageReportOptions({ product: "messaging" });
+    await client.queryUsageReport({
+      product: "messaging",
+      dimensions: ["direction", "country"],
+      metrics: ["cost", "count"],
+      startDate: "2026-05-01",
+      endDate: "2026-05-07",
+      filters: { currency: "USD", billing_group_id: "bg_keep_for_followup" },
+      sort: ["-cost"],
+      format: "json",
+      managedAccounts: false,
+      pageNumber: 1,
+      pageSize: 100
+    });
+
+    expect(calls[0]?.url).toBe("https://api.telnyx.test/v2/usage_reports/options?product=messaging");
+    expect(calls[1]?.url).toBe(
+      "https://api.telnyx.test/v2/usage_reports?product=messaging&dimensions=direction%2Ccountry&metrics=cost%2Ccount&start_date=2026-05-01&end_date=2026-05-07&filter%5Bcurrency%5D=USD&filter%5Bbilling_group_id%5D=bg_keep_for_followup&sort=-cost&format=json&page%5Bnumber%5D=1&page%5Bsize%5D=100&managed_accounts=false"
+    );
+  });
+
+  it("redacts authorization secrets from Telnyx errors while preserving operational ids", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      json(
+        {
+          errors: [
+            {
+              title: "Denied",
+              detail: "Bearer fixture_credential cannot access billing_group_id bg_keep_for_followup with api_key fixture_api_key"
+            }
+          ]
+        },
+        403
+      );
+    const client = new TelnyxBillingClient({ apiKey: "fixture_credential", fetch: fetchImpl });
+
+    await expect(client.getBalance()).rejects.toMatchObject({
+      status: 403,
+      message: expect.stringContaining("[redacted-secret]")
+    });
+    await expect(client.getBalance()).rejects.toMatchObject({
+      message: expect.stringContaining("bg_keep_for_followup")
+    });
+    try {
+      await client.getBalance();
+    } catch (error) {
+      expect(error).toBeInstanceOf(TelnyxBillingError);
+      const serialized = JSON.stringify((error as TelnyxBillingError).details);
+      expect(serialized).not.toContain("fixture_credential");
+      expect(serialized).not.toContain("fixture_api_key");
+      expect(serialized).toContain("bg_keep_for_followup");
+    }
+  });
+
+  it("sanitizes generic thrown errors", () => {
+    const sanitized = sanitizeError(new Error("Authorization: Bearer <fixture-token>; card 4242424242424242 failed"));
+    expect(sanitized.message).not.toContain("fixture_credential");
+    expect(sanitized.message).not.toContain("4242424242424242");
+  });
+});

--- a/tools/mcp-apps/apps/usage-cost-explorer/test/usageReports.test.ts
+++ b/tools/mcp-apps/apps/usage-cost-explorer/test/usageReports.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+
+import { createServer } from "../src/server.js";
+import { AUTO_RECHARGE_SETUP_UI_HTML, STORED_PAYMENT_TOP_UP_UI_HTML, USAGE_COST_EXPLORER_UI_HTML } from "../src/ui.js";
+
+describe("Usage Cost Explorer MCP server", () => {
+  it("registers the expected tools and beta Usage Reports descriptions", () => {
+    const server = createServer();
+    const tools = (server as unknown as { _registeredTools: Record<string, { description?: string; _meta?: unknown; annotations?: Record<string, boolean> }> })._registeredTools;
+
+    expect(Object.keys(tools).sort()).toEqual(
+      [
+        "billing_create_billing_group",
+        "billing_auto_recharge_setup",
+        "billing_stored_payment_top_up",
+        "billing_create_stored_payment_transaction",
+        "billing_overview",
+        "billing_get_auto_recharge_preferences",
+        "billing_get_balance",
+        "billing_get_billing_group",
+        "billing_list_billing_groups",
+        "billing_preview_auto_recharge_update",
+        "billing_preview_billing_group_update",
+        "billing_preview_stored_payment_transaction",
+        "billing_query_usage",
+        "billing_update_auto_recharge_preferences",
+        "billing_update_billing_group",
+        "billing_usage_report_options"
+      ].sort()
+    );
+    expect(tools.billing_query_usage?.description).toMatch(/beta/i);
+    expect(JSON.stringify(tools.billing_overview?._meta)).toContain("ui://usage-cost-explorer/index.html");
+    expect(JSON.stringify(tools.billing_auto_recharge_setup?._meta)).toContain("ui://usage-cost-explorer/auto-recharge.html");
+    expect(JSON.stringify(tools.billing_stored_payment_top_up?._meta)).toContain("ui://usage-cost-explorer/stored-payment-top-up.html");
+    expect(JSON.stringify(tools.billing_query_usage?._meta)).not.toContain("resourceUri");
+    expect(JSON.stringify(tools.billing_query_usage?._meta)).toContain("app");
+    expect(tools.billing_get_balance?.annotations?.readOnlyHint).toBe(true);
+    expect(tools.billing_update_auto_recharge_preferences?.annotations?.readOnlyHint).toBe(false);
+    expect(tools.billing_create_stored_payment_transaction?.annotations?.readOnlyHint).toBe(false);
+  });
+
+  it("returns safe tool errors without network when TELNYX_API_KEY is missing", async () => {
+    const oldKey = process.env.TELNYX_API_KEY;
+    delete process.env.TELNYX_API_KEY;
+    try {
+      const server = createServer();
+      const tools = (server as unknown as { _registeredTools: Record<string, { handler: (args: Record<string, unknown>, extra?: unknown) => Promise<unknown> }> })._registeredTools;
+
+      const result = await tools.billing_get_balance?.handler({}, {});
+
+      expect(result).toMatchObject({ isError: true });
+      expect(JSON.stringify(result)).toContain("TELNYX_API_KEY is not set");
+      expect(JSON.stringify(result)).not.toContain("Authorization");
+    } finally {
+      if (oldKey === undefined) delete process.env.TELNYX_API_KEY;
+      else process.env.TELNYX_API_KEY = oldKey;
+    }
+  });
+
+  it("sanitizes successful tool output while preserving operational billing group IDs", async () => {
+    const oldKey = process.env.TELNYX_API_KEY;
+    const oldFetch = globalThis.fetch;
+    process.env.TELNYX_API_KEY = "KEY_TEST_SECRET";
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          data: {
+            id: "arp_1",
+            payment_method_id: "pm_fixture_value",
+            card_last_four: "4242",
+            authorization: "Bearer should-not-leak",
+            auth: "opaque-live-secret",
+            billing_group_id: "bg_keep_for_followup"
+          }
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      )) as typeof fetch;
+    try {
+      const server = createServer();
+      const tools = (server as unknown as { _registeredTools: Record<string, { handler: (args: Record<string, unknown>, extra?: unknown) => Promise<unknown> }> })._registeredTools;
+
+      const result = await tools.billing_get_auto_recharge_preferences?.handler({}, {});
+      const serialized = JSON.stringify(result);
+
+      expect(serialized).toContain("[redacted-secret]");
+      expect(serialized).not.toContain("pm_fixture_value");
+      expect(serialized).not.toContain("should-not-leak");
+      expect(serialized).not.toContain("opaque-live-secret");
+      expect(serialized).toContain("bg_keep_for_followup");
+    } finally {
+      globalThis.fetch = oldFetch;
+      if (oldKey === undefined) delete process.env.TELNYX_API_KEY;
+      else process.env.TELNYX_API_KEY = oldKey;
+    }
+  });
+
+  it("keeps app confirmation tokens usable across preview and update tools", async () => {
+    const oldKey = process.env.TELNYX_API_KEY;
+    const oldFetch = globalThis.fetch;
+    const currentPrefs = { id: "arp_1", threshold_amount: "10.00", recharge_amount: "25.00", enabled: true, invoice_enabled: false, preference: "credit_paypal" };
+    process.env.TELNYX_API_KEY = "KEY_TEST_SECRET";
+    globalThis.fetch = (async (_url, init) => {
+      if (init?.method === "PATCH") {
+        return new Response(JSON.stringify({ data: { ...currentPrefs, enabled: false } }), { status: 200, headers: { "content-type": "application/json" } });
+      }
+      return new Response(JSON.stringify({ data: currentPrefs }), { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+    try {
+      const server = createServer();
+      const tools = (server as unknown as { _registeredTools: Record<string, { handler: (args: Record<string, unknown>, extra?: unknown) => Promise<unknown> }> })._registeredTools;
+
+      const preview = (await tools.billing_preview_auto_recharge_update?.handler({ enabled: false }, {})) as { structuredContent: { confirmation_token: string } };
+      expect(preview.structuredContent.confirmation_token).toMatch(/^[a-f0-9]{64}$/);
+
+      const result = await tools.billing_update_auto_recharge_preferences?.handler({ enabled: false, confirmation_token: preview.structuredContent.confirmation_token }, {});
+      expect(result).toMatchObject({ structuredContent: { data: { enabled: false } } });
+    } finally {
+      globalThis.fetch = oldFetch;
+      if (oldKey === undefined) delete process.env.TELNYX_API_KEY;
+      else process.env.TELNYX_API_KEY = oldKey;
+    }
+  });
+
+  it("keeps stored payment tokens usable across preview and create tools", async () => {
+    const oldKey = process.env.TELNYX_API_KEY;
+    const oldFetch = globalThis.fetch;
+    process.env.TELNYX_API_KEY = "KEY_TEST_SECRET";
+    globalThis.fetch = (async (_url, init) => {
+      if (init?.method === "POST") {
+        return new Response(JSON.stringify({ data: { id: "txn_1", record_type: "transaction", amount_cents: 2500, processor_status: "submitted_for_settlement", amount_currency: "USD" } }), { status: 200, headers: { "content-type": "application/json" } });
+      }
+      return new Response(JSON.stringify({ data: { record_type: "balance", balance: "10.00", currency: "USD" } }), { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+    try {
+      const server = createServer();
+      const tools = (server as unknown as { _registeredTools: Record<string, { handler: (args: Record<string, unknown>, extra?: unknown) => Promise<unknown> }> })._registeredTools;
+
+      const preview = (await tools.billing_preview_stored_payment_transaction?.handler({ amount: "25.00" }, {})) as { structuredContent: { confirmation_token: string } };
+      expect(preview.structuredContent.confirmation_token).toMatch(/^[a-f0-9]{64}$/);
+
+      const result = await tools.billing_create_stored_payment_transaction?.handler({ amount: "25.00", confirmation_token: preview.structuredContent.confirmation_token }, {});
+      expect(result).toMatchObject({ structuredContent: { data: { id: "txn_1", amount_cents: 2500 } } });
+    } finally {
+      globalThis.fetch = oldFetch;
+      if (oldKey === undefined) delete process.env.TELNYX_API_KEY;
+      else process.env.TELNYX_API_KEY = oldKey;
+    }
+  });
+
+  it("exports a self-contained UI resource that references beta Usage Reports", () => {
+    expect(USAGE_COST_EXPLORER_UI_HTML).toContain("Billing Dashboard");
+    expect(USAGE_COST_EXPLORER_UI_HTML).toMatch(/Usage Reports.*beta/i);
+    expect(AUTO_RECHARGE_SETUP_UI_HTML).toContain("Set Up Auto Recharge");
+    expect(AUTO_RECHARGE_SETUP_UI_HTML).toContain("No direct payments");
+    expect(STORED_PAYMENT_TOP_UP_UI_HTML).toContain("Top Up Balance");
+    expect(STORED_PAYMENT_TOP_UP_UI_HTML).toContain("Submit payment");
+  });
+});

--- a/tools/mcp-apps/apps/usage-cost-explorer/tsconfig.json
+++ b/tools/mcp-apps/apps/usage-cost-explorer/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "**/*.test.ts"]
+}

--- a/tools/mcp-apps/apps/usage-cost-explorer/vitest.config.ts
+++ b/tools/mcp-apps/apps/usage-cost-explorer/vitest.config.ts
@@ -1,0 +1,10 @@
+/// <reference types="vitest" />
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+    clearMocks: true
+  }
+});

--- a/tools/mcp-apps/apps/voice-monitor/.env.example
+++ b/tools/mcp-apps/apps/voice-monitor/.env.example
@@ -1,0 +1,11 @@
+# Required for live Telnyx API reads.
+TELNYX_API_KEY=
+
+# Optional: override Telnyx base URL. Defaults to https://api.telnyx.com/v2.
+# TELNYX_API_BASE_URL=https://api.telnyx.com/v2
+
+# Optional app guardrails.
+# VOICE_MONITOR_MAX_PAGE_SIZE=100
+# VOICE_MONITOR_MAX_DISCOVERY_CONNECTIONS=10
+# VOICE_MONITOR_MAX_TIMELINE_WINDOW_HOURS=168
+# VOICE_MONITOR_MAX_RECORDING_WINDOW_HOURS=168

--- a/tools/mcp-apps/apps/voice-monitor/README.md
+++ b/tools/mcp-apps/apps/voice-monitor/README.md
@@ -1,0 +1,45 @@
+# Telnyx Voice Monitor MCP App
+
+Read-only Telnyx MCP App for active-call monitoring, call timelines, call status, and post-call recording discovery.
+
+## Tools
+
+- `voice_monitor_list_options` — discovers connections, call-control applications, and voice numbers for dropdowns.
+- `voice_monitor_active_calls` — lists active calls for a selected connection, or a capped set of discovered connections when omitted.
+- `voice_monitor_call_timeline` — reads `GET /call_events` with supported deepObject filters.
+- `voice_monitor_call_status` — reads `GET /calls/{call_control_id}`.
+- `voice_monitor_recordings` — searches recordings with sensitive URLs/transcripts/metadata redacted.
+
+## Safety
+
+This app is read-only. It does not answer, hang up, transfer, speak, record, modify conferences, modify queues, or mutate Telnyx resources.
+
+The app preserves operational IDs needed for follow-up (`connection_id`, `call_control_id`, `call_leg_id`, `call_session_id`) while redacting phone numbers, credentials, recording URLs, transcripts, and metadata.
+
+## Configuration
+
+Copy `.env.example` and set:
+
+```sh
+TELNYX_API_KEY=***
+```
+
+Optional guardrails:
+
+```sh
+VOICE_MONITOR_MAX_PAGE_SIZE=100
+VOICE_MONITOR_MAX_DISCOVERY_CONNECTIONS=10
+VOICE_MONITOR_MAX_TIMELINE_WINDOW_HOURS=168
+VOICE_MONITOR_MAX_RECORDING_WINDOW_HOURS=168
+```
+
+## Development
+
+From `tools/mcp-apps`:
+
+```sh
+npm install
+npm --workspace @telnyx-mcp-apps/voice-monitor test
+npm --workspace @telnyx-mcp-apps/voice-monitor run typecheck
+npm --workspace @telnyx-mcp-apps/voice-monitor run build
+```

--- a/tools/mcp-apps/apps/voice-monitor/package.json
+++ b/tools/mcp-apps/apps/voice-monitor/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@telnyx-mcp-apps/voice-monitor",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Read-only Telnyx MCP app for active-call monitoring, call timelines, status lookup, and recording discovery.",
+  "main": "dist/server.js",
+  "scripts": {
+    "test": "vitest run",
+    "dev": "tsx src/server.ts",
+    "start": "node dist/server.js",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "build": "tsc -p tsconfig.json"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/team-telnyx/ai",
+    "directory": "tools/mcp-apps/apps/voice-monitor"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/ext-apps": "^1.7.2",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "dotenv": "^17.4.2"
+  }
+}

--- a/tools/mcp-apps/apps/voice-monitor/src/server.ts
+++ b/tools/mcp-apps/apps/voice-monitor/src/server.ts
@@ -1,0 +1,277 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  RESOURCE_MIME_TYPE,
+  registerAppResource,
+  registerAppTool
+} from "@modelcontextprotocol/ext-apps/server";
+import { z } from "zod";
+
+import {
+  createVoiceMonitorService,
+  DEFAULT_MAX_DISCOVERY_CONNECTIONS,
+  DEFAULT_MAX_PAGE_SIZE,
+  DEFAULT_MAX_RECORDING_WINDOW_HOURS,
+  DEFAULT_MAX_TIMELINE_WINDOW_HOURS
+} from "./service.js";
+import { TelnyxVoiceMonitorClient, sanitizeError, sanitizeVoiceMonitorValue } from "./telnyxClient.js";
+import type { VoiceMonitorService } from "./service.js";
+import { VOICE_MONITOR_UI_HTML } from "./ui.js";
+
+const UI_RESOURCE_URI = "ui://voice-monitor/index.html";
+const READ_ONLY_ANNOTATIONS = { readOnlyHint: true, destructiveHint: false, openWorldHint: true };
+
+const pagingSchema = {
+  page_number: z.number().int().positive().optional().describe("1-based page number. Defaults to 1."),
+  page_size: z.number().int().positive().optional().describe(`Page size. Defaults conservatively and is capped at ${DEFAULT_MAX_PAGE_SIZE}.`)
+};
+const optionalString = z.string().trim().min(1).optional();
+const timeFilterSchema = {
+  occurred_at_gte: optionalString.describe("Optional ISO start time (inclusive)."),
+  occurred_at_lte: optionalString.describe("Optional ISO end time (inclusive).")
+};
+
+export function createServer(): McpServer {
+  const server = new McpServer({
+    name: "telnyx-voice-monitor",
+    version: "0.1.0"
+  });
+
+  registerReadTool(
+    server,
+    "voice_monitor_dashboard",
+    "Open Voice Monitor",
+    "Open a single read-only Telnyx voice monitor workspace with preloaded dropdowns, active calls, call timelines, status lookup, and recording search.",
+    pagingSchema,
+    async (service, input) => {
+      const options = await service.listOptions({ pageNumber: input.page_number, pageSize: input.page_size });
+      const active_calls = await service.activeCalls({ pageNumber: input.page_number, pageSize: input.page_size });
+      return { options, active_calls };
+    },
+    UI_RESOURCE_URI
+  );
+
+  registerReadTool(
+    server,
+    "voice_monitor_list_options",
+    "Load Voice Monitor options",
+    "Discover app-friendly dropdown options for connections, call-control applications, and voice numbers so users do not need to paste IDs.",
+    pagingSchema,
+    async (service, input) => service.listOptions({ pageNumber: input.page_number, pageSize: input.page_size })
+  );
+
+  registerReadTool(
+    server,
+    "voice_monitor_active_calls",
+    "List active calls",
+    "List active calls for a selected Call Control Application ID. If omitted, discovers a bounded set of call-control applications and queries each; it never assumes a global active-calls endpoint.",
+    {
+      connection_id: optionalString.describe("Optional Telnyx Call Control Application ID accepted by the active-calls endpoint. Prefer selecting from the dashboard dropdown."),
+      max_connections: z.number().int().positive().optional().describe("When connection_id is omitted, cap how many discovered connections are queried."),
+      ...pagingSchema
+    },
+    async (service, input) =>
+      service.activeCalls({
+        connectionId: input.connection_id,
+        maxConnections: input.max_connections,
+        pageNumber: input.page_number,
+        pageSize: input.page_size
+      })
+  );
+
+  registerReadTool(
+    server,
+    "voice_monitor_call_timeline",
+    "Read call timeline",
+    "Read Telnyx GET /call_events with supported filters. Prefer call_leg_id or call_session_id/application_session_id; connection-only searches default to the last 24 hours.",
+    {
+      call_leg_id: optionalString.describe("Telnyx call leg ID (filter[leg_id])."),
+      call_session_id: optionalString.describe("Telnyx call/session ID; mapped to filter[application_session_id] if application_session_id is omitted."),
+      application_session_id: optionalString.describe("Telnyx application session ID (filter[application_session_id])."),
+      connection_id: optionalString.describe("Optional connection_id, preferably selected from options."),
+      product: optionalString,
+      failed: z.boolean().optional(),
+      from: optionalString,
+      to: optionalString,
+      name: optionalString,
+      type: optionalString,
+      status: optionalString,
+      occurred_at_eq: optionalString,
+      occurred_at_gt: optionalString,
+      ...timeFilterSchema,
+      occurred_at_lt: optionalString,
+      ...pagingSchema
+    },
+    async (service, input) =>
+      service.callTimeline({
+        callLegId: input.call_leg_id,
+        callSessionId: input.call_session_id,
+        applicationSessionId: input.application_session_id,
+        connectionId: input.connection_id,
+        product: input.product,
+        failed: input.failed,
+        from: input.from,
+        to: input.to,
+        name: input.name,
+        type: input.type,
+        status: input.status,
+        occurredAtEq: input.occurred_at_eq,
+        occurredAtGt: input.occurred_at_gt,
+        occurredAtGte: input.occurred_at_gte,
+        occurredAtLt: input.occurred_at_lt,
+        occurredAtLte: input.occurred_at_lte,
+        pageNumber: input.page_number,
+        pageSize: input.page_size
+      })
+  );
+
+  registerReadTool(
+    server,
+    "voice_monitor_call_status",
+    "Get call status",
+    "Read call status from GET /calls/{call_control_id}. This is read-only and does not issue Call Control commands.",
+    {
+      call_control_id: z.string().trim().min(1).describe("Telnyx call_control_id to fetch.")
+    },
+    async (service, input) => service.callStatus({ callControlId: input.call_control_id })
+  );
+
+  registerReadTool(
+    server,
+    "voice_monitor_recordings",
+    "Search recordings",
+    "Search Telnyx recordings for post-call investigation. Recording URLs, transcripts, and metadata are redacted in output.",
+    {
+      call_control_id: optionalString,
+      call_leg_id: optionalString,
+      call_session_id: optionalString,
+      connection_id: optionalString,
+      ...timeFilterSchema,
+      ...pagingSchema
+    },
+    async (service, input) =>
+      service.recordings({
+        callControlId: input.call_control_id,
+        callLegId: input.call_leg_id,
+        callSessionId: input.call_session_id,
+        connectionId: input.connection_id,
+        occurredAtGte: input.occurred_at_gte,
+        occurredAtLte: input.occurred_at_lte,
+        pageNumber: input.page_number,
+        pageSize: input.page_size
+      })
+  );
+
+  registerAppResource(
+    server,
+    "Voice Monitor UI",
+    UI_RESOURCE_URI,
+    {
+      description: "Interactive read-only Telnyx voice monitor with option discovery dropdowns, active calls, call timelines, status lookup, and recording search."
+    },
+    async () => ({
+      contents: [
+        {
+          uri: UI_RESOURCE_URI,
+          mimeType: RESOURCE_MIME_TYPE,
+          text: VOICE_MONITOR_UI_HTML
+        }
+      ]
+    })
+  );
+
+  return server;
+}
+
+type ToolShape = Record<string, z.ZodTypeAny>;
+type ToolInput<T extends ToolShape> = { [K in keyof T]: z.infer<T[K]> };
+
+function registerReadTool<T extends ToolShape>(
+  server: McpServer,
+  name: string,
+  title: string,
+  description: string,
+  inputSchema: T,
+  run: (service: VoiceMonitorService, input: ToolInput<T>) => Promise<unknown>,
+  uiResourceUri?: string
+): void {
+  (registerAppTool as unknown as (...args: unknown[]) => void)(
+    server,
+    name,
+    {
+      title,
+      description,
+      inputSchema,
+      annotations: READ_ONLY_ANNOTATIONS,
+      _meta: { ui: uiResourceUri ? { resourceUri: uiResourceUri } : { visibility: ["app"] } }
+    },
+    async (input: ToolInput<T>) => {
+      const service = createLiveService();
+      if (!service) return missingApiKeyResult();
+      try {
+        return toolResult(await run(service, input));
+      } catch (error) {
+        return safeToolError(error);
+      }
+    }
+  );
+}
+
+function createLiveService(): VoiceMonitorService | undefined {
+  const apiKey = process.env.TELNYX_API_KEY;
+  if (!apiKey) return undefined;
+  const client = new TelnyxVoiceMonitorClient({ apiKey, baseUrl: process.env.TELNYX_API_BASE_URL });
+  return createVoiceMonitorService(client, {
+    maxPageSize: envNumber("VOICE_MONITOR_MAX_PAGE_SIZE", DEFAULT_MAX_PAGE_SIZE),
+    maxDiscoveryConnections: envNumber("VOICE_MONITOR_MAX_DISCOVERY_CONNECTIONS", DEFAULT_MAX_DISCOVERY_CONNECTIONS),
+    maxTimelineWindowHours: envNumber("VOICE_MONITOR_MAX_TIMELINE_WINDOW_HOURS", DEFAULT_MAX_TIMELINE_WINDOW_HOURS),
+    maxRecordingWindowHours: envNumber("VOICE_MONITOR_MAX_RECORDING_WINDOW_HOURS", DEFAULT_MAX_RECORDING_WINDOW_HOURS)
+  });
+}
+
+function envNumber(name: string, fallback: number): number {
+  const value = process.env[name];
+  if (!value) return fallback;
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : fallback;
+}
+
+function toolResult(result: unknown): { content: Array<{ type: "text"; text: string }>; structuredContent: Record<string, unknown> } {
+  const structuredContent = asStructuredContent(sanitizeVoiceMonitorValue(result));
+  return {
+    content: [{ type: "text", text: JSON.stringify(structuredContent, null, 2) }],
+    structuredContent
+  };
+}
+
+function asStructuredContent(result: unknown): Record<string, unknown> {
+  if (result && typeof result === "object" && !Array.isArray(result)) return result as Record<string, unknown>;
+  return { result };
+}
+
+function missingApiKeyResult(): { isError: true; content: Array<{ type: "text"; text: string }> } {
+  return {
+    isError: true,
+    content: [
+      {
+        type: "text",
+        text: "TELNYX_API_KEY is not set. Provide a read-only Telnyx API key with least-privilege voice/call monitoring access to run live Voice Monitor tools."
+      }
+    ]
+  };
+}
+
+function safeToolError(error: unknown): { isError: true; content: Array<{ type: "text"; text: string }> } {
+  return { isError: true, content: [{ type: "text", text: sanitizeError(error).message }] };
+}
+
+async function main(): Promise<void> {
+  await import("dotenv/config");
+  const server = createServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main();
+}

--- a/tools/mcp-apps/apps/voice-monitor/src/service.ts
+++ b/tools/mcp-apps/apps/voice-monitor/src/service.ts
@@ -1,0 +1,364 @@
+import type {
+  ActiveCallsInput,
+  CallControlApplicationData,
+  CallStatusRequest,
+  CallTimelineRequest,
+  ConnectionData,
+  DiscoveryOption,
+  ListOptionsInput,
+  RecordingsRequest,
+  TelnyxEnvelope,
+  VoiceMonitorClient,
+  VoiceMonitorServiceOptions,
+  VoiceNumberData
+} from "./types.js";
+import { sanitizeVoiceMonitorValue } from "./telnyxClient.js";
+
+export const DEFAULT_MAX_PAGE_SIZE = 100;
+export const DEFAULT_MAX_DISCOVERY_CONNECTIONS = 10;
+export const DEFAULT_MAX_TIMELINE_WINDOW_HOURS = 168;
+export const DEFAULT_MAX_RECORDING_WINDOW_HOURS = 168;
+
+export function createVoiceMonitorService(client: VoiceMonitorClient, options: VoiceMonitorServiceOptions = {}) {
+  const maxPageSize = options.maxPageSize ?? DEFAULT_MAX_PAGE_SIZE;
+  const maxDiscoveryConnections = options.maxDiscoveryConnections ?? DEFAULT_MAX_DISCOVERY_CONNECTIONS;
+  const maxTimelineWindowHours = options.maxTimelineWindowHours ?? DEFAULT_MAX_TIMELINE_WINDOW_HOURS;
+  const maxRecordingWindowHours = options.maxRecordingWindowHours ?? DEFAULT_MAX_RECORDING_WINDOW_HOURS;
+  const now = options.now ?? (() => new Date());
+
+  return {
+    async listOptions(input: ListOptionsInput = {}) {
+      const page = normalizePage(input, maxPageSize);
+      const warnings: Array<{ source: string; message: string }> = [];
+
+      const [connectionsEnvelope, applicationsEnvelope, phoneNumbersEnvelope] = await Promise.all([
+        safeRead("connections", () => client.listConnections(page), warnings),
+        safeRead("call_control_applications", () => client.listCallControlApplications(page), warnings),
+        safeRead("voice_numbers", () => client.listPhoneNumbers(page), warnings)
+      ]);
+
+      const connections = dataArray<ConnectionData>(connectionsEnvelope);
+      const phoneNumbers = dataArray<VoiceNumberData>(phoneNumbersEnvelope);
+      const numberCounts = countNumbersByConnection(phoneNumbers);
+      const connectionOptions = connections.map((connection) => connectionOption(connection, numberCounts));
+      const applicationOptions = dataArray<Record<string, unknown>>(applicationsEnvelope).map(applicationOption).filter(Boolean) as DiscoveryOption[];
+      const voiceNumberOptions = phoneNumbers.map(voiceNumberOption).filter(Boolean) as DiscoveryOption[];
+
+      return sanitizeVoiceMonitorValue({
+        options: {
+          connections: connectionOptions,
+          call_control_applications: applicationOptions,
+          active_call_targets: applicationOptions,
+          voice_numbers: voiceNumberOptions
+        },
+        summary: {
+          connection_count: connectionOptions.length,
+          call_control_application_count: applicationOptions.length,
+          voice_number_count: voiceNumberOptions.length
+        },
+        warnings,
+        limits: {
+          page_size: page.pageSize,
+          max_discovery_connections: maxDiscoveryConnections
+        }
+      });
+    },
+
+    async activeCalls(input: ActiveCallsInput = {}) {
+      const page = normalizePage(input, maxPageSize);
+      const requestedConnectionId = normalizeOptionalString(input.connectionId);
+      const maxConnections = Math.min(normalizePositiveInt(input.maxConnections, maxDiscoveryConnections), maxDiscoveryConnections);
+      const warnings: Array<{ source: string; message: string }> = [];
+      const connections = requestedConnectionId ? [requestedConnectionId] : await discoverActiveCallTargetIds(client, page, maxConnections, warnings);
+      const allCalls: unknown[] = [];
+      const perConnection: Array<{ connection_id: string; active_call_count: number; data: unknown[] }> = [];
+
+      for (const connectionId of connections) {
+        try {
+          const envelope = await client.listActiveCalls(connectionId, page);
+          const calls = dataArray(envelope).map((call) => attachConnectionId(call, connectionId));
+          allCalls.push(...calls);
+          perConnection.push({ connection_id: connectionId, active_call_count: calls.length, data: calls });
+        } catch (error) {
+          warnings.push({ source: `active_calls:${connectionId}`, message: errorMessage(error) });
+        }
+      }
+
+      return sanitizeVoiceMonitorValue({
+        connections_consulted: connections,
+        truncated_connections: !requestedConnectionId && connections.length === maxConnections,
+        total_active_calls: allCalls.length,
+        active_calls: allCalls,
+        per_connection: perConnection,
+        warnings,
+        limits: { page_size: page.pageSize, max_connections: maxConnections }
+      });
+    },
+
+    async callTimeline(input: CallTimelineRequest = {}) {
+      const page = normalizePage(input, maxPageSize);
+      const normalized = normalizeTimelineInput(input, page, now, maxTimelineWindowHours);
+      const envelope = await client.listCallEvents(normalized);
+      return sanitizeVoiceMonitorValue({
+        ...envelope,
+        filters_notice: normalized.notice,
+        applied_filters: normalized.appliedFilters
+      });
+    },
+
+    async callStatus(input: CallStatusRequest) {
+      const callControlId = normalizeRequiredString(input.callControlId, "call_control_id is required.");
+      return sanitizeVoiceMonitorValue(await client.getCallStatus(callControlId));
+    },
+
+    async recordings(input: RecordingsRequest = {}) {
+      const page = normalizePage(input, maxPageSize);
+      const normalized = normalizeRecordingsInput(input, page, now, maxRecordingWindowHours);
+      const envelope = await client.listRecordings(normalized);
+      return sanitizeVoiceMonitorValue({ ...envelope, applied_filters: normalized.appliedFilters });
+    }
+  };
+}
+
+export type VoiceMonitorService = ReturnType<typeof createVoiceMonitorService>;
+
+type Page = { pageNumber: number; pageSize: number };
+type TimelineClientInput = Parameters<VoiceMonitorClient["listCallEvents"]>[0] & { notice?: string; appliedFilters?: Record<string, unknown> };
+type RecordingsClientInput = Parameters<VoiceMonitorClient["listRecordings"]>[0] & { appliedFilters?: Record<string, unknown> };
+
+async function safeRead<T>(source: string, read: () => Promise<T>, warnings: Array<{ source: string; message: string }>): Promise<T | undefined> {
+  try {
+    return await read();
+  } catch (error) {
+    warnings.push({ source, message: errorMessage(error) });
+    return undefined;
+  }
+}
+
+async function discoverActiveCallTargetIds(
+  client: VoiceMonitorClient,
+  page: Page,
+  maxConnections: number,
+  warnings: Array<{ source: string; message: string }>
+): Promise<string[]> {
+  const envelope = await safeRead("call_control_applications", () => client.listCallControlApplications({ pageNumber: page.pageNumber, pageSize: maxConnections }), warnings);
+  return dataArray<CallControlApplicationData>(envelope)
+    .map((application) => normalizeOptionalString(valueAsString(application.id ?? application.application_id)))
+    .filter((value): value is string => Boolean(value))
+    .slice(0, maxConnections);
+}
+
+function normalizeTimelineInput(input: CallTimelineRequest, page: Page, now: () => Date, maxWindowHours: number): TimelineClientInput {
+  const applicationSessionId = normalizeOptionalString(input.applicationSessionId ?? input.callSessionId);
+  const callLegId = normalizeOptionalString(input.callLegId);
+  const hasLegOrSession = Boolean(callLegId || applicationSessionId);
+  let occurredAtGte = normalizeOptionalString(input.occurredAtGte);
+  let occurredAtLte = normalizeOptionalString(input.occurredAtLte);
+  let notice: string | undefined;
+
+  if (!hasLegOrSession && !input.occurredAtEq && !input.occurredAtGt && !input.occurredAtLt && !occurredAtGte && !occurredAtLte) {
+    const end = now();
+    const start = new Date(end.getTime() - 24 * 3_600_000);
+    occurredAtGte = start.toISOString();
+    occurredAtLte = end.toISOString();
+    notice = "No call_leg_id or application_session_id was supplied; defaulted to the last 24 hours for Telnyx call_events filtering.";
+  }
+
+  enforceWindow(occurredAtGte, occurredAtLte, hasLegOrSession ? maxWindowHours : Math.min(24, maxWindowHours), "Call timeline");
+
+  const normalized: TimelineClientInput = {
+    callLegId,
+    applicationSessionId,
+    connectionId: normalizeOptionalString(input.connectionId),
+    product: normalizeOptionalString(input.product),
+    failed: input.failed,
+    from: normalizeOptionalString(input.from),
+    to: normalizeOptionalString(input.to),
+    name: normalizeOptionalString(input.name),
+    type: normalizeOptionalString(input.type),
+    status: normalizeOptionalString(input.status),
+    occurredAtEq: normalizeOptionalString(input.occurredAtEq),
+    occurredAtGt: normalizeOptionalString(input.occurredAtGt),
+    occurredAtGte,
+    occurredAtLt: normalizeOptionalString(input.occurredAtLt),
+    occurredAtLte,
+    pageNumber: page.pageNumber,
+    pageSize: page.pageSize,
+    notice
+  };
+  normalized.appliedFilters = compactRecord({
+    call_leg_id: normalized.callLegId,
+    application_session_id: normalized.applicationSessionId,
+    connection_id: normalized.connectionId,
+    product: normalized.product,
+    failed: normalized.failed,
+    from: normalized.from,
+    to: normalized.to,
+    name: normalized.name,
+    type: normalized.type,
+    status: normalized.status,
+    occurred_at_eq: normalized.occurredAtEq,
+    occurred_at_gt: normalized.occurredAtGt,
+    occurred_at_gte: normalized.occurredAtGte,
+    occurred_at_lt: normalized.occurredAtLt,
+    occurred_at_lte: normalized.occurredAtLte,
+    page_number: normalized.pageNumber,
+    page_size: normalized.pageSize
+  });
+  return normalized;
+}
+
+function normalizeRecordingsInput(input: RecordingsRequest, page: Page, now: () => Date, maxWindowHours: number): RecordingsClientInput {
+  let createdAtGte = normalizeOptionalString(input.occurredAtGte);
+  let createdAtLte = normalizeOptionalString(input.occurredAtLte);
+  const hasSpecificId = Boolean(input.callControlId || input.callLegId || input.callSessionId || input.connectionId);
+  if (!hasSpecificId && !createdAtGte && !createdAtLte) {
+    const end = now();
+    createdAtLte = end.toISOString();
+    createdAtGte = new Date(end.getTime() - 24 * 3_600_000).toISOString();
+  }
+  enforceWindow(createdAtGte, createdAtLte, maxWindowHours, "Recording search");
+  const normalized: RecordingsClientInput = {
+    callControlId: normalizeOptionalString(input.callControlId),
+    callLegId: normalizeOptionalString(input.callLegId),
+    callSessionId: normalizeOptionalString(input.callSessionId),
+    connectionId: normalizeOptionalString(input.connectionId),
+    createdAtGte,
+    createdAtLte,
+    pageNumber: page.pageNumber,
+    pageSize: page.pageSize
+  };
+  normalized.appliedFilters = compactRecord({
+    call_control_id: normalized.callControlId,
+    call_leg_id: normalized.callLegId,
+    call_session_id: normalized.callSessionId,
+    connection_id: normalized.connectionId,
+    created_at_gte: normalized.createdAtGte,
+    created_at_lte: normalized.createdAtLte,
+    page_number: normalized.pageNumber,
+    page_size: normalized.pageSize
+  });
+  return normalized;
+}
+
+function enforceWindow(startText: string | undefined, endText: string | undefined, maxHours: number, label: string): void {
+  if (!startText || !endText) return;
+  const start = parseIsoDateTime(startText, "start time");
+  const end = parseIsoDateTime(endText, "end time");
+  if (end < start) throw new Error(`${label} end time must be on or after start time.`);
+  const hours = (end.getTime() - start.getTime()) / 3_600_000;
+  if (hours > maxHours) {
+    throw new Error(`${label} windows are capped at ${maxHours} hours by this app.`);
+  }
+}
+
+function parseIsoDateTime(value: string, label: string): Date {
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) throw new Error(`${label} must be a valid ISO date-time string.`);
+  return date;
+}
+
+function connectionOption(connection: ConnectionData, counts: Map<string, number>): DiscoveryOption {
+  const value = String(connection.id ?? connection.connection_id ?? "").trim();
+  const label = String(connection.connection_name ?? connection.name ?? (value || "Unnamed connection"));
+  return {
+    kind: "connection",
+    label,
+    value,
+    description: [connection.record_type, connection.active === false ? "inactive" : connection.active === true ? "active" : undefined].filter(Boolean).join("; ") || undefined,
+    active: typeof connection.active === "boolean" ? connection.active : undefined,
+    associated_number_count: value ? counts.get(value) ?? 0 : 0
+  };
+}
+
+function applicationOption(application: Record<string, unknown>): DiscoveryOption | undefined {
+  const value = normalizeOptionalString(valueAsString(application.id ?? application.application_id));
+  if (!value) return undefined;
+  return {
+    kind: "call_control_application",
+    value,
+    label: normalizeOptionalString(valueAsString(application.application_name ?? application.name)) ?? value,
+    active: typeof application.active === "boolean" ? application.active : undefined,
+    description: typeof application.record_type === "string" ? application.record_type : undefined
+  };
+}
+
+function voiceNumberOption(phoneNumber: VoiceNumberData): DiscoveryOption | undefined {
+  const rawNumber = normalizeOptionalString(phoneNumber.phone_number ?? phoneNumber.number);
+  const value = normalizeOptionalString(phoneNumber.id);
+  if (!value && !rawNumber) return undefined;
+  const redacted = sanitizedString("phone_number", rawNumber ?? value ?? "voice number");
+  return {
+    kind: "voice_number",
+    value: value ?? redacted,
+    label: redacted,
+    connection_id: normalizeOptionalString(phoneNumber.connection_id),
+    active: typeof phoneNumber.active === "boolean" ? phoneNumber.active : phoneNumber.status ? phoneNumber.status === "active" : undefined,
+    description: phoneNumber.status ? `status: ${phoneNumber.status}` : undefined
+  };
+}
+
+function countNumbersByConnection(phoneNumbers: VoiceNumberData[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const number of phoneNumbers) {
+    const connectionId = normalizeOptionalString(number.connection_id);
+    if (connectionId) counts.set(connectionId, (counts.get(connectionId) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function dataArray<T = unknown>(envelope: TelnyxEnvelope<T[] | T> | undefined): T[] {
+  const data = envelope?.data;
+  if (Array.isArray(data)) return data;
+  if (data === undefined || data === null) return [];
+  return [data as T];
+}
+
+function attachConnectionId(call: unknown, connectionId: string): unknown {
+  if (call && typeof call === "object" && !Array.isArray(call)) {
+    return { connection_id: connectionId, ...(call as Record<string, unknown>) };
+  }
+  return { connection_id: connectionId, value: call };
+}
+
+function normalizePage(input: { pageNumber?: number; pageSize?: number }, maxPageSize: number): Page {
+  return {
+    pageNumber: normalizePositiveInt(input.pageNumber, 1),
+    pageSize: Math.min(normalizePositiveInt(input.pageSize, Math.min(DEFAULT_MAX_PAGE_SIZE, maxPageSize)), maxPageSize)
+  };
+}
+
+function normalizePositiveInt(value: number | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  const normalized = Math.trunc(value);
+  return normalized > 0 ? normalized : fallback;
+}
+
+function normalizeRequiredString(value: string | undefined, message: string): string {
+  const normalized = normalizeOptionalString(value);
+  if (!normalized) throw new Error(message);
+  return normalized;
+}
+
+function normalizeOptionalString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function valueAsString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : value === undefined || value === null ? undefined : String(value);
+}
+
+function sanitizedString(key: string, value: string): string {
+  const sanitized = sanitizeVoiceMonitorValue({ [key]: value }) as Record<string, unknown>;
+  return String(sanitized[key] ?? value);
+}
+
+function compactRecord(input: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(input).filter(([, value]) => value !== undefined && value !== ""));
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/tools/mcp-apps/apps/voice-monitor/src/telnyxClient.ts
+++ b/tools/mcp-apps/apps/voice-monitor/src/telnyxClient.ts
@@ -1,0 +1,232 @@
+import type {
+  CallControlApplicationData,
+  CallEventsInput,
+  ConnectionData,
+  PageInput,
+  RecordingsInput,
+  TelnyxClientOptions,
+  TelnyxEnvelope,
+  VoiceNumberData
+} from "./types.js";
+
+const DEFAULT_BASE_URL = "https://api.telnyx.com/v2";
+const OPERATIONAL_ID_KEYS = new Set([
+  "id",
+  "connection_id",
+  "call_control_id",
+  "call_leg_id",
+  "call_session_id",
+  "application_session_id",
+  "leg_id",
+  "conference_id",
+  "queue_name",
+  "value",
+  "connections_consulted"
+]);
+
+export class TelnyxVoiceMonitorError extends Error {
+  readonly status: number;
+  readonly details: unknown;
+
+  constructor(message: string, status: number, details: unknown) {
+    super(message);
+    this.name = "TelnyxVoiceMonitorError";
+    this.status = status;
+    this.details = details;
+  }
+}
+
+export class TelnyxVoiceMonitorClient {
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: TelnyxClientOptions) {
+    if (!options.apiKey) {
+      throw new Error("Telnyx API key is required for live Voice Monitor calls");
+    }
+    this.apiKey = options.apiKey;
+    this.baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
+    this.fetchImpl = options.fetch ?? globalThis.fetch;
+    if (!this.fetchImpl) {
+      throw new Error("A fetch implementation is required");
+    }
+  }
+
+  async listConnections(input: PageInput = {}): Promise<TelnyxEnvelope<ConnectionData[]>> {
+    const url = this.url("/connections");
+    addPaging(url, input);
+    return this.request(url, { method: "GET" });
+  }
+
+  async listCallControlApplications(input: PageInput = {}): Promise<TelnyxEnvelope<CallControlApplicationData[]>> {
+    const url = this.url("/call_control_applications");
+    addPaging(url, input);
+    return this.request(url, { method: "GET" });
+  }
+
+  async listPhoneNumbers(input: PageInput = {}): Promise<TelnyxEnvelope<VoiceNumberData[]>> {
+    const url = this.url("/phone_numbers/voice");
+    addPaging(url, input);
+    return this.request(url, { method: "GET" });
+  }
+
+  async listActiveCalls(connectionId: string, input: PageInput = {}): Promise<TelnyxEnvelope> {
+    const url = this.url(`/connections/${encodeURIComponent(connectionId)}/active_calls`);
+    addPaging(url, input);
+    return this.request(url, { method: "GET" });
+  }
+
+  async listCallEvents(input: CallEventsInput): Promise<TelnyxEnvelope> {
+    const url = this.url("/call_events");
+    addFilter(url, "leg_id", input.callLegId);
+    addFilter(url, "application_session_id", input.applicationSessionId);
+    addFilter(url, "connection_id", input.connectionId);
+    addFilter(url, "product", input.product);
+    addFilter(url, "failed", input.failed);
+    addFilter(url, "from", input.from);
+    addFilter(url, "to", input.to);
+    addFilter(url, "name", input.name);
+    addFilter(url, "type", input.type);
+    addFilter(url, "occurred_at][eq", input.occurredAtEq, "filter[occurred_at][eq]");
+    addFilter(url, "occurred_at][gt", input.occurredAtGt, "filter[occurred_at][gt]");
+    addFilter(url, "occurred_at][gte", input.occurredAtGte, "filter[occurred_at][gte]");
+    addFilter(url, "occurred_at][lt", input.occurredAtLt, "filter[occurred_at][lt]");
+    addFilter(url, "occurred_at][lte", input.occurredAtLte, "filter[occurred_at][lte]");
+    addFilter(url, "status", input.status);
+    addPaging(url, input);
+    return this.request(url, { method: "GET" });
+  }
+
+  async getCallStatus(callControlId: string): Promise<TelnyxEnvelope> {
+    return this.request(this.url(`/calls/${encodeURIComponent(callControlId)}`), { method: "GET" });
+  }
+
+  async listRecordings(input: RecordingsInput): Promise<TelnyxEnvelope> {
+    const url = this.url("/recordings");
+    addFilter(url, "call_control_id", input.callControlId);
+    addFilter(url, "call_leg_id", input.callLegId);
+    addFilter(url, "call_session_id", input.callSessionId);
+    addFilter(url, "connection_id", input.connectionId);
+    addFilter(url, "created_at][gte", input.createdAtGte, "filter[created_at][gte]");
+    addFilter(url, "created_at][lte", input.createdAtLte, "filter[created_at][lte]");
+    addPaging(url, input);
+    return this.request(url, { method: "GET" });
+  }
+
+  private url(path: string): URL {
+    return new URL(`${this.baseUrl}${path}`);
+  }
+
+  private async request<T>(url: URL, init: RequestInit): Promise<T> {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.apiKey}`,
+      Accept: "application/json",
+      ...(init.body ? { "Content-Type": "application/json" } : {}),
+      ...(init.headers as Record<string, string> | undefined)
+    };
+    const response = await this.fetchImpl(url.toString(), { ...init, headers });
+    const body = await parseJson(response);
+    if (!response.ok) {
+      const sanitizedDetails = sanitizeVoiceMonitorValue(body);
+      const message = sanitizeMessage(extractTelnyxErrorMessage(sanitizedDetails) ?? `Telnyx request failed with status ${response.status}`);
+      throw new TelnyxVoiceMonitorError(message, response.status, sanitizedDetails);
+    }
+    return body as T;
+  }
+}
+
+function addPaging(url: URL, input: PageInput): void {
+  if (input.pageNumber !== undefined) url.searchParams.set("page[number]", String(input.pageNumber));
+  if (input.pageSize !== undefined) url.searchParams.set("page[size]", String(input.pageSize));
+}
+
+function addFilter(url: URL, name: string, value: unknown, rawKey = `filter[${name}]`): void {
+  if (value === undefined || value === null || value === "") return;
+  url.searchParams.append(rawKey, String(value));
+}
+
+async function parseJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return {};
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return { text };
+  }
+}
+
+function extractTelnyxErrorMessage(body: unknown): string | undefined {
+  if (!body || typeof body !== "object") return undefined;
+  const errors = (body as { errors?: unknown }).errors;
+  if (!Array.isArray(errors) || errors.length === 0) return undefined;
+  const first = errors[0];
+  if (!first || typeof first !== "object") return undefined;
+  const title = (first as { title?: unknown }).title;
+  const detail = (first as { detail?: unknown }).detail;
+  return [title, detail].filter((value): value is string => typeof value === "string" && value.length > 0).join(": ");
+}
+
+export function sanitizeError(error: unknown): Error {
+  const source = error instanceof Error ? error : new Error(String(error));
+  const sanitized = new Error(sanitizeMessage(source.message));
+  sanitized.name = source.name;
+  return sanitized;
+}
+
+export function sanitizeVoiceMonitorValue(value: unknown, key = ""): unknown {
+  if (Array.isArray(value)) return value.map((nested) => sanitizeVoiceMonitorValue(nested, key));
+  if (value && typeof value === "object") {
+    const output: Record<string, unknown> = {};
+    for (const [nestedKey, nestedValue] of Object.entries(value)) {
+      if (isMetadataKey(nestedKey)) output[nestedKey] = "[redacted-metadata]";
+      else if (isTranscriptKey(nestedKey)) output[nestedKey] = "[redacted-transcript]";
+      else if (isRecordingUrlKey(nestedKey)) output[nestedKey] = "[redacted-recording-url]";
+      else if (isSecretKey(nestedKey)) output[nestedKey] = "[redacted-secret]";
+      else output[nestedKey] = sanitizeVoiceMonitorValue(nestedValue, nestedKey);
+    }
+    return output;
+  }
+  if (typeof value === "string") {
+    if (OPERATIONAL_ID_KEYS.has(key)) return sanitizeMessage(value, false, false);
+    if (isPhoneKey(key)) return redactPhoneNumbers(sanitizeMessage(value));
+    return sanitizeMessage(value);
+  }
+  return value;
+}
+
+function isPhoneKey(key: string): boolean {
+  return /(^|_)(from|to|phone|number|caller_id|callee_id|ani|dnis)($|_)/i.test(key) && !OPERATIONAL_ID_KEYS.has(key);
+}
+
+function isSecretKey(key: string): boolean {
+  return /(^|_)(auth|authorization|api_?key|secret|token|password|credential|private_key)($|_)/i.test(key);
+}
+
+function isRecordingUrlKey(key: string): boolean {
+  return /(^|_)(recording_?url|download_?url|media_?url|audio_?url|url)($|_)/i.test(key);
+}
+
+function isTranscriptKey(key: string): boolean {
+  return /(^|_)(transcript|transcription)($|_)/i.test(key);
+}
+
+function isMetadataKey(key: string): boolean {
+  return /(^|_)(metadata|meta|payload|webhook_payload)($|_)/i.test(key);
+}
+
+function sanitizeMessage(message: string, redactPhones = true, redactPayments = true): string {
+  const withoutSecrets = message
+    .replace(/Authorization\s*:\s*Bearer\s+[^\s;,)]+/gi, "Authorization: Bearer [redacted-secret]")
+    .replace(/Bearer\s+[^\s;,)]+/gi, "Bearer [redacted-secret]")
+    .replace(/\b(?:sk|pk|key|api)[_-]?(?:live|test|secret)?_[A-Za-z0-9_\-]{6,}\b/gi, "[redacted-secret]")
+    .replace(/\b(?:api[_-]?key|secret|token|password)\s*(?:[=:]|\s)\s*[^\s;,)]+/gi, (match) => `${match.split(/[=:\s]/)[0]}=[redacted-secret]`);
+  const withoutPayments = redactPayments ? withoutSecrets.replace(/\b(?:\d[ -]*?){13,19}\b/g, "[redacted-payment]") : withoutSecrets;
+  return redactPhones ? redactPhoneNumbers(withoutPayments) : withoutPayments;
+}
+
+function redactPhoneNumbers(value: string): string {
+  return value
+    .replace(/\+?\d[\d .()\-]{7,}\d/g, "[redacted-phone]")
+    .replace(/\b(?:\d[ -]?){10,15}\b/g, "[redacted-phone]");
+}

--- a/tools/mcp-apps/apps/voice-monitor/src/types.ts
+++ b/tools/mcp-apps/apps/voice-monitor/src/types.ts
@@ -1,0 +1,151 @@
+export interface TelnyxClientOptions {
+  apiKey: string;
+  baseUrl?: string;
+  fetch?: typeof fetch;
+}
+
+export interface TelnyxEnvelope<T = unknown> {
+  data?: T;
+  meta?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export interface PageInput {
+  pageNumber?: number;
+  pageSize?: number;
+}
+
+export interface ConnectionData {
+  id?: string;
+  connection_id?: string;
+  name?: string;
+  connection_name?: string;
+  active?: boolean;
+  record_type?: string;
+  [key: string]: unknown;
+}
+
+export interface CallControlApplicationData {
+  id?: string;
+  application_id?: string;
+  application_name?: string;
+  name?: string;
+  active?: boolean;
+  [key: string]: unknown;
+}
+
+export interface VoiceNumberData {
+  id?: string;
+  phone_number?: string;
+  number?: string;
+  connection_id?: string;
+  status?: string;
+  active?: boolean;
+  [key: string]: unknown;
+}
+
+export interface CallEventsInput extends PageInput {
+  callLegId?: string;
+  applicationSessionId?: string;
+  connectionId?: string;
+  product?: string;
+  failed?: boolean;
+  from?: string;
+  to?: string;
+  name?: string;
+  type?: string;
+  status?: string;
+  occurredAtEq?: string;
+  occurredAtGt?: string;
+  occurredAtGte?: string;
+  occurredAtLt?: string;
+  occurredAtLte?: string;
+}
+
+export interface RecordingsInput extends PageInput {
+  callControlId?: string;
+  callLegId?: string;
+  callSessionId?: string;
+  connectionId?: string;
+  createdAtGte?: string;
+  createdAtLte?: string;
+}
+
+export interface VoiceMonitorClient {
+  listConnections(input?: PageInput): Promise<TelnyxEnvelope<ConnectionData[]>>;
+  listCallControlApplications(input?: PageInput): Promise<TelnyxEnvelope<CallControlApplicationData[]>>;
+  listPhoneNumbers(input?: PageInput): Promise<TelnyxEnvelope<VoiceNumberData[]>>;
+  listActiveCalls(connectionId: string, input?: PageInput): Promise<TelnyxEnvelope>;
+  listCallEvents(input: CallEventsInput): Promise<TelnyxEnvelope>;
+  getCallStatus(callControlId: string): Promise<TelnyxEnvelope>;
+  listRecordings(input: RecordingsInput): Promise<TelnyxEnvelope>;
+}
+
+export type OptionKind = "connection" | "call_control_application" | "voice_number";
+
+export interface DiscoveryOption {
+  kind: OptionKind;
+  label: string;
+  value: string;
+  description?: string;
+  active?: boolean;
+  connection_id?: string;
+  associated_number_count?: number;
+  [key: string]: unknown;
+}
+
+export interface VoiceMonitorServiceOptions {
+  maxPageSize?: number;
+  maxDiscoveryConnections?: number;
+  maxTimelineWindowHours?: number;
+  maxRecordingWindowHours?: number;
+  now?: () => Date;
+}
+
+export interface ListOptionsInput {
+  pageNumber?: number;
+  pageSize?: number;
+}
+
+export interface ActiveCallsInput {
+  connectionId?: string;
+  pageNumber?: number;
+  pageSize?: number;
+  maxConnections?: number;
+}
+
+export interface CallTimelineRequest {
+  callLegId?: string;
+  callSessionId?: string;
+  applicationSessionId?: string;
+  connectionId?: string;
+  product?: string;
+  failed?: boolean;
+  from?: string;
+  to?: string;
+  name?: string;
+  type?: string;
+  status?: string;
+  occurredAtEq?: string;
+  occurredAtGt?: string;
+  occurredAtGte?: string;
+  occurredAtLt?: string;
+  occurredAtLte?: string;
+  pageNumber?: number;
+  pageSize?: number;
+}
+
+export interface CallStatusRequest {
+  callControlId?: string;
+}
+
+export interface RecordingsRequest {
+  callControlId?: string;
+  callLegId?: string;
+  callSessionId?: string;
+  connectionId?: string;
+  occurredAtGte?: string;
+  occurredAtLte?: string;
+  pageNumber?: number;
+  pageSize?: number;
+}

--- a/tools/mcp-apps/apps/voice-monitor/src/ui.ts
+++ b/tools/mcp-apps/apps/voice-monitor/src/ui.ts
@@ -1,0 +1,209 @@
+export const VOICE_MONITOR_UI_HTML = String.raw`<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Telnyx Voice Monitor</title>
+    <style>
+      :root { color-scheme: light dark; --bg: #f6f8fb; --panel: #fff; --soft: #eef3f7; --text: #111827; --muted: #5b6472; --line: #d7dde6; --accent: #00a3a3; --accent-strong: #057474; --good: #16803c; --warn: #a46000; --bad: #b42318; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      @media (prefers-color-scheme: dark) { :root { --bg: #09111f; --panel: #101928; --soft: #142237; --text: #f8fafc; --muted: #aab7c7; --line: #27364b; --accent: #2dd4bf; --accent-strong: #5eead4; --good: #4ade80; --warn: #fbbf24; --bad: #f87171; } }
+      * { box-sizing: border-box; } body { margin: 0; background: var(--bg); color: var(--text); } main { width: min(1160px, 100%); margin: 0 auto; padding: 22px; } header { display: flex; justify-content: space-between; gap: 16px; margin-bottom: 16px; } h1 { margin: 0; font-size: 30px; } h2 { margin: 0; font-size: 16px; } h3 { margin: 0; color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: .04em; } p { margin: 0; color: var(--muted); line-height: 1.5; } button, input, select { font: inherit; } button { min-height: 40px; border: 0; border-radius: 8px; padding: 0 13px; background: var(--accent); color: #042f2e; font-weight: 760; cursor: pointer; } button.secondary { border: 1px solid var(--line); background: var(--panel); color: var(--text); } button:disabled { cursor: progress; opacity: .65; } input, select { min-width: 0; min-height: 40px; border: 1px solid var(--line); border-radius: 8px; padding: 0 10px; background: var(--panel); color: var(--text); } label { display: grid; gap: 6px; color: var(--muted); font-size: 12px; font-weight: 720; } pre { margin: 0; white-space: pre-wrap; overflow-wrap: anywhere; max-height: 430px; overflow: auto; }
+      .eyebrow { color: var(--accent-strong); font-size: 12px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; } .pill-row { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 8px; } .pill { border: 1px solid var(--line); border-radius: 999px; padding: 6px 9px; color: var(--muted); background: var(--panel); font-size: 12px; } .grid { display: grid; gap: 12px; } .summary { grid-template-columns: repeat(3, minmax(0, 1fr)); } .main-grid { grid-template-columns: minmax(0, 1fr) minmax(340px, .75fr); } .card, .panel { border: 1px solid var(--line); border-radius: 8px; background: var(--panel); box-shadow: 0 1px 2px rgba(15,23,42,.06); } .card { padding: 14px; } .panel { padding: 16px; } .value { margin-top: 8px; font-size: 24px; font-weight: 780; overflow-wrap: anywhere; } .meta { margin-top: 6px; color: var(--muted); font-size: 13px; overflow-wrap: anywhere; } .toolbar { display: grid; grid-template-columns: 1.5fr .8fr 1fr 1fr auto; gap: 10px; align-items: end; } .stack { display: grid; gap: 12px; } .actions { display: flex; flex-wrap: wrap; gap: 8px; } .error { padding: 12px; border-radius: 8px; background: color-mix(in srgb, var(--bad), transparent 88%); color: var(--bad); font-weight: 650; } .notice { padding: 12px; border-radius: 8px; background: var(--soft); color: var(--muted); } table { width: 100%; border-collapse: collapse; } th, td { padding: 9px; border-bottom: 1px solid var(--line); text-align: left; vertical-align: top; } th { color: var(--muted); font-size: 12px; text-transform: uppercase; } .hidden { display: none; }
+      @media (max-width: 900px) { header, .main-grid { display: grid; grid-template-columns: 1fr; } .pill-row { justify-content: flex-start; } .summary, .toolbar { grid-template-columns: 1fr; } }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <div>
+          <div class="eyebrow">Telnyx MCP App</div>
+          <h1>Voice Monitor</h1>
+          <p>Read-only active-call, call timeline, status, and recording discovery with preloaded Call Control App and SIP Connection choices.</p>
+        </div>
+        <div class="pill-row">
+          <span class="pill" id="bridgeStatus">Host bridge: initializing</span>
+          <span class="pill">Read-only</span>
+          <span class="pill">No call-control mutations</span>
+        </div>
+      </header>
+
+      <div id="error" class="error hidden"></div>
+
+      <section class="grid summary" aria-label="Voice summary">
+        <article class="card"><h3>Call Control Apps</h3><div class="value" id="connectionCount">-</div><div class="meta">loaded for dropdowns</div></article>
+        <article class="card"><h3>Active Calls</h3><div class="value" id="activeCallCount">-</div><div class="meta" id="activeMeta">select a connection or discover</div></article>
+        <article class="card"><h3>Selected</h3><div class="value" id="selectedValue">-</div><div class="meta">monitor target</div></article>
+      </section>
+
+      <section class="grid main-grid" style="margin-top: 12px;">
+        <div class="stack">
+          <article class="panel stack">
+            <h2>Call Discovery</h2>
+            <p class="meta">Use Call Control Apps for active calls, and SIP Connections for timeline or recording investigation.</p>
+            <div class="toolbar">
+              <label>Call Control App<select id="connectionSelect"><option value="">All discovered (bounded)</option></select></label>
+              <label>SIP Connection<select id="sipConnectionSelect"><option value="">Any SIP connection</option></select></label>
+              <label>ID type<select id="idTypeSelect"><option value="call_session_id">Session</option><option value="call_leg_id">Leg</option></select></label>
+              <label>Call/session ID<input id="sessionInput" placeholder="paste selected ID type" /></label>
+              <label>Call control ID<input id="callControlInput" placeholder="call_control_id" /></label>
+              <button id="loadOptionsButton" type="button">Load options</button>
+            </div>
+            <div class="actions">
+              <button id="activeCallsButton" type="button">Refresh active calls</button>
+              <button class="secondary" id="timelineButton" type="button">Load timeline</button>
+              <button class="secondary" id="statusButton" type="button">Get status</button>
+              <button class="secondary" id="recordingsButton" type="button">Search recordings</button>
+            </div>
+          </article>
+
+          <article class="panel">
+            <h2>Active Calls</h2>
+            <div style="overflow-x: auto;"><table><thead><tr><th>Connection</th><th>Call Control</th><th>State</th><th>Direction</th></tr></thead><tbody id="activeBody"></tbody></table></div>
+          </article>
+        </div>
+
+        <div class="stack">
+          <article class="panel stack">
+            <h2>Manual JSON fallback</h2>
+            <p class="meta">If the MCP Apps bridge cannot call tools, copy these arguments into the matching tool manually.</p>
+            <pre id="fallbackPre">{}</pre>
+          </article>
+          <article class="panel stack">
+            <h2>Raw Data</h2>
+            <pre id="jsonPre">{}</pre>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <script>
+      const PROTOCOL_VERSION = "2026-01-26";
+      let nextId = 1;
+      const pending = new Map();
+      const state = { options: null, latest: {} };
+      const els = {
+        bridgeStatus: document.getElementById("bridgeStatus"), error: document.getElementById("error"),
+        connectionCount: document.getElementById("connectionCount"), activeCallCount: document.getElementById("activeCallCount"), activeMeta: document.getElementById("activeMeta"), selectedValue: document.getElementById("selectedValue"),
+        connectionSelect: document.getElementById("connectionSelect"), sipConnectionSelect: document.getElementById("sipConnectionSelect"), idTypeSelect: document.getElementById("idTypeSelect"), sessionInput: document.getElementById("sessionInput"), callControlInput: document.getElementById("callControlInput"),
+        loadOptionsButton: document.getElementById("loadOptionsButton"), activeCallsButton: document.getElementById("activeCallsButton"), timelineButton: document.getElementById("timelineButton"), statusButton: document.getElementById("statusButton"), recordingsButton: document.getElementById("recordingsButton"),
+        activeBody: document.getElementById("activeBody"), fallbackPre: document.getElementById("fallbackPre"), jsonPre: document.getElementById("jsonPre")
+      };
+      function send(message) { window.parent.postMessage(message, "*"); }
+      function notify(method, params) { send({ jsonrpc: "2.0", method, params }); }
+      let resizePending = false;
+      function resize() {
+        if (resizePending) return;
+        resizePending = true;
+        requestAnimationFrame(() => {
+          resizePending = false;
+          const root = document.documentElement;
+          notify("ui/notifications/size-changed", { width: Math.ceil(root.scrollWidth || window.innerWidth), height: Math.ceil(root.getBoundingClientRect().height) });
+        });
+      }
+      function request(method, params) {
+        const id = nextId++;
+        send({ jsonrpc: "2.0", id, method, params });
+        return new Promise((resolve, reject) => {
+          pending.set(id, { resolve, reject });
+          window.setTimeout(() => { if (pending.has(id)) { pending.delete(id); reject(new Error(method + " timed out")); } }, 30000);
+        });
+      }
+      async function callTool(name, args = {}) { return extractResult(await request("tools/call", { name, arguments: args })); }
+      function extractResult(result) {
+        if (result?.isError) throw new Error(result?.content?.find?.((block) => block.type === "text")?.text || "Tool request failed.");
+        if (result?.structuredContent) return result.structuredContent;
+        const text = result?.content?.find?.((block) => block.type === "text")?.text;
+        if (!text) return result;
+        try { return JSON.parse(text); } catch { return result; }
+      }
+      function setError(message) { els.error.textContent = message || ""; els.error.classList.toggle("hidden", !message); resize(); }
+      function asArray(value) { return Array.isArray(value) ? value : value ? [value] : []; }
+      function updateFallback() {
+        const active_target_id = els.connectionSelect.value || undefined;
+        const sip_connection_id = els.sipConnectionSelect.value || undefined;
+        const id = els.sessionInput.value.trim();
+        const call_control_id = els.callControlInput.value.trim();
+        const idType = els.idTypeSelect.value;
+        const args = {
+          voice_monitor_active_calls: active_target_id ? { connection_id: active_target_id } : {},
+          voice_monitor_call_timeline: { ...(sip_connection_id ? { connection_id: sip_connection_id } : {}), ...(id ? { [idType]: id } : {}) },
+          voice_monitor_call_status: call_control_id ? { call_control_id } : { call_control_id: "<paste call_control_id>" },
+          voice_monitor_recordings: { ...(sip_connection_id ? { connection_id: sip_connection_id } : {}), ...(call_control_id ? { call_control_id } : {}) }
+        };
+        els.selectedValue.textContent = sip_connection_id || active_target_id || "All";
+        els.fallbackPre.textContent = JSON.stringify(args, null, 2);
+      }
+      function renderOptions(result) {
+        state.options = result;
+        const activeTargets = asArray(result?.options?.active_call_targets ?? result?.options?.call_control_applications);
+        const sipConnections = asArray(result?.options?.connections);
+        els.connectionSelect.replaceChildren(new Option("All Call Control Apps (bounded)", ""));
+        for (const option of activeTargets) {
+          const suffix = option.associated_number_count !== undefined ? " (" + option.associated_number_count + " numbers)" : "";
+          els.connectionSelect.append(new Option((option.label || option.value) + suffix, option.value));
+        }
+        els.sipConnectionSelect.replaceChildren(new Option("Any SIP connection", ""));
+        for (const option of sipConnections) {
+          const detail = option.description ? " - " + option.description : "";
+          const suffix = option.associated_number_count !== undefined ? " (" + option.associated_number_count + " numbers)" : "";
+          els.sipConnectionSelect.append(new Option((option.label || option.value) + detail + suffix, option.value));
+        }
+        els.connectionCount.textContent = String(activeTargets.length);
+        state.latest.options = result;
+        renderJson(); updateFallback(); resize();
+      }
+      function renderActive(result) {
+        const calls = asArray(result?.active_calls ?? result?.data);
+        els.activeCallCount.textContent = String(result?.total_active_calls ?? calls.length);
+        els.activeMeta.textContent = asArray(result?.connections_consulted).length + " connection(s) consulted";
+        els.activeBody.replaceChildren();
+        if (!calls.length) {
+          const tr = document.createElement("tr"); const td = document.createElement("td"); td.colSpan = 4; td.textContent = "No active calls returned."; tr.append(td); els.activeBody.append(tr);
+        }
+        for (const call of calls) {
+          const tr = document.createElement("tr");
+          [call?.connection_id, call?.call_control_id || call?.id, call?.state || call?.status || "-", call?.direction || "-"].forEach((value) => { const td = document.createElement("td"); td.textContent = value || "-"; tr.append(td); });
+          els.activeBody.append(tr);
+        }
+        state.latest.active_calls = result; renderJson(); resize();
+      }
+      function renderJson() { els.jsonPre.textContent = JSON.stringify(state.latest, null, 2); }
+      async function loadDashboard() {
+        setError("");
+        const dashboard = await callTool("voice_monitor_dashboard", { page_size: 100 });
+        if (dashboard?.options) renderOptions(dashboard.options);
+        if (dashboard?.active_calls) renderActive(dashboard.active_calls);
+      }
+      async function loadOptions() { setError(""); renderOptions(await callTool("voice_monitor_list_options", { page_size: 100 })); }
+      async function loadActiveCalls() { setError(""); renderActive(await callTool("voice_monitor_active_calls", els.connectionSelect.value ? { connection_id: els.connectionSelect.value, page_size: 100 } : { page_size: 100 })); }
+      async function loadTimeline() { const args = JSON.parse(els.fallbackPre.textContent).voice_monitor_call_timeline; state.latest.timeline = await callTool("voice_monitor_call_timeline", { ...args, page_size: 100 }); renderJson(); resize(); }
+      async function loadStatus() { const id = els.callControlInput.value.trim(); if (!id) throw new Error("Enter a call_control_id first."); state.latest.status = await callTool("voice_monitor_call_status", { call_control_id: id }); renderJson(); resize(); }
+      async function loadRecordings() { const args = JSON.parse(els.fallbackPre.textContent).voice_monitor_recordings; state.latest.recordings = await callTool("voice_monitor_recordings", { ...args, page_size: 50 }); renderJson(); resize(); }
+      window.addEventListener("message", (event) => {
+        if (event.source !== window.parent) return;
+        const message = event.data;
+        if (!message || message.jsonrpc !== "2.0") return;
+        if (message.id !== undefined && pending.has(message.id)) {
+          const handlers = pending.get(message.id); pending.delete(message.id);
+          if (message.error) handlers.reject(new Error(message.error.message || "Request failed")); else handlers.resolve(message.result);
+        }
+      });
+      [els.connectionSelect, els.sipConnectionSelect, els.idTypeSelect, els.sessionInput, els.callControlInput].forEach((el) => el.addEventListener("input", updateFallback));
+      els.connectionSelect.addEventListener("change", updateFallback);
+      els.sipConnectionSelect.addEventListener("change", updateFallback);
+      els.idTypeSelect.addEventListener("change", updateFallback);
+      els.loadOptionsButton.addEventListener("click", () => loadOptions().catch((error) => setError(error.message || "Could not load options.")));
+      els.activeCallsButton.addEventListener("click", () => loadActiveCalls().catch((error) => setError(error.message || "Could not load active calls.")));
+      els.timelineButton.addEventListener("click", () => loadTimeline().catch((error) => setError(error.message || "Could not load timeline.")));
+      els.statusButton.addEventListener("click", () => loadStatus().catch((error) => setError(error.message || "Could not load status.")));
+      els.recordingsButton.addEventListener("click", () => loadRecordings().catch((error) => setError(error.message || "Could not load recordings.")));
+      window.addEventListener("resize", resize);
+      new ResizeObserver(resize).observe(document.documentElement);
+      new ResizeObserver(resize).observe(document.body);
+      updateFallback();
+      request("ui/initialize", { appInfo: { name: "telnyx-voice-monitor-ui", version: "0.1.0" }, appCapabilities: {}, protocolVersion: PROTOCOL_VERSION })
+        .then(async () => { els.bridgeStatus.textContent = "Host bridge: connected"; notify("ui/notifications/initialized", {}); await loadDashboard(); })
+        .catch((error) => { els.bridgeStatus.textContent = "Host bridge: unavailable"; setError("MCP App bridge unavailable; use the manual JSON fallback. " + error.message); });
+    </script>
+  </body>
+</html>`;

--- a/tools/mcp-apps/apps/voice-monitor/test/server.test.ts
+++ b/tools/mcp-apps/apps/voice-monitor/test/server.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import { createServer } from "../src/server.js";
+import { VOICE_MONITOR_UI_HTML } from "../src/ui.js";
+
+describe("Voice Monitor MCP server", () => {
+  it("registers read-only tools with the Voice Monitor UI resource", () => {
+    const server = createServer();
+    const tools = (server as unknown as { _registeredTools: Record<string, { description?: string; _meta?: unknown; annotations?: Record<string, boolean> }> })._registeredTools;
+
+    expect(Object.keys(tools).sort()).toEqual(
+      [
+        "voice_monitor_dashboard",
+        "voice_monitor_active_calls",
+        "voice_monitor_call_status",
+        "voice_monitor_call_timeline",
+        "voice_monitor_list_options",
+        "voice_monitor_recordings"
+      ].sort()
+    );
+    for (const tool of Object.values(tools)) {
+      expect(tool.annotations?.readOnlyHint).toBe(true);
+      expect(tool.annotations?.destructiveHint).toBe(false);
+    }
+    expect(JSON.stringify(tools.voice_monitor_dashboard?._meta)).toContain("ui://voice-monitor/index.html");
+    expect(JSON.stringify(tools.voice_monitor_active_calls?._meta)).not.toContain("resourceUri");
+    expect(JSON.stringify(tools.voice_monitor_active_calls?._meta)).toContain("app");
+    expect(tools.voice_monitor_active_calls?.description).toMatch(/Call Control Application/i);
+    expect(tools.voice_monitor_list_options?.description).toMatch(/dropdown/i);
+  });
+
+  it("returns a safe tool error without network when TELNYX_API_KEY is missing", async () => {
+    const oldKey = process.env.TELNYX_API_KEY;
+    delete process.env.TELNYX_API_KEY;
+    try {
+      const server = createServer();
+      const tools = (server as unknown as { _registeredTools: Record<string, { handler: (args: Record<string, unknown>, extra?: unknown) => Promise<unknown> }> })._registeredTools;
+
+      const result = await tools.voice_monitor_list_options.handler({}, {});
+
+      expect(result).toMatchObject({ isError: true });
+      expect(JSON.stringify(result)).toContain("TELNYX_API_KEY is not set");
+      expect(JSON.stringify(result)).not.toContain("Authorization");
+    } finally {
+      if (oldKey === undefined) delete process.env.TELNYX_API_KEY;
+      else process.env.TELNYX_API_KEY = oldKey;
+    }
+  });
+
+  it("sanitizes successful tool output while preserving operational call IDs", async () => {
+    const oldKey = process.env.TELNYX_API_KEY;
+    const oldFetch = globalThis.fetch;
+    process.env.TELNYX_API_KEY = "test";
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          data: {
+            connection_id: "conn_keep_for_followup",
+            call_control_id: "call_control_keep_for_followup",
+            call_leg_id: "leg_keep_for_followup",
+            call_session_id: "session_keep_for_followup",
+            from: "+15551234567",
+            recording_url: "https://recordings.example.test/secret.wav?token=abc123",
+            authorization: "Bearer should-not-leak"
+          }
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      )) as typeof fetch;
+    try {
+      const server = createServer();
+      const tools = (server as unknown as { _registeredTools: Record<string, { handler: (args: Record<string, unknown>, extra?: unknown) => Promise<unknown> }> })._registeredTools;
+
+      const result = await tools.voice_monitor_call_status.handler({ call_control_id: "call_control_keep_for_followup" }, {});
+      const serialized = JSON.stringify(result);
+
+      expect(serialized).toContain("conn_keep_for_followup");
+      expect(serialized).toContain("call_control_keep_for_followup");
+      expect(serialized).toContain("[redacted-phone]");
+      expect(serialized).toContain("[redacted-recording-url]");
+      expect(serialized).toContain("[redacted-secret]");
+      expect(serialized).not.toContain("15551234567");
+      expect(serialized).not.toContain("secret.wav");
+      expect(serialized).not.toContain("should-not-leak");
+    } finally {
+      globalThis.fetch = oldFetch;
+      if (oldKey === undefined) delete process.env.TELNYX_API_KEY;
+      else process.env.TELNYX_API_KEY = oldKey;
+    }
+  });
+
+  it("exports a self-contained UI that loads options into dropdowns and has JSON fallback", () => {
+    expect(VOICE_MONITOR_UI_HTML).toContain("Voice Monitor");
+    expect(VOICE_MONITOR_UI_HTML).toContain("voice_monitor_dashboard");
+    expect(VOICE_MONITOR_UI_HTML).toContain("voice_monitor_list_options");
+    expect(VOICE_MONITOR_UI_HTML).toContain("connectionSelect");
+    expect(VOICE_MONITOR_UI_HTML).toContain("sipConnectionSelect");
+    expect(VOICE_MONITOR_UI_HTML).toContain("idTypeSelect");
+    expect(VOICE_MONITOR_UI_HTML).toMatch(/manual JSON fallback/i);
+  });
+});

--- a/tools/mcp-apps/apps/voice-monitor/test/service.test.ts
+++ b/tools/mcp-apps/apps/voice-monitor/test/service.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+
+import { createVoiceMonitorService } from "../src/service.js";
+import type { VoiceMonitorClient } from "../src/types.js";
+
+function fakeClient(overrides: Partial<VoiceMonitorClient> = {}): VoiceMonitorClient {
+  return {
+    listConnections: async () => ({ data: [] }),
+    listCallControlApplications: async () => ({ data: [] }),
+    listPhoneNumbers: async () => ({ data: [] }),
+    listActiveCalls: async () => ({ data: [] }),
+    listCallEvents: async () => ({ data: [] }),
+    getCallStatus: async () => ({ data: {} }),
+    listRecordings: async () => ({ data: [] }),
+    ...overrides
+  };
+}
+
+describe("Voice Monitor service", () => {
+  it("discovers app-friendly dropdown options while redacting phone numbers", async () => {
+    const service = createVoiceMonitorService(
+      fakeClient({
+        listConnections: async () => ({
+          data: [
+            { id: "conn_keep_for_followup", connection_name: "Production Voice", active: true, outbound: { outbound_voice_profile_id: "ovp_1" } }
+          ]
+        }),
+        listCallControlApplications: async () => ({ data: [{ id: "app_keep_for_followup", application_name: "Support IVR", active: true }] }),
+        listPhoneNumbers: async () => ({
+          data: [
+            { id: "pn_1", phone_number: "+15551234567", connection_id: "conn_keep_for_followup", status: "active" },
+            { id: "pn_2", phone_number: "+15557654321", connection_id: "conn_keep_for_followup", status: "active" }
+          ]
+        })
+      })
+    );
+
+    const result = await service.listOptions({ pageSize: 500 });
+
+    expect(result.options.connections).toEqual([
+      expect.objectContaining({
+        kind: "connection",
+        label: "Production Voice",
+        value: "conn_keep_for_followup",
+        active: true,
+        associated_number_count: 2
+      })
+    ]);
+    expect(result.options.call_control_applications[0]).toMatchObject({ kind: "call_control_application", value: "app_keep_for_followup", label: "Support IVR" });
+    expect(result.options.active_call_targets[0]).toMatchObject({ kind: "call_control_application", value: "app_keep_for_followup", label: "Support IVR" });
+    expect(result.options.voice_numbers[0]).toMatchObject({ kind: "voice_number", label: expect.stringContaining("[redacted-phone]"), connection_id: "conn_keep_for_followup" });
+    expect(JSON.stringify(result)).not.toContain("15551234567");
+    expect(result.limits.page_size).toBe(100);
+  });
+
+  it("lists active calls for discovered bounded call-control applications when connection_id is omitted", async () => {
+    const consulted: string[] = [];
+    const service = createVoiceMonitorService(
+      fakeClient({
+        listCallControlApplications: async () => ({
+          data: [
+            { id: "app_1", application_name: "One" },
+            { id: "app_2", application_name: "Two" },
+            { id: "app_3", application_name: "Three" }
+          ]
+        }),
+        listActiveCalls: async (connectionId) => {
+          consulted.push(connectionId);
+          return { data: [{ call_control_id: `call_${connectionId}`, from: "+15551234567" }] };
+        }
+      }),
+      { maxDiscoveryConnections: 2 }
+    );
+
+    const result = await service.activeCalls({ pageSize: 5 });
+
+    expect(consulted).toEqual(["app_1", "app_2"]);
+    expect(result.connections_consulted).toEqual(["app_1", "app_2"]);
+    expect(result.truncated_connections).toBe(true);
+    expect(result.total_active_calls).toBe(2);
+    expect(JSON.stringify(result)).toContain("call_app_1");
+    expect(JSON.stringify(result)).not.toContain("15551234567");
+  });
+
+  it("lists active calls for a provided connection without discovery", async () => {
+    const calls: string[] = [];
+    const service = createVoiceMonitorService(
+      fakeClient({
+        listConnections: async () => {
+          throw new Error("discovery should not run");
+        },
+        listActiveCalls: async (connectionId, input) => {
+          calls.push(`${connectionId}:${input.pageSize}`);
+          return { data: [{ call_control_id: "call_keep_for_followup" }] };
+        }
+      })
+    );
+
+    const result = await service.activeCalls({ connectionId: " conn_keep_for_followup ", pageSize: 500 });
+
+    expect(calls).toEqual(["conn_keep_for_followup:100"]);
+    expect(result.connections_consulted).toEqual(["conn_keep_for_followup"]);
+  });
+
+  it("normalizes call timeline filters and defaults connection-only searches to a bounded last-24-hour window", async () => {
+    const inputs: unknown[] = [];
+    const service = createVoiceMonitorService(
+      fakeClient({
+        listCallEvents: async (input) => {
+          inputs.push(input);
+          return { data: [{ id: "event_1", from: "+15551234567" }] };
+        }
+      }),
+      { now: () => new Date("2026-05-20T12:00:00.000Z") }
+    );
+
+    const result = await service.callTimeline({ connectionId: "conn_keep_for_followup", pageSize: 500 });
+
+    expect(inputs[0]).toMatchObject({
+      connectionId: "conn_keep_for_followup",
+      occurredAtGte: "2026-05-19T12:00:00.000Z",
+      occurredAtLte: "2026-05-20T12:00:00.000Z",
+      pageSize: 100
+    });
+    expect(result.filters_notice).toMatch(/last 24 hours/i);
+    expect(JSON.stringify(result)).not.toContain("15551234567");
+  });
+
+  it("rejects blank call status IDs and caps recording search windows", async () => {
+    const service = createVoiceMonitorService(fakeClient(), { now: () => new Date("2026-05-20T12:00:00.000Z") });
+
+    await expect(service.callStatus({ callControlId: "   " })).rejects.toThrow(/call_control_id/i);
+    await expect(
+      service.recordings({ occurredAtGte: "2026-05-01T00:00:00.000Z", occurredAtLte: "2026-05-20T00:00:00.000Z" })
+    ).rejects.toThrow(/capped/i);
+  });
+});

--- a/tools/mcp-apps/apps/voice-monitor/test/telnyxClient.test.ts
+++ b/tools/mcp-apps/apps/voice-monitor/test/telnyxClient.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import { TelnyxVoiceMonitorClient, TelnyxVoiceMonitorError, sanitizeVoiceMonitorValue } from "../src/telnyxClient.js";
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+}
+
+describe("TelnyxVoiceMonitorClient", () => {
+  it("constructs read-only voice monitoring requests against the /v2 base URL", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchImpl: typeof fetch = async (url, init) => {
+      calls.push({ url: String(url), init });
+      return json({ data: [] });
+    };
+    const client = new TelnyxVoiceMonitorClient({ apiKey: "fixture_credential", fetch: fetchImpl });
+
+    await client.listConnections({ pageNumber: 2, pageSize: 25 });
+    await client.listCallControlApplications({ pageNumber: 1, pageSize: 10 });
+    await client.listPhoneNumbers({ pageNumber: 1, pageSize: 10 });
+    await client.listActiveCalls("conn_keep_for_followup", { pageNumber: 1, pageSize: 5 });
+    await client.getCallStatus("call_control_keep_for_followup");
+
+    expect(calls.map((call) => call.url)).toEqual([
+      "https://api.telnyx.com/v2/connections?page%5Bnumber%5D=2&page%5Bsize%5D=25",
+      "https://api.telnyx.com/v2/call_control_applications?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+      "https://api.telnyx.com/v2/phone_numbers/voice?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+      "https://api.telnyx.com/v2/connections/conn_keep_for_followup/active_calls?page%5Bnumber%5D=1&page%5Bsize%5D=5",
+      "https://api.telnyx.com/v2/calls/call_control_keep_for_followup"
+    ]);
+    expect(calls.every((call) => call.init?.method === "GET")).toBe(true);
+    expect(calls.every((call) => (call.init?.headers as Record<string, string>).Authorization === "Bearer fixture_credential")).toBe(true);
+  });
+
+  it("serializes call event and recording deepObject filters without mutating calls", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchImpl: typeof fetch = async (url, init) => {
+      calls.push({ url: String(url), init });
+      return json({ data: [] });
+    };
+    const client = new TelnyxVoiceMonitorClient({ apiKey: "fixture_credential", baseUrl: "https://api.telnyx.test/v2/", fetch: fetchImpl });
+
+    await client.listCallEvents({
+      callLegId: "leg_keep_for_followup",
+      applicationSessionId: "session_keep_for_followup",
+      connectionId: "conn_keep_for_followup",
+      product: "call_control",
+      failed: false,
+      from: "+15551234567",
+      occurredAtGte: "2026-05-20T00:00:00.000Z",
+      occurredAtLte: "2026-05-20T01:00:00.000Z",
+      status: "delivered",
+      pageNumber: 1,
+      pageSize: 20
+    });
+    await client.listRecordings({
+      callControlId: "call_control_keep_for_followup",
+      callLegId: "leg_keep_for_followup",
+      connectionId: "conn_keep_for_followup",
+      createdAtGte: "2026-05-20T00:00:00.000Z",
+      pageNumber: 1,
+      pageSize: 5
+    });
+
+    expect(calls[0]?.url).toBe(
+      "https://api.telnyx.test/v2/call_events?filter%5Bleg_id%5D=leg_keep_for_followup&filter%5Bapplication_session_id%5D=session_keep_for_followup&filter%5Bconnection_id%5D=conn_keep_for_followup&filter%5Bproduct%5D=call_control&filter%5Bfailed%5D=false&filter%5Bfrom%5D=%2B15551234567&filter%5Boccurred_at%5D%5Bgte%5D=2026-05-20T00%3A00%3A00.000Z&filter%5Boccurred_at%5D%5Blte%5D=2026-05-20T01%3A00%3A00.000Z&filter%5Bstatus%5D=delivered&page%5Bnumber%5D=1&page%5Bsize%5D=20"
+    );
+    expect(calls[1]?.url).toBe(
+      "https://api.telnyx.test/v2/recordings?filter%5Bcall_control_id%5D=call_control_keep_for_followup&filter%5Bcall_leg_id%5D=leg_keep_for_followup&filter%5Bconnection_id%5D=conn_keep_for_followup&filter%5Bcreated_at%5D%5Bgte%5D=2026-05-20T00%3A00%3A00.000Z&page%5Bnumber%5D=1&page%5Bsize%5D=5"
+    );
+    expect(calls.map((call) => call.init?.method)).toEqual(["GET", "GET"]);
+  });
+
+  it("redacts phone numbers, recording URLs, transcripts, metadata, and secrets while preserving operational IDs", async () => {
+    const sensitive = {
+      data: {
+        value: "123456789012345",
+        summary: { connection_count: 3 },
+        connection_id: "conn_keep_for_followup",
+        call_control_id: "call_control_keep_for_followup",
+        call_leg_id: "leg_keep_for_followup",
+        call_session_id: "session_keep_for_followup",
+        from: "+15551234567",
+        to: "+15557654321",
+        recording_url: "https://recordings.example.test/secret.wav?token=abc123",
+        download_url: "https://recordings.example.test/download/secret.wav",
+        transcript: "Customer said card 4242424242424242",
+        metadata: { api_key: "fixture_api_key", customer_phone_number: "+15550001111" },
+        authorization: "Bearer should-not-leak"
+      }
+    };
+
+    const sanitized = JSON.stringify(sanitizeVoiceMonitorValue(sensitive));
+
+    expect(sanitized).toContain("conn_keep_for_followup");
+    expect(sanitized).toContain("123456789012345");
+    expect(sanitized).toContain("connection_count");
+    expect(sanitized).toContain("call_control_keep_for_followup");
+    expect(sanitized).toContain("leg_keep_for_followup");
+    expect(sanitized).toContain("session_keep_for_followup");
+    expect(sanitized).toContain("[redacted-phone]");
+    expect(sanitized).toContain("[redacted-recording-url]");
+    expect(sanitized).toContain("[redacted-transcript]");
+    expect(sanitized).toContain("[redacted-metadata]");
+    expect(sanitized).toContain("[redacted-secret]");
+    expect(sanitized).not.toContain("15551234567");
+    expect(sanitized).not.toContain("secret.wav");
+    expect(sanitized).not.toContain("4242424242424242");
+  });
+
+  it("throws sanitized Telnyx errors", async () => {
+    const client = new TelnyxVoiceMonitorClient({
+      apiKey: "fixture_credential",
+      fetch: async () => json({ errors: [{ title: "Denied", detail: "Bearer fixture_credential cannot access +15551234567" }] }, 403)
+    });
+
+    await expect(client.listConnections()).rejects.toBeInstanceOf(TelnyxVoiceMonitorError);
+    await expect(client.listConnections()).rejects.toMatchObject({ status: 403, message: expect.not.stringContaining("fixture_credential") });
+    await expect(client.listConnections()).rejects.toMatchObject({ message: expect.not.stringContaining("15551234567") });
+  });
+});

--- a/tools/mcp-apps/apps/voice-monitor/tsconfig.json
+++ b/tools/mcp-apps/apps/voice-monitor/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "**/*.test.ts"]
+}

--- a/tools/mcp-apps/apps/voice-monitor/vitest.config.ts
+++ b/tools/mcp-apps/apps/voice-monitor/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"]
+  }
+});

--- a/tools/mcp-apps/package-lock.json
+++ b/tools/mcp-apps/package-lock.json
@@ -1,0 +1,3003 @@
+{
+  "name": "@telnyx/mcp-apps",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@telnyx/mcp-apps",
+      "workspaces": [
+        "apps/*"
+      ],
+      "devDependencies": {
+        "@types/node": "^24.0.0",
+        "tsx": "^4.20.6",
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.13"
+      }
+    },
+    "apps/number-intelligence": {
+      "name": "@telnyx-mcp-apps/number-intelligence",
+      "version": "0.1.0",
+      "dependencies": {
+        "@modelcontextprotocol/ext-apps": "^1.7.2",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "dotenv": "^17.4.2"
+      }
+    },
+    "apps/usage-cost-explorer": {
+      "name": "@telnyx-mcp-apps/usage-cost-explorer",
+      "version": "0.1.0",
+      "dependencies": {
+        "@modelcontextprotocol/ext-apps": "^1.7.2",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "dotenv": "^17.4.2"
+      }
+    },
+    "apps/voice-monitor": {
+      "name": "@telnyx-mcp-apps/voice-monitor",
+      "version": "0.1.0",
+      "dependencies": {
+        "@modelcontextprotocol/ext-apps": "^1.7.2",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "dotenv": "^17.4.2"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/ext-apps": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.7.2.tgz",
+      "integrity": "sha512-OOWKDxdAjYDcgHkmzVzccyyag3FK+jBWPaWu4WvTxFsU4R/cgOX4eep66zPRA5n4v6WfxUNibPyvX4iJ7egYTg==",
+      "license": "MIT",
+      "workspaces": [
+        "examples/*"
+      ],
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
+      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
+      "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
+      "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
+      "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
+      "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
+      "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
+      "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
+      "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
+      "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
+      "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
+      "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
+      "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
+      "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
+      "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
+      "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
+      "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@telnyx-mcp-apps/number-intelligence": {
+      "resolved": "apps/number-intelligence",
+      "link": true
+    },
+    "node_modules/@telnyx-mcp-apps/usage-cost-explorer": {
+      "resolved": "apps/usage-cost-explorer",
+      "link": true
+    },
+    "node_modules/@telnyx-mcp-apps/voice-monitor": {
+      "resolved": "apps/voice-monitor",
+      "link": true
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.20",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.20.tgz",
+      "integrity": "sha512-mOdYP1JU3//KG4ukutyI5zi2LOjTGMTVwpdaEi+tg2s+Cn2zx8Q1+/b3Xr1f5ynCWophNNTwY6xRzcCTT5W2kA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
+      "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.130.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.1",
+        "@rolldown/binding-darwin-arm64": "1.0.1",
+        "@rolldown/binding-darwin-x64": "1.0.1",
+        "@rolldown/binding-freebsd-x64": "1.0.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.1",
+        "@rolldown/binding-linux-arm64-musl": "1.0.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-musl": "1.0.1",
+        "@rolldown/binding-openharmony-arm64": "1.0.1",
+        "@rolldown/binding-wasm32-wasi": "1.0.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.1",
+        "@rolldown/binding-win32-x64-msvc": "1.0.1"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.13",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
+      "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.1",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/tools/mcp-apps/package.json
+++ b/tools/mcp-apps/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@telnyx/mcp-apps",
+  "private": true,
+  "type": "module",
+  "description": "App-layer Telnyx MCP servers and MCP Apps UI resources.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/team-telnyx/ai",
+    "directory": "tools/mcp-apps"
+  },
+  "workspaces": [
+    "apps/*"
+  ],
+  "scripts": {
+    "test": "npm --workspaces run test",
+    "typecheck": "npm --workspaces run typecheck",
+    "build": "npm --workspaces run build"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "typescript": "^5.9.3",
+    "tsx": "^4.20.6",
+    "vitest": "^4.0.13"
+  }
+}

--- a/tools/mcp-apps/tsconfig.json
+++ b/tools/mcp-apps/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  }
+}


### PR DESCRIPTION
## Summary
- port MCP Apps into `tools/mcp-apps` in the `team-telnyx/ai` monorepo
- include the three implemented app-layer MCP servers: Number Intelligence, Usage & Cost Explorer, and Voice Monitor
- document the split between `tools/mcp` as the generic `@telnyx/mcp` proxy and `tools/mcp-apps` as focused app-layer MCP servers
- update package metadata and repo instructions for the new monorepo path

## Notes
- intentionally excludes planning docs, future app lists, and empty package scaffolding
- only `.env.example` files are included; no local `.env` files, build artifacts, or `node_modules`

## Test Plan
- `cd tools/mcp-apps && npm install`
- `cd tools/mcp-apps && npm run typecheck`
- `cd tools/mcp-apps && npm run build`
- `cd tools/mcp-apps && npm test`
- `npm run test:guides`
- `npm run test:guides-api`

## Review
- independent evaluator reviewed the staged diff for scope, docs accuracy, artifacts/secrets, and test coverage; no blockers found
