### PR TITLE
draft: backfill voice docs and trust guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ From `tools/mcp-apps`, use `npm install`, `npm run typecheck`, `npm run build`, 
 
 ## Guides
 
-Curl-first operational guides for common Telnyx workflows — SMS messaging, voice call control, AI assistants, phone numbers, porting, verification, webhooks, 10DLC registration, WireGuard networking, x402 payments, and Edge Compute handoff patterns.
+Curl-first operational guides for common Telnyx workflows — SMS messaging, voice call control, AI assistants, phone numbers, porting, verification, webhooks, 10DLC registration, WireGuard networking, x402 payments, Edge Compute handoff patterns, and [evidence handoff / escalation runbooks](/guides/evidence-handoff.md).
 
 For Edge Compute specifically, the goal is to make the handoff testable fast: start from a real `telnyx-edge` example, deploy it, and let `team-telnyx/ai` orchestrate against that live endpoint.
 

--- a/guides/ai-assistants.md
+++ b/guides/ai-assistants.md
@@ -89,6 +89,17 @@ curl -X POST "https://api.telnyx.com/v2/ai/assistants" \
 - Telnyx-hosted inference is the default recommendation for real-time voice agents because the LLM stays on the same private Telnyx path as transcription, synthesis, and call media.
 - If you need a provider or routing policy outside the hosted catalog, use the custom OpenAI-compatible LLM path deliberately and document the external dependency in your deployment runbook.
 
+## Voice Trust Checklist
+
+Use this checklist for production voice assistants, especially outbound AI or callback flows:
+
+- Use a Telnyx number you control and present a truthful caller identity. Do not imply a bank, carrier, or government caller if the call is actually from your own workflow.
+- If your policy or local law requires AI or recording disclosure, put that disclosure in the first turn the callee hears. Do not claim blanket or implied consent in prompts or examples.
+- For outbound AI, treat iOS Call Screening and Live Voicemail as a separate branch. Use `answering_machine_detection: "premium_ios_call_screening_detection"` and wait for the screening prompt to finish before identifying the caller or starting the assistant.
+- Keep outbound reach narrow with outbound voice profile allowlists such as `whitelisted_destinations`, and review changes to those allowlists like any other fraud-sensitive config change.
+- Log webhook outcomes for screening, voicemail, and hangups. On inbound trust-sensitive flows, inspect available caller trust signals such as SHAKEN/STIR attestation before allowing high-risk actions.
+- Describe voice-data handling honestly. Avoid claims such as "always listening" unless your product really captures audio continuously and your disclosure, consent, and retention policy all support that behavior.
+
 ### List Assistants
 
 **`GET /v2/ai/assistants`**

--- a/guides/ai-assistants.md
+++ b/guides/ai-assistants.md
@@ -8,6 +8,12 @@
 - At least one phone number
 - AI credits or pay-as-you-go enabled
 
+## Model Selection
+
+- Use `openai/gpt-5.4` when you want the current Telnyx-hosted OpenAI reasoning model for voice assistants.
+- Prefer Telnyx-hosted models first for production voice flows. Keeping STT, LLM, TTS, and telephony on the same Telnyx-managed path removes an extra vendor hop and simplifies billing and operations.
+- Reach for a custom OpenAI-compatible endpoint only when you have a hard requirement that the hosted model selector does not meet.
+
 ## Quick Start
 
 ```bash
@@ -18,6 +24,7 @@ curl -X POST "https://api.telnyx.com/v2/ai/assistants" \
   -d '{
     "name": "Support Bot",
     "instructions": "You are a helpful customer support assistant. Be friendly and concise.",
+    "model": "openai/gpt-5.4",
     "voice": {"provider": "telnyx", "settings": {"voice_id": "en-US-Neural2-F"}}
   }'
 
@@ -46,7 +53,7 @@ curl -X POST "https://api.telnyx.com/v2/ai/assistants" \
         "pitch": 0
       }
     },
-    "model": "meta-llama/Llama-3.3-70B-Instruct",
+    "model": "openai/gpt-5.4",
     "greeting": "Hello! Thanks for calling Acme Corp. How can I help you today?",
     "hold_music_url": "https://example.com/hold.mp3"
   }'
@@ -69,12 +76,18 @@ curl -X POST "https://api.telnyx.com/v2/ai/assistants" \
   "id": "assistant-uuid",
   "name": "Sales Assistant",
   "instructions": "...",
-  "model": "meta-llama/Llama-3.3-70B-Instruct",
+  "model": "openai/gpt-5.4",
   "created_at": "2024-01-15T12:00:00Z"
 }
 ```
 
 > **Note:** The AI assistants API returns the object directly — not wrapped in a `"data"` field like other v2 endpoints.
+
+## Hosted Inference Guidance
+
+- `openai/gpt-5.4` is available directly in the assistant model selector and via the Assistants API.
+- Telnyx-hosted inference is the default recommendation for real-time voice agents because the LLM stays on the same private Telnyx path as transcription, synthesis, and call media.
+- If you need a provider or routing policy outside the hosted catalog, use the custom OpenAI-compatible LLM path deliberately and document the external dependency in your deployment runbook.
 
 ### List Assistants
 
@@ -207,12 +220,12 @@ assistant = requests.post(
     json={
         "name": "Support Bot",
         "instructions": "You are a helpful customer support agent.",
-        "model": "meta-llama/Llama-3.3-70B-Instruct",
+        "model": "openai/gpt-5.4",
         "voice": {"provider": "telnyx", "settings": {"voice_id": "en-US-Neural2-F"}},
         "greeting": "Hello! How can I help you today?"
     }
 ).json()
-assistant_id = assistant["data"]["id"]
+assistant_id = assistant["id"]
 print(f"Created: {assistant_id}")
 
 # List assistants
@@ -248,12 +261,12 @@ const createRes = await fetch(`${BASE_URL}/ai/assistants`, {
   body: JSON.stringify({
     name: "Support Bot",
     instructions: "You are a helpful customer support agent.",
-    model: "meta-llama/Llama-3.3-70B-Instruct",
+    model: "openai/gpt-5.4",
     voice: { provider: "telnyx", settings: { voice_id: "en-US-Neural2-F" } },
     greeting: "Hello! How can I help you today?",
   }),
 });
-const { data: assistant } = await createRes.json();
+const assistant = await createRes.json();
 console.log(`Created: ${assistant.id}`);
 
 // List assistants
@@ -287,10 +300,11 @@ toolkit = TelnyxToolkit(api_key="KEY...")
 # Create an AI assistant
 assistant = toolkit.execute("create_ai_assistant", {
     "name": "Support Bot",
-    "model": "meta-llama/Llama-3.3-70B-Instruct",
+    "model": "openai/gpt-5.4",
     "instructions": "You are a helpful customer support agent."
 })
-print(f"Created: {assistant['data']['id']}")
+assistant_id = assistant.get("data", {}).get("id") or assistant["id"]
+print(f"Created: {assistant_id}")
 
 # List assistants
 assistants = toolkit.execute("list_ai_assistants", {"page_size": 10})
@@ -333,6 +347,12 @@ curl -X PATCH "https://api.telnyx.com/v2/phone_numbers/{number_id}" \
 - `en-GB-Neural2-M` (male, UK)
 
 **ElevenLabs:** Provide your API key in voice settings for access to all ElevenLabs voices.
+
+## Operational Notes
+
+- For the lowest-friction deployment path, start with a Telnyx-hosted model such as `openai/gpt-5.4` and a Telnyx-managed voice.
+- Keep custom tool calling and knowledge-base attachments inside the assistant configuration where possible before adding an external orchestration layer.
+- Re-test latency and turn-taking after every model change. Moving from one hosted model to another is usually low risk; moving to a custom LLM endpoint changes the network path and failure surface.
 
 ## Pricing
 

--- a/guides/evidence-handoff.md
+++ b/guides/evidence-handoff.md
@@ -1,0 +1,141 @@
+# Evidence Handoff And Escalation
+
+Use this runbook when the `team-telnyx/ai` release path produces an evidence bundle for either of these incident classes:
+
+- **Publish-path alert**: npm publish is blocked, overridden, or otherwise flagged during [`.github/workflows/publish-npm.yml`](/.github/workflows/publish-npm.yml).
+- **Secret-exposure alert**: release automation, CI, or a human reviewer finds a leaked credential, internal URL, or other sensitive artifact in publishable output. The standing external reporting path remains [`.github/SECURITY.md`](/.github/SECURITY.md).
+
+This guide defines who gets the first notification, how acknowledgement is escalated, and what evidence may be handed off.
+
+## Evidence bundle contents
+
+Every alert handoff should include the smallest bundle that lets the next responder act without reopening the investigation:
+
+- incident class: `publish_path` or `secret_exposure`
+- current state event from the timeline below
+- package or workflow affected
+- timestamp in UTC
+- actor who triggered or disabled the workflow
+- incident or ticket identifier
+- reason for the disable, override, or alert
+- links or attachments to GitHub Actions step summaries, logs, or PR context
+
+For publish-path incidents, the authoritative audit fields already exist in [`.github/workflows/publish-npm.yml`](/.github/workflows/publish-npm.yml) and [`.github/bin/publish-npm`](/.github/bin/publish-npm):
+
+- `publish_disable_reason`
+- `publish_disable_incident_id`
+- `publish_disable_by`
+- `NPM_PUBLISH_DISABLE_REASON`
+- `NPM_PUBLISH_DISABLE_INCIDENT_ID`
+- `NPM_PUBLISH_DISABLED_BY`
+
+The workflow step summary and `publish-audit-log.txt` output are the preferred evidence sources for those alerts.
+
+## Recipient order
+
+### Publish-path alerts
+
+Initial recipients:
+
+1. package owner or workflow owner
+2. release/on-call operator
+3. CTO
+
+Fallback order:
+
+1. If the owner does not acknowledge inside the owner SLA, page the on-call operator and transfer ownership.
+2. If on-call does not acknowledge inside the on-call SLA, escalate to the CTO with the evidence bundle attached.
+3. If the CTO is unreachable and publish must remain blocked, keep the gate disabled and continue updates through the incident ticket until executive coverage is restored.
+
+### Secret-exposure alerts
+
+Initial recipients:
+
+1. package owner
+2. release/on-call operator
+3. CTO
+
+Fallback order:
+
+1. Notify owner and on-call at the same time because containment is time-sensitive.
+2. Escalate to the CTO immediately if a live credential, signing token, or customer-impacting secret is exposed in a published artifact.
+3. If impact is still being verified, escalate to the CTO at the on-call SLA threshold even when the owner has acknowledged but containment is incomplete.
+
+## Ack SLA and escalation thresholds
+
+| Incident class | Owner ack | On-call ack | CTO escalation threshold | Expected response |
+|---|---:|---:|---:|---|
+| `publish_path` | 10 minutes | 20 minutes | 30 minutes from alert creation | Keep publishing disabled until someone explicitly records restore approval and the incident id. |
+| `secret_exposure` | 5 minutes | 10 minutes | Immediate for confirmed live secret, otherwise 15 minutes | Contain first: revoke/rotate secret, block further publish, and hand off only redacted evidence. |
+
+Ack means the responder has posted or otherwise recorded all of the following:
+
+- they own the incident
+- the current state event
+- the next containment action
+- the next status update time
+
+Silence does not count as acknowledgement. Reactions without an explicit owner and next action do not count either.
+
+## State events and timeline
+
+Use these state events in issue comments, incident tickets, or handoff notes so downstream responders can reconstruct the incident quickly.
+
+| State event | When to emit it | Required evidence |
+|---|---|---|
+| `alert_detected` | The workflow, CI check, or human observer first identifies the condition. | Trigger source, UTC timestamp, affected package or secret scope. |
+| `owner_notified` | The owner receives the first handoff. | Owner identity and notification channel. |
+| `owner_acked` | The owner accepts responsibility within SLA. | Owner name, next action, next update time. |
+| `oncall_notified` | The owner SLA expires or the alert is severity-high on arrival. | Escalation reason and current containment status. |
+| `oncall_acked` | On-call takes operational control. | Operator name, mitigation action, next update time. |
+| `cto_notified` | On-call SLA expires or the issue meets immediate-executive criteria. | Full redacted evidence bundle and business-risk summary. |
+| `containment_started` | Publish is disabled, credentials are being rotated, or artifacts are being quarantined. | Command, workflow change, or revocation action taken. |
+| `evidence_bundle_ready` | The bundle is complete enough for a clean handoff. | Links to logs, step summary, ticket, and redacted artifacts. |
+| `restore_approved` | A named owner or CTO approves re-enable of the path. | Approval source, incident id, and rollback plan. |
+| `resolved` | Containment and follow-up actions are complete. | Final root cause, verification, and remaining follow-ups. |
+
+## Operator response behavior
+
+### Publish-path alerts
+
+1. Confirm whether [`.github/workflows/publish-npm.yml`](/.github/workflows/publish-npm.yml) blocked the run because `PUBLISH_NPM_ENABLED` is false or because a manual override was used.
+2. Capture the workflow summary plus the audit values emitted by [`.github/bin/publish-npm`](/.github/bin/publish-npm).
+3. If risk is not understood yet, leave publish disabled. Do not force release traffic back on to "see what happens."
+4. Hand off the evidence bundle to the next recipient in the order above when the active owner misses SLA or lacks the authority to restore.
+
+### Secret-exposure alerts
+
+1. Stop further distribution first: disable publish, revoke or rotate the secret, and quarantine any copied evidence.
+2. Report externally through [`.github/SECURITY.md`](/.github/SECURITY.md) when the alert could expose users, systems, or credentials outside the private incident channel.
+3. Use [`.github/bin/check-release-environment`](/.github/bin/check-release-environment) to confirm whether internal URLs or similar release-safety violations are present in publishable files.
+4. Do not paste raw secrets into issues, chat, screenshots, or step summaries. Only share fingerprints, prefixes, or other redacted identifiers.
+
+## Evidence handling guardrails
+
+- Redact tokens, API keys, cookies, JWTs, internal hostnames, and customer data before attaching evidence.
+- Prefer secret fingerprints, first/last four characters, or one-way hashes over raw values.
+- Store one canonical evidence bundle per incident id so responders are not forwarding divergent copies.
+- Keep raw logs in the system of record that generated them; handoffs should link to those logs instead of copying entire transcripts.
+- If a screenshot is required, crop it to the relevant fields and verify that browser chrome, terminal history, and notification toasts do not leak secrets.
+- When a secret might still be live, treat every downstream handoff as need-to-know and include the minimum scope necessary to continue containment.
+
+## Run instructions mapped to the timeline
+
+| Timeline point | Run instruction |
+|---|---|
+| `alert_detected` | Inspect the current GitHub Actions run in [`.github/workflows/publish-npm.yml`](/.github/workflows/publish-npm.yml). |
+| `containment_started` for publish-path | Keep `PUBLISH_NPM_ENABLED=false` and record `publish_disable_reason`, `publish_disable_incident_id`, and `publish_disable_by` on manual dispatch if used. |
+| `containment_started` for secret exposure | Revoke or rotate the secret, then rerun release safety checks with [`.github/bin/check-release-environment`](/.github/bin/check-release-environment). |
+| `evidence_bundle_ready` | Attach the step summary, audit fields, incident id, and redacted links to the active incident ticket. |
+| `restore_approved` | Re-enable publishing only after a named owner or CTO records approval and the restoration reason. |
+| `resolved` | Record final verification, including the publish gate state and any follow-up hardening tasks. |
+
+## Success condition for a clean handoff
+
+The handoff is complete when the next responder can answer all of these without re-investigating from scratch:
+
+- What happened?
+- Which package, workflow, or secret scope is affected?
+- Who owns the incident right now?
+- What containment action is already in place?
+- What is the next escalation threshold if nobody responds?

--- a/guides/voice-call-control.md
+++ b/guides/voice-call-control.md
@@ -28,6 +28,7 @@ curl -X POST "https://api.telnyx.com/v2/calls" \
 - Use `transcription_start` with `transcription_engine: "Speechmatics"` and `transcription_model: "speechmatics/standard"` when you need real-time call transcription with interim results.
 - Use `answering_machine_detection: "premium_ios_call_screening_detection"` on outbound calls when you need to distinguish a live human from iOS Call Screening or Live Voicemail before connecting an agent or starting a voice AI flow.
 - Treat screened-call handling as a webhook-driven state machine. The value is not just the first AMD result, but the follow-up events that tell you when to speak, retry, or abort.
+- For voice AI, keep trust controls explicit: identify the caller truthfully, disclose AI or recording when your policy requires it, and do not present screening-aware flows as blanket consent to capture audio.
 
 ## API Reference
 
@@ -172,6 +173,14 @@ The key webhooks are:
 - `call.machine.premium.greeting.ended` with `result=prompt_ended` when the iOS screening prompt finishes and your app can respond with who is calling and why
 - `call.machine.premium.call_screening.detected` with `result=screening` when Apple call-screening audio is detected
 - a second `call.machine.premium.detection.ended` after screening, because Telnyx restarts Premium AMD on the screened call
+
+Recommended outbound AI behavior:
+
+- Place the call with Premium AMD enabled before starting your assistant or bridging to a human queue.
+- If Telnyx reports `call.machine.premium.greeting.ended` with `result=prompt_ended`, play a short truthful identification message such as who is calling and why.
+- If `call.machine.premium.call_screening.detected` fires, wait for the restarted Premium AMD result instead of speaking over the screening flow.
+- Start the assistant only after the restarted AMD cycle indicates a live person, and fall back to your voicemail or retry policy for voicemail outcomes.
+- Keep the script factual. Avoid deceptive language such as "we are always listening" or any implication that screened-call audio equals consent for recording.
 
 ### Conference Calls
 
@@ -345,7 +354,7 @@ def handle_amd(event: dict):
         requests.post(
             f"{BASE_URL}/calls/{payload['call_control_id']}/actions/speak",
             headers=headers,
-            json={"payload": "This is Acme Support returning your call.", "voice": "female"},
+            json={"payload": "This is Acme Support calling about your open support request.", "voice": "female"},
         )
         return
 

--- a/guides/voice-call-control.md
+++ b/guides/voice-call-control.md
@@ -23,6 +23,12 @@ curl -X POST "https://api.telnyx.com/v2/calls" \
   }'
 ```
 
+## Current Voice Patterns
+
+- Use `transcription_start` with `transcription_engine: "Speechmatics"` and `transcription_model: "speechmatics/standard"` when you need real-time call transcription with interim results.
+- Use `answering_machine_detection: "premium_ios_call_screening_detection"` on outbound calls when you need to distinguish a live human from iOS Call Screening or Live Voicemail before connecting an agent or starting a voice AI flow.
+- Treat screened-call handling as a webhook-driven state machine. The value is not just the first AMD result, but the follow-up events that tell you when to speak, retry, or abort.
+
 ## API Reference
 
 ### Make a Call
@@ -110,6 +116,62 @@ curl -X POST "https://api.telnyx.com/v2/calls/{call_control_id}/actions/record_s
   -H "Content-Type: application/json" \
   -d '{"format": "wav"}'
 ```
+
+### Start Real-Time Transcription with Speechmatics
+
+**`POST /v2/calls/{call_control_id}/actions/transcription_start`**
+
+```bash
+curl -X POST "https://api.telnyx.com/v2/calls/{call_control_id}/actions/transcription_start" \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "transcription_engine": "Speechmatics",
+    "transcription_engine_config": {
+      "transcription_engine": "Speechmatics",
+      "language": "en",
+      "transcription_model": "speechmatics/standard",
+      "interim_results": true
+    }
+  }'
+```
+
+Speechmatics is available through Telnyx-managed transcription, so you keep the call-control integration and webhook shape you already use while swapping the STT engine and model.
+
+### Outbound Dialing with Premium AMD for iOS Call Screening
+
+**`POST /v2/calls`**
+
+```bash
+curl -X POST "https://api.telnyx.com/v2/calls" \
+  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": "+15559876543",
+    "from": "+15551234567",
+    "connection_id": "your-connection-id",
+    "webhook_url": "https://your-app.com/webhooks/voice",
+    "answering_machine_detection": "premium_ios_call_screening_detection",
+    "answering_machine_detection_config": {
+      "total_analysis_time_millis": 30000,
+      "greeting_duration_millis": 2000,
+      "prompt_end_timeout_millis": 30000
+    }
+  }'
+```
+
+Use this mode when your outbound workflow must react differently to:
+
+- a human answering immediately
+- a traditional voicemail greeting
+- an iOS Call Screening or Live Voicemail prompt
+
+The key webhooks are:
+
+- `call.machine.premium.detection.ended` for the initial Premium AMD classification
+- `call.machine.premium.greeting.ended` with `result=prompt_ended` when the iOS screening prompt finishes and your app can respond with who is calling and why
+- `call.machine.premium.call_screening.detected` with `result=screening` when Apple call-screening audio is detected
+- a second `call.machine.premium.detection.ended` after screening, because Telnyx restarts Premium AMD on the screened call
 
 ### Conference Calls
 
@@ -253,6 +315,48 @@ def handle_ivr(call_control_id: str, digits: str):
         )
 ```
 
+### Reacting to Speechmatics Interim Transcripts
+
+```python
+def handle_webhook(event: dict):
+    if event["data"]["event_type"] != "call.transcription":
+        return
+
+    transcription = event["data"]["payload"]["transcription_data"]
+    transcript = transcription["transcript"]
+
+    if not transcription["is_final"]:
+        print(f"Partial transcript: {transcript}")
+        return
+
+    print(f"Final transcript: {transcript}")
+```
+
+### Reacting to iOS Call Screening / Live Voicemail
+
+```python
+def handle_amd(event: dict):
+    event_type = event["data"]["event_type"]
+    payload = event["data"]["payload"]
+
+    if event_type == "call.machine.premium.greeting.ended" and payload["result"] == "prompt_ended":
+        # The screening prompt ended without a beep. This is the point where
+        # your app can identify the caller and intent for Apple Call Screening.
+        requests.post(
+            f"{BASE_URL}/calls/{payload['call_control_id']}/actions/speak",
+            headers=headers,
+            json={"payload": "This is Acme Support returning your call.", "voice": "female"},
+        )
+        return
+
+    if event_type == "call.machine.premium.call_screening.detected":
+        print("Call entered iOS screening flow; wait for the restarted AMD result.")
+        return
+
+    if event_type == "call.machine.premium.detection.ended":
+        print(f"Premium AMD result: {payload['result']}")
+```
+
 ## Error Handling
 
 | Error | HTTP Status | Resolution |
@@ -266,3 +370,5 @@ def handle_ivr(call_control_id: str, digits: str):
 
 - [Call Control API Reference](https://developers.telnyx.com/docs/api/v2/call-control)
 - [Call Control Documentation](https://developers.telnyx.com/docs/voice/call-control)
+- [Speech-to-Text with Voice API and TeXML](https://developers.telnyx.com/docs/voice/programmable-voice/speech-to-text)
+- [Answering Machine Detection](https://developers.telnyx.com/docs/voice/programmable-voice/answering-machine-detection)

--- a/providers/claude/plugin/skills/telnyx-ai-assistants-ruby/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-ai-assistants-ruby/SKILL.md
@@ -39,7 +39,7 @@ All API calls can fail with network errors, rate limits (429), validation errors
 or authentication errors (401). Always handle errors in production code:
 
 ```ruby
-assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", model: "openai/gpt-4o", name: "my-resource")
+assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", model: "openai/gpt-5.4", name: "my-resource")
 puts(assistant)
 ```
 
@@ -51,6 +51,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 
 - **Phone numbers** must be in E.164 format (e.g., `+13125550001`). Include the `+` prefix and country code. No spaces, dashes, or parentheses.
 - **Pagination:** Use `.auto_paging_each` for automatic iteration: `page.auto_paging_each { |item| puts item.id }`.
+- **Current hosted OpenAI model:** Use `openai/gpt-5.4` when you want the current Telnyx-hosted GPT model for voice assistants.
 
 ## Reference Use Rules
 
@@ -78,7 +79,7 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
-assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", model: "openai/gpt-4o", name: "my-resource")
+assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", model: "openai/gpt-5.4", name: "my-resource")
 
 puts(assistant)
 ```

--- a/providers/claude/plugin/skills/telnyx-ai-outbound-voice-python/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-ai-outbound-voice-python/SKILL.md
@@ -44,6 +44,16 @@ a specific error — see [Troubleshooting](#troubleshooting).
 4. An outbound voice profile with destination countries whitelisted
 5. An AI assistant with `telephony_settings.default_texml_app_id` set to the TeXML app
 
+## Trust and anti-scam guardrails
+
+Apply these before you automate a production outbound AI flow:
+
+- Use a Telnyx number you own and identify the caller truthfully when a human or screening prompt answers.
+- If your policy requires AI or recording disclosure, make that disclosure in the first live turn. Do not write prompts that imply blanket consent or "always listening" capture.
+- Treat iOS Call Screening and Live Voicemail as a separate branch. Premium AMD should decide when to speak, not just whether the line is answered.
+- Keep `whitelisted_destinations` tight on the outbound voice profile so accidental or abusive destination expansion becomes a visible config change.
+- Store webhook outcomes for screened calls, voicemail, and failed attempts so operators can distinguish deliverability issues from trust or anti-spam friction.
+
 ## Model availability
 
 Model availability varies by account. If `client.ai.assistants.create()` returns
@@ -154,7 +164,8 @@ assistant = client.ai.assistants.create(
     model="openai/gpt-4o",
     instructions=(
         "You are a helpful phone assistant. "
-        "Keep your answers concise and conversational since this is a phone call."
+        "Keep your answers concise and conversational since this is a phone call. "
+        "If the workflow requires disclosure, identify yourself as an AI assistant before continuing."
     ),
     greeting="Hello! How can I help you today?",
     telephony_settings={"default_texml_app_id": app_id},
@@ -189,6 +200,13 @@ event = client.ai.assistants.scheduled_events.create(
 )
 print(f"Status: {event.status}")  # "pending"
 ```
+
+If this call flow must react safely to iOS Call Screening or Live Voicemail,
+combine the assistant with a Call Control path that uses
+`answering_machine_detection: "premium_ios_call_screening_detection"` before
+starting the live AI interaction. Wait until the screening prompt finishes,
+identify the caller and reason for the call, then act on the restarted Premium
+AMD result before speaking further or transferring.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|

--- a/providers/claude/plugin/skills/telnyx-voice-curl/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-voice-curl/SKILL.md
@@ -61,6 +61,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 - Call Control is event-driven. After `dial()` or an inbound webhook, issue follow-up commands from webhook handlers using the `call_control_id` in the event payload.
 - Outbound and inbound flows are different: outbound calls start with `dial()`, while inbound calls must be answered from the incoming webhook before other commands run.
 - A publicly reachable webhook endpoint is required for real call control. Without it, calls may connect but your application cannot drive the live call state.
+- For real-time STT, `transcription_start` supports `transcription_engine: "Speechmatics"` with `transcription_model: "speechmatics/standard"` when you need interim results in a live call workflow.
+- For outbound screening-aware dialing, prefer `answering_machine_detection: "premium_ios_call_screening_detection"` over basic AMD when your workflow must react to iOS Call Screening or Live Voicemail before speaking or bridging.
 
 ## Reference Use Rules
 

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-ruby/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-ruby/SKILL.md
@@ -39,7 +39,7 @@ All API calls can fail with network errors, rate limits (429), validation errors
 or authentication errors (401). Always handle errors in production code:
 
 ```ruby
-assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", model: "openai/gpt-4o", name: "my-resource")
+assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", model: "openai/gpt-5.4", name: "my-resource")
 puts(assistant)
 ```
 
@@ -51,6 +51,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 
 - **Phone numbers** must be in E.164 format (e.g., `+13125550001`). Include the `+` prefix and country code. No spaces, dashes, or parentheses.
 - **Pagination:** Use `.auto_paging_each` for automatic iteration: `page.auto_paging_each { |item| puts item.id }`.
+- **Current hosted OpenAI model:** Use `openai/gpt-5.4` when you want the current Telnyx-hosted GPT model for voice assistants.
 
 ## Reference Use Rules
 
@@ -78,7 +79,7 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
-assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", model: "openai/gpt-4o", name: "my-resource")
+assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", model: "openai/gpt-5.4", name: "my-resource")
 
 puts(assistant)
 ```

--- a/providers/cursor/plugin/skills/telnyx-ai-outbound-voice-python/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-outbound-voice-python/SKILL.md
@@ -44,6 +44,16 @@ a specific error — see [Troubleshooting](#troubleshooting).
 4. An outbound voice profile with destination countries whitelisted
 5. An AI assistant with `telephony_settings.default_texml_app_id` set to the TeXML app
 
+## Trust and anti-scam guardrails
+
+Apply these before you automate a production outbound AI flow:
+
+- Use a Telnyx number you own and identify the caller truthfully when a human or screening prompt answers.
+- If your policy requires AI or recording disclosure, make that disclosure in the first live turn. Do not write prompts that imply blanket consent or "always listening" capture.
+- Treat iOS Call Screening and Live Voicemail as a separate branch. Premium AMD should decide when to speak, not just whether the line is answered.
+- Keep `whitelisted_destinations` tight on the outbound voice profile so accidental or abusive destination expansion becomes a visible config change.
+- Store webhook outcomes for screened calls, voicemail, and failed attempts so operators can distinguish deliverability issues from trust or anti-spam friction.
+
 ## Model availability
 
 Model availability varies by account. If `client.ai.assistants.create()` returns
@@ -154,7 +164,8 @@ assistant = client.ai.assistants.create(
     model="openai/gpt-4o",
     instructions=(
         "You are a helpful phone assistant. "
-        "Keep your answers concise and conversational since this is a phone call."
+        "Keep your answers concise and conversational since this is a phone call. "
+        "If the workflow requires disclosure, identify yourself as an AI assistant before continuing."
     ),
     greeting="Hello! How can I help you today?",
     telephony_settings={"default_texml_app_id": app_id},
@@ -189,6 +200,13 @@ event = client.ai.assistants.scheduled_events.create(
 )
 print(f"Status: {event.status}")  # "pending"
 ```
+
+If this call flow must react safely to iOS Call Screening or Live Voicemail,
+combine the assistant with a Call Control path that uses
+`answering_machine_detection: "premium_ios_call_screening_detection"` before
+starting the live AI interaction. Wait until the screening prompt finishes,
+identify the caller and reason for the call, then act on the restarted Premium
+AMD result before speaking further or transferring.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|

--- a/providers/cursor/plugin/skills/telnyx-voice-curl/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-curl/SKILL.md
@@ -61,6 +61,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 - Call Control is event-driven. After `dial()` or an inbound webhook, issue follow-up commands from webhook handlers using the `call_control_id` in the event payload.
 - Outbound and inbound flows are different: outbound calls start with `dial()`, while inbound calls must be answered from the incoming webhook before other commands run.
 - A publicly reachable webhook endpoint is required for real call control. Without it, calls may connect but your application cannot drive the live call state.
+- For real-time STT, `transcription_start` supports `transcription_engine: "Speechmatics"` with `transcription_model: "speechmatics/standard"` when you need interim results in a live call workflow.
+- For outbound screening-aware dialing, prefer `answering_machine_detection: "premium_ios_call_screening_detection"` over basic AMD when your workflow must react to iOS Call Screening or Live Voicemail before speaking or bridging.
 
 ## Reference Use Rules
 

--- a/skills/telnyx-ai-assistants-ruby/SKILL.md
+++ b/skills/telnyx-ai-assistants-ruby/SKILL.md
@@ -39,7 +39,7 @@ All API calls can fail with network errors, rate limits (429), validation errors
 or authentication errors (401). Always handle errors in production code:
 
 ```ruby
-assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", model: "openai/gpt-4o", name: "my-resource")
+assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", model: "openai/gpt-5.4", name: "my-resource")
 puts(assistant)
 ```
 
@@ -51,6 +51,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 
 - **Phone numbers** must be in E.164 format (e.g., `+13125550001`). Include the `+` prefix and country code. No spaces, dashes, or parentheses.
 - **Pagination:** Use `.auto_paging_each` for automatic iteration: `page.auto_paging_each { |item| puts item.id }`.
+- **Current hosted OpenAI model:** Use `openai/gpt-5.4` when you want the current Telnyx-hosted GPT model for voice assistants.
 
 ## Reference Use Rules
 
@@ -78,7 +79,7 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
-assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", model: "openai/gpt-4o", name: "my-resource")
+assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", model: "openai/gpt-5.4", name: "my-resource")
 
 puts(assistant)
 ```

--- a/skills/telnyx-ai-outbound-voice-python/SKILL.md
+++ b/skills/telnyx-ai-outbound-voice-python/SKILL.md
@@ -44,6 +44,16 @@ a specific error — see [Troubleshooting](#troubleshooting).
 4. An outbound voice profile with destination countries whitelisted
 5. An AI assistant with `telephony_settings.default_texml_app_id` set to the TeXML app
 
+## Trust and anti-scam guardrails
+
+Apply these before you automate a production outbound AI flow:
+
+- Use a Telnyx number you own and identify the caller truthfully when a human or screening prompt answers.
+- If your policy requires AI or recording disclosure, make that disclosure in the first live turn. Do not write prompts that imply blanket consent or "always listening" capture.
+- Treat iOS Call Screening and Live Voicemail as a separate branch. Premium AMD should decide when to speak, not just whether the line is answered.
+- Keep `whitelisted_destinations` tight on the outbound voice profile so accidental or abusive destination expansion becomes a visible config change.
+- Store webhook outcomes for screened calls, voicemail, and failed attempts so operators can distinguish deliverability issues from trust or anti-spam friction.
+
 ## Model availability
 
 Model availability varies by account. If `client.ai.assistants.create()` returns
@@ -154,7 +164,8 @@ assistant = client.ai.assistants.create(
     model="openai/gpt-4o",
     instructions=(
         "You are a helpful phone assistant. "
-        "Keep your answers concise and conversational since this is a phone call."
+        "Keep your answers concise and conversational since this is a phone call. "
+        "If the workflow requires disclosure, identify yourself as an AI assistant before continuing."
     ),
     greeting="Hello! How can I help you today?",
     telephony_settings={"default_texml_app_id": app_id},
@@ -189,6 +200,13 @@ event = client.ai.assistants.scheduled_events.create(
 )
 print(f"Status: {event.status}")  # "pending"
 ```
+
+If this call flow must react safely to iOS Call Screening or Live Voicemail,
+combine the assistant with a Call Control path that uses
+`answering_machine_detection: "premium_ios_call_screening_detection"` before
+starting the live AI interaction. Wait until the screening prompt finishes,
+identify the caller and reason for the call, then act on the restarted Premium
+AMD result before speaking further or transferring.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|

--- a/skills/telnyx-voice-curl/SKILL.md
+++ b/skills/telnyx-voice-curl/SKILL.md
@@ -61,6 +61,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 - Call Control is event-driven. After `dial()` or an inbound webhook, issue follow-up commands from webhook handlers using the `call_control_id` in the event payload.
 - Outbound and inbound flows are different: outbound calls start with `dial()`, while inbound calls must be answered from the incoming webhook before other commands run.
 - A publicly reachable webhook endpoint is required for real call control. Without it, calls may connect but your application cannot drive the live call state.
+- For real-time STT, `transcription_start` supports `transcription_engine: "Speechmatics"` with `transcription_model: "speechmatics/standard"` when you need interim results in a live call workflow.
+- For outbound screening-aware dialing, prefer `answering_machine_detection: "premium_ios_call_screening_detection"` over basic AMD when your workflow must react to iOS Call Screening or Live Voicemail before speaking or bridging.
 
 ## Reference Use Rules
 


### PR DESCRIPTION
## Summary
Backfill draft PR for the recovered voice docs refresh and trust guidance work.

## Covered issues
- TEL-191
- TEL-203

## Notes
Recovered from local git history ahead of `origin/main` during TEL-266 audit.
