### PR TITLE
Add Aaron as global code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # All changes require approval from a codeowner
-* @aisling404 @Oliver-Zimmerman @gbattistel
+* @aisling404 @Oliver-Zimmerman @aaronjo-Telnyx @gbattistel
 /plugins/opencode/ @aaronjo-Telnyx


### PR DESCRIPTION
## Summary
- Adds `@aaronjo-Telnyx` to the global CODEOWNERS rule so he has the same broad codeowner coverage as `@aisling404`, `@Oliver-Zimmerman`, and `@gbattistel`.

## Notes
- Repo permissions for `@aaronjo-Telnyx` and `@gbattistel` have already been updated to admin to match `@aisling404`.
- Branch protection already listed both users in the `main` push and PR-review bypass allowlists.