### PR TITLE
draft: backfill publish secret scan preflight

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -29,8 +29,25 @@ on:
     types: [published]
 
 jobs:
+  publish-preflight:
+    name: publish preflight
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Run publish secret scan
+        run: npm run publish:preflight
+
   publish-typescript:
     name: publish @telnyx/agent-toolkit
+    needs: publish-preflight
     runs-on: ubuntu-latest
     if: >-
       github.repository == 'team-telnyx/ai' &&
@@ -55,6 +72,7 @@ jobs:
 
   publish-cli:
     name: publish @telnyx/agent-cli
+    needs: publish-preflight
     runs-on: ubuntu-latest
     if: >-
       github.repository == 'team-telnyx/ai' &&
@@ -79,6 +97,7 @@ jobs:
 
   publish-mcp:
     name: publish @telnyx/mcp
+    needs: publish-preflight
     runs-on: ubuntu-latest
     if: >-
       github.repository == 'team-telnyx/ai' &&
@@ -103,6 +122,7 @@ jobs:
 
   publish-opencode:
     name: publish @telnyx/opencode
+    needs: publish-preflight
     runs-on: ubuntu-latest
     if: >-
       github.repository == 'team-telnyx/ai' &&
@@ -130,7 +150,7 @@ jobs:
   publish-mcp-registry:
     name: publish to MCP Registry
     runs-on: ubuntu-latest
-    needs: publish-mcp
+    needs: [publish-preflight, publish-mcp]
     if: >-
       github.repository == 'team-telnyx/ai' &&
       (github.event_name == 'release' || github.event.inputs.package == 'all' || github.event.inputs.package == 'mcp')

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ From `tools/mcp-apps`, use `npm install`, `npm run typecheck`, `npm run build`, 
 
 ## Guides
 
-Curl-first operational guides for common Telnyx workflows — SMS messaging, voice call control, AI assistants, phone numbers, porting, verification, webhooks, 10DLC registration, WireGuard networking, x402 payments, and Edge Compute handoff patterns.
+Curl-first operational guides for common Telnyx workflows — SMS messaging, voice call control, AI assistants, phone numbers, porting, verification, webhooks, 10DLC registration, WireGuard networking, x402 payments, Edge Compute handoff patterns, and [evidence handoff / escalation runbooks](/guides/evidence-handoff.md).
 
 For Edge Compute specifically, the goal is to make the handoff testable fast: start from a real `telnyx-edge` example, deploy it, and let `team-telnyx/ai` orchestrate against that live endpoint.
 

--- a/guides/evidence-handoff.md
+++ b/guides/evidence-handoff.md
@@ -1,0 +1,141 @@
+# Evidence Handoff And Escalation
+
+Use this runbook when the `team-telnyx/ai` release path produces an evidence bundle for either of these incident classes:
+
+- **Publish-path alert**: npm publish is blocked, overridden, or otherwise flagged during [`.github/workflows/publish-npm.yml`](/.github/workflows/publish-npm.yml).
+- **Secret-exposure alert**: release automation, CI, or a human reviewer finds a leaked credential, internal URL, or other sensitive artifact in publishable output. The standing external reporting path remains [`.github/SECURITY.md`](/.github/SECURITY.md).
+
+This guide defines who gets the first notification, how acknowledgement is escalated, and what evidence may be handed off.
+
+## Evidence bundle contents
+
+Every alert handoff should include the smallest bundle that lets the next responder act without reopening the investigation:
+
+- incident class: `publish_path` or `secret_exposure`
+- current state event from the timeline below
+- package or workflow affected
+- timestamp in UTC
+- actor who triggered or disabled the workflow
+- incident or ticket identifier
+- reason for the disable, override, or alert
+- links or attachments to GitHub Actions step summaries, logs, or PR context
+
+For publish-path incidents, the authoritative audit fields already exist in [`.github/workflows/publish-npm.yml`](/.github/workflows/publish-npm.yml) and [`.github/bin/publish-npm`](/.github/bin/publish-npm):
+
+- `publish_disable_reason`
+- `publish_disable_incident_id`
+- `publish_disable_by`
+- `NPM_PUBLISH_DISABLE_REASON`
+- `NPM_PUBLISH_DISABLE_INCIDENT_ID`
+- `NPM_PUBLISH_DISABLED_BY`
+
+The workflow step summary and `publish-audit-log.txt` output are the preferred evidence sources for those alerts.
+
+## Recipient order
+
+### Publish-path alerts
+
+Initial recipients:
+
+1. package owner or workflow owner
+2. release/on-call operator
+3. CTO
+
+Fallback order:
+
+1. If the owner does not acknowledge inside the owner SLA, page the on-call operator and transfer ownership.
+2. If on-call does not acknowledge inside the on-call SLA, escalate to the CTO with the evidence bundle attached.
+3. If the CTO is unreachable and publish must remain blocked, keep the gate disabled and continue updates through the incident ticket until executive coverage is restored.
+
+### Secret-exposure alerts
+
+Initial recipients:
+
+1. package owner
+2. release/on-call operator
+3. CTO
+
+Fallback order:
+
+1. Notify owner and on-call at the same time because containment is time-sensitive.
+2. Escalate to the CTO immediately if a live credential, signing token, or customer-impacting secret is exposed in a published artifact.
+3. If impact is still being verified, escalate to the CTO at the on-call SLA threshold even when the owner has acknowledged but containment is incomplete.
+
+## Ack SLA and escalation thresholds
+
+| Incident class | Owner ack | On-call ack | CTO escalation threshold | Expected response |
+|---|---:|---:|---:|---|
+| `publish_path` | 10 minutes | 20 minutes | 30 minutes from alert creation | Keep publishing disabled until someone explicitly records restore approval and the incident id. |
+| `secret_exposure` | 5 minutes | 10 minutes | Immediate for confirmed live secret, otherwise 15 minutes | Contain first: revoke/rotate secret, block further publish, and hand off only redacted evidence. |
+
+Ack means the responder has posted or otherwise recorded all of the following:
+
+- they own the incident
+- the current state event
+- the next containment action
+- the next status update time
+
+Silence does not count as acknowledgement. Reactions without an explicit owner and next action do not count either.
+
+## State events and timeline
+
+Use these state events in issue comments, incident tickets, or handoff notes so downstream responders can reconstruct the incident quickly.
+
+| State event | When to emit it | Required evidence |
+|---|---|---|
+| `alert_detected` | The workflow, CI check, or human observer first identifies the condition. | Trigger source, UTC timestamp, affected package or secret scope. |
+| `owner_notified` | The owner receives the first handoff. | Owner identity and notification channel. |
+| `owner_acked` | The owner accepts responsibility within SLA. | Owner name, next action, next update time. |
+| `oncall_notified` | The owner SLA expires or the alert is severity-high on arrival. | Escalation reason and current containment status. |
+| `oncall_acked` | On-call takes operational control. | Operator name, mitigation action, next update time. |
+| `cto_notified` | On-call SLA expires or the issue meets immediate-executive criteria. | Full redacted evidence bundle and business-risk summary. |
+| `containment_started` | Publish is disabled, credentials are being rotated, or artifacts are being quarantined. | Command, workflow change, or revocation action taken. |
+| `evidence_bundle_ready` | The bundle is complete enough for a clean handoff. | Links to logs, step summary, ticket, and redacted artifacts. |
+| `restore_approved` | A named owner or CTO approves re-enable of the path. | Approval source, incident id, and rollback plan. |
+| `resolved` | Containment and follow-up actions are complete. | Final root cause, verification, and remaining follow-ups. |
+
+## Operator response behavior
+
+### Publish-path alerts
+
+1. Confirm whether [`.github/workflows/publish-npm.yml`](/.github/workflows/publish-npm.yml) blocked the run because `PUBLISH_NPM_ENABLED` is false or because a manual override was used.
+2. Capture the workflow summary plus the audit values emitted by [`.github/bin/publish-npm`](/.github/bin/publish-npm).
+3. If risk is not understood yet, leave publish disabled. Do not force release traffic back on to "see what happens."
+4. Hand off the evidence bundle to the next recipient in the order above when the active owner misses SLA or lacks the authority to restore.
+
+### Secret-exposure alerts
+
+1. Stop further distribution first: disable publish, revoke or rotate the secret, and quarantine any copied evidence.
+2. Report externally through [`.github/SECURITY.md`](/.github/SECURITY.md) when the alert could expose users, systems, or credentials outside the private incident channel.
+3. Use [`.github/bin/check-release-environment`](/.github/bin/check-release-environment) to confirm whether internal URLs or similar release-safety violations are present in publishable files.
+4. Do not paste raw secrets into issues, chat, screenshots, or step summaries. Only share fingerprints, prefixes, or other redacted identifiers.
+
+## Evidence handling guardrails
+
+- Redact tokens, API keys, cookies, JWTs, internal hostnames, and customer data before attaching evidence.
+- Prefer secret fingerprints, first/last four characters, or one-way hashes over raw values.
+- Store one canonical evidence bundle per incident id so responders are not forwarding divergent copies.
+- Keep raw logs in the system of record that generated them; handoffs should link to those logs instead of copying entire transcripts.
+- If a screenshot is required, crop it to the relevant fields and verify that browser chrome, terminal history, and notification toasts do not leak secrets.
+- When a secret might still be live, treat every downstream handoff as need-to-know and include the minimum scope necessary to continue containment.
+
+## Run instructions mapped to the timeline
+
+| Timeline point | Run instruction |
+|---|---|
+| `alert_detected` | Inspect the current GitHub Actions run in [`.github/workflows/publish-npm.yml`](/.github/workflows/publish-npm.yml). |
+| `containment_started` for publish-path | Keep `PUBLISH_NPM_ENABLED=false` and record `publish_disable_reason`, `publish_disable_incident_id`, and `publish_disable_by` on manual dispatch if used. |
+| `containment_started` for secret exposure | Revoke or rotate the secret, then rerun release safety checks with [`.github/bin/check-release-environment`](/.github/bin/check-release-environment). |
+| `evidence_bundle_ready` | Attach the step summary, audit fields, incident id, and redacted links to the active incident ticket. |
+| `restore_approved` | Re-enable publishing only after a named owner or CTO records approval and the restoration reason. |
+| `resolved` | Record final verification, including the publish gate state and any follow-up hardening tasks. |
+
+## Success condition for a clean handoff
+
+The handoff is complete when the next responder can answer all of these without re-investigating from scratch:
+
+- What happened?
+- Which package, workflow, or secret scope is affected?
+- Who owns the incident right now?
+- What containment action is already in place?
+- What is the next escalation threshold if nobody responds?

--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "private": true,
   "description": "Telnyx AI skills monorepo — SDKs, CLI, guides, and agent skills",
   "scripts": {
+    "publish:preflight": "npx tsx scripts/publish-secret-scan.ts --ci",
     "test:guides": "npx tsx --test tests/guides.test.ts",
-    "test:guides-api": "npx tsx --test tests/guides-api.test.ts"
+    "test:guides-api": "npx tsx --test tests/guides-api.test.ts",
+    "test:publish-preflight": "npx tsx --test tests/publish-secret-scan.test.ts"
   },
   "devDependencies": {
     "tsx": "^4.19.0"

--- a/scripts/publish-secret-scan-suppressions.md
+++ b/scripts/publish-secret-scan-suppressions.md
@@ -1,0 +1,8 @@
+# Publish secret scan suppressions
+
+Use `secret-scan: ignore reason=<why>` on the same line as an intentionally fake fixture or placeholder that must remain in a publish surface.
+
+Rules:
+- Only suppress synthetic test material or documented placeholders.
+- Include a human-readable `reason=...` so triage consumers know why the finding is safe.
+- Suppressed findings remain in the JSON report with suppression metadata, but they do not count as blocking findings.

--- a/scripts/publish-secret-scan.ts
+++ b/scripts/publish-secret-scan.ts
@@ -1,0 +1,321 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { extname, join, relative } from "node:path";
+
+export type SourceSurface = "docs" | "examples" | "templates" | "publish_artifact" | "other";
+
+export type Suppression = {
+  kind: "inline";
+  reason: string;
+};
+
+export type SecretFinding = {
+  reportVersion: "1";
+  findingId: string;
+  evidenceFingerprint: string;
+  detectorId: string;
+  secretClass: string;
+  severity: "low" | "medium" | "high" | "critical";
+  confidence: "low" | "medium" | "high";
+  path: string;
+  line: number;
+  sourceSurface: SourceSurface;
+  matchLength: number;
+  suppression?: Suppression;
+};
+
+export type ScanReport = {
+  reportVersion: "1";
+  scannedPaths: string[];
+  summary: {
+    filesScanned: number;
+    findings: number;
+    blockingFindings: number;
+    suppressedFindings: number;
+  };
+  findings: SecretFinding[];
+};
+
+type Detector = {
+  detectorId: string;
+  secretClass: string;
+  severity: SecretFinding["severity"];
+  confidence: SecretFinding["confidence"];
+  pattern: RegExp;
+  extractValue(match: RegExpExecArray): string;
+};
+
+const REPORT_VERSION = "1";
+const DEFAULT_SCAN_PATHS = [
+  ".github",
+  "guides",
+  "skills",
+  "providers",
+  "cli",
+  "plugins",
+  "tools",
+];
+const TEXT_EXTENSIONS = new Set([
+  ".cjs",
+  ".env",
+  ".js",
+  ".json",
+  ".jsx",
+  ".md",
+  ".mjs",
+  ".sh",
+  ".text",
+  ".tpl",
+  ".ts",
+  ".tsx",
+  ".txt",
+  ".yaml",
+  ".yml",
+]);
+const SUPPRESSION_PATTERN = /secret-scan:\s*ignore(?:\s+reason=([^\n]+))?/i;
+
+const DETECTORS: Detector[] = [
+  {
+    detectorId: "github_pat",
+    secretClass: "github_pat",
+    severity: "critical",
+    confidence: "high",
+    pattern: /\b(ghp_[A-Za-z0-9]{36})\b/g,
+    extractValue: (match) => match[1],
+  },
+  {
+    detectorId: "npm_token",
+    secretClass: "npm_token",
+    severity: "critical",
+    confidence: "high",
+    pattern: /\b(npm_[A-Za-z0-9]{36})\b/g,
+    extractValue: (match) => match[1],
+  },
+  {
+    detectorId: "aws_access_key_id",
+    secretClass: "aws_access_key_id",
+    severity: "high",
+    confidence: "high",
+    pattern: /\b(AKIA[0-9A-Z]{16})\b/g,
+    extractValue: (match) => match[1],
+  },
+  {
+    detectorId: "generic_env_secret",
+    secretClass: "generic_api_secret",
+    severity: "high",
+    confidence: "medium",
+    pattern: /\b[A-Z][A-Z0-9_]*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD)[A-Z0-9_]*\b\s*[:=]\s*["']?([A-Za-z0-9/_+=-]{20,})["']?/g,
+    extractValue: (match) => match[1],
+  },
+];
+
+function hashText(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function normalizePath(path: string): string {
+  return path.replaceAll("\\", "/");
+}
+
+function isTextFile(path: string): boolean {
+  return TEXT_EXTENSIONS.has(extname(path).toLowerCase());
+}
+
+function walkFiles(path: string): string[] {
+  if (!existsSync(path)) {
+    return [];
+  }
+
+  const stats = statSync(path);
+  if (stats.isFile()) {
+    return isTextFile(path) ? [path] : [];
+  }
+
+  const files: string[] = [];
+  for (const entry of readdirSync(path, { withFileTypes: true })) {
+    if (entry.name === ".git" || entry.name === "node_modules") {
+      continue;
+    }
+    files.push(...walkFiles(join(path, entry.name)));
+  }
+  return files;
+}
+
+function classifySourceSurface(path: string): SourceSurface {
+  const normalizedPath = normalizePath(path).toLowerCase();
+
+  if (normalizedPath.includes("/examples/")) {
+    return "examples";
+  }
+  if (normalizedPath.includes("/templates/")) {
+    return "templates";
+  }
+  if (
+    normalizedPath.startsWith("guides/") ||
+    normalizedPath.startsWith("skills/") ||
+    normalizedPath.startsWith("providers/") ||
+    normalizedPath.endsWith(".md")
+  ) {
+    return "docs";
+  }
+  if (
+    normalizedPath.includes("/artifacts/") ||
+    normalizedPath.startsWith(".github/") ||
+    normalizedPath.startsWith("cli/") ||
+    normalizedPath.startsWith("plugins/") ||
+    normalizedPath.startsWith("tools/")
+  ) {
+    return "publish_artifact";
+  }
+  return "other";
+}
+
+function getSuppression(line: string): Suppression | undefined {
+  const match = line.match(SUPPRESSION_PATTERN);
+  if (!match) {
+    return undefined;
+  }
+
+  return {
+    kind: "inline",
+    reason: match[1]?.trim() || "inline ignore",
+  };
+}
+
+function isPlaceholderValue(value: string): boolean {
+  const normalized = value.toLowerCase();
+  const placeholderPatterns = [
+    /changeme/,
+    /dummy/,
+    /example/,
+    /placeholder/,
+    /redacted/,
+    /sample/,
+    /test[-_]?key/,
+    /your[_-]/,
+    /^\${.+}$/,
+    /^<.+>$/,
+  ];
+
+  if (placeholderPatterns.some((pattern) => pattern.test(normalized))) {
+    return true;
+  }
+
+  return /^([a-z0-9])\1{9,}$/i.test(value);
+}
+
+function scanLine(path: string, line: string, lineNumber: number): SecretFinding[] {
+  const findings: SecretFinding[] = [];
+  const suppression = getSuppression(line);
+
+  for (const detector of DETECTORS) {
+    detector.pattern.lastIndex = 0;
+    let match: RegExpExecArray | null;
+
+    while ((match = detector.pattern.exec(line)) !== null) {
+      const secretValue = detector.extractValue(match);
+      if (isPlaceholderValue(secretValue)) {
+        continue;
+      }
+
+      const evidenceFingerprint = hashText(`${detector.detectorId}:${secretValue}`).slice(0, 16);
+      const relativePath = normalizePath(path);
+      const findingId = hashText(
+        [
+          REPORT_VERSION,
+          detector.detectorId,
+          detector.secretClass,
+          relativePath,
+          String(lineNumber),
+          evidenceFingerprint,
+        ].join(":")
+      ).slice(0, 20);
+
+      findings.push({
+        reportVersion: REPORT_VERSION,
+        findingId,
+        evidenceFingerprint,
+        detectorId: detector.detectorId,
+        secretClass: detector.secretClass,
+        severity: detector.severity,
+        confidence: detector.confidence,
+        path: relativePath,
+        line: lineNumber,
+        sourceSurface: classifySourceSurface(relativePath),
+        matchLength: secretValue.length,
+        suppression,
+      });
+    }
+  }
+
+  return findings;
+}
+
+export function scanPaths(scanPaths: string[], baseDir = process.cwd()): ScanReport {
+  const normalizedPaths = scanPaths.map((path) => normalizePath(path));
+  const findings: SecretFinding[] = [];
+  let filesScanned = 0;
+
+  for (const scanPath of scanPaths) {
+    for (const file of walkFiles(join(baseDir, scanPath))) {
+      filesScanned += 1;
+      const relativePath = normalizePath(relative(baseDir, file));
+      const content = readFileSync(file, "utf8");
+      const lines = content.split(/\r?\n/);
+
+      lines.forEach((line, index) => {
+        findings.push(...scanLine(relativePath, line, index + 1));
+      });
+    }
+  }
+
+  const suppressedFindings = findings.filter((finding) => finding.suppression).length;
+
+  return {
+    reportVersion: REPORT_VERSION,
+    scannedPaths: normalizedPaths,
+    summary: {
+      filesScanned,
+      findings: findings.length,
+      blockingFindings: findings.length - suppressedFindings,
+      suppressedFindings,
+    },
+    findings,
+  };
+}
+
+function parseArgs(argv: string[]): { scanPaths: string[]; failOnFindings: boolean } {
+  const scanPaths: string[] = [];
+  let failOnFindings = false;
+
+  for (const arg of argv) {
+    if (arg === "--ci") {
+      failOnFindings = true;
+      continue;
+    }
+    if (arg === "--no-fail-on-findings") {
+      failOnFindings = false;
+      continue;
+    }
+    scanPaths.push(arg);
+  }
+
+  return {
+    scanPaths: scanPaths.length > 0 ? scanPaths : DEFAULT_SCAN_PATHS,
+    failOnFindings,
+  };
+}
+
+function main() {
+  const { scanPaths: requestedPaths, failOnFindings } = parseArgs(process.argv.slice(2));
+  const report = scanPaths(requestedPaths, process.cwd());
+  console.log(JSON.stringify(report, null, 2));
+
+  if (failOnFindings && report.summary.blockingFindings > 0) {
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/tests/fixtures/publish-secret-scan/artifacts/env-secret.env
+++ b/tests/fixtures/publish-secret-scan/artifacts/env-secret.env
@@ -1,0 +1,1 @@
+PUBLISH_TOKEN=ProdSecretTokenValue987654321

--- a/tests/fixtures/publish-secret-scan/artifacts/suppressed-secret.env
+++ b/tests/fixtures/publish-secret-scan/artifacts/suppressed-secret.env
@@ -1,0 +1,1 @@
+PUBLISH_TOKEN=ProdSecretTokenValue987654321 secret-scan: ignore reason=fixture placeholder for suppression coverage

--- a/tests/fixtures/publish-secret-scan/docs/github-token.md
+++ b/tests/fixtures/publish-secret-scan/docs/github-token.md
@@ -1,0 +1,1 @@
+Use the sample token `ghp_0123456789abcdef0123456789abcdef0123` only in fixture validation.

--- a/tests/fixtures/publish-secret-scan/examples/npm-token.ts
+++ b/tests/fixtures/publish-secret-scan/examples/npm-token.ts
@@ -1,0 +1,1 @@
+export const token = "npm_0123456789abcdef0123456789abcdef0123";

--- a/tests/fixtures/publish-secret-scan/negatives/placeholders.md
+++ b/tests/fixtures/publish-secret-scan/negatives/placeholders.md
@@ -1,0 +1,3 @@
+Authorization: Bearer ${TELNYX_API_KEY}
+TELNYX_API_KEY=your_api_key_here
+NPM_TOKEN=example-token-placeholder

--- a/tests/fixtures/publish-secret-scan/templates/aws-key.tpl
+++ b/tests/fixtures/publish-secret-scan/templates/aws-key.tpl
@@ -1,0 +1,1 @@
+aws_access_key_id=AKIA1234567890ABCD12

--- a/tests/publish-secret-scan.test.ts
+++ b/tests/publish-secret-scan.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { scanPaths } from "../scripts/publish-secret-scan.ts";
+
+const __dirname = typeof import.meta.dirname === "string"
+  ? import.meta.dirname
+  : dirname(fileURLToPath(import.meta.url));
+const FIXTURE_ROOT = join(__dirname, "fixtures", "publish-secret-scan");
+
+describe("publish secret scan fixtures", () => {
+  it("detects representative positive fixtures at or above 80% coverage", () => {
+    const report = scanPaths([
+      "tests/fixtures/publish-secret-scan/docs",
+      "tests/fixtures/publish-secret-scan/examples",
+      "tests/fixtures/publish-secret-scan/templates",
+      "tests/fixtures/publish-secret-scan/artifacts",
+    ], join(__dirname, ".."));
+
+    const positivePaths = new Set([
+      "tests/fixtures/publish-secret-scan/docs/github-token.md",
+      "tests/fixtures/publish-secret-scan/examples/npm-token.ts",
+      "tests/fixtures/publish-secret-scan/templates/aws-key.tpl",
+      "tests/fixtures/publish-secret-scan/artifacts/env-secret.env",
+      "tests/fixtures/publish-secret-scan/artifacts/suppressed-secret.env",
+    ]);
+    const hitPaths = new Set(
+      report.findings
+        .map((finding) => finding.path)
+        .filter((path) => positivePaths.has(path))
+    );
+    const coverage = hitPaths.size / positivePaths.size;
+
+    assert.ok(
+      coverage >= 0.8,
+      `expected >=80% fixture coverage, received ${(coverage * 100).toFixed(1)}%`
+    );
+    assert.equal(coverage, 1);
+  });
+
+  it("does not hard-fail placeholder or non-secret fixtures", () => {
+    const report = scanPaths([
+      "tests/fixtures/publish-secret-scan/negatives",
+    ], join(__dirname, ".."));
+
+    assert.equal(report.summary.blockingFindings, 0);
+    assert.equal(report.findings.length, 0);
+  });
+
+  it("emits deterministic finding ids, evidence fingerprints, and suppression metadata", () => {
+    const first = scanPaths([
+      "tests/fixtures/publish-secret-scan",
+    ], join(__dirname, ".."));
+    const second = scanPaths([
+      "tests/fixtures/publish-secret-scan",
+    ], join(__dirname, ".."));
+
+    assert.deepEqual(first.findings, second.findings);
+
+    for (const finding of first.findings) {
+      assert.equal(finding.reportVersion, "1");
+      assert.ok(finding.findingId.length > 0);
+      assert.ok(finding.evidenceFingerprint.length > 0);
+      assert.ok(finding.detectorId.length > 0);
+      assert.ok(finding.secretClass.length > 0);
+      assert.ok(finding.path.length > 0);
+      assert.ok(finding.line > 0);
+      assert.ok(finding.sourceSurface.length > 0);
+    }
+
+    const suppressed = first.findings.find((finding) => finding.suppression);
+    assert.ok(suppressed, "expected a suppressed finding fixture");
+    assert.equal(suppressed?.suppression?.kind, "inline");
+    assert.match(suppressed?.suppression?.reason || "", /fixture placeholder/i);
+  });
+
+  it("never emits raw fixture secret material in the JSON report", () => {
+    const report = scanPaths([
+      "tests/fixtures/publish-secret-scan",
+    ], join(__dirname, ".."));
+    const json = JSON.stringify(report);
+    const rawSecrets = [
+      "ghp_0123456789abcdef0123456789abcdef0123",
+      "npm_0123456789abcdef0123456789abcdef0123",
+      "AKIA1234567890ABCD12",
+      "ProdSecretTokenValue987654321",
+    ];
+
+    for (const rawSecret of rawSecrets) {
+      assert.equal(json.includes(rawSecret), false, `report leaked raw secret ${rawSecret}`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Backfill draft PR for the recovered publish secret-scan preflight work that landed in `team-telnyx/ai` without a review artifact.

## Covered issues
- TEL-108

## Notes
Recovered from local git history ahead of `origin/main` during TEL-266 audit.
External-repo publish workflow issues like TEL-131 and TEL-144 need separate repo-scoped follow-up instead of being claimed by this `/ai` PR.
