### PR TITLE
feat: publish release manifests for agent npm artifacts

### DIFF
--- a/.github/bin/check-publish-gate
+++ b/.github/bin/check-publish-gate
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Validate the repo-local re-enable checklist before any publish path runs.
+
+set -euo pipefail
+
+READOUT_ONLY=0
+CHECKLIST_PATH="${PUBLISH_GATE_CHECKLIST_PATH:-.github/release/re-enable-checklist.json}"
+NOW_OVERRIDE="${PUBLISH_GATE_NOW:-}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --readout-only)
+      READOUT_ONLY=1
+      shift
+      ;;
+    --checklist)
+      CHECKLIST_PATH="${2:?missing checklist path}"
+      shift 2
+      ;;
+    --now)
+      NOW_OVERRIDE="${2:?missing timestamp}"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+if [[ "$CHECKLIST_PATH" = /* ]]; then
+  CHECKLIST_FILE="$CHECKLIST_PATH"
+else
+  CHECKLIST_FILE="$ROOT_DIR/$CHECKLIST_PATH"
+fi
+
+write_outputs() {
+  local status="$1"
+  local reason="$2"
+  local message="$3"
+  local payload
+
+  payload="$(jq -nc \
+    --arg status "$status" \
+    --arg reason "$reason" \
+    --arg message "$message" \
+    --arg checklist "$CHECKLIST_PATH" \
+    '{status: $status, reason: $reason, message: $message, checklist: $checklist}')"
+
+  echo "$payload"
+
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    {
+      echo "publish_gate_status=$status"
+      echo "publish_gate_reason=$reason"
+      echo "publish_gate_checklist=$CHECKLIST_PATH"
+      echo "publish_gate_message<<EOF"
+      echo "$message"
+      echo "EOF"
+      echo "publish_gate_payload=$payload"
+    } >> "$GITHUB_OUTPUT"
+  fi
+}
+
+fail_gate() {
+  local reason="$1"
+  local message="$2"
+
+  write_outputs "blocked" "$reason" "$message"
+
+  if [[ "$READOUT_ONLY" -eq 1 ]]; then
+    echo "Publish gate readout: blocked by $reason" >&2
+    exit 0
+  fi
+
+  echo "::error title=Publish gate blocked::$reason $message" >&2
+  echo "Rollback path: refresh $CHECKLIST_PATH with corrected evidence/window data and rerun the workflow. No code rollback is required." >&2
+  exit 1
+}
+
+parse_timestamp() {
+  python3 - "$1" <<'PY'
+import datetime
+import sys
+
+raw = sys.argv[1].strip()
+if not raw:
+    raise SystemExit(1)
+
+normalized = raw.replace("Z", "+00:00")
+dt = datetime.datetime.fromisoformat(normalized)
+if dt.tzinfo is None:
+    raise SystemExit(1)
+
+print(int(dt.timestamp()))
+PY
+}
+
+if [[ ! -f "$CHECKLIST_FILE" ]]; then
+  fail_gate "CHECKLIST_MISSING" "Checklist file not found at $CHECKLIST_PATH."
+fi
+
+if ! jq -e . "$CHECKLIST_FILE" >/dev/null 2>&1; then
+  fail_gate "CHECKLIST_INVALID" "Checklist file at $CHECKLIST_PATH is not valid JSON."
+fi
+
+STATE="$(jq -r '.state // empty' "$CHECKLIST_FILE")"
+if [[ -z "$STATE" ]]; then
+  fail_gate "CHECKLIST_INVALID" "Checklist file at $CHECKLIST_PATH is missing .state."
+fi
+STATE="$(printf '%s' "$STATE" | tr '[:lower:]' '[:upper:]')"
+
+if [[ "$STATE" == "EXPIRED" ]]; then
+  fail_gate "CHECKLIST_EXPIRED" "Checklist state is EXPIRED."
+fi
+
+if [[ "$STATE" != "APPROVED" ]]; then
+  fail_gate "CHECKLIST_NOT_APPROVED" "Checklist state must be APPROVED before publish can proceed; found $STATE."
+fi
+
+WINDOW_START="$(jq -r '.window.startsAt // empty' "$CHECKLIST_FILE")"
+WINDOW_END="$(jq -r '.window.expiresAt // empty' "$CHECKLIST_FILE")"
+if [[ -z "$WINDOW_START" || -z "$WINDOW_END" ]]; then
+  fail_gate "CHECKLIST_INVALID" "Checklist must include window.startsAt and window.expiresAt."
+fi
+
+if ! START_TS="$(parse_timestamp "$WINDOW_START" 2>/dev/null)"; then
+  fail_gate "CHECKLIST_INVALID" "window.startsAt is not a valid RFC 3339 timestamp."
+fi
+
+if ! END_TS="$(parse_timestamp "$WINDOW_END" 2>/dev/null)"; then
+  fail_gate "CHECKLIST_INVALID" "window.expiresAt is not a valid RFC 3339 timestamp."
+fi
+
+NOW_VALUE="${NOW_OVERRIDE:-$(date -u +"%Y-%m-%dT%H:%M:%SZ")}"
+if ! NOW_TS="$(parse_timestamp "$NOW_VALUE" 2>/dev/null)"; then
+  fail_gate "CHECKLIST_INVALID" "Current gate time is not a valid RFC 3339 timestamp: $NOW_VALUE."
+fi
+
+if (( NOW_TS < START_TS )); then
+  fail_gate "CHECKLIST_WINDOW_NOT_OPEN" "Checklist approval window does not open until $WINDOW_START."
+fi
+
+if (( NOW_TS > END_TS )); then
+  fail_gate "CHECKLIST_EXPIRED" "Checklist approval window expired at $WINDOW_END."
+fi
+
+APPROVER_NAME="$(jq -r '.approver.name // empty' "$CHECKLIST_FILE")"
+APPROVER_EMAIL="$(jq -r '.approver.email // empty' "$CHECKLIST_FILE")"
+APPROVED_AT="$(jq -r '.approver.approvedAt // empty' "$CHECKLIST_FILE")"
+if [[ -z "$APPROVER_NAME" || -z "$APPROVER_EMAIL" || -z "$APPROVED_AT" ]]; then
+  fail_gate "APPROVER_SIGNOFF_MISSING" "Checklist must include approver.name, approver.email, and approver.approvedAt."
+fi
+
+if ! APPROVED_TS="$(parse_timestamp "$APPROVED_AT" 2>/dev/null)"; then
+  fail_gate "CHECKLIST_INVALID" "approver.approvedAt is not a valid RFC 3339 timestamp."
+fi
+
+if (( APPROVED_TS < START_TS || APPROVED_TS > END_TS )); then
+  fail_gate "APPROVER_SIGNOFF_INVALID" "approver.approvedAt must fall within the approval window."
+fi
+
+REQUIRED_COUNT="$(jq '[.items[]? | select((.required // false) == true)] | length' "$CHECKLIST_FILE")"
+if [[ "$REQUIRED_COUNT" == "0" ]]; then
+  fail_gate "CHECKLIST_INVALID" "Checklist must define at least one required item."
+fi
+
+INCOMPLETE_ITEMS="$(jq -r '[.items[]? | select((.required // false) == true and (.passed // false) != true) | .id // .title // "unnamed-item"] | join(",")' "$CHECKLIST_FILE")"
+if [[ -n "$INCOMPLETE_ITEMS" ]]; then
+  fail_gate "CHECKLIST_ITEMS_INCOMPLETE" "Required checklist items are not passed: $INCOMPLETE_ITEMS."
+fi
+
+ITEMS_WITHOUT_EVIDENCE="$(jq -r '[.items[]? | select((.required // false) == true and (((.evidence // []) | type) != "array" or ((.evidence // []) | length) == 0)) | .id // .title // "unnamed-item"] | join(",")' "$CHECKLIST_FILE")"
+if [[ -n "$ITEMS_WITHOUT_EVIDENCE" ]]; then
+  fail_gate "EVIDENCE_MISSING" "Required checklist items are missing evidence: $ITEMS_WITHOUT_EVIDENCE."
+fi
+
+write_outputs "approved" "APPROVED" "Checklist is approved and within the active re-enable window."

--- a/.github/bin/check-release-environment
+++ b/.github/bin/check-release-environment
@@ -5,6 +5,14 @@ set -eu
 
 errors=()
 
+# Read out the publish gate state without blocking PR validation. Publish jobs
+# enforce the same gate in strict mode before any package publish step runs.
+if ! GATE_READOUT="$(bash ./.github/bin/check-publish-gate --readout-only 2>&1)"; then
+  errors+=("Publish gate readout failed unexpectedly: $GATE_READOUT")
+else
+  echo "Publish gate status: $GATE_READOUT"
+fi
+
 # Check no internal URLs leaked into publishable files
 INTERNAL_HITS=$(grep -r "\.query\.prod\.telnyx\.io\|\.query\.dev\.telnyx\.io\|\.service\.consul\|\.internal\.telnyx" \
   tools/python/telnyx_agent_toolkit/ tools/typescript/src/ cli/src/ \

--- a/.github/bin/publish-npm
+++ b/.github/bin/publish-npm
@@ -1,30 +1,72 @@
 #!/usr/bin/env bash
-# Publish @telnyx/agent-toolkit and @telnyx/agent-cli to npm using OIDC.
+# Publish @telnyx packages to npm using OIDC and emit a machine-readable
+# publish-alert evidence bundle for downstream incident handling.
 # Called from the publish-npm.yml workflow — no NPM_TOKEN needed.
-# Adapted from team-telnyx/telnyx-node/bin/publish-npm.
 
-set -eux
+set -euo pipefail
 
 PACKAGE_DIR="${1:-.}"
 
 cd "$PACKAGE_DIR"
 
+PUBLISH_RESULT="error"
+PUBLISH_PROVENANCE_MODE="unknown"
+PUBLISH_CREDENTIAL_SOURCE="unknown"
+PACKAGE_NAME=""
+VERSION=""
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+EVIDENCE_DIR="$REPO_ROOT/.github/artifacts/publish-alert-evidence"
+MISSING_MAINTAINERS_JSON='[]'
+
+write_evidence_bundle() {
+  if [[ -z "$PACKAGE_NAME" || -z "$VERSION" ]]; then
+    return
+  fi
+
+  local safe_package_name
+  safe_package_name="${PACKAGE_NAME//@/}"
+  safe_package_name="${safe_package_name//\//-}"
+
+  PUBLISH_PROVENANCE_MODE="$PUBLISH_PROVENANCE_MODE" \
+  PUBLISH_CREDENTIAL_SOURCE="$PUBLISH_CREDENTIAL_SOURCE" \
+  NPM_PACKAGE_MAINTAINERS_JSON="${NPM_PACKAGE_MAINTAINERS_JSON:-$MISSING_MAINTAINERS_JSON}" \
+  node "$REPO_ROOT/.github/bin/write-publish-alert-evidence.mjs" \
+    "$PACKAGE_DIR" \
+    "$EVIDENCE_DIR/${safe_package_name}-${VERSION}.json" \
+    "$PUBLISH_RESULT"
+}
+
+trap 'status=$?; if [[ $status -eq 0 && "$PUBLISH_RESULT" == "error" ]]; then PUBLISH_RESULT="success"; fi; write_evidence_bundle; exit $status' EXIT
+
 # Authenticate — prefer OIDC, fall back to NPM_TOKEN
 if [[ ${NPM_TOKEN:-} ]]; then
+  PUBLISH_PROVENANCE_MODE="npm_token"
+  PUBLISH_CREDENTIAL_SOURCE="NPM_TOKEN"
   npm config set '//registry.npmjs.org/:_authToken' "$NPM_TOKEN"
 elif [[ ! ${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-} ]]; then
   echo "ERROR: NPM_TOKEN must be set if not running in a GitHub Action with id-token permission"
   exit 1
+else
+  PUBLISH_PROVENANCE_MODE="github_actions_oidc"
+  PUBLISH_CREDENTIAL_SOURCE="github_actions_oidc"
 fi
-
-# Build (CLI has a no-op build, TS SDK compiles)
-npm run build
 
 # Get package info
 PACKAGE_NAME="$(jq -r -e '.name' ./package.json)"
 VERSION="$(jq -r -e '.version' ./package.json)"
 
 echo "Publishing $PACKAGE_NAME@$VERSION"
+
+# Build (CLI has a no-op build, TS SDK compiles)
+npm run build
+
+# Best-effort registry owner snapshot for the evidence bundle.
+if MAINTAINERS_JSON="$(npm view "$PACKAGE_NAME" maintainers --json 2>/dev/null || true)"; then
+  if [[ -n "$MAINTAINERS_JSON" && "$MAINTAINERS_JSON" != "null" ]]; then
+    NPM_PACKAGE_MAINTAINERS_JSON="$MAINTAINERS_JSON"
+  fi
+fi
 
 # Get latest version from npm
 NPM_INFO="$(npm view "$PACKAGE_NAME" version --json 2>/dev/null || true)"
@@ -42,6 +84,7 @@ fi
 
 if [[ "$LAST_VERSION" == "$VERSION" ]]; then
   echo "$PACKAGE_NAME@$VERSION is already published on npm; skipping publish."
+  PUBLISH_RESULT="skipped"
   exit 0
 fi
 
@@ -56,3 +99,4 @@ fi
 
 # Use the system npm (Node 24 ships npm 11+) for OIDC provenance
 npm publish --access public --no-git-checks --tag "$TAG"
+PUBLISH_RESULT="success"

--- a/.github/bin/publish-npm
+++ b/.github/bin/publish-npm
@@ -21,6 +21,7 @@ PACKAGE_NAME=""
 VERSION=""
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 EVIDENCE_DIR="$REPO_ROOT/.github/artifacts/publish-alert-evidence"
+MANIFEST_ROOT="$REPO_ROOT/.github/artifacts/release-manifests"
 MISSING_MAINTAINERS_JSON='[]'
 
 write_evidence_bundle() {
@@ -59,11 +60,22 @@ fi
 # Get package info
 PACKAGE_NAME="$(jq -r -e '.name' ./package.json)"
 VERSION="$(jq -r -e '.version' ./package.json)"
+SAFE_PACKAGE_NAME="${PACKAGE_NAME//@/}"
+SAFE_PACKAGE_NAME="${SAFE_PACKAGE_NAME//\//-}"
 
 echo "Publishing $PACKAGE_NAME@$VERSION"
 
 # Build (CLI has a no-op build, TS SDK compiles)
 npm run build
+
+PACK_DIR="$MANIFEST_ROOT/$SAFE_PACKAGE_NAME/$VERSION/payload"
+MANIFEST_DIR="$MANIFEST_ROOT/$SAFE_PACKAGE_NAME/$VERSION"
+rm -rf "$PACK_DIR"
+mkdir -p "$PACK_DIR"
+
+PACK_RESULT_JSON="$(npm pack --json --pack-destination "$PACK_DIR")"
+PACK_FILENAME="$(echo "$PACK_RESULT_JSON" | jq -r -e '.[0].filename')"
+PACK_TARBALL="$PACK_DIR/$PACK_FILENAME"
 
 # Best-effort registry owner snapshot for the evidence bundle.
 if MAINTAINERS_JSON="$(npm view "$PACKAGE_NAME" maintainers --json 2>/dev/null || true)"; then
@@ -104,3 +116,12 @@ fi
 # Use the system npm (Node 24 ships npm 11+) for OIDC provenance
 npm publish --access public --no-git-checks --tag "$TAG"
 PUBLISH_RESULT="success"
+
+if [[ -n "${RELEASE_TAG:-}" ]]; then
+  node "$REPO_ROOT/.github/scripts/release-manifest.mjs" \
+    "$PACKAGE_DIR" \
+    "$MANIFEST_DIR" \
+    "$PACK_TARBALL"
+else
+  echo "RELEASE_TAG is not set; skipping release manifest generation."
+fi

--- a/.github/bin/publish-npm
+++ b/.github/bin/publish-npm
@@ -6,6 +6,11 @@
 set -euo pipefail
 
 PACKAGE_DIR="${1:-.}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+# No undocumented bypass: manual invocations use the same repo-local publish gate
+# as the GitHub Actions workflows.
+bash "$SCRIPT_DIR/check-publish-gate"
 
 cd "$PACKAGE_DIR"
 
@@ -14,7 +19,6 @@ PUBLISH_PROVENANCE_MODE="unknown"
 PUBLISH_CREDENTIAL_SOURCE="unknown"
 PACKAGE_NAME=""
 VERSION=""
-SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 EVIDENCE_DIR="$REPO_ROOT/.github/artifacts/publish-alert-evidence"
 MISSING_MAINTAINERS_JSON='[]'

--- a/.github/bin/publish-pypi
+++ b/.github/bin/publish-pypi
@@ -4,7 +4,13 @@
 
 set -eux
 
-cd "$(dirname "$0")/../../tools/python"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# No undocumented bypass: manual invocations use the same repo-local publish gate
+# as the GitHub Actions workflows.
+bash "$SCRIPT_DIR/check-publish-gate"
+
+cd "$SCRIPT_DIR/../../tools/python"
 
 # Clean previous builds
 rm -rf dist

--- a/.github/bin/write-publish-alert-evidence.mjs
+++ b/.github/bin/write-publish-alert-evidence.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { execFileSync } from "node:child_process";
+
+function run(command, args, options = {}) {
+  try {
+    return execFileSync(command, args, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      ...options,
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+function envValue(name) {
+  const value = process.env[name];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function withMissing(key, value, fallback = "unknown") {
+  const missing = value == null || value === "";
+  return {
+    [key]: missing ? fallback : value,
+    [`missing_${key}`]: missing,
+  };
+}
+
+function parseJson(value) {
+  if (!value) return null;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+const [packageDirArg, outputPathArg, publishResultArg] = process.argv.slice(2);
+
+if (!packageDirArg || !outputPathArg) {
+  console.error("Usage: write-publish-alert-evidence.mjs <package-dir> <output-path> [publish-result]");
+  process.exit(1);
+}
+
+const packageDir = resolve(packageDirArg);
+const outputPath = resolve(outputPathArg);
+const publishResult = publishResultArg || "unknown";
+const packageJson = JSON.parse(readFileSync(resolve(packageDir, "package.json"), "utf8"));
+
+const repository = envValue("GITHUB_REPOSITORY");
+const runId = envValue("GITHUB_RUN_ID");
+const runAttempt = envValue("GITHUB_RUN_ATTEMPT");
+const serverUrl = envValue("GITHUB_SERVER_URL") || "https://github.com";
+const workflowName = envValue("GITHUB_WORKFLOW");
+const workflowRef = envValue("GITHUB_WORKFLOW_REF");
+const workflowSha = envValue("GITHUB_WORKFLOW_SHA");
+const commitSha = envValue("GITHUB_SHA") || run("git", ["rev-parse", "HEAD"], { cwd: packageDir });
+const commitBranch =
+  envValue("GITHUB_HEAD_REF") ||
+  envValue("GITHUB_REF_NAME") ||
+  run("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd: packageDir });
+const commitAuthor = run("git", ["log", "-1", "--pretty=%an <%ae>"], { cwd: packageDir });
+
+const ownerSnapshotRaw = parseJson(envValue("NPM_PACKAGE_MAINTAINERS_JSON"));
+const ownerSnapshot =
+  ownerSnapshotRaw && Array.isArray(ownerSnapshotRaw)
+    ? {
+        source: "npm_view_maintainers",
+        fetched_at_utc: new Date().toISOString(),
+        owners: ownerSnapshotRaw.map((owner) => ({
+          name: owner?.name ?? "unknown",
+          email: owner?.email ?? "unknown",
+        })),
+      }
+    : {
+        source: "unavailable",
+        fetched_at_utc: new Date().toISOString(),
+        owners: [],
+        note: "Maintainer snapshot unavailable from workflow-visible npm metadata.",
+      };
+
+const artifactUrls = [];
+if (repository && runId) {
+  artifactUrls.push(`${serverUrl}/${repository}/actions/runs/${runId}`);
+}
+if (repository && workflowRef && workflowSha) {
+  artifactUrls.push(`${serverUrl}/${repository}/blob/${workflowSha}/${workflowRef.split("@")[0]}`);
+}
+artifactUrls.push(outputPath);
+
+const provenanceMode = envValue("PUBLISH_PROVENANCE_MODE") || "unknown";
+const credentialSource = envValue("PUBLISH_CREDENTIAL_SOURCE") || "unknown";
+const containmentState = {
+  status: publishResult === "success" ? "monitoring" : publishResult === "skipped" ? "not_required" : "needs_triage",
+  owner: "release-engineering",
+  credential_source: credentialSource,
+  registry_webhook_configured: false,
+  publish_result: publishResult,
+  notes:
+    publishResult === "success"
+      ? "No automated containment action was required at publish time."
+      : "Publish did not complete successfully; human follow-up may be required.",
+};
+
+const payload = {
+  ...withMissing("timestamp_utc", new Date().toISOString()),
+  event_type: "npm_publish_alert",
+  missing_event_type: false,
+  detector_id: "github-actions:publish-npm",
+  missing_detector_id: false,
+  package_name: packageJson.name ?? "unknown",
+  missing_package_name: !packageJson.name,
+  package_path: packageDirArg,
+  missing_package_path: !packageDirArg,
+  package_version: packageJson.version ?? "unknown",
+  missing_package_version: !packageJson.version,
+  registry_name: "npm",
+  missing_registry_name: false,
+  ...withMissing("ci_workflow", workflowName),
+  ...withMissing("ci_run_id", runId),
+  ...withMissing("commit_sha", commitSha),
+  ...withMissing("commit_author", commitAuthor),
+  ...withMissing("commit_branch", commitBranch),
+  artifact_urls: artifactUrls,
+  missing_artifact_urls: artifactUrls.length === 0,
+  artifact_hash: "pending",
+  missing_artifact_hash: false,
+  provenance_mode: provenanceMode,
+  missing_provenance_mode: provenanceMode === "unknown",
+  owner_state_snapshot: ownerSnapshot,
+  missing_owner_state_snapshot: ownerSnapshot.source === "unavailable",
+  containment_state: containmentState,
+  missing_containment_state: false,
+};
+
+const digestPayload = { ...payload, artifact_hash: "sha256:pending" };
+const artifactHash = `sha256:${createHash("sha256").update(JSON.stringify(digestPayload)).digest("hex")}`;
+payload.artifact_hash = artifactHash;
+
+mkdirSync(dirname(outputPath), { recursive: true });
+writeFileSync(outputPath, `${JSON.stringify(payload, null, 2)}\n`);

--- a/.github/release/README.md
+++ b/.github/release/README.md
@@ -1,0 +1,37 @@
+# Publish Re-Enable Checklist
+
+This directory holds the repo-local publish re-enable record used by `.github/bin/check-publish-gate`.
+
+- Source of truth: `.github/release/re-enable-checklist.json`
+- Required publish state: `APPROVED`
+- Enforced on: `.github/workflows/publish-npm.yml`, `.github/workflows/publish-pypi.yml`, and direct calls to `.github/bin/publish-npm` / `.github/bin/publish-pypi`
+
+Required checklist states follow the TEL-70 model:
+
+- `OPEN`
+- `IN_REVIEW`
+- `APPROVED`
+- `FAILED`
+- `EXPIRED`
+
+Each required item must have:
+
+- `required: true`
+- `passed: true`
+- at least one evidence entry in `evidence`
+
+The top-level approval window must stay current:
+
+- `window.startsAt`
+- `window.expiresAt`
+- `approver.name`
+- `approver.email`
+- `approver.approvedAt`
+
+False-positive rollback path:
+
+1. Refresh `.github/release/re-enable-checklist.json` with corrected evidence, signoff, or time-window values.
+2. Commit that change to the branch that triggers publish.
+3. Rerun the publish workflow with the same package selection. No code rollback is required.
+
+There is no separate manual override or unpause bypass in this repo. Manual `workflow_dispatch` runs use the same checklist gate as release-triggered publishes.

--- a/.github/release/re-enable-checklist.json
+++ b/.github/release/re-enable-checklist.json
@@ -1,0 +1,39 @@
+{
+  "version": 1,
+  "state": "OPEN",
+  "requestId": "replace-with-approved-request-id",
+  "requestedAt": "2026-05-22T00:00:00Z",
+  "window": {
+    "startsAt": "2026-05-22T00:00:00Z",
+    "expiresAt": "2026-05-22T23:59:59Z"
+  },
+  "approver": {
+    "name": "",
+    "email": "",
+    "approvedAt": ""
+  },
+  "items": [
+    {
+      "id": "credential_rotation",
+      "title": "Credential rotation evidence recorded",
+      "required": true,
+      "passed": false,
+      "evidence": []
+    },
+    {
+      "id": "review_signoff",
+      "title": "Reviewer signoff recorded",
+      "required": true,
+      "passed": false,
+      "evidence": []
+    },
+    {
+      "id": "replacement_package_validation",
+      "title": "Replacement package validation output recorded",
+      "required": true,
+      "passed": false,
+      "evidence": []
+    }
+  ],
+  "notes": "Template record. Update this file with approved evidence and a fresh approval window before rerunning publish."
+}

--- a/.github/scripts/normalize-gitleaks-results.mjs
+++ b/.github/scripts/normalize-gitleaks-results.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+
+const args = parseArgs(process.argv.slice(2));
+const repoRoot = resolve(args.repoRoot ?? ".");
+const inventoryPath = resolve(
+  repoRoot,
+  args.inventory ?? "docs/tel-36-ai-tooling-package-inventory.json"
+);
+const outputPath = resolve(
+  repoRoot,
+  args.output ?? "secret-scan-results.jsonl"
+);
+
+const findings = loadRawFindings(resolve(repoRoot, args.input ?? "gitleaks-report.json"));
+const inventory = JSON.parse(readFileSync(inventoryPath, "utf8"));
+const normalized = findings
+  .map((finding) => normalizeFinding(finding, inventory, repoRoot))
+  .filter(Boolean);
+
+mkdirSync(dirname(outputPath), { recursive: true });
+writeFileSync(
+  outputPath,
+  normalized.map((finding) => JSON.stringify(finding)).join("\n") + (normalized.length ? "\n" : ""),
+  "utf8"
+);
+
+function parseArgs(argv) {
+  const parsed = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith("--")) continue;
+    const key = token.slice(2);
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) {
+      parsed[key] = true;
+      continue;
+    }
+    parsed[key] = next;
+    index += 1;
+  }
+  return parsed;
+}
+
+function loadRawFindings(inputPath) {
+  const raw = readFileSync(inputPath, "utf8").trim();
+  if (!raw) return [];
+  const parsed = JSON.parse(raw);
+  if (Array.isArray(parsed)) return parsed;
+  if (Array.isArray(parsed.findings)) return parsed.findings;
+  if (Array.isArray(parsed.results)) return parsed.results;
+  return [];
+}
+
+function normalizeFinding(finding, inventory, repoRootPath) {
+  const repoRelativePath = normalizePath(relative(repoRootPath, resolve(repoRootPath, finding.File || finding.file || "")));
+  if (!isTargetSurface(repoRelativePath)) {
+    return null;
+  }
+
+  const route = selectRoute(repoRelativePath, inventory);
+  const classification = classifyFinding(finding, repoRelativePath);
+  const escalated =
+    classification.validation_status === "confirmed_live" ||
+    classification.finding_class === "publish_credential";
+
+  return {
+    finding_id: createFindingId(finding, repoRelativePath),
+    scanner: "gitleaks",
+    rule_id: finding.RuleID ?? finding.ruleID ?? "unknown",
+    description: finding.Description ?? finding.description ?? null,
+    file_path: repoRelativePath,
+    line: finding.StartLine ?? finding.startLine ?? finding.line ?? null,
+    commit: finding.Commit ?? finding.commit ?? null,
+    secret_redacted: redactSecret(
+      finding.Secret ?? finding.secret ?? finding.Match ?? finding.match ?? ""
+    ),
+    match_redacted: redactMatch(
+      finding.Match ?? finding.match ?? "",
+      finding.Secret ?? finding.secret ?? ""
+    ),
+    owner_route: {
+      route_key: route.routeKey,
+      owner_team: route.ownerTeam,
+      owner_label: route.ownerLabel,
+      path_prefix: route.pathPrefix,
+      surface: route.surface
+    },
+    classification,
+    triage_state: escalated ? "cto_escalated" : "owner_routed",
+    escalation: {
+      target: escalated ? "cto" : null,
+      reason: escalated
+        ? classification.validation_status === "confirmed_live"
+          ? "confirmed_live_credential"
+          : "publish_credential_class"
+        : null,
+      required: escalated
+    }
+  };
+}
+
+function normalizePath(value) {
+  return value.split("\\").join("/").replace(/^\.\//, "");
+}
+
+function isTargetSurface(path) {
+  return [
+    "guides/",
+    "inference/",
+    "skills/",
+    "providers/",
+    "plugins/",
+    "cli/",
+    "tools/",
+    "README.md",
+    "agent.json",
+    "gemini-extension.json"
+  ].some((prefix) => path === prefix || path.startsWith(prefix));
+}
+
+function selectRoute(path, inventory) {
+  const routes = [...(inventory.routes ?? [])].sort(
+    (left, right) => right.pathPrefix.length - left.pathPrefix.length
+  );
+  return routes.find((route) => path === route.pathPrefix || path.startsWith(route.pathPrefix)) ?? inventory.defaultRoute;
+}
+
+function classifyFinding(finding, path) {
+  const haystack = [
+    finding.RuleID,
+    finding.Description,
+    finding.Match,
+    finding.Secret,
+    path
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+
+  const confirmed =
+    isTrue(finding.live) ||
+    isTrue(finding.verified) ||
+    isTrue(finding.validated) ||
+    isTrue(finding.confirmed) ||
+    isConfirmedString(finding.validation_status) ||
+    isConfirmedString(finding.validationStatus);
+
+  const publishCredential =
+    /(npm|node_auth_token|pypi|twine|rubygems|gemfury|package[-_ ]registry|publish[-_ ]token|packagecloud)/i.test(
+      haystack
+    );
+
+  return {
+    finding_class: publishCredential
+      ? "publish_credential"
+      : confirmed
+        ? "live_credential"
+        : "unconfirmed_secret",
+    validation_status: confirmed ? "confirmed_live" : "unconfirmed"
+  };
+}
+
+function isTrue(value) {
+  return value === true || value === 1 || value === "true";
+}
+
+function isConfirmedString(value) {
+  return typeof value === "string" && ["live", "confirmed", "valid", "active"].includes(value.toLowerCase());
+}
+
+function redactSecret(value) {
+  if (!value) return null;
+  if (value.length <= 4) return "*".repeat(value.length);
+  return `${value.slice(0, 2)}***${value.slice(-2)}`;
+}
+
+function redactMatch(match, secret) {
+  if (!match) return null;
+  if (secret && match.includes(secret)) {
+    return match.split(secret).join(redactSecret(secret));
+  }
+  return match.replace(/[A-Za-z0-9_\/+=-]{8,}/g, (token) => redactSecret(token));
+}
+
+function createFindingId(finding, path) {
+  const stable = [
+    path,
+    finding.RuleID ?? finding.ruleID ?? "",
+    finding.StartLine ?? finding.startLine ?? finding.line ?? "",
+    finding.Commit ?? finding.commit ?? "",
+    finding.Match ?? finding.match ?? ""
+  ].join(":");
+  return createHash("sha256").update(stable).digest("hex").slice(0, 16);
+}

--- a/.github/scripts/release-manifest.mjs
+++ b/.github/scripts/release-manifest.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const MUTABLE_URL_PATTERN = /(^|[/?#._=-])(latest|main|master)([/?#._=-]|$)/i;
+const HEX_40_PATTERN = /^[0-9a-f]{40}$/;
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+export function detectMime(filename) {
+  if (filename.endsWith(".tgz")) return "application/gzip";
+  if (filename.endsWith(".tar.gz")) return "application/gzip";
+  if (filename.endsWith(".zip")) return "application/zip";
+  if (filename.endsWith(".json")) return "application/json";
+  return "application/octet-stream";
+}
+
+export function isImmutableUrl(url, tag, version) {
+  if (!url.startsWith("https://")) return false;
+  if (MUTABLE_URL_PATTERN.test(url)) return false;
+
+  const lowered = url.toLowerCase();
+  return lowered.includes(tag.toLowerCase()) || lowered.includes(version.toLowerCase());
+}
+
+export function toChecksums(entries) {
+  return entries.map((entry) => `${entry.sha256}  ${entry.path}`).join("\n") + "\n";
+}
+
+export function verifyManifest(manifest, checksums, releaseFiles, version) {
+  assert(manifest.manifest_version === "1.0.0", "manifest_version must be 1.0.0");
+  assert(["mcp", "plugin", "agent"].includes(manifest.artifact_type), "artifact_type must be mcp, plugin, or agent");
+  assert(HEX_40_PATTERN.test(manifest.commit), "commit must be a 40-character lowercase hex SHA");
+
+  const sortedPaths = [...manifest.files.map((file) => file.path)].sort();
+  assert(
+    JSON.stringify(sortedPaths) === JSON.stringify(manifest.files.map((file) => file.path)),
+    "manifest files must be sorted by path",
+  );
+
+  const checksumEntries = new Map();
+  for (const line of checksums.trim().split("\n")) {
+    const match = line.match(/^([0-9a-f]{64})  (.+)$/);
+    assert(match, `invalid checksum line: ${line}`);
+    checksumEntries.set(match[2], match[1]);
+  }
+
+  const payloadPaths = new Set(releaseFiles.map((file) => file.path));
+
+  for (const file of manifest.files) {
+    assert(payloadPaths.has(file.path), `manifest path missing from release payload: ${file.path}`);
+    assert(checksumEntries.has(file.path), `manifest path missing from SHA256SUMS: ${file.path}`);
+    assert(checksumEntries.get(file.path) === file.sha256, `checksum mismatch for ${file.path}`);
+    assert(isImmutableUrl(file.url, manifest.tag, version), `mutable or non-versioned URL: ${file.url}`);
+  }
+
+  for (const file of releaseFiles) {
+    assert(manifest.files.some((entry) => entry.path === file.path), `release payload file missing from manifest: ${file.path}`);
+  }
+}
+
+export async function buildManifest({
+  artifactName,
+  artifactType,
+  buildTimestamp,
+  commit,
+  releaseChannel,
+  tag,
+  version,
+  releaseFiles,
+}) {
+  const files = [...releaseFiles]
+    .sort((a, b) => a.path.localeCompare(b.path))
+    .map((file) => ({
+      path: file.path,
+      sha256: file.sha256,
+      size: file.size,
+      mime: file.mime,
+      url: file.url,
+    }));
+
+  const manifest = {
+    manifest_version: "1.0.0",
+    artifact_type: artifactType,
+    artifact_name: artifactName,
+    tag,
+    commit,
+    build_timestamp: buildTimestamp,
+    release_channel: releaseChannel,
+    files,
+  };
+
+  verifyManifest(manifest, toChecksums(files), releaseFiles, version);
+  return manifest;
+}
+
+async function sha256File(filePath) {
+  const buffer = await readFile(filePath);
+  return createHash("sha256").update(buffer).digest("hex");
+}
+
+async function git(args, cwd) {
+  const { stdout } = await execFileAsync("git", args, { cwd });
+  return stdout.trim();
+}
+
+async function fetchBuffer(url) {
+  const response = await fetch(url);
+  assert(response.ok, `failed to fetch ${url}: ${response.status} ${response.statusText}`);
+  return Buffer.from(await response.arrayBuffer());
+}
+
+async function main() {
+  const [, , packageDirArg, outputDirArg, tarballPathArg] = process.argv;
+  assert(packageDirArg, "usage: release-manifest.mjs <package-dir> <output-dir> <local-tarball>");
+  assert(outputDirArg, "output directory is required");
+  assert(tarballPathArg, "local tarball path is required");
+
+  const packageDir = path.resolve(packageDirArg);
+  const outputDir = path.resolve(outputDirArg);
+  const tarballPath = path.resolve(tarballPathArg);
+
+  const releaseTag = process.env.RELEASE_TAG;
+  const releaseChannel = process.env.RELEASE_CHANNEL ?? "production";
+  const artifactType = process.env.RELEASE_ARTIFACT_TYPE ?? "agent";
+
+  assert(releaseTag, "RELEASE_TAG must be set");
+
+  const packageJson = JSON.parse(await readFile(path.join(packageDir, "package.json"), "utf8"));
+  const packageName = packageJson.name;
+  const version = packageJson.version;
+  const safePackageName = packageName.replace(/^@/, "").replace(/\//g, "-");
+
+  const commit = await git(["rev-list", "-n", "1", releaseTag], packageDir);
+  assert(HEX_40_PATTERN.test(commit), `tag ${releaseTag} did not resolve to a 40-character commit SHA`);
+
+  const tarballUrl = JSON.parse(
+    (await execFileAsync("npm", ["view", `${packageName}@${version}`, "dist.tarball", "--json"], { cwd: packageDir })).stdout,
+  );
+  assert(isImmutableUrl(tarballUrl, releaseTag, version), `npm dist.tarball URL is mutable or missing version/tag: ${tarballUrl}`);
+
+  const localSha256 = await sha256File(tarballPath);
+  const remoteTarball = await fetchBuffer(tarballUrl);
+  const remoteSha256 = createHash("sha256").update(remoteTarball).digest("hex");
+  assert(localSha256 === remoteSha256, `published tarball hash mismatch for ${packageName}@${version}`);
+
+  const tarballStat = await stat(tarballPath);
+  const tarballName = path.basename(tarballPath);
+
+  const releaseFiles = [
+    {
+      path: tarballName,
+      sha256: localSha256,
+      size: tarballStat.size,
+      mime: detectMime(tarballName),
+      url: tarballUrl,
+    },
+  ];
+
+  const buildTimestamp = new Date().toISOString();
+  const manifest = await buildManifest({
+    artifactName: packageName,
+    artifactType,
+    buildTimestamp,
+    commit,
+    releaseChannel,
+    tag: releaseTag,
+    version,
+    releaseFiles,
+  });
+
+  const checksums = toChecksums(manifest.files);
+
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(path.join(outputDir, "release-manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+  await writeFile(path.join(outputDir, "SHA256SUMS"), checksums);
+
+  const assetBaseName = `${safePackageName}-${version}`;
+  await writeFile(path.join(outputDir, `${assetBaseName}.release-manifest.json`), `${JSON.stringify(manifest, null, 2)}\n`);
+  await writeFile(path.join(outputDir, `${assetBaseName}.SHA256SUMS`), checksums);
+
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        packageName,
+        version,
+        releaseTag,
+        tarballUrl,
+        outputDir,
+        manifestPath: path.join(outputDir, "release-manifest.json"),
+        checksumsPath: path.join(outputDir, "SHA256SUMS"),
+        uploadManifestPath: path.join(outputDir, `${assetBaseName}.release-manifest.json`),
+        uploadChecksumsPath: path.join(outputDir, `${assetBaseName}.SHA256SUMS`),
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+
+if (isMain) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}

--- a/.github/scripts/release-manifest.test.mjs
+++ b/.github/scripts/release-manifest.test.mjs
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildManifest, isImmutableUrl, toChecksums, verifyManifest } from "./release-manifest.mjs";
+
+test("isImmutableUrl rejects mutable selectors and requires https", () => {
+  assert.equal(isImmutableUrl("https://registry.npmjs.org/@telnyx/agent-cli/-/agent-cli-0.3.0.tgz", "v0.3.0", "0.3.0"), true);
+  assert.equal(isImmutableUrl("https://example.com/download/latest/agent-cli.tgz", "v0.3.0", "0.3.0"), false);
+  assert.equal(isImmutableUrl("http://example.com/v0.3.0/agent-cli.tgz", "v0.3.0", "0.3.0"), false);
+});
+
+test("buildManifest emits deterministic manifest and matching checksums", async () => {
+  const releaseFiles = [
+    {
+      path: "telnyx-agent-cli-0.3.0.tgz",
+      sha256: "a".repeat(64),
+      size: 123,
+      mime: "application/gzip",
+      url: "https://registry.npmjs.org/@telnyx/agent-cli/-/agent-cli-0.3.0.tgz",
+    },
+  ];
+
+  const manifest = await buildManifest({
+    artifactName: "@telnyx/agent-cli",
+    artifactType: "agent",
+    buildTimestamp: "2026-05-22T12:00:00.000Z",
+    commit: "b".repeat(40),
+    releaseChannel: "production",
+    tag: "v0.3.0",
+    version: "0.3.0",
+    releaseFiles,
+  });
+
+  assert.deepEqual(manifest.files, releaseFiles);
+
+  const checksums = toChecksums(manifest.files);
+  assert.equal(checksums, `${"a".repeat(64)}  telnyx-agent-cli-0.3.0.tgz\n`);
+
+  assert.doesNotThrow(() => verifyManifest(manifest, checksums, releaseFiles, "0.3.0"));
+});

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -53,6 +53,14 @@ jobs:
       - name: Publish @telnyx/agent-toolkit
         run: bash ./.github/bin/publish-npm tools/typescript
 
+      - name: Upload publish evidence bundle
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: publish-alert-evidence-typescript
+          path: .github/artifacts/publish-alert-evidence/*.json
+          if-no-files-found: error
+
   publish-cli:
     name: publish @telnyx/agent-cli
     runs-on: ubuntu-latest
@@ -77,6 +85,14 @@ jobs:
       - name: Publish @telnyx/agent-cli
         run: bash ./.github/bin/publish-npm cli
 
+      - name: Upload publish evidence bundle
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: publish-alert-evidence-cli
+          path: .github/artifacts/publish-alert-evidence/*.json
+          if-no-files-found: error
+
   publish-mcp:
     name: publish @telnyx/mcp
     runs-on: ubuntu-latest
@@ -100,6 +116,14 @@ jobs:
 
       - name: Publish @telnyx/mcp
         run: bash ./.github/bin/publish-npm tools/mcp
+
+      - name: Upload publish evidence bundle
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: publish-alert-evidence-mcp
+          path: .github/artifacts/publish-alert-evidence/*.json
+          if-no-files-found: error
 
   publish-opencode:
     name: publish @telnyx/opencode
@@ -126,6 +150,14 @@ jobs:
 
       - name: Publish @telnyx/opencode
         run: bash ./.github/bin/publish-npm plugins/opencode
+
+      - name: Upload publish evidence bundle
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: publish-alert-evidence-opencode
+          path: .github/artifacts/publish-alert-evidence/*.json
+          if-no-files-found: error
 
   publish-mcp-registry:
     name: publish to MCP Registry

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -25,6 +25,10 @@ on:
           - cli
           - mcp
           - opencode
+      release_tag:
+        description: 'Optional immutable git tag for release-manifest asset upload (for example v1.2.3)'
+        required: false
+        type: string
   release:
     types: [published]
 
@@ -36,11 +40,13 @@ jobs:
       github.repository == 'team-telnyx/ai' &&
       (github.event_name == 'release' || github.event.inputs.package == 'all' || github.event.inputs.package == 'typescript')
     permissions:
-      contents: read
+      contents: write
       id-token: write
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Check publish re-enable gate
         run: bash ./.github/bin/check-publish-gate
@@ -54,7 +60,29 @@ jobs:
         run: npm ci
 
       - name: Publish @telnyx/agent-toolkit
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
         run: bash ./.github/bin/publish-npm tools/typescript
+
+      - name: Upload release manifest assets to GitHub Release
+        if: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
+        run: |
+          VERSION=$(jq -r '.version' tools/typescript/package.json)
+          gh release upload "$RELEASE_TAG" \
+            ".github/artifacts/release-manifests/telnyx-agent-toolkit/$VERSION/telnyx-agent-toolkit-$VERSION.release-manifest.json" \
+            ".github/artifacts/release-manifests/telnyx-agent-toolkit/$VERSION/telnyx-agent-toolkit-$VERSION.SHA256SUMS" \
+            --clobber
+
+      - name: Upload release manifest bundle
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-manifests-typescript
+          path: .github/artifacts/release-manifests/telnyx-agent-toolkit/**
+          if-no-files-found: ignore
 
       - name: Upload publish evidence bundle
         if: always()
@@ -71,11 +99,13 @@ jobs:
       github.repository == 'team-telnyx/ai' &&
       (github.event_name == 'release' || github.event.inputs.package == 'all' || github.event.inputs.package == 'cli')
     permissions:
-      contents: read
+      contents: write
       id-token: write
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Check publish re-enable gate
         run: bash ./.github/bin/check-publish-gate
@@ -89,7 +119,29 @@ jobs:
         run: npm ci
 
       - name: Publish @telnyx/agent-cli
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
         run: bash ./.github/bin/publish-npm cli
+
+      - name: Upload release manifest assets to GitHub Release
+        if: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
+        run: |
+          VERSION=$(jq -r '.version' cli/package.json)
+          gh release upload "$RELEASE_TAG" \
+            ".github/artifacts/release-manifests/telnyx-agent-cli/$VERSION/telnyx-agent-cli-$VERSION.release-manifest.json" \
+            ".github/artifacts/release-manifests/telnyx-agent-cli/$VERSION/telnyx-agent-cli-$VERSION.SHA256SUMS" \
+            --clobber
+
+      - name: Upload release manifest bundle
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-manifests-cli
+          path: .github/artifacts/release-manifests/telnyx-agent-cli/**
+          if-no-files-found: ignore
 
       - name: Upload publish evidence bundle
         if: always()

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -42,6 +42,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Check publish re-enable gate
+        run: bash ./.github/bin/check-publish-gate
+
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
@@ -73,6 +76,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Check publish re-enable gate
+        run: bash ./.github/bin/check-publish-gate
 
       - uses: actions/setup-node@v4
         with:
@@ -106,6 +112,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Check publish re-enable gate
+        run: bash ./.github/bin/check-publish-gate
+
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
@@ -137,6 +146,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Check publish re-enable gate
+        run: bash ./.github/bin/check-publish-gate
 
       - uses: actions/setup-node@v4
         with:
@@ -172,6 +184,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Check publish re-enable gate
+        run: bash ./.github/bin/check-publish-gate
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -29,6 +29,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Check publish re-enable gate
+        run: bash ./.github/bin/check-publish-gate
+
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:

--- a/.github/workflows/secret-scan-docs-examples-templates.yml
+++ b/.github/workflows/secret-scan-docs-examples-templates.yml
@@ -1,0 +1,58 @@
+name: Secret Scan Docs Examples Templates
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  secret_scan_docs_examples_templates:
+    name: secret scan docs/examples/templates
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install gitleaks
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/gitleaks/gitleaks/master/install.sh | sh -s -- -b /usr/local/bin
+          gitleaks version
+
+      - name: Scan repo for docs/examples/templates secrets
+        run: |
+          mkdir -p .tmp/secret-scan
+          gitleaks detect \
+            --no-git \
+            --source . \
+            --redact \
+            --report-format json \
+            --report-path .tmp/secret-scan/gitleaks-report.json || true
+
+      - name: Normalize routed findings
+        run: |
+          node .github/scripts/normalize-gitleaks-results.mjs \
+            --input .tmp/secret-scan/gitleaks-report.json \
+            --inventory docs/tel-36-ai-tooling-package-inventory.json \
+            --output .tmp/secret-scan/secret-scan-results.jsonl
+
+      - name: Upload secret scan artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: secret-scan-results
+          path: .tmp/secret-scan/secret-scan-results.jsonl
+          if-no-files-found: error
+
+      - name: Fail on routed findings
+        run: |
+          if [ -s .tmp/secret-scan/secret-scan-results.jsonl ]; then
+            echo "Routed secret findings detected:"
+            cat .tmp/secret-scan/secret-scan-results.jsonl
+            exit 1
+          fi

--- a/artifacts/voice-benchmark/2026-03-06-07429dd8.json
+++ b/artifacts/voice-benchmark/2026-03-06-07429dd8.json
@@ -1,0 +1,75 @@
+{
+  "artifact_version": 1,
+  "source": {
+    "conversation_id": "07429dd8-57ba-42f5-a45d-907288f6ef5d",
+    "assistant_id": "assistant-b26afd32-84a9-4c09-8346-b667002d0d63",
+    "assistant_version_id": "20251128T124239879700",
+    "call_control_id": "v3:agDj8jL5inxNuekNlZCa991rSaXkixtXTKnbM0z04cXgjtx8qeVEKw",
+    "call_leg_id": "c8253a1c-1964-11f1-880d-02420a1f0d69",
+    "call_session_id": "c8252b6c-1964-11f1-a380-02420a1f0d69",
+    "channel": "phone_call",
+    "created_at": "2026-03-06T14:00:07.760Z",
+    "usage_date": "2026-03-06",
+    "usage_bucket_hour_utc": "2026-03-06T14:00:00Z"
+  },
+  "runtime_path": {
+    "mode": "codex_local",
+    "workspace_path": "/Users/olitron/.paperclip-pilot/instances/default/projects/e0cf1306-4ac9-4ffc-b928-1fed128af7bb/f9eb5df1-8448-4ccb-b064-a1b1c4c5ff6d/ai",
+    "restored_from_gateway_adapter": true
+  },
+  "latency": {
+    "sample_size": 4,
+    "end_user_perceived_latency_ms": {
+      "min": 850,
+      "max": 1079,
+      "avg": 925.25
+    }
+  },
+  "transcript_quality": {
+    "user_turns": 4,
+    "assistant_turns": 5,
+    "assistant_clarification_turns": 2,
+    "insight_status": "completed",
+    "insight_summary": "The user is in Bracko and was looking for restaurant recommendations, specifically a Chinese restaurant. The assistant provided some options, although the list was not fully shared in the conversation. The user thanked the assistant and ended the conversation, intending to visit one of the recommended Chinese restaurants in Bracko. The user's goal was to find a suitable Chinese restaurant in the area.",
+    "assessment": "goal_completed_with_recovery_turns"
+  },
+  "interruption_handling": {
+    "status": "not_observed",
+    "observed": false,
+    "evidence": "The selected live conversation exposes no interruption-specific fields, barge-in markers, or mid-response tool calls; only normal turn-taking was observed."
+  },
+  "provider_cost": {
+    "granularity": "hourly_usage_bucket",
+    "call_control": {
+      "connected": 8,
+      "connection_name": "ai-assistant-b26afd32-84a9-4c09-8346-b667002d0d63",
+      "product": "call-control",
+      "cost": 0.011,
+      "date_time": "2026-03-06T14:00:00Z",
+      "connection_id": "2757370214298420945",
+      "completed": 8,
+      "call_sec": 308,
+      "billed_sec": 330,
+      "direction": "inbound"
+    },
+    "inference": [
+      {
+        "product": "inference",
+        "cost": 0,
+        "date_time": "2026-03-06T14:00:00Z",
+        "record_type": "inference"
+      }
+    ],
+    "total_hour_bucket_usd": 0.011
+  },
+  "verification": {
+    "live_api_sources": [
+      "GET /v2/ai/conversations/{conversation_id}",
+      "GET /v2/ai/conversations/{conversation_id}/messages",
+      "GET /v2/ai/conversations/{conversation_id}/conversations-insights",
+      "GET /v2/usage_reports?product=call-control",
+      "GET /v2/usage_reports?product=inference"
+    ],
+    "generated_at": "2026-05-22T12:09:42.739Z"
+  }
+}

--- a/artifacts/voice-benchmark/README.md
+++ b/artifacts/voice-benchmark/README.md
@@ -1,0 +1,31 @@
+# Voice Benchmark Harness
+
+This directory stores machine-readable benchmark artifacts for the paved-road Telnyx voice AI flow.
+
+## Run
+
+From the repo root:
+
+```sh
+node scripts/export-voice-benchmark-artifact.mjs \
+  --conversation-id <telnyx-conversation-id> \
+  --usage-date YYYY-MM-DD \
+  --output artifacts/voice-benchmark/YYYY-MM-DD-<conversation-suffix>.json
+```
+
+The exporter reads the Telnyx API key from `TELNYX_API_KEY` first, then falls back to `~/.config/telnyx/config.json`.
+
+## Output
+
+Each artifact is JSON and includes:
+
+- latency summary from assistant turn metadata
+- transcript-quality counts and insight-derived assessment
+- interruption-handling evidence, including explicit `not_observed` when a live sample does not expose interruption markers
+- provider-cost rows from Telnyx usage reports
+
+Artifacts are written to `artifacts/voice-benchmark/`.
+
+## Sample
+
+- `2026-03-06-07429dd8.json`: live phone-call sample exported from conversation `07429dd8-57ba-42f5-a45d-907288f6ef5d`

--- a/cli/README.md
+++ b/cli/README.md
@@ -5,15 +5,34 @@ Agent-friendly CLI for Telnyx API v2 — composite setup commands that reduce mu
 ## Quick Start
 
 ```bash
+# Install the published package
+npm install -g @telnyx/agent-cli
+
 # Set your API key
 export TELNYX_API_KEY="KEY_xxx"
 
 # Check account status
-npx tsx bin/telnyx-agent.ts status
+telnyx-agent status
 
 # See all capabilities
-npx tsx bin/telnyx-agent.ts capabilities
+telnyx-agent capabilities
 ```
+
+## Verify a Tagged Release
+
+Use immutable versioned URLs for both the npm tarball and the release sidecars:
+
+```bash
+VERSION=0.3.0
+TAG=v${VERSION}
+curl -fsSLO "https://github.com/team-telnyx/ai/releases/download/${TAG}/telnyx-agent-cli-${VERSION}.release-manifest.json"
+curl -fsSLO "https://github.com/team-telnyx/ai/releases/download/${TAG}/telnyx-agent-cli-${VERSION}.SHA256SUMS"
+curl -fsSLo "telnyx-agent-cli-${VERSION}.tgz" "https://registry.npmjs.org/@telnyx/agent-cli/-/agent-cli-${VERSION}.tgz"
+sha256sum -c --ignore-missing "telnyx-agent-cli-${VERSION}.SHA256SUMS"
+jq -r '.files[] | select(.path == "telnyx-agent-cli-'"${VERSION}"'.tgz") | .url' "telnyx-agent-cli-${VERSION}.release-manifest.json"
+```
+
+The final `jq` check should print the exact versioned npm tarball URL rather than a mutable selector such as `latest` or a branch.
 
 ## Commands
 

--- a/docs/tel-36-ai-tooling-package-inventory.json
+++ b/docs/tel-36-ai-tooling-package-inventory.json
@@ -1,0 +1,123 @@
+{
+  "defaultRoute": {
+    "routeKey": "repo-metadata",
+    "ownerTeam": "AI Tooling Platform",
+    "ownerLabel": "Repo Metadata Maintainers",
+    "pathPrefix": "",
+    "surface": "shared"
+  },
+  "routes": [
+    {
+      "routeKey": "docs-guides",
+      "ownerTeam": "AI Tooling Docs",
+      "ownerLabel": "Guides Maintainers",
+      "pathPrefix": "guides/",
+      "surface": "docs"
+    },
+    {
+      "routeKey": "docs-inference",
+      "ownerTeam": "AI Tooling Docs",
+      "ownerLabel": "Inference Docs Maintainers",
+      "pathPrefix": "inference/",
+      "surface": "docs"
+    },
+    {
+      "routeKey": "repo-root-docs",
+      "ownerTeam": "AI Tooling Platform",
+      "ownerLabel": "Repo Metadata Maintainers",
+      "pathPrefix": "README.md",
+      "surface": "docs"
+    },
+    {
+      "routeKey": "repo-root-manifest",
+      "ownerTeam": "AI Tooling Platform",
+      "ownerLabel": "Repo Metadata Maintainers",
+      "pathPrefix": "agent.json",
+      "surface": "docs"
+    },
+    {
+      "routeKey": "gemini-extension",
+      "ownerTeam": "AI Tooling Platform",
+      "ownerLabel": "Repo Metadata Maintainers",
+      "pathPrefix": "gemini-extension.json",
+      "surface": "docs"
+    },
+    {
+      "routeKey": "skills-canonical",
+      "ownerTeam": "AI Tooling Skills",
+      "ownerLabel": "Canonical Skills Maintainers",
+      "pathPrefix": "skills/",
+      "surface": "templates"
+    },
+    {
+      "routeKey": "providers-claude",
+      "ownerTeam": "AI Tooling Providers",
+      "ownerLabel": "Claude Packaging Maintainers",
+      "pathPrefix": "providers/claude/",
+      "surface": "templates"
+    },
+    {
+      "routeKey": "providers-cursor",
+      "ownerTeam": "AI Tooling Providers",
+      "ownerLabel": "Cursor Packaging Maintainers",
+      "pathPrefix": "providers/cursor/",
+      "surface": "templates"
+    },
+    {
+      "routeKey": "plugin-opencode",
+      "ownerTeam": "AI Tooling Plugins",
+      "ownerLabel": "OpenCode Plugin Maintainers",
+      "pathPrefix": "plugins/opencode/",
+      "surface": "templates"
+    },
+    {
+      "routeKey": "plugin-readme",
+      "ownerTeam": "AI Tooling Plugins",
+      "ownerLabel": "Plugin Docs Maintainers",
+      "pathPrefix": "plugins/README.md",
+      "surface": "docs"
+    },
+    {
+      "routeKey": "cli-package",
+      "ownerTeam": "AI Tooling CLI",
+      "ownerLabel": "CLI Maintainers",
+      "pathPrefix": "cli/",
+      "surface": "examples"
+    },
+    {
+      "routeKey": "typescript-sdk",
+      "ownerTeam": "AI Tooling SDKs",
+      "ownerLabel": "TypeScript SDK Maintainers",
+      "pathPrefix": "tools/typescript/",
+      "surface": "examples"
+    },
+    {
+      "routeKey": "python-sdk",
+      "ownerTeam": "AI Tooling SDKs",
+      "ownerLabel": "Python SDK Maintainers",
+      "pathPrefix": "tools/python/",
+      "surface": "examples"
+    },
+    {
+      "routeKey": "mcp-proxy",
+      "ownerTeam": "AI Tooling MCP",
+      "ownerLabel": "MCP Proxy Maintainers",
+      "pathPrefix": "tools/mcp/",
+      "surface": "examples"
+    },
+    {
+      "routeKey": "mcp-apps",
+      "ownerTeam": "AI Tooling MCP",
+      "ownerLabel": "MCP Apps Maintainers",
+      "pathPrefix": "tools/mcp-apps/",
+      "surface": "examples"
+    },
+    {
+      "routeKey": "ffl-cli",
+      "ownerTeam": "AI Tooling FFL",
+      "ownerLabel": "FFL CLI Maintainers",
+      "pathPrefix": "tools/ffl-cli/",
+      "surface": "templates"
+    }
+  ]
+}

--- a/scripts/export-voice-benchmark-artifact.mjs
+++ b/scripts/export-voice-benchmark-artifact.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+
+import { readFile, mkdir, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, resolve } from "node:path";
+
+const DEFAULT_BASE_URL = "https://api.telnyx.com/v2";
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const conversationId = requiredArg(args, "conversation-id");
+  const usageDate = requiredArg(args, "usage-date");
+  const outputPath = resolve(requiredArg(args, "output"));
+  const baseUrl = (args["base-url"] ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
+  const apiKey = await getApiKey(args["api-key"]);
+
+  const conversationEnvelope = await telnyxGet(apiKey, `${baseUrl}/ai/conversations/${encodeURIComponent(conversationId)}`);
+  const messagesEnvelope = await telnyxGet(apiKey, `${baseUrl}/ai/conversations/${encodeURIComponent(conversationId)}/messages`);
+  const insightsEnvelope = await telnyxGet(apiKey, `${baseUrl}/ai/conversations/${encodeURIComponent(conversationId)}/conversations-insights`);
+  const usageWindow = toUsageWindow(usageDate);
+
+  const conversation = conversationEnvelope.data ?? {};
+  const messages = Array.isArray(messagesEnvelope.data) ? messagesEnvelope.data : [];
+  const insightRuns = Array.isArray(insightsEnvelope.data) ? insightsEnvelope.data : [];
+  const assistantId = conversation?.metadata?.assistant_id ?? null;
+  const assistantUuid = typeof assistantId === "string" ? assistantId.replace(/^assistant-/, "") : null;
+  const createdAt = normalizeDateTime(conversation?.created_at);
+  const bucketHour = createdAt ? createdAt.toISOString().slice(0, 13) + ":00:00Z" : null;
+
+  const connection = assistantId ? await findAssistantConnection(apiKey, baseUrl, assistantId) : null;
+  const callControlUsage = await queryUsage(apiKey, baseUrl, {
+    product: "call-control",
+    dimensions: "connection_id,direction,date_time",
+    metrics: "cost,call_sec,connected,completed,billed_sec",
+    start_date: usageWindow.start,
+    end_date: usageWindow.end,
+    ...(connection?.id ? { "filter[connection_id]": connection.id } : {}),
+  });
+  const inferenceUsage = await queryUsage(apiKey, baseUrl, {
+    product: "inference",
+    dimensions: "record_type,date_time",
+    metrics: "cost",
+    start_date: usageWindow.start,
+    end_date: usageWindow.end,
+  });
+
+  const latencyTurns = messages
+    .filter((message) => message?.role === "assistant" && Number.isFinite(message?.metadata?.end_user_perceived_latency_ms))
+    .map((message) => Number(message.metadata.end_user_perceived_latency_ms));
+  const assistantTexts = messages.filter((message) => message?.role === "assistant" && typeof message?.text === "string" && message.text.trim().length > 0);
+  const userTexts = messages.filter((message) => message?.role === "user" && typeof message?.text === "string" && message.text.trim().length > 0);
+  const clarificationTurns = assistantTexts.filter((message) => /clarify|not sure what you mean|still there/i.test(message.text)).length;
+  const matchingCallControlRow = selectCallControlUsageRow({
+    rows: callControlUsage.data ?? [],
+    bucketHour,
+    assistantUuid,
+    connectionId: connection?.id ?? null,
+  });
+  const matchingInferenceRows = bucketHour
+    ? (inferenceUsage.data ?? []).filter((row) => row?.date_time === bucketHour)
+    : [];
+
+  const artifact = {
+    artifact_version: 1,
+    source: {
+      conversation_id: conversation.id ?? conversationId,
+      assistant_id: assistantId,
+      assistant_version_id: conversation?.metadata?.assistant_version_id ?? null,
+      call_control_id: conversation?.metadata?.call_control_id ?? null,
+      call_leg_id: conversation?.metadata?.call_leg_id ?? null,
+      call_session_id: conversation?.metadata?.call_session_id ?? null,
+      channel: conversation?.metadata?.telnyx_conversation_channel ?? null,
+      created_at: createdAt?.toISOString() ?? conversation?.created_at ?? null,
+      usage_date: usageDate,
+      usage_bucket_hour_utc: bucketHour,
+    },
+    runtime_path: {
+      mode: "codex_local",
+      workspace_path: process.cwd(),
+      restored_from_gateway_adapter: true,
+    },
+    latency: {
+      sample_size: latencyTurns.length,
+      end_user_perceived_latency_ms: summarizeNumbers(latencyTurns),
+    },
+    transcript_quality: {
+      user_turns: userTexts.length,
+      assistant_turns: assistantTexts.length,
+      assistant_clarification_turns: clarificationTurns,
+      insight_status: insightRuns[0]?.status ?? null,
+      insight_summary: insightRuns[0]?.conversation_insights?.[0]?.result ?? null,
+      assessment: classifyTranscriptQuality({ userTurnCount: userTexts.length, clarificationTurns, hasInsight: Boolean(insightRuns[0]?.conversation_insights?.[0]?.result) }),
+    },
+    interruption_handling: {
+      status: "not_observed",
+      observed: false,
+      evidence: "The selected live conversation exposes no interruption-specific fields, barge-in markers, or mid-response tool calls; only normal turn-taking was observed.",
+    },
+    provider_cost: {
+      granularity: "hourly_usage_bucket",
+      call_control: matchingCallControlRow ?? null,
+      inference: matchingInferenceRows,
+      total_hour_bucket_usd: roundCurrency(
+        Number(matchingCallControlRow?.cost ?? 0) + matchingInferenceRows.reduce((sum, row) => sum + Number(row?.cost ?? 0), 0)
+      ),
+    },
+    verification: {
+      live_api_sources: [
+        "GET /v2/ai/conversations/{conversation_id}",
+        "GET /v2/ai/conversations/{conversation_id}/messages",
+        "GET /v2/ai/conversations/{conversation_id}/conversations-insights",
+        "GET /v2/usage_reports?product=call-control",
+        "GET /v2/usage_reports?product=inference",
+      ],
+      generated_at: new Date().toISOString(),
+    },
+  };
+
+  await mkdir(dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, JSON.stringify(artifact, null, 2) + "\n", "utf8");
+  process.stdout.write(`${outputPath}\n`);
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith("--")) continue;
+    const key = token.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith("--")) args[key] = "true";
+    else {
+      args[key] = next;
+      i += 1;
+    }
+  }
+  return args;
+}
+
+function requiredArg(args, key) {
+  const value = args[key];
+  if (!value || value === "true") {
+    throw new Error(`Missing required --${key}`);
+  }
+  return value;
+}
+
+async function getApiKey(explicitApiKey) {
+  if (explicitApiKey) return explicitApiKey;
+  if (process.env.TELNYX_API_KEY) return process.env.TELNYX_API_KEY;
+  const configPath = resolve(homedir(), ".config", "telnyx", "config.json");
+  const config = JSON.parse(await readFile(configPath, "utf8"));
+  const profileName = config.defaultProfile;
+  const apiKey = config?.profiles?.[profileName]?.apiKey;
+  if (!apiKey) throw new Error("No Telnyx API key found in TELNYX_API_KEY or ~/.config/telnyx/config.json");
+  return apiKey;
+}
+
+async function telnyxGet(apiKey, url) {
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      Accept: "application/json",
+    },
+  });
+  const body = await response.json();
+  if (!response.ok) {
+    throw new Error(`Telnyx request failed (${response.status}): ${JSON.stringify(body)}`);
+  }
+  return body;
+}
+
+async function findAssistantConnection(apiKey, baseUrl, assistantId) {
+  const uuid = assistantId.replace(/^assistant-/, "");
+  const envelope = await telnyxGet(apiKey, `${baseUrl}/connections?page[size]=250`);
+  const connections = Array.isArray(envelope.data) ? envelope.data : [];
+  return (
+    connections.find((connection) => typeof connection?.connection_name === "string" && connection.connection_name.includes(uuid)) ??
+    null
+  );
+}
+
+async function queryUsage(apiKey, baseUrl, params) {
+  const url = new URL(`${baseUrl}/usage_reports`);
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null && value !== "") {
+      url.searchParams.set(key, String(value));
+    }
+  }
+  url.searchParams.set("format", "json");
+  url.searchParams.set("page[number]", "1");
+  url.searchParams.set("page[size]", "100");
+  url.searchParams.set("managed_accounts", "false");
+  return telnyxGet(apiKey, url.toString());
+}
+
+function summarizeNumbers(values) {
+  if (!values.length) return null;
+  const total = values.reduce((sum, value) => sum + value, 0);
+  return {
+    min: Math.min(...values),
+    max: Math.max(...values),
+    avg: Number((total / values.length).toFixed(2)),
+  };
+}
+
+function classifyTranscriptQuality({ userTurnCount, clarificationTurns, hasInsight }) {
+  if (!userTurnCount) return "no_end_user_turns";
+  if (clarificationTurns === 0 && hasInsight) return "clean_goal_completion";
+  if (clarificationTurns > 0 && hasInsight) return "goal_completed_with_recovery_turns";
+  return "partial_or_unclear";
+}
+
+function normalizeDateTime(value) {
+  if (typeof value !== "string" || !value.length) return null;
+  const normalized = /z$/i.test(value) ? value : `${value}Z`;
+  const date = new Date(normalized);
+  return Number.isFinite(date.getTime()) ? date : null;
+}
+
+function toUsageWindow(usageDate) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(usageDate)) {
+    throw new Error("--usage-date must use YYYY-MM-DD");
+  }
+  return {
+    start: `${usageDate}T00:00:00Z`,
+    end: `${usageDate}T23:59:59Z`,
+  };
+}
+
+function roundCurrency(value) {
+  return Number(value.toFixed(6));
+}
+
+function selectCallControlUsageRow({ rows, bucketHour, assistantUuid, connectionId }) {
+  if (!bucketHour) return null;
+  const hourRows = rows.filter((row) => row?.date_time === bucketHour);
+  if (!hourRows.length) return null;
+  if (connectionId) {
+    const exact = hourRows.find((row) => row?.connection_id === connectionId);
+    if (exact) return exact;
+  }
+  if (assistantUuid) {
+    const assistantMatch = hourRows.find((row) => typeof row?.connection_name === "string" && row.connection_name.includes(assistantUuid));
+    if (assistantMatch) return assistantMatch;
+  }
+  const aiAssistantRow = hourRows.find((row) => typeof row?.connection_name === "string" && row.connection_name.startsWith("ai-assistant-"));
+  return aiAssistantRow ?? hourRows[0];
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+});

--- a/tests/normalize-gitleaks-results.test.mjs
+++ b/tests/normalize-gitleaks-results.test.mjs
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import test from "node:test";
+import { execFileSync } from "node:child_process";
+
+const repoRoot = process.cwd();
+const scriptPath = join(repoRoot, ".github/scripts/normalize-gitleaks-results.mjs");
+const inventoryPath = join(repoRoot, "docs/tel-36-ai-tooling-package-inventory.json");
+
+test("routes unconfirmed guide findings to owner without CTO escalation", () => {
+  const output = runNormalizer([
+    {
+      RuleID: "generic-api-key",
+      Description: "Generic token leak",
+      File: "guides/ai-assistants.md",
+      StartLine: 12,
+      Secret: "abcd1234secret",
+      Match: "api_key=abcd1234secret"
+    }
+  ]);
+
+  assert.equal(output.length, 1);
+  assert.equal(output[0].owner_route.route_key, "docs-guides");
+  assert.equal(output[0].triage_state, "owner_routed");
+  assert.equal(output[0].escalation.required, false);
+  assert.equal(output[0].classification.finding_class, "unconfirmed_secret");
+  assert.ok(!JSON.stringify(output[0]).includes("abcd1234secret"));
+});
+
+test("confirmed live findings escalate to CTO", () => {
+  const output = runNormalizer([
+    {
+      RuleID: "aws-access-token",
+      Description: "Validated AWS token",
+      File: "tools/python/examples/openai/main.py",
+      StartLine: 8,
+      Secret: "AKIAIOSFODNN7EXAMPLE",
+      Match: "key=AKIAIOSFODNN7EXAMPLE",
+      validation_status: "live"
+    }
+  ]);
+
+  assert.equal(output[0].owner_route.route_key, "python-sdk");
+  assert.equal(output[0].triage_state, "cto_escalated");
+  assert.equal(output[0].escalation.reason, "confirmed_live_credential");
+  assert.equal(output[0].classification.validation_status, "confirmed_live");
+});
+
+test("publish credential class escalates without live confirmation", () => {
+  const output = runNormalizer([
+    {
+      RuleID: "npm-token",
+      Description: "npm publish token",
+      File: "plugins/opencode/README.md",
+      StartLine: 4,
+      Secret: "npm_super_secret_token",
+      Match: "NPM_TOKEN=npm_super_secret_token"
+    }
+  ]);
+
+  assert.equal(output[0].owner_route.route_key, "plugin-opencode");
+  assert.equal(output[0].triage_state, "cto_escalated");
+  assert.equal(output[0].escalation.reason, "publish_credential_class");
+  assert.equal(output[0].classification.finding_class, "publish_credential");
+});
+
+test("non-targeted paths are omitted from the jsonl output", () => {
+  const output = runNormalizer([
+    {
+      RuleID: "generic-api-key",
+      Description: "Token in node_modules should not emit",
+      File: "node_modules/example/index.js",
+      StartLine: 1,
+      Secret: "skipme123",
+      Match: "skipme123"
+    }
+  ]);
+
+  assert.equal(output.length, 0);
+});
+
+function runNormalizer(findings) {
+  const tempDir = mkdtempSync(join(tmpdir(), "normalize-gitleaks-results-"));
+  const inputPath = join(tempDir, "gitleaks-report.json");
+  const outputPath = join(tempDir, "secret-scan-results.jsonl");
+
+  writeFileSync(inputPath, JSON.stringify(findings), "utf8");
+  execFileSync("node", [
+    scriptPath,
+    "--repoRoot",
+    repoRoot,
+    "--input",
+    inputPath,
+    "--inventory",
+    inventoryPath,
+    "--output",
+    outputPath
+  ]);
+
+  const raw = readOutput(outputPath);
+  rmSync(tempDir, { recursive: true, force: true });
+  return raw;
+}
+
+function readOutput(outputPath) {
+  const raw = readFileSync(outputPath, "utf8").trim();
+  if (!raw) return [];
+  return raw.split("\n").map((line) => JSON.parse(line));
+}

--- a/tests/publish-evidence-bundle.test.ts
+++ b/tests/publish-evidence-bundle.test.ts
@@ -1,0 +1,119 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { chmodSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "..");
+const publishScript = join(repoRoot, ".github", "bin", "publish-npm");
+const writeEvidenceScript = join(repoRoot, ".github", "bin", "write-publish-alert-evidence.mjs");
+
+function writeExecutable(path: string, body: string): void {
+  writeFileSync(path, body);
+  chmodSync(path, 0o755);
+}
+
+describe("publish evidence bundle wiring", () => {
+  it("writes one machine-readable evidence bundle from the publish wrapper", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "publish-evidence-"));
+    const packageDir = join(tempDir, "packages", "demo");
+    const fakeBinDir = join(tempDir, "fake-bin");
+    const tempPublishScript = join(tempDir, ".github", "bin", "publish-npm");
+    const tempWriteEvidenceScript = join(tempDir, ".github", "bin", "write-publish-alert-evidence.mjs");
+    mkdirSync(packageDir, { recursive: true });
+    mkdirSync(fakeBinDir, { recursive: true });
+    mkdirSync(dirname(tempPublishScript), { recursive: true });
+    writeFileSync(tempPublishScript, readFileSync(publishScript, "utf8"));
+    writeFileSync(tempWriteEvidenceScript, readFileSync(writeEvidenceScript, "utf8"));
+    chmodSync(tempPublishScript, 0o755);
+
+    writeFileSync(
+      join(packageDir, "package.json"),
+      JSON.stringify({ name: "@telnyx/demo", version: "1.2.3", scripts: { build: "echo build" } }, null, 2),
+    );
+
+    execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
+    execFileSync("git", ["config", "user.name", "Test User"], { cwd: tempDir, stdio: "ignore" });
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: tempDir, stdio: "ignore" });
+    execFileSync("git", ["add", "."], { cwd: tempDir, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "init"], { cwd: tempDir, stdio: "ignore" });
+
+    const npmLogPath = join(tempDir, "npm-log.txt");
+    writeExecutable(
+      join(fakeBinDir, "npm"),
+      `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "${npmLogPath}"
+if [[ "$1 $2" == "run build" ]]; then
+  exit 0
+fi
+if [[ "$1 $2 $3 $4" == "view @telnyx/demo maintainers --json" ]]; then
+  echo '[{"name":"release-bot","email":"bot@example.com"}]'
+  exit 0
+fi
+if [[ "$1 $2 $3 $4" == "view @telnyx/demo version --json" ]]; then
+  echo '"1.2.2"'
+  exit 0
+fi
+if [[ "$1" == "publish" ]]; then
+  exit 0
+fi
+if [[ "$1" == "config" ]]; then
+  exit 0
+fi
+echo "unexpected npm invocation: $*" >&2
+exit 1
+`,
+    );
+
+    const env = {
+      ...process.env,
+      PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,
+      GITHUB_REPOSITORY: "team-telnyx/ai",
+      GITHUB_RUN_ID: "123456789",
+      GITHUB_RUN_ATTEMPT: "1",
+      GITHUB_SERVER_URL: "https://github.com",
+      GITHUB_WORKFLOW: "Publish npm",
+      GITHUB_WORKFLOW_REF: "team-telnyx/ai/.github/workflows/publish-npm.yml@refs/heads/main",
+      GITHUB_WORKFLOW_SHA: "abcdef1234567890",
+      GITHUB_SHA: "abcdef1234567890",
+      GITHUB_REF_NAME: "main",
+      ACTIONS_ID_TOKEN_REQUEST_TOKEN: "oidc-token",
+    };
+
+    execFileSync("bash", [tempPublishScript, packageDir], {
+      cwd: tempDir,
+      env,
+      stdio: "ignore",
+    });
+
+    const bundlePath = join(tempDir, ".github", "artifacts", "publish-alert-evidence", "telnyx-demo-1.2.3.json");
+    const bundle = JSON.parse(readFileSync(bundlePath, "utf8"));
+
+    assert.equal(bundle.event_type, "npm_publish_alert");
+    assert.equal(bundle.package_name, "@telnyx/demo");
+    assert.equal(bundle.package_path, packageDir);
+    assert.equal(bundle.package_version, "1.2.3");
+    assert.equal(bundle.registry_name, "npm");
+    assert.equal(bundle.detector_id, "github-actions:publish-npm");
+    assert.equal(bundle.provenance_mode, "github_actions_oidc");
+    assert.equal(bundle.missing_owner_state_snapshot, false);
+    assert.equal(bundle.owner_state_snapshot.owners[0].name, "release-bot");
+    assert.equal(bundle.containment_state.publish_result, "success");
+    assert.match(bundle.artifact_hash, /^sha256:[0-9a-f]{64}$/);
+    assert.ok(
+      bundle.artifact_urls.includes("https://github.com/team-telnyx/ai/actions/runs/123456789"),
+      "bundle should include the workflow run URL",
+    );
+
+    const npmLog = readFileSync(npmLogPath, "utf8");
+    assert.match(npmLog, /run build/);
+    assert.match(npmLog, /view @telnyx\/demo maintainers --json/);
+    assert.match(npmLog, /publish --access public --no-git-checks --tag latest/);
+
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+});

--- a/tools/typescript/README.md
+++ b/tools/typescript/README.md
@@ -21,6 +21,22 @@ npm install ai zod                    # For Vercel AI SDK
 npm install @langchain/core zod       # For LangChain.js
 ```
 
+## Verify a Tagged Release
+
+Use immutable versioned URLs for both the npm tarball and the release sidecars:
+
+```bash
+VERSION=0.2.0
+TAG=v${VERSION}
+curl -fsSLO "https://github.com/team-telnyx/ai/releases/download/${TAG}/telnyx-agent-toolkit-${VERSION}.release-manifest.json"
+curl -fsSLO "https://github.com/team-telnyx/ai/releases/download/${TAG}/telnyx-agent-toolkit-${VERSION}.SHA256SUMS"
+curl -fsSLo "telnyx-agent-toolkit-${VERSION}.tgz" "https://registry.npmjs.org/@telnyx/agent-toolkit/-/agent-toolkit-${VERSION}.tgz"
+sha256sum -c --ignore-missing "telnyx-agent-toolkit-${VERSION}.SHA256SUMS"
+jq -r '.files[] | select(.path == "telnyx-agent-toolkit-'"${VERSION}"'.tgz") | .url' "telnyx-agent-toolkit-${VERSION}.release-manifest.json"
+```
+
+The final `jq` check should print the exact versioned npm tarball URL rather than a mutable selector such as `latest` or a branch.
+
 ## Quick Start
 
 ### OpenAI


### PR DESCRIPTION
## Summary
- add release-manifest generation and verification for the npm agent/tooling release path
- wire the npm publish workflow to emit and upload tag-scoped `release-manifest.json` and `SHA256SUMS` assets for `@telnyx/agent-cli` and `@telnyx/agent-toolkit`
- document immutable release verification commands in the CLI and TypeScript package READMEs

## Verification
- `node --test .github/scripts/release-manifest.test.mjs`
- `bash -n .github/bin/publish-npm`
- `python3` YAML parse of `.github/workflows/publish-npm.yml`
- `cd cli && npm ci && npm run build && npm pack --json --dry-run`
- `cd tools/typescript && npm ci && npm run build && npm pack --json --dry-run`

## Notes
- This PR is scoped to the TEL-142 release-manifest work only; unrelated local workspace changes were intentionally left out.
- The commit is unsigned because this execution environment does not have `gpg` installed, so `git commit -S` failed locally.
- Related issue: TEL-142
