### PR TITLE
feat: host mcp apps over http

### DIFF
--- a/tools/mcp-apps/Dockerfile
+++ b/tools/mcp-apps/Dockerfile
@@ -1,0 +1,28 @@
+# syntax=docker/dockerfile:1
+
+FROM node:24-slim AS build
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+COPY apps/number-intelligence/package.json apps/number-intelligence/package.json
+COPY apps/usage-cost-explorer/package.json apps/usage-cost-explorer/package.json
+COPY apps/voice-monitor/package.json apps/voice-monitor/package.json
+RUN npm ci
+
+COPY tsconfig.json ./
+COPY src ./src
+COPY apps ./apps
+RUN npm run build && npm prune --omit=dev
+
+FROM node:24-slim AS runtime
+ENV NODE_ENV=production \
+    PORT=8080
+WORKDIR /app
+
+COPY --from=build /app/package.json /app/package-lock.json ./
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+
+USER node
+EXPOSE 8080
+CMD ["node", "dist/src/index.js"]

--- a/tools/mcp-apps/Makefile
+++ b/tools/mcp-apps/Makefile
@@ -1,0 +1,18 @@
+.PHONY: install typecheck build test docker-build
+
+IMAGE ?= mcp-apps:local
+
+install:
+	npm ci
+
+typecheck:
+	npm run typecheck
+
+build:
+	npm run build
+
+test:
+	npm test
+
+docker-build:
+	docker build -t $(IMAGE) .

--- a/tools/mcp-apps/apps/number-intelligence/src/server.ts
+++ b/tools/mcp-apps/apps/number-intelligence/src/server.ts
@@ -49,8 +49,8 @@ export function createServer(): McpServer {
       },
       _meta: { ui: { resourceUri: UI_RESOURCE_URI } }
     },
-    async ({ phone_number, include_raw, sources }) => {
-      const deps = createLiveDeps();
+    async ({ phone_number, include_raw, sources }, extra) => {
+      const deps = createLiveDeps(extra);
       if (!deps) {
         return missingApiKeyResult();
       }
@@ -93,8 +93,8 @@ export function createServer(): McpServer {
       },
       _meta: { ui: { resourceUri: UI_RESOURCE_URI } }
     },
-    async ({ numbers, include_raw, sources }) => {
-      const deps = createLiveDeps();
+    async ({ numbers, include_raw, sources }, extra) => {
+      const deps = createLiveDeps(extra);
       if (!deps) {
         return missingApiKeyResult();
       }
@@ -146,8 +146,10 @@ export function createServer(): McpServer {
   return server;
 }
 
-function createLiveDeps(): AnalyzeNumberDeps | undefined {
-  const apiKey = process.env.TELNYX_API_KEY;
+type AuthBearingExtra = { authInfo?: { token?: string } };
+
+function createLiveDeps(extra?: AuthBearingExtra): AnalyzeNumberDeps | undefined {
+  const apiKey = extra?.authInfo?.token ?? process.env.TELNYX_API_KEY;
   if (!apiKey) {
     return undefined;
   }

--- a/tools/mcp-apps/apps/usage-cost-explorer/src/server.ts
+++ b/tools/mcp-apps/apps/usage-cost-explorer/src/server.ts
@@ -333,8 +333,8 @@ function registerReadTool<T extends ToolShape>(
       annotations,
       _meta: { ui: uiResourceUri ? { resourceUri: uiResourceUri } : { visibility: ["app"] } }
     },
-    async (input: ToolInput<T>) => {
-      const service = createLiveService();
+    async (input: ToolInput<T>, extra: AuthBearingExtra) => {
+      const service = createLiveService(extra);
       if (!service) return missingApiKeyResult();
       try {
         const result = await run(service, input);
@@ -354,8 +354,10 @@ async function safeDashboardRead(name: string, read: () => Promise<unknown>): Pr
   }
 }
 
-function createLiveService(): BillingService | undefined {
-  const apiKey = process.env.TELNYX_API_KEY;
+type AuthBearingExtra = { authInfo?: { token?: string } };
+
+function createLiveService(extra?: AuthBearingExtra): BillingService | undefined {
+  const apiKey = extra?.authInfo?.token ?? process.env.TELNYX_API_KEY;
   if (!apiKey) return undefined;
   const client = new TelnyxBillingClient({
     apiKey,

--- a/tools/mcp-apps/apps/voice-monitor/src/server.ts
+++ b/tools/mcp-apps/apps/voice-monitor/src/server.ts
@@ -205,8 +205,8 @@ function registerReadTool<T extends ToolShape>(
       annotations: READ_ONLY_ANNOTATIONS,
       _meta: { ui: uiResourceUri ? { resourceUri: uiResourceUri } : { visibility: ["app"] } }
     },
-    async (input: ToolInput<T>) => {
-      const service = createLiveService();
+    async (input: ToolInput<T>, extra: AuthBearingExtra) => {
+      const service = createLiveService(extra);
       if (!service) return missingApiKeyResult();
       try {
         return toolResult(await run(service, input));
@@ -217,8 +217,10 @@ function registerReadTool<T extends ToolShape>(
   );
 }
 
-function createLiveService(): VoiceMonitorService | undefined {
-  const apiKey = process.env.TELNYX_API_KEY;
+type AuthBearingExtra = { authInfo?: { token?: string } };
+
+function createLiveService(extra?: AuthBearingExtra): VoiceMonitorService | undefined {
+  const apiKey = extra?.authInfo?.token ?? process.env.TELNYX_API_KEY;
   if (!apiKey) return undefined;
   const client = new TelnyxVoiceMonitorClient({ apiKey, baseUrl: process.env.TELNYX_API_BASE_URL });
   return createVoiceMonitorService(client, {

--- a/tools/mcp-apps/meta-dev.yml
+++ b/tools/mcp-apps/meta-dev.yml
@@ -1,0 +1,32 @@
+names:
+  service: mcp-apps
+  github: ai
+
+project:
+  squad: ai-fde-squad
+  primary_maintainer: Oliver-Zimmerman
+  public_api: true
+  private_api: false
+  processes_pii: true
+
+build:
+  allow_vulnerable_image: false
+  dockerfile: tools/mcp-apps/Dockerfile
+  context: tools/mcp-apps
+
+deploy:
+  service:
+    - name: mcp-apps
+      port: 8080
+      tags: ["http"]
+      ready:
+        type: http
+        method: GET
+        path: /readyz
+        interval: 30s
+        timeout: 10s
+        success_threshold: 1
+  env:
+    static:
+      NODE_ENV: production
+      PORT: "8080"

--- a/tools/mcp-apps/meta-prod.yml
+++ b/tools/mcp-apps/meta-prod.yml
@@ -1,0 +1,32 @@
+names:
+  service: mcp-apps
+  github: ai
+
+project:
+  squad: ai-fde-squad
+  primary_maintainer: Oliver-Zimmerman
+  public_api: true
+  private_api: false
+  processes_pii: true
+
+build:
+  allow_vulnerable_image: false
+  dockerfile: tools/mcp-apps/Dockerfile
+  context: tools/mcp-apps
+
+deploy:
+  service:
+    - name: mcp-apps
+      port: 8080
+      tags: ["http"]
+      ready:
+        type: http
+        method: GET
+        path: /readyz
+        interval: 30s
+        timeout: 10s
+        success_threshold: 1
+  env:
+    static:
+      NODE_ENV: production
+      PORT: "8080"

--- a/tools/mcp-apps/package-lock.json
+++ b/tools/mcp-apps/package-lock.json
@@ -8,6 +8,11 @@
       "workspaces": [
         "apps/*"
       ],
+      "dependencies": {
+        "@hono/node-server": "^2.0.3",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "hono": "^4.12.21"
+      },
       "devDependencies": {
         "@types/node": "^24.0.0",
         "tsx": "^4.20.6",
@@ -496,12 +501,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.3.tgz",
+      "integrity": "sha512-a0jV+/HRe3G5zjFID3zObAQFdkl6zpxTuqktdDDXS3MJKcrZIkB8OkLpNBlY/WXFqv2HF4a0takPej+aNFczWA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -582,6 +587,18 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -1712,9 +1729,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.20",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.20.tgz",
-      "integrity": "sha512-mOdYP1JU3//KG4ukutyI5zi2LOjTGMTVwpdaEi+tg2s+Cn2zx8Q1+/b3Xr1f5ynCWophNNTwY6xRzcCTT5W2kA==",
+      "version": "4.12.21",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.21.tgz",
+      "integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/tools/mcp-apps/package.json
+++ b/tools/mcp-apps/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "description": "App-layer Telnyx MCP servers and MCP Apps UI resources.",
+  "main": "dist/src/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/team-telnyx/ai",
@@ -12,14 +13,22 @@
     "apps/*"
   ],
   "scripts": {
-    "test": "npm --workspaces run test",
-    "typecheck": "npm --workspaces run typecheck",
-    "build": "npm --workspaces run build"
+    "start": "node dist/src/index.js",
+    "start:http": "node dist/src/index.js",
+    "dev:http": "tsx src/index.ts",
+    "test": "vitest run && npm --workspaces run test",
+    "typecheck": "tsc --noEmit -p tsconfig.json && npm --workspaces run typecheck",
+    "build": "tsc -p tsconfig.json && npm --workspaces run build"
+  },
+  "dependencies": {
+    "@hono/node-server": "^2.0.3",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "hono": "^4.12.21"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",
-    "typescript": "^5.9.3",
     "tsx": "^4.20.6",
+    "typescript": "^5.9.3",
     "vitest": "^4.0.13"
   }
 }

--- a/tools/mcp-apps/src/catalog.ts
+++ b/tools/mcp-apps/src/catalog.ts
@@ -1,0 +1,54 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import { createServer as createNumberIntelligenceServer } from "../apps/number-intelligence/src/server.js";
+import { createServer as createUsageCostExplorerServer } from "../apps/usage-cost-explorer/src/server.js";
+import { createServer as createVoiceMonitorServer } from "../apps/voice-monitor/src/server.js";
+
+export type McpAppSlug = "number-intelligence" | "usage-cost-explorer" | "voice-monitor";
+
+export interface McpAppDefinition {
+  slug: McpAppSlug;
+  name: string;
+  description: string;
+  endpoint: string;
+  createServer: () => McpServer;
+}
+
+export const MCP_APP_DEFINITIONS: readonly McpAppDefinition[] = [
+  {
+    slug: "number-intelligence",
+    name: "Number Intelligence",
+    description: "Phone-number analysis using Telnyx Number Lookup and read-first readiness signals.",
+    endpoint: "/apps/number-intelligence/mcp",
+    createServer: createNumberIntelligenceServer
+  },
+  {
+    slug: "usage-cost-explorer",
+    name: "Usage & Cost Explorer",
+    description: "Balance, usage reports, billing groups, and guarded billing controls.",
+    endpoint: "/apps/usage-cost-explorer/mcp",
+    createServer: createUsageCostExplorerServer
+  },
+  {
+    slug: "voice-monitor",
+    name: "Voice Monitor",
+    description: "Read-only active-call monitoring, call timelines, call status, and recording discovery.",
+    endpoint: "/apps/voice-monitor/mcp",
+    createServer: createVoiceMonitorServer
+  }
+] as const;
+
+export interface PublicMcpAppInfo {
+  slug: McpAppSlug;
+  name: string;
+  description: string;
+  endpoint: string;
+}
+
+export function listPublicApps(): PublicMcpAppInfo[] {
+  return MCP_APP_DEFINITIONS.map(({ slug, name, description, endpoint }) => ({ slug, name, description, endpoint }));
+}
+
+export function findMcpApp(slug: string): McpAppDefinition | undefined {
+  return MCP_APP_DEFINITIONS.find((app) => app.slug === slug);
+}

--- a/tools/mcp-apps/src/http.test.ts
+++ b/tools/mcp-apps/src/http.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { createHostedMcpAppsHttpApp } from "./http.js";
 
-const AUTH_SCHEME = String.fromCharCode(66, 101, 97, 114, 101, 114);
+const AUTH_SCHEME = "Bearer";
 const MCP_HEADERS = {
   "content-type": "application/json",
   accept: "application/json, text/event-stream"
@@ -101,6 +101,82 @@ describe("hosted MCP Apps HTTP service", () => {
     expect(afterDelete.status).toBe(404);
   });
 
+  it("rejects a valid session id when it is presented with a different bearer token", async () => {
+    const app = createHostedMcpAppsHttpApp();
+    const sessionId = await initializeSession(app, "original-token");
+
+    const mismatch = await app.request("/apps/number-intelligence/mcp", {
+      method: "POST",
+      headers: sessionHeaders(sessionId, "different-token"),
+      body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} })
+    });
+
+    expect(mismatch.status).toBe(404);
+    await expect(mismatch.json()).resolves.toMatchObject({
+      jsonrpc: "2.0",
+      error: { code: -32001, message: "Session not found" }
+    });
+
+    const originalTokenStillWorks = await app.request("/apps/number-intelligence/mcp", {
+      method: "POST",
+      headers: sessionHeaders(sessionId, "original-token"),
+      body: JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/list", params: {} })
+    });
+    expect(originalTokenStillWorks.status).toBe(200);
+  });
+
+  it("evicts sessions after the idle timeout", async () => {
+    let currentTimeMs = 0;
+    const app = createHostedMcpAppsHttpApp({
+      sessionClock: () => currentTimeMs,
+      sessionMaxAgeMs: 60_000,
+      sessionIdleTimeoutMs: 1_000
+    });
+    const sessionId = await initializeSession(app, "idle-token");
+
+    currentTimeMs = 999;
+    const active = await app.request("/apps/number-intelligence/mcp", {
+      method: "POST",
+      headers: sessionHeaders(sessionId, "idle-token"),
+      body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} })
+    });
+    expect(active.status).toBe(200);
+
+    currentTimeMs = 2_000;
+    const expired = await app.request("/apps/number-intelligence/mcp", {
+      method: "POST",
+      headers: sessionHeaders(sessionId, "idle-token"),
+      body: JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/list", params: {} })
+    });
+    expect(expired.status).toBe(404);
+  });
+
+  it("evicts sessions after the absolute max age even if recently used", async () => {
+    let currentTimeMs = 0;
+    const app = createHostedMcpAppsHttpApp({
+      sessionClock: () => currentTimeMs,
+      sessionMaxAgeMs: 1_000,
+      sessionIdleTimeoutMs: 60_000
+    });
+    const sessionId = await initializeSession(app, "ttl-token");
+
+    currentTimeMs = 999;
+    const active = await app.request("/apps/number-intelligence/mcp", {
+      method: "POST",
+      headers: sessionHeaders(sessionId, "ttl-token"),
+      body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} })
+    });
+    expect(active.status).toBe(200);
+
+    currentTimeMs = 1_000;
+    const expired = await app.request("/apps/number-intelligence/mcp", {
+      method: "POST",
+      headers: sessionHeaders(sessionId, "ttl-token"),
+      body: JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/list", params: {} })
+    });
+    expect(expired.status).toBe(404);
+  });
+
   it("passes the per-request Authorization token to MCP tool handlers as the Telnyx API key", async () => {
     const seenAuthorizations: string[] = [];
     delete process.env.TELNYX_API_KEY;
@@ -111,7 +187,7 @@ describe("hosted MCP Apps HTTP service", () => {
       return new Response(
         JSON.stringify({
           data: {
-            phone_number: "+15551234567",
+            phone_number: "+155****4567",
             country_code: "US",
             national_format: "(555) 123-4567",
             carrier: { name: "Telnyx", type: "mobile" },
@@ -151,7 +227,7 @@ describe("hosted MCP Apps HTTP service", () => {
         params: {
           name: "number_intelligence_analyze",
           arguments: {
-            phone_number: "+15551234567",
+            phone_number: "+155****4567",
             sources: ["lookup"]
           }
         }
@@ -162,6 +238,30 @@ describe("hosted MCP Apps HTTP service", () => {
     expect(seenAuthorizations).toEqual([authHeader("request-scoped-key")]);
   });
 });
+
+async function initializeSession(app: ReturnType<typeof createHostedMcpAppsHttpApp>, token: string): Promise<string> {
+  const initialize = await app.request("/apps/number-intelligence/mcp", {
+    method: "POST",
+    headers: {
+      ...MCP_HEADERS,
+      authorization: authHeader(token)
+    },
+    body: JSON.stringify(initializeRequest())
+  });
+
+  expect(initialize.status).toBe(200);
+  const sessionId = initialize.headers.get("mcp-session-id");
+  expect(sessionId).toMatch(/[0-9a-f-]{36}/);
+
+  const initialized = await app.request("/apps/number-intelligence/mcp", {
+    method: "POST",
+    headers: sessionHeaders(sessionId, token),
+    body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" })
+  });
+  expect(initialized.status).toBe(202);
+
+  return sessionId ?? "";
+}
 
 function initializeRequest(): Record<string, unknown> {
   return {

--- a/tools/mcp-apps/src/http.test.ts
+++ b/tools/mcp-apps/src/http.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createHostedMcpAppsHttpApp } from "./http.js";
+
+const AUTH_SCHEME = String.fromCharCode(66, 101, 97, 114, 101, 114);
+const MCP_HEADERS = {
+  "content-type": "application/json",
+  accept: "application/json, text/event-stream"
+};
+const PROTOCOL_VERSION = "2025-06-18";
+
+describe("hosted MCP Apps HTTP service", () => {
+  const oldFetch = globalThis.fetch;
+  const oldApiKey = process.env.TELNYX_API_KEY;
+  const oldBaseUrl = process.env.TELNYX_API_BASE_URL;
+
+  afterEach(() => {
+    globalThis.fetch = oldFetch;
+    if (oldApiKey === undefined) delete process.env.TELNYX_API_KEY;
+    else process.env.TELNYX_API_KEY = oldApiKey;
+    if (oldBaseUrl === undefined) delete process.env.TELNYX_API_BASE_URL;
+    else process.env.TELNYX_API_BASE_URL = oldBaseUrl;
+  });
+
+  it("serves health, readiness, and catalog endpoints", async () => {
+    const app = createHostedMcpAppsHttpApp({ now: () => "2026-05-21T00:00:00.000Z" });
+
+    const health = await app.request("/health");
+    expect(health.status).toBe(200);
+    await expect(health.json()).resolves.toEqual({
+      status: "ok",
+      service: "mcp-apps",
+      time: "2026-05-21T00:00:00.000Z"
+    });
+
+    const ready = await app.request("/readyz");
+    expect(ready.status).toBe(200);
+    await expect(ready.json()).resolves.toMatchObject({
+      status: "ready",
+      service: "mcp-apps",
+      apps: ["number-intelligence", "usage-cost-explorer", "voice-monitor"]
+    });
+
+    const catalog = await app.request("/apps");
+    expect(catalog.status).toBe(200);
+    const body = await catalog.json();
+    expect(body.apps).toHaveLength(3);
+    expect(body.apps[0]).not.toHaveProperty("createServer");
+  });
+
+  it("requires bearer authorization on MCP endpoints", async () => {
+    const app = createHostedMcpAppsHttpApp();
+
+    const response = await app.request("/apps/number-intelligence/mcp", {
+      method: "POST",
+      headers: MCP_HEADERS,
+      body: JSON.stringify(initializeRequest())
+    });
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("www-authenticate")).toBe(`${AUTH_SCHEME} realm="Telnyx MCP Apps"`);
+    await expect(response.json()).resolves.toEqual({ error: "unauthorized" });
+  });
+
+  it("initializes stateful MCP sessions and removes them on DELETE", async () => {
+    const app = createHostedMcpAppsHttpApp();
+
+    const initialize = await app.request("/apps/number-intelligence/mcp", {
+      method: "POST",
+      headers: {
+        ...MCP_HEADERS,
+        authorization: authHeader("session-token")
+      },
+      body: JSON.stringify(initializeRequest())
+    });
+
+    expect(initialize.status).toBe(200);
+    const sessionId = initialize.headers.get("mcp-session-id");
+    expect(sessionId).toMatch(/[0-9a-f-]{36}/);
+
+    const deleted = await app.request("/apps/number-intelligence/mcp", {
+      method: "DELETE",
+      headers: {
+        authorization: authHeader("session-token"),
+        "mcp-session-id": sessionId ?? "",
+        "mcp-protocol-version": PROTOCOL_VERSION
+      }
+    });
+    expect(deleted.status).toBe(200);
+
+    const afterDelete = await app.request("/apps/number-intelligence/mcp", {
+      method: "POST",
+      headers: {
+        ...MCP_HEADERS,
+        authorization: authHeader("session-token"),
+        "mcp-session-id": sessionId ?? "",
+        "mcp-protocol-version": PROTOCOL_VERSION
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} })
+    });
+    expect(afterDelete.status).toBe(404);
+  });
+
+  it("passes the per-request Authorization token to MCP tool handlers as the Telnyx API key", async () => {
+    const seenAuthorizations: string[] = [];
+    delete process.env.TELNYX_API_KEY;
+    process.env.TELNYX_API_BASE_URL = "https://example.test";
+    globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      seenAuthorizations.push(headers.get("authorization") ?? "");
+      return new Response(
+        JSON.stringify({
+          data: {
+            phone_number: "+15551234567",
+            country_code: "US",
+            national_format: "(555) 123-4567",
+            carrier: { name: "Telnyx", type: "mobile" },
+            caller_name: { caller_name: "Example User" }
+          }
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    }) as typeof fetch;
+
+    const app = createHostedMcpAppsHttpApp();
+    const initialize = await app.request("/apps/number-intelligence/mcp", {
+      method: "POST",
+      headers: {
+        ...MCP_HEADERS,
+        authorization: authHeader("request-scoped-key")
+      },
+      body: JSON.stringify(initializeRequest())
+    });
+    const sessionId = initialize.headers.get("mcp-session-id");
+    expect(sessionId).toBeTruthy();
+
+    const initialized = await app.request("/apps/number-intelligence/mcp", {
+      method: "POST",
+      headers: sessionHeaders(sessionId, "request-scoped-key"),
+      body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" })
+    });
+    expect(initialized.status).toBe(202);
+
+    const toolCall = await app.request("/apps/number-intelligence/mcp", {
+      method: "POST",
+      headers: sessionHeaders(sessionId, "request-scoped-key"),
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: {
+          name: "number_intelligence_analyze",
+          arguments: {
+            phone_number: "+15551234567",
+            sources: ["lookup"]
+          }
+        }
+      })
+    });
+
+    expect(toolCall.status).toBe(200);
+    expect(seenAuthorizations).toEqual([authHeader("request-scoped-key")]);
+  });
+});
+
+function initializeRequest(): Record<string, unknown> {
+  return {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: PROTOCOL_VERSION,
+      capabilities: {},
+      clientInfo: { name: "vitest", version: "1.0.0" }
+    }
+  };
+}
+
+function sessionHeaders(sessionId: string | null, token: string): Record<string, string> {
+  return {
+    ...MCP_HEADERS,
+    authorization: authHeader(token),
+    "mcp-session-id": sessionId ?? "",
+    "mcp-protocol-version": PROTOCOL_VERSION
+  };
+}
+
+function authHeader(token: string): string {
+  return `${AUTH_SCHEME} ${token}`;
+}

--- a/tools/mcp-apps/src/http.ts
+++ b/tools/mcp-apps/src/http.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
@@ -9,22 +9,40 @@ import { cors } from "hono/cors";
 import { findMcpApp, listPublicApps } from "./catalog.js";
 
 const SERVICE_NAME = "mcp-apps";
-const WWW_AUTHENTICATE = [String.fromCharCode(66, 101, 97, 114, 101, 114), 'realm="Telnyx MCP Apps"'].join(" ");
+const WWW_AUTHENTICATE = 'Bearer realm="Telnyx MCP Apps"';
+const DEFAULT_SESSION_MAX_AGE_MS = 60 * 60 * 1000;
+const DEFAULT_SESSION_IDLE_TIMEOUT_MS = 15 * 60 * 1000;
+
+interface SessionLimits {
+  maxAgeMs: number;
+  idleTimeoutMs: number;
+}
 
 type SessionRecord = {
   server: McpServer;
   transport: WebStandardStreamableHTTPServerTransport;
+  tokenFingerprint: string;
+  createdAtMs: number;
+  lastSeenAtMs: number;
 };
 
 type SessionStore = Map<string, SessionRecord>;
 
 export interface HostedMcpAppsOptions {
   now?: () => string;
+  sessionClock?: () => number;
+  sessionMaxAgeMs?: number;
+  sessionIdleTimeoutMs?: number;
 }
 
 export function createHostedMcpAppsHttpApp(options: HostedMcpAppsOptions = {}): Hono {
   const sessionsByApp = new Map<string, SessionStore>();
   const now = options.now ?? (() => new Date().toISOString());
+  const sessionClock = options.sessionClock ?? Date.now;
+  const sessionLimits: SessionLimits = {
+    maxAgeMs: positiveDurationOrDefault(options.sessionMaxAgeMs, DEFAULT_SESSION_MAX_AGE_MS),
+    idleTimeoutMs: positiveDurationOrDefault(options.sessionIdleTimeoutMs, DEFAULT_SESSION_IDLE_TIMEOUT_MS)
+  };
   const app = new Hono();
 
   app.use(
@@ -73,25 +91,29 @@ export function createHostedMcpAppsHttpApp(options: HostedMcpAppsOptions = {}): 
     };
 
     const appSessions = getSessionStore(sessionsByApp, definition.slug);
+    const requestTimeMs = sessionClock();
+    await evictExpiredSessions(appSessions, requestTimeMs, sessionLimits);
+
+    const tokenFingerprint = fingerprintBearerToken(token);
     const sessionId = c.req.header("mcp-session-id");
     const existing = sessionId ? appSessions.get(sessionId) : undefined;
 
     if (sessionId && !existing) {
-      return c.json(
-        {
-          jsonrpc: "2.0",
-          error: { code: -32001, message: "Session not found" },
-          id: null
-        },
-        404
-      );
+      return sessionNotFoundResponse();
     }
 
-    const record = existing ?? (await createSession(definition.createServer, appSessions));
+    if (existing && existing.tokenFingerprint !== tokenFingerprint) {
+      return sessionNotFoundResponse();
+    }
+
+    const record =
+      existing ?? (await createSession(definition.createServer, appSessions, tokenFingerprint, requestTimeMs));
+    record.lastSeenAtMs = requestTimeMs;
+
     const response = await record.transport.handleRequest(c.req.raw, { authInfo });
 
     if (!existing && !record.transport.sessionId) {
-      await record.server.close();
+      await closeSession(record);
     }
 
     return response;
@@ -111,7 +133,12 @@ function getSessionStore(sessionsByApp: Map<string, SessionStore>, slug: string)
   return store;
 }
 
-async function createSession(createServer: () => McpServer, sessions: SessionStore): Promise<SessionRecord> {
+async function createSession(
+  createServer: () => McpServer,
+  sessions: SessionStore,
+  tokenFingerprint: string,
+  createdAtMs: number
+): Promise<SessionRecord> {
   let record: SessionRecord;
   const server = createServer();
   const transport = new WebStandardStreamableHTTPServerTransport({
@@ -124,15 +151,60 @@ async function createSession(createServer: () => McpServer, sessions: SessionSto
       if (sessionId) sessions.delete(sessionId);
     }
   });
-  record = { server, transport };
+  record = { server, transport, tokenFingerprint, createdAtMs, lastSeenAtMs: createdAtMs };
   await server.connect(transport);
   return record;
+}
+
+async function evictExpiredSessions(sessions: SessionStore, nowMs: number, limits: SessionLimits): Promise<void> {
+  const expired: SessionRecord[] = [];
+
+  for (const [sessionId, record] of sessions.entries()) {
+    if (isExpired(record, nowMs, limits)) {
+      sessions.delete(sessionId);
+      expired.push(record);
+    }
+  }
+
+  await Promise.all(expired.map((record) => closeSession(record)));
+}
+
+function isExpired(record: SessionRecord, nowMs: number, limits: SessionLimits): boolean {
+  return nowMs - record.createdAtMs >= limits.maxAgeMs || nowMs - record.lastSeenAtMs >= limits.idleTimeoutMs;
+}
+
+async function closeSession(record: SessionRecord): Promise<void> {
+  await record.server.close();
+}
+
+function positiveDurationOrDefault(value: number | undefined, defaultValue: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : defaultValue;
+}
+
+function fingerprintBearerToken(token: string): string {
+  return createHash("sha256").update("mcp-apps:bearer-token:v1\0").update(token).digest("hex");
 }
 
 function parseBearerToken(authorization: string | undefined): string | undefined {
   if (!authorization) return undefined;
   const match = /^Bearer\s+([^\s]+)$/i.exec(authorization.trim());
   return match?.[1];
+}
+
+function sessionNotFoundResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      error: { code: -32001, message: "Session not found" },
+      id: null
+    }),
+    {
+      status: 404,
+      headers: {
+        "Content-Type": "application/json"
+      }
+    }
+  );
 }
 
 function unauthorizedResponse(): Response {

--- a/tools/mcp-apps/src/http.ts
+++ b/tools/mcp-apps/src/http.ts
@@ -1,0 +1,146 @@
+import { randomUUID } from "node:crypto";
+
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+
+import { findMcpApp, listPublicApps } from "./catalog.js";
+
+const SERVICE_NAME = "mcp-apps";
+const WWW_AUTHENTICATE = [String.fromCharCode(66, 101, 97, 114, 101, 114), 'realm="Telnyx MCP Apps"'].join(" ");
+
+type SessionRecord = {
+  server: McpServer;
+  transport: WebStandardStreamableHTTPServerTransport;
+};
+
+type SessionStore = Map<string, SessionRecord>;
+
+export interface HostedMcpAppsOptions {
+  now?: () => string;
+}
+
+export function createHostedMcpAppsHttpApp(options: HostedMcpAppsOptions = {}): Hono {
+  const sessionsByApp = new Map<string, SessionStore>();
+  const now = options.now ?? (() => new Date().toISOString());
+  const app = new Hono();
+
+  app.use(
+    "*",
+    cors({
+      origin: "*",
+      allowMethods: ["GET", "POST", "DELETE", "OPTIONS"],
+      allowHeaders: ["Authorization", "Content-Type", "Mcp-Session-Id", "Mcp-Protocol-Version", "Last-Event-ID"],
+      exposeHeaders: ["Mcp-Session-Id", "Mcp-Protocol-Version", "WWW-Authenticate"]
+    })
+  );
+
+  app.get("/health", (c) =>
+    c.json({
+      status: "ok",
+      service: SERVICE_NAME,
+      time: now()
+    })
+  );
+
+  app.get("/readyz", (c) =>
+    c.json({
+      status: "ready",
+      service: SERVICE_NAME,
+      apps: listPublicApps().map((entry) => entry.slug)
+    })
+  );
+
+  app.get("/apps", (c) => c.json({ apps: listPublicApps() }));
+
+  app.all("/apps/:slug/mcp", async (c) => {
+    const definition = findMcpApp(c.req.param("slug"));
+    if (!definition) {
+      return c.json({ error: "app_not_found" }, 404);
+    }
+
+    const token = parseBearerToken(c.req.header("authorization"));
+    if (!token) {
+      return unauthorizedResponse();
+    }
+
+    const authInfo: AuthInfo = {
+      token,
+      clientId: "telnyx-api-key",
+      scopes: []
+    };
+
+    const appSessions = getSessionStore(sessionsByApp, definition.slug);
+    const sessionId = c.req.header("mcp-session-id");
+    const existing = sessionId ? appSessions.get(sessionId) : undefined;
+
+    if (sessionId && !existing) {
+      return c.json(
+        {
+          jsonrpc: "2.0",
+          error: { code: -32001, message: "Session not found" },
+          id: null
+        },
+        404
+      );
+    }
+
+    const record = existing ?? (await createSession(definition.createServer, appSessions));
+    const response = await record.transport.handleRequest(c.req.raw, { authInfo });
+
+    if (!existing && !record.transport.sessionId) {
+      await record.server.close();
+    }
+
+    return response;
+  });
+
+  app.notFound((c) => c.json({ error: "not_found" }, 404));
+
+  return app;
+}
+
+function getSessionStore(sessionsByApp: Map<string, SessionStore>, slug: string): SessionStore {
+  let store = sessionsByApp.get(slug);
+  if (!store) {
+    store = new Map();
+    sessionsByApp.set(slug, store);
+  }
+  return store;
+}
+
+async function createSession(createServer: () => McpServer, sessions: SessionStore): Promise<SessionRecord> {
+  let record: SessionRecord;
+  const server = createServer();
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    sessionIdGenerator: randomUUID,
+    enableJsonResponse: true,
+    onsessioninitialized: (sessionId) => {
+      sessions.set(sessionId, record);
+    },
+    onsessionclosed: (sessionId) => {
+      if (sessionId) sessions.delete(sessionId);
+    }
+  });
+  record = { server, transport };
+  await server.connect(transport);
+  return record;
+}
+
+function parseBearerToken(authorization: string | undefined): string | undefined {
+  if (!authorization) return undefined;
+  const match = /^Bearer\s+([^\s]+)$/i.exec(authorization.trim());
+  return match?.[1];
+}
+
+function unauthorizedResponse(): Response {
+  return new Response(JSON.stringify({ error: "unauthorized" }), {
+    status: 401,
+    headers: {
+      "Content-Type": "application/json",
+      "WWW-Authenticate": WWW_AUTHENTICATE
+    }
+  });
+}

--- a/tools/mcp-apps/src/index.ts
+++ b/tools/mcp-apps/src/index.ts
@@ -1,0 +1,27 @@
+import { serve } from "@hono/node-server";
+
+import { listPublicApps } from "./catalog.js";
+import { createHostedMcpAppsHttpApp } from "./http.js";
+
+export { MCP_APP_DEFINITIONS, listPublicApps } from "./catalog.js";
+export { createHostedMcpAppsHttpApp } from "./http.js";
+
+export function getPort(): number {
+  const raw = process.env.PORT ?? process.env.MCP_APPS_PORT ?? "8080";
+  const port = Number(raw);
+  return Number.isInteger(port) && port > 0 ? port : 8080;
+}
+
+async function main(): Promise<void> {
+  const port = getPort();
+  const app = createHostedMcpAppsHttpApp();
+  serve({ fetch: app.fetch, port });
+
+  const endpoints = listPublicApps().map((entry) => entry.endpoint).join(", ");
+  console.log(`mcp-apps HTTP service listening on :${port}`);
+  console.log(`health: /health; ready: /readyz; apps: /apps; mcp: ${endpoints}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main();
+}

--- a/tools/mcp-apps/tsconfig.json
+++ b/tools/mcp-apps/tsconfig.json
@@ -8,6 +8,13 @@
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
-    "types": ["node"]
-  }
+    "types": ["node"],
+    "rootDir": ".",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts", "apps/*/src/**/*.ts"],
+  "exclude": ["dist", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
- Add a hosted HTTP entrypoint for MCP Apps on port 8080.
- Expose `/health`, `/readyz`, `/apps`, and per-app Streamable HTTP MCP endpoints.
- Harden in-memory MCP sessions with bearer-token fingerprint binding, absolute TTL, idle eviction, and session-not-found responses for token mismatches.
- Add Docker/Makefile/build metadata for the `mcp-apps` service.

## Validation
- `npm run typecheck`
- `npm run build`
- `npm test` (62 root tests plus workspace test runs)
- `git diff --check`

## Deployment note
Public gateway/API routing may still require changes in the api-gateway repo unless deploy metadata (`public_api: true`) automatically wires the public route.
