### PR TITLE
draft: backfill publish evidence bundle chain

### DIFF
--- a/.github/bin/publish-npm
+++ b/.github/bin/publish-npm
@@ -5,9 +5,89 @@
 
 set -eux
 
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 PACKAGE_DIR="${1:-.}"
+WORKFLOW_NAME="${WORKFLOW_NAME:-publish-npm}"
+PUBLISH_NPM_GATE_STATE="${PUBLISH_NPM_GATE_STATE:-enabled}"
+PUBLISH_NPM_ENABLED="${PUBLISH_NPM_ENABLED:-true}"
+PUBLISH_DISABLE_REASON="${PUBLISH_DISABLE_REASON:-}"
+PUBLISH_DISABLE_INCIDENT_ID="${PUBLISH_DISABLE_INCIDENT_ID:-}"
+PUBLISH_DISABLED_BY="${PUBLISH_DISABLED_BY:-${GITHUB_ACTOR:-unknown}}"
+PACKAGE_OWNER_ID="${PACKAGE_OWNER_ID:-}"
+PACKAGE_OWNER_CONTACT_TARGET="${PACKAGE_OWNER_CONTACT_TARGET:-}"
+RELEASE_ONCALL_GROUP_ID="${RELEASE_ONCALL_GROUP_ID:-release-oncall}"
 
-cd "$PACKAGE_DIR"
+cd "$REPO_ROOT/$PACKAGE_DIR"
+
+PACKAGE_NAME="$(jq -r -e '.name' ./package.json)"
+VERSION="$(jq -r -e '.version' ./package.json)"
+RUN_URL="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-team-telnyx/ai}/actions/runs/${GITHUB_RUN_ID:-0}"
+TMP_DIR="$(mktemp -d)"
+SCAN_REPORT_PATH="$TMP_DIR/scan-report.json"
+HANDOFF_DIR="$TMP_DIR/evidence-handoff"
+HANDOFF_PATH="$HANDOFF_DIR/$(basename "$PACKAGE_DIR")-${PUBLISH_NPM_GATE_STATE}.json"
+
+emit_handoff_payload() {
+  local mode="$1"
+  shift
+  env \
+    EVIDENCE_PACKAGE_NAME="$PACKAGE_NAME" \
+    EVIDENCE_PACKAGE_DIR="$PACKAGE_DIR" \
+    EVIDENCE_WORKFLOW_NAME="$WORKFLOW_NAME" \
+    EVIDENCE_ACTOR="$PUBLISH_DISABLED_BY" \
+    EVIDENCE_INCIDENT_ID="${PUBLISH_DISABLE_INCIDENT_ID:-${GITHUB_RUN_ID:-manual}}" \
+    EVIDENCE_REASON="${PUBLISH_DISABLE_REASON:-publish gate triggered}" \
+    EVIDENCE_GATE_STATE="$PUBLISH_NPM_GATE_STATE" \
+    EVIDENCE_OWNER_ID="$PACKAGE_OWNER_ID" \
+    EVIDENCE_OWNER_CONTACT_TARGET="$PACKAGE_OWNER_CONTACT_TARGET" \
+    EVIDENCE_ONCALL_GROUP_ID="$RELEASE_ONCALL_GROUP_ID" \
+    EVIDENCE_RUN_URL="$RUN_URL" \
+    EVIDENCE_WORKFLOW_SUMMARY_PATH="${GITHUB_STEP_SUMMARY:-}" \
+    EVIDENCE_AUDIT_LOG_PATH="$TMP_DIR/publish-audit-log.txt" \
+    EVIDENCE_SCAN_REPORT_PATH="$SCAN_REPORT_PATH" \
+    EVIDENCE_OUTPUT_PATH="$HANDOFF_PATH" \
+    npx --yes tsx "$REPO_ROOT/scripts/evidence-handoff-cli.ts" "$mode" "$@"
+}
+
+{
+  echo "package_name=$PACKAGE_NAME"
+  echo "package_version=$VERSION"
+  echo "publish_gate_state=$PUBLISH_NPM_GATE_STATE"
+  echo "publish_disable_reason=${PUBLISH_DISABLE_REASON:-none}"
+  echo "publish_disable_incident_id=${PUBLISH_DISABLE_INCIDENT_ID:-none}"
+  echo "publish_disable_by=$PUBLISH_DISABLED_BY"
+} | tee "$TMP_DIR/publish-audit-log.txt"
+
+if [[ "$PUBLISH_NPM_ENABLED" != "true" || "$PUBLISH_NPM_GATE_STATE" == "disabled" ]]; then
+  emit_handoff_payload publish-path
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+      echo "## Publish gate disabled"
+      echo
+      echo "- package: \`$PACKAGE_NAME\`"
+      echo "- incident: \`${PUBLISH_DISABLE_INCIDENT_ID:-${GITHUB_RUN_ID:-manual}}\`"
+      echo "- reason: ${PUBLISH_DISABLE_REASON:-publish gate triggered}"
+      echo "- evidence payload: \`$HANDOFF_PATH\`"
+    } >> "$GITHUB_STEP_SUMMARY"
+  fi
+  echo "Publish gate disabled for $PACKAGE_NAME; evidence handoff payload written to $HANDOFF_PATH"
+  exit 1
+fi
+
+if [[ "$PUBLISH_NPM_GATE_STATE" == "override" ]]; then
+  emit_handoff_payload publish-path
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+      echo "## Publish gate override recorded"
+      echo
+      echo "- package: \`$PACKAGE_NAME\`"
+      echo "- incident: \`${PUBLISH_DISABLE_INCIDENT_ID:-${GITHUB_RUN_ID:-manual}}\`"
+      echo "- reason: ${PUBLISH_DISABLE_REASON:-publish gate override recorded}"
+      echo "- evidence payload: \`$HANDOFF_PATH\`"
+    } >> "$GITHUB_STEP_SUMMARY"
+  fi
+  echo "Publish gate override recorded for $PACKAGE_NAME; evidence handoff payload written to $HANDOFF_PATH"
+fi
 
 # Authenticate — prefer OIDC, fall back to NPM_TOKEN
 if [[ ${NPM_TOKEN:-} ]]; then
@@ -20,9 +100,24 @@ fi
 # Build (CLI has a no-op build, TS SDK compiles)
 npm run build
 
-# Get package info
-PACKAGE_NAME="$(jq -r -e '.name' ./package.json)"
-VERSION="$(jq -r -e '.version' ./package.json)"
+if ! (cd "$REPO_ROOT" && npx --yes tsx scripts/publish-secret-scan.ts --ci "$PACKAGE_DIR" > "$SCAN_REPORT_PATH"); then
+  PUBLISH_DISABLE_REASON="${PUBLISH_DISABLE_REASON:-release artifact secret scan detected blocking findings}"
+  PUBLISH_DISABLE_INCIDENT_ID="${PUBLISH_DISABLE_INCIDENT_ID:-${GITHUB_RUN_ID:-manual}-secret-scan}"
+  PUBLISH_NPM_GATE_STATE="disabled"
+  emit_handoff_payload secret-exposure
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+      echo "## Secret exposure scan blocked publish"
+      echo
+      echo "- package: \`$PACKAGE_NAME\`"
+      echo "- incident: \`${PUBLISH_DISABLE_INCIDENT_ID}\`"
+      echo "- report: \`$SCAN_REPORT_PATH\`"
+      echo "- evidence payload: \`$HANDOFF_PATH\`"
+    } >> "$GITHUB_STEP_SUMMARY"
+  fi
+  echo "Secret exposure scan blocked publish for $PACKAGE_NAME; evidence handoff payload written to $HANDOFF_PATH"
+  exit 1
+fi
 
 echo "Publishing $PACKAGE_NAME@$VERSION"
 

--- a/.github/bin/publish-npm
+++ b/.github/bin/publish-npm
@@ -22,6 +22,7 @@ cd "$REPO_ROOT/$PACKAGE_DIR"
 PACKAGE_NAME="$(jq -r -e '.name' ./package.json)"
 VERSION="$(jq -r -e '.version' ./package.json)"
 RUN_URL="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-team-telnyx/ai}/actions/runs/${GITHUB_RUN_ID:-0}"
+REPO_SHA="$(git -C "$REPO_ROOT" rev-parse HEAD)"
 TMP_DIR="$(mktemp -d)"
 SCAN_REPORT_PATH="$TMP_DIR/scan-report.json"
 HANDOFF_DIR="$TMP_DIR/evidence-handoff"
@@ -30,6 +31,12 @@ HANDOFF_PATH="$HANDOFF_DIR/$(basename "$PACKAGE_DIR")-${PUBLISH_NPM_GATE_STATE}.
 emit_handoff_payload() {
   local mode="$1"
   shift
+  local credential_source="unknown"
+  if [[ -n "${NPM_TOKEN:-}" ]]; then
+    credential_source="npm_token"
+  elif [[ -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]]; then
+    credential_source="github_actions_oidc"
+  fi
   env \
     EVIDENCE_PACKAGE_NAME="$PACKAGE_NAME" \
     EVIDENCE_PACKAGE_DIR="$PACKAGE_DIR" \
@@ -45,6 +52,13 @@ emit_handoff_payload() {
     EVIDENCE_WORKFLOW_SUMMARY_PATH="${GITHUB_STEP_SUMMARY:-}" \
     EVIDENCE_AUDIT_LOG_PATH="$TMP_DIR/publish-audit-log.txt" \
     EVIDENCE_SCAN_REPORT_PATH="$SCAN_REPORT_PATH" \
+    EVIDENCE_WORKSPACE_ID="${GITHUB_WORKSPACE:-$REPO_ROOT}" \
+    EVIDENCE_REPOSITORY_ROOT="$REPO_ROOT" \
+    EVIDENCE_REPO_SHA="$REPO_SHA" \
+    EVIDENCE_CREDENTIAL_SOURCE="$credential_source" \
+    EVIDENCE_REGISTRY_WEBHOOK="${EVIDENCE_REGISTRY_WEBHOOK:-}" \
+    EVIDENCE_PROVENANCE_URL="${EVIDENCE_PROVENANCE_URL:-}" \
+    EVIDENCE_VERIFICATION_COMMANDS="$(printf 'git -C %s rev-parse HEAD\ngit -C %s checkout %s\ngit -C %s status --short' "$REPO_ROOT" "$REPO_ROOT" "$REPO_SHA" "$REPO_ROOT")" \
     EVIDENCE_OUTPUT_PATH="$HANDOFF_PATH" \
     npx --yes tsx "$REPO_ROOT/scripts/evidence-handoff-cli.ts" "$mode" "$@"
 }
@@ -67,6 +81,8 @@ if [[ "$PUBLISH_NPM_ENABLED" != "true" || "$PUBLISH_NPM_GATE_STATE" == "disabled
       echo "- package: \`$PACKAGE_NAME\`"
       echo "- incident: \`${PUBLISH_DISABLE_INCIDENT_ID:-${GITHUB_RUN_ID:-manual}}\`"
       echo "- reason: ${PUBLISH_DISABLE_REASON:-publish gate triggered}"
+      echo "- workspace: \`${GITHUB_WORKSPACE:-$REPO_ROOT}\`"
+      echo "- repo sha: \`$REPO_SHA\`"
       echo "- evidence payload: \`$HANDOFF_PATH\`"
     } >> "$GITHUB_STEP_SUMMARY"
   fi
@@ -83,6 +99,8 @@ if [[ "$PUBLISH_NPM_GATE_STATE" == "override" ]]; then
       echo "- package: \`$PACKAGE_NAME\`"
       echo "- incident: \`${PUBLISH_DISABLE_INCIDENT_ID:-${GITHUB_RUN_ID:-manual}}\`"
       echo "- reason: ${PUBLISH_DISABLE_REASON:-publish gate override recorded}"
+      echo "- workspace: \`${GITHUB_WORKSPACE:-$REPO_ROOT}\`"
+      echo "- repo sha: \`$REPO_SHA\`"
       echo "- evidence payload: \`$HANDOFF_PATH\`"
     } >> "$GITHUB_STEP_SUMMARY"
   fi
@@ -112,6 +130,8 @@ if ! (cd "$REPO_ROOT" && npx --yes tsx scripts/publish-secret-scan.ts --ci "$PAC
       echo "- package: \`$PACKAGE_NAME\`"
       echo "- incident: \`${PUBLISH_DISABLE_INCIDENT_ID}\`"
       echo "- report: \`$SCAN_REPORT_PATH\`"
+      echo "- workspace: \`${GITHUB_WORKSPACE:-$REPO_ROOT}\`"
+      echo "- repo sha: \`$REPO_SHA\`"
       echo "- evidence payload: \`$HANDOFF_PATH\`"
     } >> "$GITHUB_STEP_SUMMARY"
   fi

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -25,6 +25,27 @@ on:
           - cli
           - mcp
           - opencode
+      gate_state:
+        description: 'Publish gate state for incident routing'
+        required: false
+        default: enabled
+        type: choice
+        options:
+          - enabled
+          - disabled
+          - override
+      publish_disable_reason:
+        description: 'Reason for blocking or overriding the publish gate'
+        required: false
+        type: string
+      publish_disable_incident_id:
+        description: 'Incident or ticket id for the publish-path alert'
+        required: false
+        type: string
+      publish_disable_by:
+        description: 'Actor recording the disable or override'
+        required: false
+        type: string
   release:
     types: [published]
 
@@ -68,6 +89,15 @@ jobs:
         run: npm ci
 
       - name: Publish @telnyx/agent-toolkit
+        env:
+          PUBLISH_NPM_ENABLED: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.gate_state == 'disabled' && 'false' || 'true' }}
+          PUBLISH_NPM_GATE_STATE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.gate_state || 'enabled' }}
+          PUBLISH_DISABLE_REASON: ${{ github.event.inputs.publish_disable_reason }}
+          PUBLISH_DISABLE_INCIDENT_ID: ${{ github.event.inputs.publish_disable_incident_id }}
+          PUBLISH_DISABLED_BY: ${{ github.event.inputs.publish_disable_by || github.actor }}
+          PACKAGE_OWNER_ID: aisling404
+          RELEASE_ONCALL_GROUP_ID: release-oncall
+          WORKFLOW_NAME: publish-npm
         run: bash ./.github/bin/publish-npm tools/typescript
 
   publish-cli:
@@ -93,6 +123,15 @@ jobs:
         run: npm ci
 
       - name: Publish @telnyx/agent-cli
+        env:
+          PUBLISH_NPM_ENABLED: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.gate_state == 'disabled' && 'false' || 'true' }}
+          PUBLISH_NPM_GATE_STATE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.gate_state || 'enabled' }}
+          PUBLISH_DISABLE_REASON: ${{ github.event.inputs.publish_disable_reason }}
+          PUBLISH_DISABLE_INCIDENT_ID: ${{ github.event.inputs.publish_disable_incident_id }}
+          PUBLISH_DISABLED_BY: ${{ github.event.inputs.publish_disable_by || github.actor }}
+          PACKAGE_OWNER_ID: aisling404
+          RELEASE_ONCALL_GROUP_ID: release-oncall
+          WORKFLOW_NAME: publish-npm
         run: bash ./.github/bin/publish-npm cli
 
   publish-mcp:
@@ -118,6 +157,15 @@ jobs:
         run: npm ci
 
       - name: Publish @telnyx/mcp
+        env:
+          PUBLISH_NPM_ENABLED: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.gate_state == 'disabled' && 'false' || 'true' }}
+          PUBLISH_NPM_GATE_STATE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.gate_state || 'enabled' }}
+          PUBLISH_DISABLE_REASON: ${{ github.event.inputs.publish_disable_reason }}
+          PUBLISH_DISABLE_INCIDENT_ID: ${{ github.event.inputs.publish_disable_incident_id }}
+          PUBLISH_DISABLED_BY: ${{ github.event.inputs.publish_disable_by || github.actor }}
+          PACKAGE_OWNER_ID: aisling404
+          RELEASE_ONCALL_GROUP_ID: release-oncall
+          WORKFLOW_NAME: publish-npm
         run: bash ./.github/bin/publish-npm tools/mcp
 
   publish-opencode:
@@ -145,6 +193,15 @@ jobs:
         run: npm ci --legacy-peer-deps
 
       - name: Publish @telnyx/opencode
+        env:
+          PUBLISH_NPM_ENABLED: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.gate_state == 'disabled' && 'false' || 'true' }}
+          PUBLISH_NPM_GATE_STATE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.gate_state || 'enabled' }}
+          PUBLISH_DISABLE_REASON: ${{ github.event.inputs.publish_disable_reason }}
+          PUBLISH_DISABLE_INCIDENT_ID: ${{ github.event.inputs.publish_disable_incident_id }}
+          PUBLISH_DISABLED_BY: ${{ github.event.inputs.publish_disable_by || github.actor }}
+          PACKAGE_OWNER_ID: aaronjo-Telnyx
+          RELEASE_ONCALL_GROUP_ID: release-oncall
+          WORKFLOW_NAME: publish-npm
         run: bash ./.github/bin/publish-npm plugins/opencode
 
   publish-mcp-registry:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "publish:preflight": "npx tsx scripts/publish-secret-scan.ts --ci",
     "test:guides": "npx tsx --test tests/guides.test.ts",
     "test:guides-api": "npx tsx --test tests/guides-api.test.ts",
-    "test:publish-preflight": "npx tsx --test tests/publish-secret-scan.test.ts"
+    "test:publish-preflight": "npx tsx --test tests/publish-secret-scan.test.ts tests/evidence-handoff.test.ts"
   },
   "devDependencies": {
     "tsx": "^4.19.0"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "publish:preflight": "npx tsx scripts/publish-secret-scan.ts --ci",
     "test:guides": "npx tsx --test tests/guides.test.ts",
     "test:guides-api": "npx tsx --test tests/guides-api.test.ts",
-    "test:publish-preflight": "npx tsx --test tests/publish-secret-scan.test.ts tests/evidence-handoff.test.ts"
+    "test:publish-preflight": "npx tsx --test tests/publish-secret-scan.test.ts tests/evidence-handoff.test.ts tests/publish-npm.test.ts"
   },
   "devDependencies": {
     "tsx": "^4.19.0"

--- a/scripts/evidence-escalation.ts
+++ b/scripts/evidence-escalation.ts
@@ -1,0 +1,110 @@
+import type { ConfidenceLevel, IncidentClass, OwnerIdentity } from "./evidence-handoff.ts";
+
+export type EscalationTimelineEvent =
+  | "alert_detected"
+  | "owner_notified"
+  | "owner_acked"
+  | "oncall_notified"
+  | "oncall_acked"
+  | "cto_notified"
+  | "containment_started"
+  | "evidence_bundle_ready"
+  | "restore_approved"
+  | "resolved";
+
+export interface EscalationContact {
+  id: string;
+  contactTarget: string;
+}
+
+export interface EscalationRoute {
+  currentEvent: EscalationTimelineEvent;
+  escalationState: "owner_notified" | "oncall_notified" | "cto_notified";
+  ackDeadlineUtc: string;
+  nextEscalationState?: "oncall_notified" | "cto_notified";
+  nextEscalationAtUtc?: string;
+  targets: {
+    owner: OwnerIdentity;
+    onCall: EscalationContact;
+    cto: EscalationContact;
+  };
+}
+
+export interface EscalationInput {
+  incidentClass: IncidentClass;
+  timestampUtc: string;
+  owner: OwnerIdentity;
+  onCallGroupId: string;
+  confidenceLevel: ConfidenceLevel;
+  publishGateState?: "enabled" | "disabled" | "override";
+}
+
+const DEFAULT_CTO_CONTACT: EscalationContact = {
+  id: "cto",
+  contactTarget: "group:cto",
+};
+
+function addMinutes(timestampUtc: string, minutes: number): string {
+  const time = new Date(timestampUtc);
+  time.setUTCMinutes(time.getUTCMinutes() + minutes);
+  return time.toISOString();
+}
+
+function getCurrentState(input: EscalationInput): EscalationRoute["escalationState"] {
+  if (input.incidentClass === "publish_path") {
+    return input.publishGateState === "override" ? "oncall_notified" : "owner_notified";
+  }
+
+  return input.confidenceLevel === "critical" ? "cto_notified" : "oncall_notified";
+}
+
+function getAckMinutes(incidentClass: IncidentClass, escalationState: EscalationRoute["escalationState"]): number {
+  if (incidentClass === "publish_path") {
+    if (escalationState === "owner_notified") return 10;
+    if (escalationState === "oncall_notified") return 20;
+    return 30;
+  }
+
+  if (escalationState === "oncall_notified") return 10;
+  if (escalationState === "owner_notified") return 5;
+  return 0;
+}
+
+function getNextEscalationState(
+  incidentClass: IncidentClass,
+  escalationState: EscalationRoute["escalationState"],
+): EscalationRoute["nextEscalationState"] {
+  if (incidentClass === "publish_path") {
+    if (escalationState === "owner_notified") return "oncall_notified";
+    if (escalationState === "oncall_notified") return "cto_notified";
+    return undefined;
+  }
+
+  if (escalationState === "oncall_notified") {
+    return "cto_notified";
+  }
+
+  return undefined;
+}
+
+export function buildEscalationRoute(input: EscalationInput): EscalationRoute {
+  const escalationState = getCurrentState(input);
+  const ackDeadlineUtc = addMinutes(input.timestampUtc, getAckMinutes(input.incidentClass, escalationState));
+  const nextEscalationState = getNextEscalationState(input.incidentClass, escalationState);
+
+  return {
+    currentEvent: escalationState,
+    escalationState,
+    ackDeadlineUtc,
+    nextEscalationState,
+    nextEscalationAtUtc: nextEscalationState ? ackDeadlineUtc : undefined,
+    targets: {
+      owner: input.owner,
+      onCall: {
+        id: input.onCallGroupId,
+        contactTarget: `group:${input.onCallGroupId}`,
+      },
+      cto: DEFAULT_CTO_CONTACT,
+    },
+  };
+}

--- a/scripts/evidence-handoff-cli.ts
+++ b/scripts/evidence-handoff-cli.ts
@@ -1,0 +1,83 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+import {
+  buildPublishPathPayload,
+  buildSecretExposurePayload,
+  loadCodeownersText,
+} from "./evidence-handoff.ts";
+import type { ScanReport } from "./publish-secret-scan.ts";
+
+function getRequiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable ${name}`);
+  }
+  return value;
+}
+
+function writePayloadIfRequested(payload: unknown) {
+  const outputPath = process.env.EVIDENCE_OUTPUT_PATH;
+  const json = JSON.stringify(payload, null, 2);
+  if (outputPath) {
+    mkdirSync(dirname(outputPath), { recursive: true });
+    writeFileSync(outputPath, `${json}\n`, "utf8");
+  }
+  console.log(json);
+}
+
+function buildPublishPathFromEnv() {
+  return buildPublishPathPayload({
+    packageName: getRequiredEnv("EVIDENCE_PACKAGE_NAME"),
+    packageDir: getRequiredEnv("EVIDENCE_PACKAGE_DIR"),
+    workflow: process.env.EVIDENCE_WORKFLOW_NAME || "publish-npm",
+    actor: process.env.EVIDENCE_ACTOR || "unknown",
+    incidentId: getRequiredEnv("EVIDENCE_INCIDENT_ID"),
+    reason: getRequiredEnv("EVIDENCE_REASON"),
+    timestampUtc: process.env.EVIDENCE_TIMESTAMP_UTC,
+    gateState: (process.env.EVIDENCE_GATE_STATE as "enabled" | "disabled" | "override") || "disabled",
+    ownerId: process.env.EVIDENCE_OWNER_ID,
+    ownerContactTarget: process.env.EVIDENCE_OWNER_CONTACT_TARGET,
+    onCallGroupId: process.env.EVIDENCE_ONCALL_GROUP_ID,
+    codeownersText: loadCodeownersText(process.env.EVIDENCE_CODEOWNERS_PATH),
+    workflowSummaryPath: process.env.EVIDENCE_WORKFLOW_SUMMARY_PATH,
+    auditLogPath: process.env.EVIDENCE_AUDIT_LOG_PATH,
+    runUrl: process.env.EVIDENCE_RUN_URL,
+  });
+}
+
+function buildSecretExposureFromEnv() {
+  const reportPath = getRequiredEnv("EVIDENCE_SCAN_REPORT_PATH");
+  const report = JSON.parse(readFileSync(reportPath, "utf8")) as ScanReport;
+  return buildSecretExposurePayload({
+    packageName: getRequiredEnv("EVIDENCE_PACKAGE_NAME"),
+    packageDir: getRequiredEnv("EVIDENCE_PACKAGE_DIR"),
+    workflow: process.env.EVIDENCE_WORKFLOW_NAME || "publish-npm",
+    actor: process.env.EVIDENCE_ACTOR || "unknown",
+    incidentId: getRequiredEnv("EVIDENCE_INCIDENT_ID"),
+    reason: getRequiredEnv("EVIDENCE_REASON"),
+    timestampUtc: process.env.EVIDENCE_TIMESTAMP_UTC,
+    ownerId: process.env.EVIDENCE_OWNER_ID,
+    ownerContactTarget: process.env.EVIDENCE_OWNER_CONTACT_TARGET,
+    onCallGroupId: process.env.EVIDENCE_ONCALL_GROUP_ID,
+    codeownersText: loadCodeownersText(process.env.EVIDENCE_CODEOWNERS_PATH),
+    runUrl: process.env.EVIDENCE_RUN_URL,
+    scanReportPath: reportPath,
+    report,
+  });
+}
+
+function main() {
+  const mode = process.argv[2];
+  if (mode === "publish-path") {
+    writePayloadIfRequested(buildPublishPathFromEnv());
+    return;
+  }
+  if (mode === "secret-exposure") {
+    writePayloadIfRequested(buildSecretExposureFromEnv());
+    return;
+  }
+  throw new Error(`Unsupported evidence handoff mode: ${mode}`);
+}
+
+main();

--- a/scripts/evidence-handoff-cli.ts
+++ b/scripts/evidence-handoff-cli.ts
@@ -2,10 +2,13 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 
 import {
+  type EvidenceHandoffPayload,
+  validateEvidenceHandoffPayload,
   buildPublishPathPayload,
   buildSecretExposurePayload,
   loadCodeownersText,
 } from "./evidence-handoff.ts";
+import { assessWorkspaceIntegrity } from "./evidence-escalation.ts";
 import type { ScanReport } from "./publish-secret-scan.ts";
 
 function getRequiredEnv(name: string): string {
@@ -26,6 +29,29 @@ function writePayloadIfRequested(payload: unknown) {
   console.log(json);
 }
 
+function getSnapshotEnv() {
+  const verificationCommands = process.env.EVIDENCE_VERIFICATION_COMMANDS
+    ?.split("\n")
+    .map((command) => command.trim())
+    .filter(Boolean);
+
+  return {
+    sourceIssueId: process.env.EVIDENCE_SOURCE_ISSUE_ID,
+    workspaceIdentity: process.env.EVIDENCE_WORKSPACE_ID,
+    repoSha: process.env.EVIDENCE_REPO_SHA,
+    repositoryRoot: process.env.EVIDENCE_REPOSITORY_ROOT,
+    verificationCommands,
+  };
+}
+
+function getDependencyAvailabilityEnv() {
+  return {
+    credentialSource: process.env.EVIDENCE_CREDENTIAL_SOURCE,
+    registryWebhook: process.env.EVIDENCE_REGISTRY_WEBHOOK,
+    provenanceUrl: process.env.EVIDENCE_PROVENANCE_URL,
+  };
+}
+
 function buildPublishPathFromEnv() {
   return buildPublishPathPayload({
     packageName: getRequiredEnv("EVIDENCE_PACKAGE_NAME"),
@@ -43,6 +69,8 @@ function buildPublishPathFromEnv() {
     workflowSummaryPath: process.env.EVIDENCE_WORKFLOW_SUMMARY_PATH,
     auditLogPath: process.env.EVIDENCE_AUDIT_LOG_PATH,
     runUrl: process.env.EVIDENCE_RUN_URL,
+    ...getDependencyAvailabilityEnv(),
+    ...getSnapshotEnv(),
   });
 }
 
@@ -64,6 +92,33 @@ function buildSecretExposureFromEnv() {
     runUrl: process.env.EVIDENCE_RUN_URL,
     scanReportPath: reportPath,
     report,
+    ...getDependencyAvailabilityEnv(),
+    ...getSnapshotEnv(),
+  });
+}
+
+function readEvidencePayloadFromEnv(): EvidenceHandoffPayload {
+  const payloadPath = getRequiredEnv("EVIDENCE_PAYLOAD_PATH");
+  const payload = JSON.parse(readFileSync(payloadPath, "utf8")) as EvidenceHandoffPayload;
+  validateEvidenceHandoffPayload(payload);
+  return payload;
+}
+
+function buildSnapshotIntegrityFromEnv() {
+  const payload = readEvidencePayloadFromEnv();
+  const reviewerSnapshot = {
+    workspaceIdentity: getRequiredEnv("EVIDENCE_REVIEWER_WORKSPACE_ID"),
+    repoSha: getRequiredEnv("EVIDENCE_REVIEWER_REPO_SHA"),
+  };
+
+  return assessWorkspaceIntegrity({
+    sourceIssueId: payload.snapshot.sourceIssueId,
+    evidenceSnapshot: {
+      workspaceIdentity: payload.snapshot.workspaceIdentity,
+      repoSha: payload.snapshot.repoSha,
+    },
+    reviewerSnapshot,
+    activeBlockerIssueId: process.env.EVIDENCE_ACTIVE_BLOCKER_ISSUE_ID,
   });
 }
 
@@ -75,6 +130,10 @@ function main() {
   }
   if (mode === "secret-exposure") {
     writePayloadIfRequested(buildSecretExposureFromEnv());
+    return;
+  }
+  if (mode === "snapshot-integrity") {
+    writePayloadIfRequested(buildSnapshotIntegrityFromEnv());
     return;
   }
   throw new Error(`Unsupported evidence handoff mode: ${mode}`);

--- a/scripts/evidence-handoff.ts
+++ b/scripts/evidence-handoff.ts
@@ -1,0 +1,466 @@
+import { readFileSync } from "node:fs";
+
+import type { ScanReport, SecretFinding } from "./publish-secret-scan.ts";
+
+export type IncidentClass = "publish_path" | "secret_exposure";
+export type EscalationState = "owner_notified" | "oncall_notified" | "cto_notified";
+export type OwnerResolutionState = "resolved_owner" | "fallback_owner";
+export type ConfidenceLevel = "low" | "medium" | "high" | "critical";
+export type EvidenceReferenceType = "workflow_summary" | "audit_log" | "scan_report" | "secret_finding";
+
+export interface OwnerIdentity {
+  id: string;
+  contactTarget: string;
+}
+
+export interface OwnerResolution {
+  state: OwnerResolutionState;
+  owner: OwnerIdentity;
+  source: "explicit" | "codeowners" | "fallback";
+  reason?: string;
+}
+
+export interface ConfidenceMetadata {
+  level: ConfidenceLevel;
+  source: string;
+  score?: number;
+}
+
+export interface EvidenceReference {
+  type: EvidenceReferenceType;
+  label: string;
+  path?: string;
+  url?: string;
+  line?: number;
+  findingId?: string;
+  fingerprint?: string;
+  classification?: string;
+  severity?: SecretFinding["severity"];
+  confidence?: SecretFinding["confidence"];
+}
+
+export interface EvidenceHandoffPayload {
+  schemaVersion: "1";
+  incidentClass: IncidentClass;
+  workflow: string;
+  packageName: string;
+  incidentId: string;
+  timestampUtc: string;
+  actor: string;
+  reason: string;
+  routing: {
+    owner: OwnerIdentity;
+    ownerResolutionState: OwnerResolutionState;
+    ownerResolutionSource: OwnerResolution["source"];
+    onCallGroupId: string;
+    ackDeadlineUtc: string;
+    escalationState: EscalationState;
+  };
+  confidence: ConfidenceMetadata;
+  evidenceReferences: EvidenceReference[];
+  metadata: {
+    fallbackOwnerUsed: boolean;
+    ownerResolutionReason?: string;
+    gateState?: "enabled" | "disabled" | "override";
+    summary?: Record<string, number | string | boolean>;
+  };
+}
+
+export interface PublishPathPayloadInput {
+  packageName: string;
+  packageDir: string;
+  workflow: string;
+  actor: string;
+  incidentId: string;
+  reason: string;
+  timestampUtc?: string;
+  gateState: "enabled" | "disabled" | "override";
+  ownerId?: string;
+  ownerContactTarget?: string;
+  onCallGroupId?: string;
+  codeownersText?: string;
+  workflowSummaryPath?: string;
+  auditLogPath?: string;
+  runUrl?: string;
+}
+
+export interface SecretExposurePayloadInput {
+  packageName: string;
+  packageDir: string;
+  workflow: string;
+  actor: string;
+  incidentId: string;
+  reason: string;
+  report: ScanReport;
+  timestampUtc?: string;
+  ownerId?: string;
+  ownerContactTarget?: string;
+  onCallGroupId?: string;
+  codeownersText?: string;
+  runUrl?: string;
+  scanReportPath?: string;
+}
+
+const DEFAULT_ONCALL_GROUP_ID = "release-oncall";
+const DEFAULT_FALLBACK_OWNER = "release-oncall";
+const DEFAULT_FALLBACK_CONTACT = "group:release-oncall";
+const VALID_OWNER_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})$/;
+const VALID_CONTACT_PATTERN = /^(?:github:@[A-Za-z0-9-]+|group:[A-Za-z0-9._-]+|mailto:[^@\s]+@[^@\s]+\.[^@\s]+)$/;
+
+type CodeownerEntry = {
+  pattern: string;
+  owners: string[];
+};
+
+function normalizePath(path: string): string {
+  return path.replaceAll("\\", "/").replace(/\/+/g, "/").replace(/^\.?\//, "");
+}
+
+function isValidOwner(ownerId: string | undefined): ownerId is string {
+  return Boolean(ownerId && VALID_OWNER_PATTERN.test(ownerId));
+}
+
+function isValidContactTarget(contactTarget: string | undefined): contactTarget is string {
+  return Boolean(contactTarget && VALID_CONTACT_PATTERN.test(contactTarget));
+}
+
+function deriveGithubContactTarget(ownerId: string): string {
+  return `github:@${ownerId}`;
+}
+
+function parseCodeowners(codeownersText: string): CodeownerEntry[] {
+  return codeownersText
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#"))
+    .map((line) => {
+      const parts = line.split(/\s+/).filter(Boolean);
+      return {
+        pattern: parts[0],
+        owners: parts.slice(1).map((owner) => owner.replace(/^@/, "")).filter(isValidOwner),
+      };
+    })
+    .filter((entry) => entry.owners.length > 0);
+}
+
+function codeownersPatternMatches(pattern: string, path: string): boolean {
+  if (pattern === "*") {
+    return true;
+  }
+
+  const normalizedPattern = normalizePath(pattern).replace(/\/$/, "");
+  const normalizedPath = normalizePath(path);
+
+  if (pattern.endsWith("/")) {
+    return normalizedPath.startsWith(`${normalizedPattern}/`) || normalizedPath === normalizedPattern;
+  }
+
+  if (normalizedPattern.includes("*")) {
+    const regex = new RegExp(`^${normalizedPattern.split("*").map(escapeRegExp).join(".*")}$`);
+    return regex.test(normalizedPath);
+  }
+
+  return normalizedPath === normalizedPattern || normalizedPath.startsWith(`${normalizedPattern}/`);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function resolveOwnerFromCodeowners(packageDir: string, codeownersText?: string): OwnerResolution | null {
+  if (!codeownersText) {
+    return null;
+  }
+
+  const entries = parseCodeowners(codeownersText);
+  const normalizedPackageDir = normalizePath(packageDir).replace(/\/$/, "");
+  let bestEntry: CodeownerEntry | null = null;
+
+  for (const entry of entries) {
+    if (!codeownersPatternMatches(entry.pattern, normalizedPackageDir)) {
+      continue;
+    }
+    if (!bestEntry || entry.pattern.length >= bestEntry.pattern.length) {
+      bestEntry = entry;
+    }
+  }
+
+  if (!bestEntry) {
+    return null;
+  }
+
+  const ownerId = bestEntry.owners[0];
+  return {
+    state: "fallback_owner",
+    owner: {
+      id: ownerId,
+      contactTarget: deriveGithubContactTarget(ownerId),
+    },
+    source: "codeowners",
+    reason: `resolved from CODEOWNERS pattern ${bestEntry.pattern}`,
+  };
+}
+
+export function resolveOwner(input: {
+  packageDir: string;
+  ownerId?: string;
+  ownerContactTarget?: string;
+  codeownersText?: string;
+}): OwnerResolution {
+  if (isValidOwner(input.ownerId)) {
+    return {
+      state: "resolved_owner",
+      owner: {
+        id: input.ownerId,
+        contactTarget: isValidContactTarget(input.ownerContactTarget)
+          ? input.ownerContactTarget
+          : deriveGithubContactTarget(input.ownerId),
+      },
+      source: "explicit",
+      reason: isValidContactTarget(input.ownerContactTarget) ? undefined : "derived github contact target from explicit owner",
+    };
+  }
+
+  const codeownersResolution = resolveOwnerFromCodeowners(input.packageDir, input.codeownersText);
+  if (codeownersResolution) {
+    return {
+      ...codeownersResolution,
+      reason: input.ownerId ? `invalid explicit owner "${input.ownerId}"; ${codeownersResolution.reason}` : codeownersResolution.reason,
+    };
+  }
+
+  return {
+    state: "fallback_owner",
+    owner: {
+      id: DEFAULT_FALLBACK_OWNER,
+      contactTarget: DEFAULT_FALLBACK_CONTACT,
+    },
+    source: "fallback",
+    reason: input.ownerId ? `invalid explicit owner "${input.ownerId}" and no CODEOWNERS match` : "missing owner and no CODEOWNERS match",
+  };
+}
+
+function getAckMinutes(incidentClass: IncidentClass, escalationState: EscalationState): number {
+  if (incidentClass === "publish_path") {
+    if (escalationState === "owner_notified") return 10;
+    if (escalationState === "oncall_notified") return 20;
+    return 30;
+  }
+
+  if (escalationState === "owner_notified") return 5;
+  if (escalationState === "oncall_notified") return 10;
+  return 15;
+}
+
+function addMinutes(timestampUtc: string, minutes: number): string {
+  const time = new Date(timestampUtc);
+  time.setUTCMinutes(time.getUTCMinutes() + minutes);
+  return time.toISOString();
+}
+
+function buildBasePayload(input: {
+  incidentClass: IncidentClass;
+  workflow: string;
+  packageName: string;
+  incidentId: string;
+  actor: string;
+  reason: string;
+  timestampUtc?: string;
+  packageDir: string;
+  ownerId?: string;
+  ownerContactTarget?: string;
+  onCallGroupId?: string;
+  codeownersText?: string;
+  escalationState: EscalationState;
+  confidence: ConfidenceMetadata;
+  evidenceReferences: EvidenceReference[];
+  metadata?: EvidenceHandoffPayload["metadata"];
+}): EvidenceHandoffPayload {
+  const timestampUtc = input.timestampUtc ?? new Date().toISOString();
+  const ownerResolution = resolveOwner({
+    packageDir: input.packageDir,
+    ownerId: input.ownerId,
+    ownerContactTarget: input.ownerContactTarget,
+    codeownersText: input.codeownersText,
+  });
+
+  const payload: EvidenceHandoffPayload = {
+    schemaVersion: "1",
+    incidentClass: input.incidentClass,
+    workflow: input.workflow,
+    packageName: input.packageName,
+    incidentId: input.incidentId,
+    timestampUtc,
+    actor: input.actor,
+    reason: input.reason,
+    routing: {
+      owner: ownerResolution.owner,
+      ownerResolutionState: ownerResolution.state,
+      ownerResolutionSource: ownerResolution.source,
+      onCallGroupId: input.onCallGroupId || DEFAULT_ONCALL_GROUP_ID,
+      ackDeadlineUtc: addMinutes(timestampUtc, getAckMinutes(input.incidentClass, input.escalationState)),
+      escalationState: input.escalationState,
+    },
+    confidence: input.confidence,
+    evidenceReferences: input.evidenceReferences,
+    metadata: {
+      fallbackOwnerUsed: ownerResolution.state === "fallback_owner",
+      ownerResolutionReason: ownerResolution.reason,
+      ...input.metadata,
+    },
+  };
+
+  validateEvidenceHandoffPayload(payload);
+  return payload;
+}
+
+export function buildPublishPathPayload(input: PublishPathPayloadInput): EvidenceHandoffPayload {
+  const evidenceReferences: EvidenceReference[] = [
+    {
+      type: "workflow_summary",
+      label: "GitHub Actions workflow context",
+      path: input.workflowSummaryPath,
+      url: input.runUrl,
+    },
+  ];
+  if (input.auditLogPath) {
+    evidenceReferences.push({
+      type: "audit_log",
+      label: "publish gate audit log",
+      path: input.auditLogPath,
+    });
+  }
+
+  return buildBasePayload({
+    incidentClass: "publish_path",
+    workflow: input.workflow,
+    packageName: input.packageName,
+    incidentId: input.incidentId,
+    actor: input.actor,
+    reason: input.reason,
+    timestampUtc: input.timestampUtc,
+    packageDir: input.packageDir,
+    ownerId: input.ownerId,
+    ownerContactTarget: input.ownerContactTarget,
+    onCallGroupId: input.onCallGroupId,
+    codeownersText: input.codeownersText,
+    escalationState: input.gateState === "override" ? "oncall_notified" : "owner_notified",
+    confidence: {
+      level: input.gateState === "override" ? "critical" : "high",
+      source: "publish_gate",
+      score: input.gateState === "override" ? 1 : 0.95,
+    },
+    evidenceReferences,
+    metadata: {
+      gateState: input.gateState,
+      summary: {
+        gateDisabled: input.gateState === "disabled",
+        gateOverride: input.gateState === "override",
+      },
+    },
+  });
+}
+
+function findingToEvidenceReference(finding: SecretFinding): EvidenceReference {
+  return {
+    type: "secret_finding",
+    label: `${finding.secretClass} in ${finding.path}:${finding.line}`,
+    path: finding.path,
+    line: finding.line,
+    findingId: finding.findingId,
+    fingerprint: finding.evidenceFingerprint,
+    classification: finding.secretClass,
+    severity: finding.severity,
+    confidence: finding.confidence,
+  };
+}
+
+export function buildSecretExposurePayload(input: SecretExposurePayloadInput): EvidenceHandoffPayload {
+  const findings = input.report.findings.filter((finding) => !finding.suppression);
+  const highestSeverity = findings.some((finding) => finding.severity === "critical")
+    ? "critical"
+    : findings.some((finding) => finding.severity === "high")
+      ? "high"
+      : "medium";
+
+  const evidenceReferences: EvidenceReference[] = [
+    {
+      type: "scan_report",
+      label: "release artifact secret scan report",
+      path: input.scanReportPath,
+      url: input.runUrl,
+    },
+    ...findings.map(findingToEvidenceReference),
+  ];
+
+  return buildBasePayload({
+    incidentClass: "secret_exposure",
+    workflow: input.workflow,
+    packageName: input.packageName,
+    incidentId: input.incidentId,
+    actor: input.actor,
+    reason: input.reason,
+    timestampUtc: input.timestampUtc,
+    packageDir: input.packageDir,
+    ownerId: input.ownerId,
+    ownerContactTarget: input.ownerContactTarget,
+    onCallGroupId: input.onCallGroupId,
+    codeownersText: input.codeownersText,
+    escalationState: "oncall_notified",
+    confidence: {
+      level: highestSeverity,
+      source: "publish_secret_scan",
+      score: findings.length > 0 ? 0.95 : 0.5,
+    },
+    evidenceReferences,
+    metadata: {
+      summary: {
+        filesScanned: input.report.summary.filesScanned,
+        findings: input.report.summary.findings,
+        blockingFindings: input.report.summary.blockingFindings,
+        suppressedFindings: input.report.summary.suppressedFindings,
+      },
+    },
+  });
+}
+
+export function validateEvidenceHandoffPayload(payload: EvidenceHandoffPayload): void {
+  if (payload.schemaVersion !== "1") {
+    throw new Error(`Unsupported evidence handoff schema version: ${payload.schemaVersion}`);
+  }
+  if (!["publish_path", "secret_exposure"].includes(payload.incidentClass)) {
+    throw new Error(`Unsupported incident class: ${payload.incidentClass}`);
+  }
+  if (!payload.workflow || !payload.packageName || !payload.incidentId || !payload.actor || !payload.reason) {
+    throw new Error("Evidence handoff payload is missing required top-level fields");
+  }
+  if (!isValidOwner(payload.routing.owner.id)) {
+    throw new Error(`Invalid routing owner id: ${payload.routing.owner.id}`);
+  }
+  if (!isValidContactTarget(payload.routing.owner.contactTarget)) {
+    throw new Error(`Invalid routing contact target: ${payload.routing.owner.contactTarget}`);
+  }
+  if (!payload.routing.onCallGroupId) {
+    throw new Error("Missing on-call group id");
+  }
+  if (Number.isNaN(Date.parse(payload.timestampUtc)) || Number.isNaN(Date.parse(payload.routing.ackDeadlineUtc))) {
+    throw new Error("Evidence handoff payload contains invalid timestamps");
+  }
+  if (!Array.isArray(payload.evidenceReferences) || payload.evidenceReferences.length === 0) {
+    throw new Error("Evidence handoff payload must include at least one evidence reference");
+  }
+
+  for (const reference of payload.evidenceReferences) {
+    if (!reference.type || !reference.label) {
+      throw new Error("Evidence reference is missing type or label");
+    }
+  }
+}
+
+export function loadCodeownersText(path = ".github/CODEOWNERS"): string | undefined {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return undefined;
+  }
+}

--- a/scripts/evidence-handoff.ts
+++ b/scripts/evidence-handoff.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 
 import type { ScanReport, SecretFinding } from "./publish-secret-scan.ts";
+import { buildEscalationRoute } from "./evidence-escalation.ts";
 
 export type IncidentClass = "publish_path" | "secret_exposure";
 export type EscalationState = "owner_notified" | "oncall_notified" | "cto_notified";
@@ -55,6 +56,20 @@ export interface EvidenceHandoffPayload {
     onCallGroupId: string;
     ackDeadlineUtc: string;
     escalationState: EscalationState;
+    currentEvent: string;
+    nextEscalationState?: EscalationState;
+    nextEscalationAtUtc?: string;
+    notificationTargets: {
+      owner: OwnerIdentity;
+      onCall: {
+        id: string;
+        contactTarget: string;
+      };
+      cto: {
+        id: string;
+        contactTarget: string;
+      };
+    };
   };
   confidence: ConfidenceMetadata;
   evidenceReferences: EvidenceReference[];
@@ -240,24 +255,6 @@ export function resolveOwner(input: {
   };
 }
 
-function getAckMinutes(incidentClass: IncidentClass, escalationState: EscalationState): number {
-  if (incidentClass === "publish_path") {
-    if (escalationState === "owner_notified") return 10;
-    if (escalationState === "oncall_notified") return 20;
-    return 30;
-  }
-
-  if (escalationState === "owner_notified") return 5;
-  if (escalationState === "oncall_notified") return 10;
-  return 15;
-}
-
-function addMinutes(timestampUtc: string, minutes: number): string {
-  const time = new Date(timestampUtc);
-  time.setUTCMinutes(time.getUTCMinutes() + minutes);
-  return time.toISOString();
-}
-
 function buildBasePayload(input: {
   incidentClass: IncidentClass;
   workflow: string;
@@ -271,7 +268,6 @@ function buildBasePayload(input: {
   ownerContactTarget?: string;
   onCallGroupId?: string;
   codeownersText?: string;
-  escalationState: EscalationState;
   confidence: ConfidenceMetadata;
   evidenceReferences: EvidenceReference[];
   metadata?: EvidenceHandoffPayload["metadata"];
@@ -282,6 +278,15 @@ function buildBasePayload(input: {
     ownerId: input.ownerId,
     ownerContactTarget: input.ownerContactTarget,
     codeownersText: input.codeownersText,
+  });
+  const onCallGroupId = input.onCallGroupId || DEFAULT_ONCALL_GROUP_ID;
+  const route = buildEscalationRoute({
+    incidentClass: input.incidentClass,
+    timestampUtc,
+    owner: ownerResolution.owner,
+    onCallGroupId,
+    confidenceLevel: input.confidence.level,
+    publishGateState: input.metadata?.gateState,
   });
 
   const payload: EvidenceHandoffPayload = {
@@ -297,9 +302,13 @@ function buildBasePayload(input: {
       owner: ownerResolution.owner,
       ownerResolutionState: ownerResolution.state,
       ownerResolutionSource: ownerResolution.source,
-      onCallGroupId: input.onCallGroupId || DEFAULT_ONCALL_GROUP_ID,
-      ackDeadlineUtc: addMinutes(timestampUtc, getAckMinutes(input.incidentClass, input.escalationState)),
-      escalationState: input.escalationState,
+      onCallGroupId,
+      ackDeadlineUtc: route.ackDeadlineUtc,
+      escalationState: route.escalationState,
+      currentEvent: route.currentEvent,
+      nextEscalationState: route.nextEscalationState,
+      nextEscalationAtUtc: route.nextEscalationAtUtc,
+      notificationTargets: route.targets,
     },
     confidence: input.confidence,
     evidenceReferences: input.evidenceReferences,
@@ -344,7 +353,6 @@ export function buildPublishPathPayload(input: PublishPathPayloadInput): Evidenc
     ownerContactTarget: input.ownerContactTarget,
     onCallGroupId: input.onCallGroupId,
     codeownersText: input.codeownersText,
-    escalationState: input.gateState === "override" ? "oncall_notified" : "owner_notified",
     confidence: {
       level: input.gateState === "override" ? "critical" : "high",
       source: "publish_gate",
@@ -406,7 +414,6 @@ export function buildSecretExposurePayload(input: SecretExposurePayloadInput): E
     ownerContactTarget: input.ownerContactTarget,
     onCallGroupId: input.onCallGroupId,
     codeownersText: input.codeownersText,
-    escalationState: "oncall_notified",
     confidence: {
       level: highestSeverity,
       source: "publish_secret_scan",
@@ -442,6 +449,12 @@ export function validateEvidenceHandoffPayload(payload: EvidenceHandoffPayload):
   }
   if (!payload.routing.onCallGroupId) {
     throw new Error("Missing on-call group id");
+  }
+  if (!isValidContactTarget(payload.routing.notificationTargets.onCall.contactTarget)) {
+    throw new Error(`Invalid on-call contact target: ${payload.routing.notificationTargets.onCall.contactTarget}`);
+  }
+  if (!isValidContactTarget(payload.routing.notificationTargets.cto.contactTarget)) {
+    throw new Error(`Invalid CTO contact target: ${payload.routing.notificationTargets.cto.contactTarget}`);
   }
   if (Number.isNaN(Date.parse(payload.timestampUtc)) || Number.isNaN(Date.parse(payload.routing.ackDeadlineUtc))) {
     throw new Error("Evidence handoff payload contains invalid timestamps");

--- a/scripts/evidence-handoff.ts
+++ b/scripts/evidence-handoff.ts
@@ -1,7 +1,9 @@
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 
 import type { ScanReport, SecretFinding } from "./publish-secret-scan.ts";
-import { buildEscalationRoute } from "./evidence-escalation.ts";
+import { assessWorkspaceIntegrity, buildEscalationRoute } from "./evidence-escalation.ts";
 
 export type IncidentClass = "publish_path" | "secret_exposure";
 export type EscalationState = "owner_notified" | "oncall_notified" | "cto_notified";
@@ -40,6 +42,15 @@ export interface EvidenceReference {
   confidence?: SecretFinding["confidence"];
 }
 
+export interface ExecutionSnapshot {
+  sourceIssueId: string;
+  workspaceIdentity: string;
+  repoSha: string;
+  repositoryRoot: string;
+  packageDir: string;
+  verificationCommands: string[];
+}
+
 export interface EvidenceHandoffPayload {
   schemaVersion: "1";
   incidentClass: IncidentClass;
@@ -73,10 +84,35 @@ export interface EvidenceHandoffPayload {
   };
   confidence: ConfidenceMetadata;
   evidenceReferences: EvidenceReference[];
+  snapshot: ExecutionSnapshot;
   metadata: {
     fallbackOwnerUsed: boolean;
     ownerResolutionReason?: string;
     gateState?: "enabled" | "disabled" | "override";
+    registryOwnerSnapshot: {
+      owner: OwnerIdentity;
+      resolutionState: OwnerResolutionState;
+      resolutionSource: OwnerResolution["source"];
+      missingOwnerContactTarget: boolean;
+    };
+    containment: {
+      state: "publish_disabled" | "publish_override" | "publish_enabled" | "secret_rotation_required";
+      status: "active" | "partial" | "none";
+      summary: string;
+    };
+    dependencyAvailability: {
+      credentialSource: string;
+      missingCredentialSource: boolean;
+      registryWebhook: string;
+      missingRegistryWebhook: boolean;
+      provenanceUrl: string;
+      missingProvenanceUrl: boolean;
+    };
+    workspaceIntegrity: {
+      dedupeKey: string;
+      suppressCorrectiveChildrenWhileBlocked: boolean;
+      reviewerAction: string;
+    };
     summary?: Record<string, number | string | boolean>;
   };
 }
@@ -97,6 +133,14 @@ export interface PublishPathPayloadInput {
   workflowSummaryPath?: string;
   auditLogPath?: string;
   runUrl?: string;
+  credentialSource?: string;
+  registryWebhook?: string;
+  provenanceUrl?: string;
+  sourceIssueId?: string;
+  workspaceIdentity?: string;
+  repoSha?: string;
+  repositoryRoot?: string;
+  verificationCommands?: string[];
 }
 
 export interface SecretExposurePayloadInput {
@@ -114,6 +158,14 @@ export interface SecretExposurePayloadInput {
   codeownersText?: string;
   runUrl?: string;
   scanReportPath?: string;
+  credentialSource?: string;
+  registryWebhook?: string;
+  provenanceUrl?: string;
+  sourceIssueId?: string;
+  workspaceIdentity?: string;
+  repoSha?: string;
+  repositoryRoot?: string;
+  verificationCommands?: string[];
 }
 
 const DEFAULT_ONCALL_GROUP_ID = "release-oncall";
@@ -126,6 +178,78 @@ type CodeownerEntry = {
   pattern: string;
   owners: string[];
 };
+
+type SnapshotInput = {
+  sourceIssueId?: string;
+  workflow: string;
+  incidentId: string;
+  packageDir: string;
+  workspaceIdentity?: string;
+  repoSha?: string;
+  repositoryRoot?: string;
+  verificationCommands?: string[];
+};
+
+type DependencyAvailability = EvidenceHandoffPayload["metadata"]["dependencyAvailability"];
+
+function withPlaceholder(value: string | undefined, placeholder: string): { value: string; missing: boolean } {
+  if (value && value.trim().length > 0) {
+    return { value, missing: false };
+  }
+  return { value: placeholder, missing: true };
+}
+
+function buildDependencyAvailability(input: {
+  credentialSource?: string;
+  registryWebhook?: string;
+  provenanceUrl?: string;
+}): DependencyAvailability {
+  const credentialSource = withPlaceholder(input.credentialSource, "unknown");
+  const registryWebhook = withPlaceholder(input.registryWebhook, "unknown");
+  const provenanceUrl = withPlaceholder(input.provenanceUrl, "unknown");
+
+  return {
+    credentialSource: credentialSource.value,
+    missingCredentialSource: credentialSource.missing,
+    registryWebhook: registryWebhook.value,
+    missingRegistryWebhook: registryWebhook.missing,
+    provenanceUrl: provenanceUrl.value,
+    missingProvenanceUrl: provenanceUrl.missing,
+  };
+}
+
+function buildContainmentMetadata(input: {
+  incidentClass: IncidentClass;
+  gateState?: "enabled" | "disabled" | "override";
+}): EvidenceHandoffPayload["metadata"]["containment"] {
+  if (input.incidentClass === "publish_path") {
+    if (input.gateState === "disabled") {
+      return {
+        state: "publish_disabled",
+        status: "active",
+        summary: "Publish remains blocked while the incident is triaged.",
+      };
+    }
+    if (input.gateState === "override") {
+      return {
+        state: "publish_override",
+        status: "partial",
+        summary: "A publish override is active and requires escalated review.",
+      };
+    }
+    return {
+      state: "publish_enabled",
+      status: "none",
+      summary: "No automated publish containment is currently active.",
+    };
+  }
+
+  return {
+    state: "secret_rotation_required",
+    status: "active",
+    summary: "Further publish must stay blocked until exposed credentials are revoked or rotated.",
+  };
+}
 
 function normalizePath(path: string): string {
   return path.replaceAll("\\", "/").replace(/\/+/g, "/").replace(/^\.?\//, "");
@@ -180,6 +304,49 @@ function codeownersPatternMatches(pattern: string, path: string): boolean {
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function runGit(args: string[], cwd: string): string | undefined {
+  try {
+    return execFileSync("git", args, {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return undefined;
+  }
+}
+
+function buildExecutionSnapshot(input: SnapshotInput): ExecutionSnapshot {
+  const repositoryRoot = input.repositoryRoot
+    ? resolve(input.repositoryRoot)
+    : runGit(["rev-parse", "--show-toplevel"], process.cwd()) ?? process.cwd();
+  const repoSha = input.repoSha ?? runGit(["rev-parse", "HEAD"], repositoryRoot);
+
+  if (!repoSha) {
+    throw new Error("Unable to resolve repository SHA for evidence snapshot");
+  }
+
+  const workspaceIdentity = input.workspaceIdentity
+    ?? process.env.PAPERCLIP_TASK_ID
+    ?? process.env.GITHUB_WORKSPACE
+    ?? repositoryRoot;
+
+  const verificationCommands = input.verificationCommands?.filter(Boolean) ?? [
+    `git -C ${repositoryRoot} rev-parse HEAD`,
+    `git -C ${repositoryRoot} checkout ${repoSha}`,
+    `git -C ${repositoryRoot} status --short`,
+  ];
+
+  return {
+    sourceIssueId: input.sourceIssueId ?? input.incidentId,
+    workspaceIdentity,
+    repoSha,
+    repositoryRoot,
+    packageDir: normalizePath(input.packageDir).replace(/\/$/, ""),
+    verificationCommands,
+  };
 }
 
 function resolveOwnerFromCodeowners(packageDir: string, codeownersText?: string): OwnerResolution | null {
@@ -270,6 +437,8 @@ function buildBasePayload(input: {
   codeownersText?: string;
   confidence: ConfidenceMetadata;
   evidenceReferences: EvidenceReference[];
+  snapshot: SnapshotInput;
+  dependencyAvailability?: DependencyAvailability;
   metadata?: EvidenceHandoffPayload["metadata"];
 }): EvidenceHandoffPayload {
   const timestampUtc = input.timestampUtc ?? new Date().toISOString();
@@ -287,6 +456,23 @@ function buildBasePayload(input: {
     onCallGroupId,
     confidenceLevel: input.confidence.level,
     publishGateState: input.metadata?.gateState,
+  });
+  const snapshot = buildExecutionSnapshot(input.snapshot);
+  const workspaceIntegrity = assessWorkspaceIntegrity({
+    sourceIssueId: snapshot.sourceIssueId,
+    evidenceSnapshot: {
+      workspaceIdentity: snapshot.workspaceIdentity,
+      repoSha: snapshot.repoSha,
+    },
+    reviewerSnapshot: {
+      workspaceIdentity: snapshot.workspaceIdentity,
+      repoSha: snapshot.repoSha,
+    },
+  });
+  const dependencyAvailability = input.dependencyAvailability ?? buildDependencyAvailability({});
+  const containment = input.metadata?.containment ?? buildContainmentMetadata({
+    incidentClass: input.incidentClass,
+    gateState: input.metadata?.gateState,
   });
 
   const payload: EvidenceHandoffPayload = {
@@ -312,9 +498,23 @@ function buildBasePayload(input: {
     },
     confidence: input.confidence,
     evidenceReferences: input.evidenceReferences,
+    snapshot,
     metadata: {
       fallbackOwnerUsed: ownerResolution.state === "fallback_owner",
       ownerResolutionReason: ownerResolution.reason,
+      registryOwnerSnapshot: {
+        owner: ownerResolution.owner,
+        resolutionState: ownerResolution.state,
+        resolutionSource: ownerResolution.source,
+        missingOwnerContactTarget: !isValidContactTarget(ownerResolution.owner.contactTarget),
+      },
+      containment,
+      dependencyAvailability,
+      workspaceIntegrity: {
+        dedupeKey: workspaceIntegrity.blocker.dedupeKey,
+        suppressCorrectiveChildrenWhileBlocked: workspaceIntegrity.blocker.suppressCorrectiveChildren,
+        reviewerAction: workspaceIntegrity.blocker.action,
+      },
       ...input.metadata,
     },
   };
@@ -359,6 +559,21 @@ export function buildPublishPathPayload(input: PublishPathPayloadInput): Evidenc
       score: input.gateState === "override" ? 1 : 0.95,
     },
     evidenceReferences,
+    dependencyAvailability: buildDependencyAvailability({
+      credentialSource: input.credentialSource,
+      registryWebhook: input.registryWebhook,
+      provenanceUrl: input.provenanceUrl,
+    }),
+    snapshot: {
+      sourceIssueId: input.sourceIssueId,
+      workflow: input.workflow,
+      incidentId: input.incidentId,
+      packageDir: input.packageDir,
+      workspaceIdentity: input.workspaceIdentity,
+      repoSha: input.repoSha,
+      repositoryRoot: input.repositoryRoot,
+      verificationCommands: input.verificationCommands,
+    },
     metadata: {
       gateState: input.gateState,
       summary: {
@@ -420,6 +635,21 @@ export function buildSecretExposurePayload(input: SecretExposurePayloadInput): E
       score: findings.length > 0 ? 0.95 : 0.5,
     },
     evidenceReferences,
+    dependencyAvailability: buildDependencyAvailability({
+      credentialSource: input.credentialSource,
+      registryWebhook: input.registryWebhook,
+      provenanceUrl: input.provenanceUrl,
+    }),
+    snapshot: {
+      sourceIssueId: input.sourceIssueId,
+      workflow: input.workflow,
+      incidentId: input.incidentId,
+      packageDir: input.packageDir,
+      workspaceIdentity: input.workspaceIdentity,
+      repoSha: input.repoSha,
+      repositoryRoot: input.repositoryRoot,
+      verificationCommands: input.verificationCommands,
+    },
     metadata: {
       summary: {
         filesScanned: input.report.summary.filesScanned,
@@ -458,6 +688,21 @@ export function validateEvidenceHandoffPayload(payload: EvidenceHandoffPayload):
   }
   if (Number.isNaN(Date.parse(payload.timestampUtc)) || Number.isNaN(Date.parse(payload.routing.ackDeadlineUtc))) {
     throw new Error("Evidence handoff payload contains invalid timestamps");
+  }
+  if (!payload.snapshot.sourceIssueId || !payload.snapshot.workspaceIdentity || !payload.snapshot.repositoryRoot) {
+    throw new Error("Evidence handoff payload is missing required snapshot metadata");
+  }
+  if (!/^[0-9a-f]{7,40}$/i.test(payload.snapshot.repoSha)) {
+    throw new Error(`Invalid snapshot repo SHA: ${payload.snapshot.repoSha}`);
+  }
+  if (!Array.isArray(payload.snapshot.verificationCommands) || payload.snapshot.verificationCommands.length === 0) {
+    throw new Error("Evidence handoff payload must include snapshot verification commands");
+  }
+  if (!payload.metadata.registryOwnerSnapshot.owner.id || !payload.metadata.containment.summary) {
+    throw new Error("Evidence handoff payload is missing required owner snapshot or containment metadata");
+  }
+  if (!payload.metadata.dependencyAvailability.credentialSource || !payload.metadata.dependencyAvailability.registryWebhook || !payload.metadata.dependencyAvailability.provenanceUrl) {
+    throw new Error("Evidence handoff payload is missing dependency availability placeholders");
   }
   if (!Array.isArray(payload.evidenceReferences) || payload.evidenceReferences.length === 0) {
     throw new Error("Evidence handoff payload must include at least one evidence reference");

--- a/scripts/publish-secret-scan.ts
+++ b/scripts/publish-secret-scan.ts
@@ -36,6 +36,16 @@ export type ScanReport = {
   findings: SecretFinding[];
 };
 
+export const DEFAULT_SCAN_PATHS = [
+  ".github",
+  "guides",
+  "skills",
+  "providers",
+  "cli",
+  "plugins",
+  "tools",
+];
+
 type Detector = {
   detectorId: string;
   secretClass: string;
@@ -46,15 +56,6 @@ type Detector = {
 };
 
 const REPORT_VERSION = "1";
-const DEFAULT_SCAN_PATHS = [
-  ".github",
-  "guides",
-  "skills",
-  "providers",
-  "cli",
-  "plugins",
-  "tools",
-];
 const TEXT_EXTENSIONS = new Set([
   ".cjs",
   ".env",

--- a/tests/evidence-handoff.test.ts
+++ b/tests/evidence-handoff.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  buildPublishPathPayload,
+  buildSecretExposurePayload,
+  resolveOwner,
+} from "../scripts/evidence-handoff.ts";
+import { scanPaths } from "../scripts/publish-secret-scan.ts";
+
+describe("evidence handoff payload builder", () => {
+  const codeownersText = [
+    "* @aisling404 @Oliver-Zimmerman",
+    "/plugins/opencode/ @aaronjo-Telnyx",
+  ].join("\n");
+
+  it("builds publish-path payloads with explicit owner routing and ack deadline", () => {
+    const payload = buildPublishPathPayload({
+      packageName: "@telnyx/agent-toolkit",
+      packageDir: "tools/typescript",
+      workflow: "publish-npm",
+      actor: "release-bot",
+      incidentId: "INC-123",
+      reason: "manual publish gate disable",
+      timestampUtc: "2026-05-22T12:00:00.000Z",
+      gateState: "disabled",
+      ownerId: "aisling404",
+      ownerContactTarget: "github:@aisling404",
+      onCallGroupId: "release-oncall",
+      codeownersText,
+      workflowSummaryPath: "/tmp/summary.md",
+      auditLogPath: "/tmp/publish-audit-log.txt",
+      runUrl: "https://github.com/team-telnyx/ai/actions/runs/123",
+    });
+
+    assert.equal(payload.incidentClass, "publish_path");
+    assert.equal(payload.routing.owner.id, "aisling404");
+    assert.equal(payload.routing.ownerResolutionState, "resolved_owner");
+    assert.equal(payload.routing.ackDeadlineUtc, "2026-05-22T12:10:00.000Z");
+    assert.equal(payload.routing.escalationState, "owner_notified");
+    assert.equal(payload.metadata.gateState, "disabled");
+    assert.equal(payload.evidenceReferences.length, 2);
+  });
+
+  it("escalates publish-path overrides to on-call without losing owner routing", () => {
+    const payload = buildPublishPathPayload({
+      packageName: "@telnyx/opencode",
+      packageDir: "plugins/opencode",
+      workflow: "publish-npm",
+      actor: "release-bot",
+      incidentId: "INC-124",
+      reason: "manual override while publish gate is active",
+      timestampUtc: "2026-05-22T12:00:00.000Z",
+      gateState: "override",
+      ownerId: "aaronjo-Telnyx",
+      onCallGroupId: "release-oncall",
+      codeownersText,
+      workflowSummaryPath: "/tmp/summary.md",
+      auditLogPath: "/tmp/publish-audit-log.txt",
+    });
+
+    assert.equal(payload.routing.escalationState, "oncall_notified");
+    assert.equal(payload.routing.ackDeadlineUtc, "2026-05-22T12:20:00.000Z");
+    assert.equal(payload.routing.owner.id, "aaronjo-Telnyx");
+  });
+
+  it("builds secret-exposure payloads without leaking raw findings and escalates to on-call", () => {
+    const report = scanPaths([
+      "tests/fixtures/publish-secret-scan",
+    ], process.cwd());
+    const payload = buildSecretExposurePayload({
+      packageName: "@telnyx/agent-cli",
+      packageDir: "cli",
+      workflow: "publish-npm",
+      actor: "release-bot",
+      incidentId: "INC-456",
+      reason: "blocking secret scan findings",
+      timestampUtc: "2026-05-22T12:00:00.000Z",
+      ownerId: "aisling404",
+      ownerContactTarget: "github:@aisling404",
+      onCallGroupId: "release-oncall",
+      codeownersText,
+      scanReportPath: "/tmp/scan-report.json",
+      runUrl: "https://github.com/team-telnyx/ai/actions/runs/456",
+      report,
+    });
+
+    assert.equal(payload.incidentClass, "secret_exposure");
+    assert.equal(payload.routing.escalationState, "oncall_notified");
+    assert.equal(payload.routing.ackDeadlineUtc, "2026-05-22T12:10:00.000Z");
+    assert.equal(payload.confidence.source, "publish_secret_scan");
+    assert.ok(payload.evidenceReferences.some((reference) => reference.type === "secret_finding"));
+
+    const json = JSON.stringify(payload);
+    assert.equal(json.includes("ghp_0123456789abcdef0123456789abcdef0123"), false);
+    assert.equal(json.includes("npm_0123456789abcdef0123456789abcdef0123"), false);
+    assert.equal(json.includes("ProdSecretTokenValue987654321"), false);
+  });
+
+  it("falls back deterministically when explicit owner input is invalid", () => {
+    const resolution = resolveOwner({
+      packageDir: "plugins/opencode",
+      ownerId: "not valid",
+      codeownersText,
+    });
+
+    assert.equal(resolution.state, "fallback_owner");
+    assert.equal(resolution.source, "codeowners");
+    assert.equal(resolution.owner.id, "aaronjo-Telnyx");
+    assert.equal(resolution.owner.contactTarget, "github:@aaronjo-Telnyx");
+    assert.match(resolution.reason || "", /invalid explicit owner/i);
+  });
+});

--- a/tests/evidence-handoff.test.ts
+++ b/tests/evidence-handoff.test.ts
@@ -6,6 +6,7 @@ import {
   buildSecretExposurePayload,
   resolveOwner,
 } from "../scripts/evidence-handoff.ts";
+import { assessWorkspaceIntegrity } from "../scripts/evidence-escalation.ts";
 import type { ScanReport } from "../scripts/publish-secret-scan.ts";
 import { scanPaths } from "../scripts/publish-secret-scan.ts";
 
@@ -32,6 +33,14 @@ describe("evidence handoff payload builder", () => {
       workflowSummaryPath: "/tmp/summary.md",
       auditLogPath: "/tmp/publish-audit-log.txt",
       runUrl: "https://github.com/team-telnyx/ai/actions/runs/123",
+      sourceIssueId: "TEL-116",
+      workspaceIdentity: "paperclip-workspace-123",
+      repoSha: "2a35f387abcd1234abcd1234abcd1234abcd1234",
+      repositoryRoot: "/repo",
+      verificationCommands: [
+        "git -C /repo rev-parse HEAD",
+        "git -C /repo checkout 2a35f387abcd1234abcd1234abcd1234abcd1234",
+      ],
     });
 
     assert.equal(payload.incidentClass, "publish_path");
@@ -44,6 +53,16 @@ describe("evidence handoff payload builder", () => {
     assert.equal(payload.routing.nextEscalationAtUtc, "2026-05-22T12:10:00.000Z");
     assert.equal(payload.routing.notificationTargets.onCall.contactTarget, "group:release-oncall");
     assert.equal(payload.metadata.gateState, "disabled");
+    assert.equal(payload.metadata.registryOwnerSnapshot.owner.id, "aisling404");
+    assert.equal(payload.metadata.registryOwnerSnapshot.resolutionState, "resolved_owner");
+    assert.equal(payload.metadata.containment.state, "publish_disabled");
+    assert.equal(payload.metadata.containment.status, "active");
+    assert.equal(payload.metadata.dependencyAvailability.credentialSource, "unknown");
+    assert.equal(payload.metadata.dependencyAvailability.missingCredentialSource, true);
+    assert.equal(payload.snapshot.sourceIssueId, "TEL-116");
+    assert.equal(payload.snapshot.workspaceIdentity, "paperclip-workspace-123");
+    assert.equal(payload.snapshot.repoSha, "2a35f387abcd1234abcd1234abcd1234abcd1234");
+    assert.equal(payload.metadata.workspaceIntegrity.dedupeKey, "workspace-integrity:TEL-116");
     assert.equal(payload.evidenceReferences.length, 2);
   });
 
@@ -62,12 +81,22 @@ describe("evidence handoff payload builder", () => {
       codeownersText,
       workflowSummaryPath: "/tmp/summary.md",
       auditLogPath: "/tmp/publish-audit-log.txt",
+      sourceIssueId: "TEL-116",
+      workspaceIdentity: "paperclip-workspace-123",
+      repoSha: "2a35f387abcd1234abcd1234abcd1234abcd1234",
+      repositoryRoot: "/repo",
+      verificationCommands: [
+        "git -C /repo rev-parse HEAD",
+        "git -C /repo checkout 2a35f387abcd1234abcd1234abcd1234abcd1234",
+      ],
     });
 
     assert.equal(payload.routing.escalationState, "oncall_notified");
     assert.equal(payload.routing.ackDeadlineUtc, "2026-05-22T12:20:00.000Z");
     assert.equal(payload.routing.nextEscalationState, "cto_notified");
     assert.equal(payload.routing.owner.id, "aaronjo-Telnyx");
+    assert.equal(payload.metadata.containment.state, "publish_override");
+    assert.equal(payload.metadata.containment.status, "partial");
   });
 
   it("builds secret-exposure payloads without leaking raw findings and escalates to CTO for live critical findings", () => {
@@ -87,6 +116,14 @@ describe("evidence handoff payload builder", () => {
       scanReportPath: "/tmp/scan-report.json",
       runUrl: "https://github.com/team-telnyx/ai/actions/runs/456",
       report,
+      sourceIssueId: "TEL-116",
+      workspaceIdentity: "paperclip-workspace-123",
+      repoSha: "2a35f387abcd1234abcd1234abcd1234abcd1234",
+      repositoryRoot: "/repo",
+      verificationCommands: [
+        "git -C /repo rev-parse HEAD",
+        "git -C /repo checkout 2a35f387abcd1234abcd1234abcd1234abcd1234",
+      ],
     });
 
     assert.equal(payload.incidentClass, "secret_exposure");
@@ -95,6 +132,8 @@ describe("evidence handoff payload builder", () => {
     assert.equal(payload.routing.ackDeadlineUtc, "2026-05-22T12:00:00.000Z");
     assert.equal(payload.routing.nextEscalationState, undefined);
     assert.equal(payload.confidence.source, "publish_secret_scan");
+    assert.equal(payload.metadata.containment.state, "secret_rotation_required");
+    assert.equal(payload.metadata.containment.status, "active");
     assert.ok(payload.evidenceReferences.some((reference) => reference.type === "secret_finding"));
 
     const json = JSON.stringify(payload);
@@ -142,6 +181,14 @@ describe("evidence handoff payload builder", () => {
       onCallGroupId: "release-oncall",
       codeownersText,
       report,
+      sourceIssueId: "TEL-116",
+      workspaceIdentity: "paperclip-workspace-123",
+      repoSha: "2a35f387abcd1234abcd1234abcd1234abcd1234",
+      repositoryRoot: "/repo",
+      verificationCommands: [
+        "git -C /repo rev-parse HEAD",
+        "git -C /repo checkout 2a35f387abcd1234abcd1234abcd1234abcd1234",
+      ],
     });
 
     assert.equal(payload.routing.escalationState, "oncall_notified");
@@ -161,5 +208,27 @@ describe("evidence handoff payload builder", () => {
     assert.equal(resolution.owner.id, "aaronjo-Telnyx");
     assert.equal(resolution.owner.contactTarget, "github:@aaronjo-Telnyx");
     assert.match(resolution.reason || "", /invalid explicit owner/i);
+  });
+
+  it("emits one workspace-integrity blocker path for reviewer snapshot mismatches", () => {
+    const assessment = assessWorkspaceIntegrity({
+      sourceIssueId: "TEL-116",
+      evidenceSnapshot: {
+        workspaceIdentity: "paperclip-workspace-123",
+        repoSha: "2a35f387abcd1234abcd1234abcd1234abcd1234",
+      },
+      reviewerSnapshot: {
+        workspaceIdentity: "paperclip-workspace-456",
+        repoSha: "d7ec0520abcd1234abcd1234abcd1234abcd1234",
+      },
+      activeBlockerIssueId: "TEL-254",
+    });
+
+    assert.equal(assessment.status, "mismatch");
+    assert.deepEqual(assessment.mismatchFields, ["workspaceIdentity", "repoSha"]);
+    assert.equal(assessment.blocker.dedupeKey, "workspace-integrity:TEL-116");
+    assert.equal(assessment.blocker.shouldCreateBlocker, false);
+    assert.equal(assessment.blocker.activeBlockerIssueId, "TEL-254");
+    assert.equal(assessment.blocker.suppressCorrectiveChildren, true);
   });
 });

--- a/tests/evidence-handoff.test.ts
+++ b/tests/evidence-handoff.test.ts
@@ -6,6 +6,7 @@ import {
   buildSecretExposurePayload,
   resolveOwner,
 } from "../scripts/evidence-handoff.ts";
+import type { ScanReport } from "../scripts/publish-secret-scan.ts";
 import { scanPaths } from "../scripts/publish-secret-scan.ts";
 
 describe("evidence handoff payload builder", () => {
@@ -38,6 +39,10 @@ describe("evidence handoff payload builder", () => {
     assert.equal(payload.routing.ownerResolutionState, "resolved_owner");
     assert.equal(payload.routing.ackDeadlineUtc, "2026-05-22T12:10:00.000Z");
     assert.equal(payload.routing.escalationState, "owner_notified");
+    assert.equal(payload.routing.currentEvent, "owner_notified");
+    assert.equal(payload.routing.nextEscalationState, "oncall_notified");
+    assert.equal(payload.routing.nextEscalationAtUtc, "2026-05-22T12:10:00.000Z");
+    assert.equal(payload.routing.notificationTargets.onCall.contactTarget, "group:release-oncall");
     assert.equal(payload.metadata.gateState, "disabled");
     assert.equal(payload.evidenceReferences.length, 2);
   });
@@ -61,13 +66,12 @@ describe("evidence handoff payload builder", () => {
 
     assert.equal(payload.routing.escalationState, "oncall_notified");
     assert.equal(payload.routing.ackDeadlineUtc, "2026-05-22T12:20:00.000Z");
+    assert.equal(payload.routing.nextEscalationState, "cto_notified");
     assert.equal(payload.routing.owner.id, "aaronjo-Telnyx");
   });
 
-  it("builds secret-exposure payloads without leaking raw findings and escalates to on-call", () => {
-    const report = scanPaths([
-      "tests/fixtures/publish-secret-scan",
-    ], process.cwd());
+  it("builds secret-exposure payloads without leaking raw findings and escalates to CTO for live critical findings", () => {
+    const report = scanPaths(["tests/fixtures/publish-secret-scan"], process.cwd());
     const payload = buildSecretExposurePayload({
       packageName: "@telnyx/agent-cli",
       packageDir: "cli",
@@ -86,8 +90,10 @@ describe("evidence handoff payload builder", () => {
     });
 
     assert.equal(payload.incidentClass, "secret_exposure");
-    assert.equal(payload.routing.escalationState, "oncall_notified");
-    assert.equal(payload.routing.ackDeadlineUtc, "2026-05-22T12:10:00.000Z");
+    assert.equal(payload.routing.escalationState, "cto_notified");
+    assert.equal(payload.routing.currentEvent, "cto_notified");
+    assert.equal(payload.routing.ackDeadlineUtc, "2026-05-22T12:00:00.000Z");
+    assert.equal(payload.routing.nextEscalationState, undefined);
     assert.equal(payload.confidence.source, "publish_secret_scan");
     assert.ok(payload.evidenceReferences.some((reference) => reference.type === "secret_finding"));
 
@@ -95,6 +101,52 @@ describe("evidence handoff payload builder", () => {
     assert.equal(json.includes("ghp_0123456789abcdef0123456789abcdef0123"), false);
     assert.equal(json.includes("npm_0123456789abcdef0123456789abcdef0123"), false);
     assert.equal(json.includes("ProdSecretTokenValue987654321"), false);
+  });
+
+  it("keeps non-critical secret exposure handoffs at on-call with the shared escalation route", () => {
+    const report: ScanReport = {
+      reportVersion: "1",
+      scannedPaths: ["cli"],
+      summary: {
+        filesScanned: 1,
+        findings: 1,
+        blockingFindings: 1,
+        suppressedFindings: 0,
+      },
+      findings: [
+        {
+          reportVersion: "1",
+          findingId: "finding-1",
+          evidenceFingerprint: "abc123def4567890",
+          detectorId: "aws_access_key_id",
+          secretClass: "aws_access_key_id",
+          severity: "high",
+          confidence: "high",
+          path: "cli/example.ts",
+          line: 12,
+          sourceSurface: "publish_artifact",
+          matchLength: 20,
+        },
+      ],
+    };
+
+    const payload = buildSecretExposurePayload({
+      packageName: "@telnyx/agent-cli",
+      packageDir: "cli",
+      workflow: "publish-npm",
+      actor: "release-bot",
+      incidentId: "INC-789",
+      reason: "blocking secret scan findings",
+      timestampUtc: "2026-05-22T12:00:00.000Z",
+      ownerId: "aisling404",
+      onCallGroupId: "release-oncall",
+      codeownersText,
+      report,
+    });
+
+    assert.equal(payload.routing.escalationState, "oncall_notified");
+    assert.equal(payload.routing.ackDeadlineUtc, "2026-05-22T12:10:00.000Z");
+    assert.equal(payload.routing.nextEscalationState, "cto_notified");
   });
 
   it("falls back deterministically when explicit owner input is invalid", () => {

--- a/tests/publish-npm.test.ts
+++ b/tests/publish-npm.test.ts
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, it } from "node:test";
+
+import type { EvidenceHandoffPayload } from "../scripts/evidence-handoff.ts";
+
+const __dirname = typeof import.meta.dirname === "string"
+  ? import.meta.dirname
+  : dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const SCRIPT = join(REPO_ROOT, ".github", "bin", "publish-npm");
+
+const temporaryPaths = new Set<string>();
+
+afterEach(() => {
+  for (const path of temporaryPaths) {
+    try {
+      unlinkSync(path);
+    } catch {
+      // Best-effort temp cleanup for test-created files.
+    }
+  }
+  temporaryPaths.clear();
+});
+
+function createTempFile(prefix: string): string {
+  const tempDir = mkdtempSync(join(tmpdir(), "publish-npm-test-"));
+  const path = join(tempDir, prefix);
+  writeFileSync(path, "", "utf8");
+  temporaryPaths.add(path);
+  return path;
+}
+
+function extractPayloadPath(output: string): string {
+  const match = output.match(/evidence handoff payload written to (\S+)/);
+  assert.ok(match?.[1], `expected payload path in output, received:\n${output}`);
+  return match[1];
+}
+
+function readPayload(path: string): EvidenceHandoffPayload {
+  return JSON.parse(readFileSync(path, "utf8")) as EvidenceHandoffPayload;
+}
+
+function createFakeNpmBin(): string {
+  const tempDir = mkdtempSync(join(tmpdir(), "publish-npm-fake-bin-"));
+  const npmPath = join(tempDir, "npm");
+  writeFileSync(
+    npmPath,
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "config" && "$2" == "set" ]]; then
+  exit 0
+fi
+if [[ "$1" == "run" && "$2" == "build" ]]; then
+  echo "fake build"
+  exit 0
+fi
+if [[ "$1" == "view" ]]; then
+  echo '"0.0.0"'
+  exit 0
+fi
+if [[ "$1" == "publish" ]]; then
+  echo "fake publish"
+  exit 0
+fi
+echo "unexpected npm invocation: $*" >&2
+exit 1
+`,
+    "utf8",
+  );
+  chmodSync(npmPath, 0o755);
+  return tempDir;
+}
+
+describe("publish-npm evidence bundle verification", () => {
+  it("writes a publish-path evidence bundle when the gate is disabled", () => {
+    const summaryPath = createTempFile("summary.md");
+    const result = spawnSync("bash", [SCRIPT, "tools/typescript"], {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GITHUB_STEP_SUMMARY: summaryPath,
+        GITHUB_RUN_ID: "123",
+        GITHUB_REPOSITORY: "team-telnyx/ai",
+        GITHUB_SERVER_URL: "https://github.com",
+        PACKAGE_OWNER_ID: "aisling404",
+        PUBLISH_DISABLE_INCIDENT_ID: "INC-123",
+        PUBLISH_DISABLE_REASON: "manual gate disable",
+        PUBLISH_DISABLED_BY: "release-bot",
+        PUBLISH_NPM_ENABLED: "false",
+        PUBLISH_NPM_GATE_STATE: "disabled",
+        RELEASE_ONCALL_GROUP_ID: "release-oncall",
+        WORKFLOW_NAME: "publish-npm",
+      },
+    });
+
+    assert.equal(result.status, 1, result.stderr || result.stdout);
+    const combinedOutput = `${result.stdout}\n${result.stderr}`;
+    const payloadPath = extractPayloadPath(combinedOutput);
+    const payload = readPayload(payloadPath);
+    const summary = readFileSync(summaryPath, "utf8");
+
+    assert.equal(payload.incidentClass, "publish_path");
+    assert.equal(payload.routing.escalationState, "owner_notified");
+    assert.equal(payload.metadata.gateState, "disabled");
+    assert.equal(payload.routing.owner.id, "aisling404");
+    assert.match(summary, /Publish gate disabled/);
+    assert.match(summary, /INC-123/);
+  });
+
+  it("preserves publish-path evidence when the gate is overridden", () => {
+    const summaryPath = createTempFile("override-summary.md");
+    const fakeBinDir = createFakeNpmBin();
+    const result = spawnSync("bash", [SCRIPT, "plugins/opencode"], {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GITHUB_STEP_SUMMARY: summaryPath,
+        GITHUB_RUN_ID: "456",
+        GITHUB_REPOSITORY: "team-telnyx/ai",
+        GITHUB_SERVER_URL: "https://github.com",
+        NPM_TOKEN: "test-token",
+        PACKAGE_OWNER_ID: "aaronjo-Telnyx",
+        PATH: `${fakeBinDir}:${process.env.PATH}`,
+        PUBLISH_DISABLE_INCIDENT_ID: "INC-456",
+        PUBLISH_DISABLE_REASON: "approved override",
+        PUBLISH_DISABLED_BY: "release-bot",
+        PUBLISH_NPM_ENABLED: "true",
+        PUBLISH_NPM_GATE_STATE: "override",
+        RELEASE_ONCALL_GROUP_ID: "release-oncall",
+        WORKFLOW_NAME: "publish-npm",
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const combinedOutput = `${result.stdout}\n${result.stderr}`;
+    const payloadPath = extractPayloadPath(combinedOutput);
+    const payload = readPayload(payloadPath);
+    const summary = readFileSync(summaryPath, "utf8");
+
+    assert.equal(payload.incidentClass, "publish_path");
+    assert.equal(payload.routing.escalationState, "oncall_notified");
+    assert.equal(payload.metadata.gateState, "override");
+    assert.equal(payload.routing.owner.id, "aaronjo-Telnyx");
+    assert.match(summary, /Publish gate override recorded/);
+    assert.match(combinedOutput, /Publishing @telnyx\/opencode@/);
+  });
+});

--- a/tests/publish-npm.test.ts
+++ b/tests/publish-npm.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, it } from "node:test";
+import { execFileSync } from "node:child_process";
 
 import type { EvidenceHandoffPayload } from "../scripts/evidence-handoff.ts";
 
@@ -13,6 +14,7 @@ const __dirname = typeof import.meta.dirname === "string"
   : dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(__dirname, "..");
 const SCRIPT = join(REPO_ROOT, ".github", "bin", "publish-npm");
+const REPO_SHA = execFileSync("git", ["-C", REPO_ROOT, "rev-parse", "HEAD"], { encoding: "utf8" }).trim();
 
 const temporaryPaths = new Set<string>();
 
@@ -109,8 +111,16 @@ describe("publish-npm evidence bundle verification", () => {
     assert.equal(payload.routing.escalationState, "owner_notified");
     assert.equal(payload.metadata.gateState, "disabled");
     assert.equal(payload.routing.owner.id, "aisling404");
+    assert.equal(payload.metadata.registryOwnerSnapshot.owner.id, "aisling404");
+    assert.equal(payload.metadata.containment.state, "publish_disabled");
+    assert.equal(payload.metadata.dependencyAvailability.credentialSource, "unknown");
+    assert.equal(payload.metadata.dependencyAvailability.missingRegistryWebhook, true);
+    assert.equal(payload.metadata.dependencyAvailability.missingProvenanceUrl, true);
+    assert.equal(payload.snapshot.repoSha, REPO_SHA);
+    assert.equal(payload.snapshot.workspaceIdentity, REPO_ROOT);
     assert.match(summary, /Publish gate disabled/);
     assert.match(summary, /INC-123/);
+    assert.match(summary, new RegExp(REPO_SHA));
   });
 
   it("preserves publish-path evidence when the gate is overridden", () => {
@@ -148,6 +158,10 @@ describe("publish-npm evidence bundle verification", () => {
     assert.equal(payload.routing.escalationState, "oncall_notified");
     assert.equal(payload.metadata.gateState, "override");
     assert.equal(payload.routing.owner.id, "aaronjo-Telnyx");
+    assert.equal(payload.metadata.containment.state, "publish_override");
+    assert.equal(payload.metadata.dependencyAvailability.credentialSource, "npm_token");
+    assert.equal(payload.metadata.dependencyAvailability.missingCredentialSource, false);
+    assert.equal(payload.snapshot.repoSha, REPO_SHA);
     assert.match(summary, /Publish gate override recorded/);
     assert.match(combinedOutput, /Publishing @telnyx\/opencode@/);
   });


### PR DESCRIPTION
## Summary
Backfill draft PR for the recovered publish evidence-bundle and escalation chain that landed without a review artifact.

## Covered issues
- TEL-116
- TEL-135
- TEL-140
- TEL-149
- TEL-155
- TEL-156
- TEL-160
- TEL-261
- TEL-262

## Notes
Recovered from local git history ahead of `origin/main` during TEL-266 audit.
Stacked on #201 because the recovered history depends on the secret-scan preflight commit.
