### PR TITLE
draft: backfill governed communications docs and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Add the Telnyx MCP server to your project's `.cursor/mcp.json`:
 
 Integrate Telnyx APIs with popular agent frameworks through function calling — available in [Python](/tools/python) and [TypeScript](/tools/typescript).
 
+For external or approval-sensitive agents, prefer a focused governed MCP App before exposing raw toolkit tools. The governed OpenAI, LangChain, and CrewAI examples live under [`tools/python/examples`](/tools/python/examples).
+
 ### Python
 
 ```sh
@@ -176,6 +178,8 @@ See [MCP](/tools/mcp) for more details about the generic API MCP proxy.
 
 [`tools/mcp-apps`](/tools/mcp-apps) contains app-layer MCP servers with MCP Apps UI resources for focused Telnyx workflows. These are separate from the generic `@telnyx/mcp` proxy above.
 
+Use MCP Apps when the agent should stay on a read-first or preview-first contract with least-privilege credentials. Use the generic proxy only when you intentionally need the broader Telnyx API MCP surface.
+
 Current apps:
 
 - Number Intelligence (`tools/mcp-apps/apps/number-intelligence`)
@@ -183,6 +187,15 @@ Current apps:
 - Voice Monitor (`tools/mcp-apps/apps/voice-monitor`)
 
 From `tools/mcp-apps`, use `npm install`, `npm run typecheck`, `npm run build`, and `npm test`.
+
+The public docs-facing MCP Apps discovery contract is intended to live on `https://developers.telnyx.com` with these proof URLs:
+
+- `https://developers.telnyx.com/.well-known/mcp-app-registry.json`
+- `https://developers.telnyx.com/.well-known/mcp-apps.json`
+- `https://developers.telnyx.com/apps/number-intelligence`
+- `https://developers.telnyx.com/apps/number-intelligence/mcp`
+
+From the repo root, `npm run verify:live-docs-mcp-apps` probes that hosted surface and reports whether the public registry, per-app discovery document, tool annotations, and `ui://` resources are actually visible end-to-end.
 
 ## Guides
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ Curl-first operational guides for common Telnyx workflows — SMS messaging, voi
 
 For Edge Compute specifically, the goal is to make the handoff testable fast: start from a real `telnyx-edge` example, deploy it, and let `team-telnyx/ai` orchestrate against that live endpoint.
 
+For the managed-agent packaging pattern that ties discovery, skills, MCP apps, and least-privilege operations together, see [Managed Telecom Agents](/managed-telecom-agents.md).
+
 See [Guides](/guides) for the full list.
 
 ## Edge Compute

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ From `tools/mcp-apps`, use `npm install`, `npm run typecheck`, `npm run build`, 
 
 ## Guides
 
-Curl-first operational guides for common Telnyx workflows — SMS messaging, voice call control, AI assistants, phone numbers, porting, verification, webhooks, 10DLC registration, WireGuard networking, x402 payments, and Edge Compute handoff patterns.
+Curl-first operational guides for common Telnyx workflows — SMS messaging, voice call control, AI assistants, phone numbers, porting, verification, webhooks, 10DLC registration, WireGuard networking, x402 payments, Edge Compute handoff patterns, and [evidence handoff / escalation runbooks](/guides/evidence-handoff.md).
 
 For Edge Compute specifically, the goal is to make the handoff testable fast: start from a real `telnyx-edge` example, deploy it, and let `team-telnyx/ai` orchestrate against that live endpoint.
 

--- a/guides/evidence-handoff.md
+++ b/guides/evidence-handoff.md
@@ -1,0 +1,141 @@
+# Evidence Handoff And Escalation
+
+Use this runbook when the `team-telnyx/ai` release path produces an evidence bundle for either of these incident classes:
+
+- **Publish-path alert**: npm publish is blocked, overridden, or otherwise flagged during [`.github/workflows/publish-npm.yml`](/.github/workflows/publish-npm.yml).
+- **Secret-exposure alert**: release automation, CI, or a human reviewer finds a leaked credential, internal URL, or other sensitive artifact in publishable output. The standing external reporting path remains [`.github/SECURITY.md`](/.github/SECURITY.md).
+
+This guide defines who gets the first notification, how acknowledgement is escalated, and what evidence may be handed off.
+
+## Evidence bundle contents
+
+Every alert handoff should include the smallest bundle that lets the next responder act without reopening the investigation:
+
+- incident class: `publish_path` or `secret_exposure`
+- current state event from the timeline below
+- package or workflow affected
+- timestamp in UTC
+- actor who triggered or disabled the workflow
+- incident or ticket identifier
+- reason for the disable, override, or alert
+- links or attachments to GitHub Actions step summaries, logs, or PR context
+
+For publish-path incidents, the authoritative audit fields already exist in [`.github/workflows/publish-npm.yml`](/.github/workflows/publish-npm.yml) and [`.github/bin/publish-npm`](/.github/bin/publish-npm):
+
+- `publish_disable_reason`
+- `publish_disable_incident_id`
+- `publish_disable_by`
+- `NPM_PUBLISH_DISABLE_REASON`
+- `NPM_PUBLISH_DISABLE_INCIDENT_ID`
+- `NPM_PUBLISH_DISABLED_BY`
+
+The workflow step summary and `publish-audit-log.txt` output are the preferred evidence sources for those alerts.
+
+## Recipient order
+
+### Publish-path alerts
+
+Initial recipients:
+
+1. package owner or workflow owner
+2. release/on-call operator
+3. CTO
+
+Fallback order:
+
+1. If the owner does not acknowledge inside the owner SLA, page the on-call operator and transfer ownership.
+2. If on-call does not acknowledge inside the on-call SLA, escalate to the CTO with the evidence bundle attached.
+3. If the CTO is unreachable and publish must remain blocked, keep the gate disabled and continue updates through the incident ticket until executive coverage is restored.
+
+### Secret-exposure alerts
+
+Initial recipients:
+
+1. package owner
+2. release/on-call operator
+3. CTO
+
+Fallback order:
+
+1. Notify owner and on-call at the same time because containment is time-sensitive.
+2. Escalate to the CTO immediately if a live credential, signing token, or customer-impacting secret is exposed in a published artifact.
+3. If impact is still being verified, escalate to the CTO at the on-call SLA threshold even when the owner has acknowledged but containment is incomplete.
+
+## Ack SLA and escalation thresholds
+
+| Incident class | Owner ack | On-call ack | CTO escalation threshold | Expected response |
+|---|---:|---:|---:|---|
+| `publish_path` | 10 minutes | 20 minutes | 30 minutes from alert creation | Keep publishing disabled until someone explicitly records restore approval and the incident id. |
+| `secret_exposure` | 5 minutes | 10 minutes | Immediate for confirmed live secret, otherwise 15 minutes | Contain first: revoke/rotate secret, block further publish, and hand off only redacted evidence. |
+
+Ack means the responder has posted or otherwise recorded all of the following:
+
+- they own the incident
+- the current state event
+- the next containment action
+- the next status update time
+
+Silence does not count as acknowledgement. Reactions without an explicit owner and next action do not count either.
+
+## State events and timeline
+
+Use these state events in issue comments, incident tickets, or handoff notes so downstream responders can reconstruct the incident quickly.
+
+| State event | When to emit it | Required evidence |
+|---|---|---|
+| `alert_detected` | The workflow, CI check, or human observer first identifies the condition. | Trigger source, UTC timestamp, affected package or secret scope. |
+| `owner_notified` | The owner receives the first handoff. | Owner identity and notification channel. |
+| `owner_acked` | The owner accepts responsibility within SLA. | Owner name, next action, next update time. |
+| `oncall_notified` | The owner SLA expires or the alert is severity-high on arrival. | Escalation reason and current containment status. |
+| `oncall_acked` | On-call takes operational control. | Operator name, mitigation action, next update time. |
+| `cto_notified` | On-call SLA expires or the issue meets immediate-executive criteria. | Full redacted evidence bundle and business-risk summary. |
+| `containment_started` | Publish is disabled, credentials are being rotated, or artifacts are being quarantined. | Command, workflow change, or revocation action taken. |
+| `evidence_bundle_ready` | The bundle is complete enough for a clean handoff. | Links to logs, step summary, ticket, and redacted artifacts. |
+| `restore_approved` | A named owner or CTO approves re-enable of the path. | Approval source, incident id, and rollback plan. |
+| `resolved` | Containment and follow-up actions are complete. | Final root cause, verification, and remaining follow-ups. |
+
+## Operator response behavior
+
+### Publish-path alerts
+
+1. Confirm whether [`.github/workflows/publish-npm.yml`](/.github/workflows/publish-npm.yml) blocked the run because `PUBLISH_NPM_ENABLED` is false or because a manual override was used.
+2. Capture the workflow summary plus the audit values emitted by [`.github/bin/publish-npm`](/.github/bin/publish-npm).
+3. If risk is not understood yet, leave publish disabled. Do not force release traffic back on to "see what happens."
+4. Hand off the evidence bundle to the next recipient in the order above when the active owner misses SLA or lacks the authority to restore.
+
+### Secret-exposure alerts
+
+1. Stop further distribution first: disable publish, revoke or rotate the secret, and quarantine any copied evidence.
+2. Report externally through [`.github/SECURITY.md`](/.github/SECURITY.md) when the alert could expose users, systems, or credentials outside the private incident channel.
+3. Use [`.github/bin/check-release-environment`](/.github/bin/check-release-environment) to confirm whether internal URLs or similar release-safety violations are present in publishable files.
+4. Do not paste raw secrets into issues, chat, screenshots, or step summaries. Only share fingerprints, prefixes, or other redacted identifiers.
+
+## Evidence handling guardrails
+
+- Redact tokens, API keys, cookies, JWTs, internal hostnames, and customer data before attaching evidence.
+- Prefer secret fingerprints, first/last four characters, or one-way hashes over raw values.
+- Store one canonical evidence bundle per incident id so responders are not forwarding divergent copies.
+- Keep raw logs in the system of record that generated them; handoffs should link to those logs instead of copying entire transcripts.
+- If a screenshot is required, crop it to the relevant fields and verify that browser chrome, terminal history, and notification toasts do not leak secrets.
+- When a secret might still be live, treat every downstream handoff as need-to-know and include the minimum scope necessary to continue containment.
+
+## Run instructions mapped to the timeline
+
+| Timeline point | Run instruction |
+|---|---|
+| `alert_detected` | Inspect the current GitHub Actions run in [`.github/workflows/publish-npm.yml`](/.github/workflows/publish-npm.yml). |
+| `containment_started` for publish-path | Keep `PUBLISH_NPM_ENABLED=false` and record `publish_disable_reason`, `publish_disable_incident_id`, and `publish_disable_by` on manual dispatch if used. |
+| `containment_started` for secret exposure | Revoke or rotate the secret, then rerun release safety checks with [`.github/bin/check-release-environment`](/.github/bin/check-release-environment). |
+| `evidence_bundle_ready` | Attach the step summary, audit fields, incident id, and redacted links to the active incident ticket. |
+| `restore_approved` | Re-enable publishing only after a named owner or CTO records approval and the restoration reason. |
+| `resolved` | Record final verification, including the publish gate state and any follow-up hardening tasks. |
+
+## Success condition for a clean handoff
+
+The handoff is complete when the next responder can answer all of these without re-investigating from scratch:
+
+- What happened?
+- Which package, workflow, or secret scope is affected?
+- Who owns the incident right now?
+- What containment action is already in place?
+- What is the next escalation threshold if nobody responds?

--- a/managed-telecom-agents.md
+++ b/managed-telecom-agents.md
@@ -1,0 +1,153 @@
+# Managed Telecom Agents
+
+Use this pattern when you want a Telnyx-managed agent package for a bounded telecom workflow instead of an open-ended "agent that can do everything."
+
+## Recommended First Slice
+
+Start with **voice debugging and call-triage**.
+
+This repo already contains the right paved road in [`tools/mcp-apps/apps/voice-monitor`](/tools/mcp-apps/apps/voice-monitor):
+
+- the workflow is operationally real, not a toy demo
+- the tool surface is already read-only
+- the app preserves the IDs humans need for escalation while redacting sensitive payloads
+- the failure modes are familiar and high-value: webhook failures, timing gaps, call status drift, recordings, and AI assistant wiring
+
+This beats messaging deliverability, SIP routing mutation, or assistant self-healing as a first package because it proves the control-plane pattern without requiring write access on day one.
+
+## Package Shape
+
+A managed telecom agent package should map onto existing repo surfaces like this:
+
+| Layer | Repo surface | Role |
+| --- | --- | --- |
+| Discovery and auth | [`agent.json`](/agent.json), [`README.md`](/README.md) | Publish bearer-auth discovery, MCP entry points, capability links, and quickstarts |
+| Runtime operating contract | [`AGENTS.md`](/AGENTS.md) | Define how coding/runtime agents should approach setup, tests, and package boundaries |
+| Workflow-specific behavior | `skills/<workflow>/SKILL.md` | Encode the narrow task, required identifiers, escalation path, and safe operating steps |
+| Focused tool surface | [`tools/mcp-apps`](/tools/mcp-apps) app or [`tools/mcp`](/tools/mcp) proxy | Expose only the MCP tools the workflow needs |
+| Human/operator guide | `guides/<workflow>.md` | Show prerequisites, trust boundaries, and the paved-road debug or recovery flow |
+| Optional provisioning wrapper | [`cli/`](/cli) | Collapse setup into a repeatable command when the workflow benefits from one-shot provisioning |
+
+The package should be versioned as a **bundle**, not as disconnected docs. In practice that means the skill, guide, MCP app surface, and any manifest/discovery changes land together in one change set.
+
+## Control Boundaries
+
+Default to **diagnostic-first** packaging.
+
+Diagnostic actions belong in the base package:
+
+- read call state, timelines, recordings, webhook deliveries, and account-safe metadata
+- summarize evidence into a debug report
+- preserve operational IDs such as `connection_id`, `call_control_id`, `call_leg_id`, `call_session_id`, `assistant_id`, and `conversation_id`
+- redact phone numbers, recording URLs, transcripts, credentials, and arbitrary metadata unless the workflow explicitly requires them
+
+Mutating actions should be separated behind a second package or approval gate:
+
+- hanging up or transferring a call
+- changing SIP connection or voice application configuration
+- patching assistant instructions or model settings
+- replaying webhooks or modifying queues/conferences
+- buying numbers, changing billing state, or rotating credentials
+
+The rule is simple: if a tool can change customer traffic, billing, routing, policy, or retained content, do not ship it in the diagnostic package by default.
+
+## Least-Privilege Defaults
+
+The default managed package should assume:
+
+- one workflow-specific MCP app, not the entire generic API surface
+- read-only Telnyx API credentials where the workflow allows it
+- capped lookback windows, page sizes, and discovery breadth
+- explicit environment variables for every guardrail
+- no cross-account or cross-project actions without an operator choosing the scope
+
+For the first voice package, the existing `voice-monitor` guardrails are the right model:
+
+- read-only app semantics
+- bounded page and time windows
+- redaction of sensitive artifacts
+- manual escalation path once the diagnosis identifies the next human or mutating action
+
+## Audit Expectations
+
+Every managed telecom package should produce enough evidence for a human to understand what happened without replaying the whole session.
+
+Minimum audit trail:
+
+- package version or git revision
+- MCP app/tool invoked
+- sanitized input filters
+- preserved operational IDs
+- timestamps and correlation windows
+- any redaction behavior applied
+- the final recommendation or escalation target
+
+For mutating follow-up packages, add:
+
+- before/after config summary
+- actor identity
+- approval or confirmation reference
+- rollback path
+
+The existing repo already points in this direction through the read-only `voice-monitor` design and the evidence-oriented handoff guidance in [`guides/evidence-handoff.md`](/guides/evidence-handoff.md).
+
+## AGENTS.md and SKILL.md Roles
+
+Use the files differently:
+
+- `AGENTS.md` defines the repo-level operating contract: setup, test commands, generated directories, and where canonical sources live
+- `SKILL.md` defines the workflow contract: what the agent is trying to achieve, what identifiers it needs, which tools are allowed, what must be redacted, and when to escalate
+
+Do not put workflow-specific telecom policy only in `AGENTS.md`; runtime agents consuming the package need the narrow instructions in the skill itself.
+
+## MCP Surface Pattern
+
+Prefer a two-tier surface:
+
+1. `tools/mcp` remains the broad remote API proxy for expert or build-your-own clients.
+2. `tools/mcp-apps/apps/<workflow>` provides the narrow managed package for a specific telecom job.
+
+That keeps the package aligned with the current repo shape:
+
+- broad access still exists for power users
+- the managed package uses a purpose-built MCP app with constrained tools and UI resources
+- the guide and skill can describe one stable surface instead of an unbounded API catalog
+
+## First Vertical Slice
+
+Implement the first managed telecom package as **Voice Incident Triage** built on `voice-monitor`.
+
+Scope:
+
+- active-call lookup
+- call timeline inspection
+- call status lookup
+- recording discovery with redaction
+- debug report generation for voice AI and call-control incidents
+
+Success criteria for that slice:
+
+- a runtime agent can diagnose a live or recent voice incident without write access
+- the package returns stable correlation IDs for human escalation
+- the guide, skill, and MCP app all describe the same operational path
+- the package makes it obvious when a separate mutating workflow is required
+
+## Follow-Up Implementation Tickets
+
+After the diagnostic voice package is formalized, the next repo tickets should be:
+
+1. Add a dedicated `skills/voice-incident-triage/SKILL.md` that points directly at the `voice-monitor` MCP app and documents escalation rules.
+2. Add package-level discovery metadata so the managed workflow is listed as a first-class guided surface, not only as a source tree path.
+3. Define a separate approval-gated mutating package for voice remediation actions, if needed, rather than widening the diagnostic package.
+
+## Why This Pattern
+
+The reusable Telnyx pattern is:
+
+- discovery in `agent.json`
+- repo/runtime contract in `AGENTS.md`
+- narrow workflow behavior in `SKILL.md`
+- constrained execution in an MCP app
+- audit-ready human handoff in a guide
+
+That gives Telnyx a managed telecom agent package that looks like the rest of the repo, uses existing runtime surfaces, and starts from the safest high-signal workflow already present in code.

--- a/tools/mcp-apps/README.md
+++ b/tools/mcp-apps/README.md
@@ -57,3 +57,41 @@ npm run dev --workspace @telnyx-mcp-apps/voice-monitor
 ## MCP Apps surface
 
 Each app exposes a stdio MCP server using `@modelcontextprotocol/sdk` and registers MCP Apps metadata/UI resources using `@modelcontextprotocol/ext-apps`. See the app READMEs for tool names, environment variables, and safety behavior.
+
+## When to use MCP Apps vs other Telnyx surfaces
+
+Choose the narrowest surface that matches the agent's trust boundary:
+
+- Use a focused MCP App when the workflow should stay governed, least-privilege, and aligned to a single operational contract.
+- Use [`tools/mcp`](../mcp) when an expert client truly needs the broad generic Telnyx MCP proxy.
+- Use the raw SDK/toolkit packages when you own the agent's mutation policy, approval flow, and idempotency behavior in-process.
+
+For external-agent builders, the intended default is: discover an app at `/apps/:slug`, bind only the listed tools, and follow that app's contract rather than recreating raw Telnyx endpoint behavior in prompts.
+
+## Governed contract for external agents
+
+The MCP Apps in this repo are meant to be consumed as policy-bearing tool surfaces, not just transport wrappers.
+
+- Read-first tools can run directly and should be the default troubleshooting path.
+- Preview-first or confirmation-gated tools must keep their confirmation token or explicit `confirm=true` requirement intact. Do not compress preview and mutation into one synthetic step.
+- Use least-privilege API keys for the chosen app. A diagnostic app should not run with a write-everything credential.
+- When a governed surface accepts an idempotency field or confirmation token, keep that value stable across retries and log it in your orchestration layer.
+- If the app does not expose the mutation you want, stop at the governed boundary and hand off to a broader reviewed surface instead of inventing a second behavior model.
+
+The hosted HTTP wrapper also exposes public discovery surfaces for deploys:
+
+- `GET /apps` — public app catalog
+- `GET /apps/:slug` — per-app discovery document with bearer-auth contract, absolute MCP URL, tool names, and `ui://` resource URIs
+- `GET /.well-known/mcp-app-registry.json` — machine-readable MCP Apps registry for scanners and server cards
+- `GET /.well-known/mcp-apps.json` — alias of the registry endpoint above
+
+On the hosted MCP endpoint itself, `tools/list` returns the app tool annotations and `_meta.ui.resourceUri` values, and `resources/list` returns the corresponding `ui://` app resources. That is the public runtime proof path for ORA-style scanners and clients.
+
+For the public docs-facing deployment, the expected hosted proof path is:
+
+- `https://developers.telnyx.com/.well-known/mcp-app-registry.json`
+- `https://developers.telnyx.com/.well-known/mcp-apps.json`
+- `https://developers.telnyx.com/apps/number-intelligence`
+- `https://developers.telnyx.com/apps/number-intelligence/mcp`
+
+From the repo root, run `npm run verify:live-docs-mcp-apps` to check that the hosted docs wrapper publishes the registry, the per-app discovery document, and the runtime `tools/list` / `resources/list` surface for the proof app.

--- a/tools/mcp-apps/fixtures/governed-communications/idempotent-replay-start-verification.json
+++ b/tools/mcp-apps/fixtures/governed-communications/idempotent-replay-start-verification.json
@@ -1,0 +1,41 @@
+{
+  "ok": true,
+  "tool": "communications_start_verification",
+  "request_id": "req_01jwc8ye3mkn7h8h6yq5ga4vg5",
+  "operation": {
+    "id": "op_01jwc8z8q71w61d14bwdprp5pf",
+    "resource_type": "verification",
+    "resource_id": "ver_8d98f1cb-9d10-4819-b6a1-a58bdfbb8710",
+    "status": "accepted"
+  },
+  "policy": {
+    "name": "default-verification",
+    "version": "2026-05-23",
+    "decision": "allow",
+    "selector_result": {
+      "verification_profile_id": "7bc4c21f-4e1a-45eb-a942-7d7bc228bf31",
+      "country_code": "IE"
+    }
+  },
+  "approval": {
+    "mode": "auto",
+    "state": "approved",
+    "reference": null
+  },
+  "idempotency": {
+    "key": "idem-verify-20260523-001",
+    "first_seen_at": "2026-05-23T17:40:02Z",
+    "replayed": true
+  },
+  "data": {
+    "verification_id": "ver_8d98f1cb-9d10-4819-b6a1-a58bdfbb8710",
+    "to": "+353861234567",
+    "channel": "sms",
+    "profile_id": "7bc4c21f-4e1a-45eb-a942-7d7bc228bf31",
+    "status": "pending",
+    "started_at": "2026-05-23T17:39:58Z",
+    "expires_at": "2026-05-23T17:44:58Z"
+  },
+  "warnings": [],
+  "provider": null
+}

--- a/tools/mcp-apps/fixtures/governed-communications/policy-denial-send-message.json
+++ b/tools/mcp-apps/fixtures/governed-communications/policy-denial-send-message.json
@@ -1,0 +1,40 @@
+{
+  "ok": false,
+  "tool": "communications_send_message",
+  "request_id": "req_01jwc8a6nx6rbh5h0k9qkz6cna",
+  "operation": {
+    "id": "op_01jwc8b5a0h5gbqwt4ws5pg6fv",
+    "resource_type": "message",
+    "resource_id": null,
+    "status": "failed"
+  },
+  "policy": {
+    "name": "default-us-messaging",
+    "version": "2026-05-23",
+    "decision": "deny",
+    "selector_result": null
+  },
+  "approval": {
+    "mode": "deny",
+    "state": "rejected",
+    "reference": null
+  },
+  "idempotency": {
+    "key": "idem-msg-20260523-002",
+    "first_seen_at": "2026-05-23T17:29:10Z",
+    "replayed": false
+  },
+  "error": {
+    "class": "policy_denied",
+    "code": "policy.sender_not_allowed",
+    "message": "No allowed sender route matched the request policy.",
+    "retryable": false,
+    "details": {
+      "country_code": "GB",
+      "channel": "sms",
+      "suggested_action": "Choose an approved sender pool or adjust policy configuration."
+    }
+  },
+  "warnings": [],
+  "provider": null
+}

--- a/tools/mcp-apps/fixtures/governed-communications/success-send-message.json
+++ b/tools/mcp-apps/fixtures/governed-communications/success-send-message.json
@@ -1,0 +1,45 @@
+{
+  "ok": true,
+  "tool": "communications_send_message",
+  "request_id": "req_01jwc7mkyj8f6fh0xv2m8f4s8q",
+  "operation": {
+    "id": "op_01jwc7n6f7f9ng74jfn6bdw0ta",
+    "resource_type": "message",
+    "resource_id": "4011777e-8010-4c9f-9f7c-935e0f8a4f38",
+    "status": "accepted"
+  },
+  "policy": {
+    "name": "default-us-messaging",
+    "version": "2026-05-23",
+    "decision": "allow",
+    "selector_result": {
+      "sender_id": "1293384261075731499",
+      "sender_type": "long_code",
+      "messaging_profile_id": "4001777e-8010-4c9f-9f7c-935e0f8a4f38",
+      "country_code": "US"
+    }
+  },
+  "approval": {
+    "mode": "auto",
+    "state": "approved",
+    "reference": null
+  },
+  "idempotency": {
+    "key": "idem-msg-20260523-001",
+    "first_seen_at": "2026-05-23T17:22:40Z",
+    "replayed": false
+  },
+  "data": {
+    "message_id": "4011777e-8010-4c9f-9f7c-935e0f8a4f38",
+    "to": [
+      "+353861234567"
+    ],
+    "from": "+13125550123",
+    "channel": "sms",
+    "accepted_at": "2026-05-23T17:22:41Z",
+    "status": "queued",
+    "messaging_profile_id": "4001777e-8010-4c9f-9f7c-935e0f8a4f38"
+  },
+  "warnings": [],
+  "provider": null
+}

--- a/tools/mcp-apps/fixtures/governed-communications/transient-upstream-failure-call.json
+++ b/tools/mcp-apps/fixtures/governed-communications/transient-upstream-failure-call.json
@@ -1,0 +1,49 @@
+{
+  "ok": false,
+  "tool": "communications_start_outbound_call",
+  "request_id": "req_01jwc8nr6s0n1rv2d89pp11evk",
+  "operation": {
+    "id": "op_01jwc8p02v0h5cae7tm4r2xjdc",
+    "resource_type": "call",
+    "resource_id": null,
+    "status": "failed"
+  },
+  "policy": {
+    "name": "default-global-outbound-voice",
+    "version": "2026-05-23",
+    "decision": "allow",
+    "selector_result": {
+      "connection_id": "2309958742199946301",
+      "sender_id": "1293384261075731499",
+      "sender_type": "long_code"
+    }
+  },
+  "approval": {
+    "mode": "confirm",
+    "state": "approved",
+    "reference": "apr_01jwc8nn4ng7j4gt3c4h7v1s7h"
+  },
+  "idempotency": {
+    "key": "idem-call-20260523-001",
+    "first_seen_at": "2026-05-23T17:34:55Z",
+    "replayed": false
+  },
+  "error": {
+    "class": "provider_transient",
+    "code": "provider.timeout",
+    "message": "The upstream provider did not confirm call creation before the timeout.",
+    "retryable": true,
+    "details": {
+      "connection_id": "2309958742199946301",
+      "retry_after_secs": 15
+    }
+  },
+  "warnings": [],
+  "provider": {
+    "name": "telnyx",
+    "error": {
+      "status": 504,
+      "title": "Gateway Timeout"
+    }
+  }
+}

--- a/tools/mcp-apps/governed-communications-contract.md
+++ b/tools/mcp-apps/governed-communications-contract.md
@@ -1,0 +1,474 @@
+# Governed Communications MCP Contract
+
+This document defines the V1 contract for a governed Telnyx communications MCP app. It is the implementation source for the future app package, framework examples, and follow-up operator docs.
+
+The strategy note referenced by `TEL-218` (`plans/2026-05-23-tel-216-tool-connector-patterns.md`) is not present in this checkout. This contract therefore anchors itself to the existing MCP app patterns in `tools/mcp-apps/` and the control-boundary guidance in `managed-telecom-agents.md`.
+
+## Goals
+
+- Expose a narrow communications tool surface that works across MCP hosts without leaking raw Telnyx API shapes into every client.
+- Make selector policy, approval requirements, and idempotent mutation semantics explicit enough to test with fixtures.
+- Preserve the IDs operators need for escalation while redacting secrets and optional sensitive content.
+
+## Non-Goals
+
+- Expose the full Telnyx API.
+- Let hosts bypass policy selection by posting raw connection IDs, profile IDs, or API paths.
+- Normalize every upstream Telnyx field. V1 normalizes the operational contract and preserves provider payloads only in bounded `provider` sections when enabled.
+
+## App Identity
+
+- App slug: `governed-communications`
+- Transport: stdio MCP server with optional hosted HTTP wrapper, matching the pattern already used in `tools/mcp-apps`
+- Default runtime posture: governed write surface with approval and selector policy checks on every mutating tool
+
+## V1 Tools
+
+V1 includes six tools.
+
+| Tool | Category | Purpose |
+| --- | --- | --- |
+| `communications_list_owned_senders` | read | Discover numbers, messaging profiles, and voice-capable senders the account owns and may use under policy |
+| `communications_send_message` | mutate | Send an SMS or MMS through a policy-selected sender/profile |
+| `communications_start_outbound_call` | mutate | Start an outbound voice call through a policy-selected connection/application |
+| `communications_start_verification` | mutate | Start an SMS or voice verification workflow |
+| `communications_get_status` | read | Fetch normalized status for a prior message, call, or verification attempt |
+| `communications_get_call_timeline` | read | Return normalized call events for an existing call, session, or policy correlation window |
+
+`communications_get_status` is intentionally generic across resource types because the issue scope calls for status retrieval as a single V1 capability. Hosts should not need separate status tools to handle common polling flows.
+
+## Shared Request Envelope
+
+Every tool accepts its own arguments plus these shared top-level fields.
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `request_id` | string | no | Caller-generated trace ID echoed back in the response |
+| `policy_context` | object | no | Hints for selector evaluation such as environment, project, campaign, geography, or tenant labels |
+| `approval` | object | no | Approval token or confirmation mode metadata for governed mutating tools |
+| `idempotency_key` | string | mutating tools: yes | Stable caller-supplied key for dedupe and replay |
+| `include_provider_payload` | boolean | no | Defaults to `false`; when `true`, a redacted provider block may be included |
+
+`policy_context` is advisory. Policy can use it to narrow matches, but callers cannot force policy bypass by setting values that conflict with the server's own configuration.
+
+## Shared Response Envelope
+
+Every tool returns a normalized object with the same top-level shape.
+
+```json
+{
+  "ok": true,
+  "tool": "communications_send_message",
+  "request_id": "req_01jwc7mkyj8f6fh0xv2m8f4s8q",
+  "operation": {
+    "id": "op_01jwc7n6f7f9ng74jfn6bdw0ta",
+    "resource_type": "message",
+    "resource_id": "msg_01jwc7nb9m4v8cb8shqk9d9s8m",
+    "status": "accepted"
+  },
+  "policy": {
+    "name": "default-us-messaging",
+    "version": "2026-05-23",
+    "decision": "allow",
+    "selector_result": {
+      "sender_id": "1293384261075731499",
+      "sender_type": "long_code",
+      "messaging_profile_id": "4001777e-8010-4c9f-9f7c-935e0f8a4f38"
+    }
+  },
+  "approval": {
+    "mode": "auto",
+    "state": "approved",
+    "reference": null
+  },
+  "idempotency": {
+    "key": "idem-msg-20260523-001",
+    "first_seen_at": "2026-05-23T17:22:40Z",
+    "replayed": false
+  },
+  "data": {},
+  "warnings": [],
+  "provider": null
+}
+```
+
+Top-level response rules:
+
+- `ok=true` means the tool completed and `data` is populated.
+- `ok=false` means the tool failed and an `error` object replaces `data`.
+- `operation.id` is the governed app operation ID, not necessarily the raw Telnyx resource ID.
+- `operation.resource_id` preserves the normalized provider resource identifier when one exists.
+- `provider` is omitted or `null` unless `include_provider_payload=true`.
+
+## Policy Model
+
+The server owns policy configuration. MCP callers can only provide hints.
+
+### Policy Object
+
+The runtime policy model should support this shape:
+
+```json
+{
+  "policies": [
+    {
+      "name": "default-us-messaging",
+      "version": "2026-05-23",
+      "applies_to": ["communications_send_message"],
+      "match": {
+        "environment": ["prod"],
+        "channel": ["sms", "mms"],
+        "countries": ["US", "CA"],
+        "tags": ["customer-notifications"]
+      },
+      "selector": {
+        "sender_pool": "north-america-notifications",
+        "messaging_profile": "default-a2p",
+        "fallback_sender_pool": "shared-overflow"
+      },
+      "approval_mode": "auto"
+    }
+  ]
+}
+```
+
+### Selector Inputs
+
+The selector engine may evaluate:
+
+- tool name
+- destination country and channel
+- caller `policy_context.environment`
+- caller `policy_context.tenant`
+- caller `policy_context.tags`
+- content classification supplied by the host, such as `notification`, `otp`, or `support`
+- compliance state implied by server-side policy, such as whether a sender pool may carry verification traffic
+
+### Selector Outputs
+
+Selectors resolve platform-specific resources into a normalized result with fields such as:
+
+- `sender_id`
+- `sender_type`
+- `messaging_profile_id`
+- `from`
+- `connection_id`
+- `call_control_application_id`
+- `verification_profile_id`
+- `country_code`
+- `tags`
+
+Selectors must not return secrets. If a selector cannot produce an allowed route, the tool fails with `policy_denied`.
+
+## Approval Modes
+
+V1 approval is tool-scoped and policy-driven.
+
+| Mode | Meaning | Allowed tools |
+| --- | --- | --- |
+| `auto` | Execute immediately after selector/policy validation | any tool |
+| `confirm` | Caller must provide an approval token created by a server-side preview or out-of-band approval step | mutating tools only |
+| `deny` | Tool is exposed but policy forbids execution for the matched context | any tool |
+
+Approval contract:
+
+- Read tools default to `auto`.
+- Mutating tools must return `approval.state=required` and `ok=false` if policy requires `confirm` and the caller omitted a valid token.
+- Approval tokens are single-purpose. A token approved for `communications_send_message` cannot be reused for `communications_start_outbound_call`.
+- Approval evaluation happens before the provider mutation call but after selector resolution, so the approval payload can reflect the selected sender/connection.
+
+## Idempotency Contract
+
+All mutating tools require `idempotency_key`.
+
+Rules:
+
+- The dedupe scope is `(tool name, idempotency_key, policy identity, normalized request fingerprint)`.
+- Reusing the same key with a materially different normalized request must fail with `idempotency_conflict`.
+- Reusing the same key with the same normalized request must return the original result with `idempotency.replayed=true`.
+- The original governed `operation.id` is returned on replay.
+- Provider idempotency headers may be used internally, but the governed app response is authoritative for replay semantics.
+
+Normalization for fingerprinting should include:
+
+- selected tool name
+- normalized destination(s)
+- normalized content or template references
+- normalized selector result
+- normalized approval mode
+- resource-specific inputs such as timeout seconds or verification channel
+
+## Normalized Error Taxonomy
+
+Errors use a stable app-level taxonomy so framework code does not need to inspect raw Telnyx responses.
+
+```json
+{
+  "ok": false,
+  "tool": "communications_send_message",
+  "request_id": "req_01jwc8a6nx6rbh5h0k9qkz6cna",
+  "operation": {
+    "id": "op_01jwc8b5a0h5gbqwt4ws5pg6fv",
+    "resource_type": "message",
+    "resource_id": null,
+    "status": "failed"
+  },
+  "policy": {
+    "name": "default-us-messaging",
+    "version": "2026-05-23",
+    "decision": "deny",
+    "selector_result": null
+  },
+  "approval": {
+    "mode": "deny",
+    "state": "rejected",
+    "reference": null
+  },
+  "idempotency": {
+    "key": "idem-msg-20260523-002",
+    "first_seen_at": "2026-05-23T17:29:10Z",
+    "replayed": false
+  },
+  "error": {
+    "class": "policy_denied",
+    "code": "policy.sender_not_allowed",
+    "message": "No allowed sender route matched the request policy.",
+    "retryable": false,
+    "details": {
+      "suggested_action": "Choose an approved sender pool or adjust policy configuration."
+    }
+  },
+  "warnings": [],
+  "provider": null
+}
+```
+
+V1 error classes:
+
+| Class | Retryable | Meaning |
+| --- | --- | --- |
+| `validation_error` | no | Caller request is malformed or missing required fields |
+| `policy_denied` | no | No allowed selector match or policy forbids the requested action |
+| `approval_required` | no | A valid approval token or confirmation step is required |
+| `idempotency_conflict` | no | The same idempotency key was reused with a different normalized request |
+| `not_found` | no | The referenced governed or provider resource is unknown |
+| `rate_limited` | yes | Provider or app rate limit exceeded |
+| `provider_transient` | yes | Upstream transport or 5xx-class failure that may succeed on retry |
+| `provider_terminal` | no | Upstream rejected the request in a non-retryable way |
+| `internal_error` | maybe | Unexpected app failure; retry policy is host-dependent |
+
+Error payload rules:
+
+- `error.code` is namespaced and stable, for example `policy.sender_not_allowed` or `provider.timeout`.
+- `error.message` is safe for end users and must not contain API keys, auth headers, full card-like strings, or optional secrets.
+- `error.details` may preserve safe operational IDs, limits, and normalized filter values.
+- If `include_provider_payload=true`, `provider.error` may include redacted upstream context, but framework examples should rely only on the normalized `error` object.
+
+## Tool Contracts
+
+### `communications_list_owned_senders`
+
+Purpose: discover owned senders and governed routing affordances.
+
+Inputs:
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `channel` | enum | no | `sms`, `mms`, `voice`, or `all`; defaults to `all` |
+| `country_code` | string | no | ISO 3166-1 alpha-2 hint |
+| `capabilities` | string[] | no | Values such as `messaging`, `voice`, `verification` |
+| `tags` | string[] | no | Policy tag hint |
+| `page_size` | integer | no | Server-capped |
+| `page_token` | string | no | Cursor for pagination |
+
+Normalized `data`:
+
+- `senders`: array of sender summaries
+- `next_page_token`: nullable string
+- `applied_filters`: normalized filters after defaults/caps
+
+Sender summary fields:
+
+- `sender_id`
+- `sender_type`
+- `from`
+- `country_code`
+- `capabilities`
+- `messaging_profile_id`
+- `connection_id`
+- `policy_eligible`
+- `policy_tags`
+
+### `communications_send_message`
+
+Purpose: send an SMS or MMS through a governed selector.
+
+Inputs:
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `to` | string or string[] | yes | One or more E.164 destinations; V1 may cap fanout to a small server-defined limit |
+| `text` | string | yes unless `media_urls` only template flow is later added | Message body |
+| `media_urls` | string[] | no | MMS only; server-capped |
+| `sender` | object | no | Optional selector hint such as `from`, `sender_pool`, or `messaging_profile` |
+| `content_classification` | enum | no | Recommended: `notification`, `support`, `marketing`, `otp` |
+
+Normalized `data`:
+
+- `message_id`
+- `to`
+- `from`
+- `channel`
+- `accepted_at`
+- `status`
+- `messaging_profile_id`
+
+### `communications_start_outbound_call`
+
+Purpose: start an outbound call through a governed voice route.
+
+Inputs:
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `to` | string | yes | E.164 destination |
+| `connection` | object | no | Optional selector hint such as `connection_group` or `application_label` |
+| `from` | string | no | Optional sender hint; policy may ignore it |
+| `webhook_url` | string | no | Optional host callback URL if the future implementation allows it |
+| `timeout_secs` | integer | no | Server-capped |
+| `metadata` | object | no | Safe, size-capped metadata |
+
+Normalized `data`:
+
+- `call_control_id`
+- `call_leg_id`
+- `call_session_id`
+- `to`
+- `from`
+- `connection_id`
+- `status`
+- `started_at`
+
+### `communications_start_verification`
+
+Purpose: start an OTP or identity verification flow using a governed profile.
+
+Inputs:
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `to` | string | yes | E.164 destination |
+| `channel` | enum | yes | `sms` or `call` |
+| `brand` | string | no | Selector hint |
+| `locale` | string | no | BCP 47 locale hint |
+| `code_length` | integer | no | Server may ignore if profile fixes length |
+| `ttl_secs` | integer | no | Server-capped |
+
+Normalized `data`:
+
+- `verification_id`
+- `to`
+- `channel`
+- `profile_id`
+- `status`
+- `started_at`
+- `expires_at`
+
+### `communications_get_status`
+
+Purpose: poll the normalized status of a previously created message, call, or verification.
+
+Inputs:
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `resource_type` | enum | yes | `message`, `call`, or `verification` |
+| `resource_id` | string | yes | Normalized provider ID |
+
+Normalized `data`:
+
+- `resource_type`
+- `resource_id`
+- `status`
+- `updated_at`
+- `terminal`
+- `direction`
+- `failure_reason`
+- `timeline_hint`
+
+`timeline_hint` is optional. For calls it may include a suggested `call_control_id` or `call_session_id` to pass into `communications_get_call_timeline`.
+
+### `communications_get_call_timeline`
+
+Purpose: return a normalized timeline for an existing call.
+
+Inputs:
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `call_control_id` | string | no | One of the primary call identifiers is required |
+| `call_session_id` | string | no | One of the primary call identifiers is required |
+| `call_leg_id` | string | no | Optional secondary filter |
+| `connection_id` | string | no | Optional filter |
+| `start_time` | string | no | ISO timestamp; bounded by server caps |
+| `end_time` | string | no | ISO timestamp; bounded by server caps |
+| `page_size` | integer | no | Server-capped |
+| `page_token` | string | no | Cursor for pagination |
+
+Normalized `data`:
+
+- `events`: array of normalized timeline events
+- `next_page_token`: nullable string
+- `applied_filters`: normalized/capped filters
+
+Timeline event fields:
+
+- `event_id`
+- `occurred_at`
+- `event_type`
+- `call_control_id`
+- `call_session_id`
+- `call_leg_id`
+- `connection_id`
+- `direction`
+- `details`
+
+## Sensitive Data Rules
+
+The governed app must preserve operational IDs but redact or omit:
+
+- API keys and Authorization headers
+- webhook signing secrets
+- payment-like values if they ever appear in upstream errors
+- full transcripts unless a future policy explicitly allows them
+- recording URLs unless a future policy explicitly allows them
+- arbitrary metadata blobs that are not required for routing or support
+
+Phone numbers may be preserved in mutating tool outputs because send and call tools inherently operate on explicit destinations. Read tools should prefer redacted display fields when full numbers are not required.
+
+## Fixture Set
+
+V1 fixtures live in `tools/mcp-apps/fixtures/governed-communications/`.
+
+| Fixture | Purpose |
+| --- | --- |
+| `success-send-message.json` | Successful governed message send |
+| `policy-denial-send-message.json` | Selector/policy denial before mutation |
+| `transient-upstream-failure-call.json` | Retryable upstream failure during outbound call start |
+| `idempotent-replay-start-verification.json` | Successful replay of a prior verification start |
+
+These fixtures are intended as the compatibility corpus for the future app tests and framework examples.
+
+## Compatibility Notes
+
+- Framework adapters should branch on `ok`, `error.class`, and `idempotency.replayed`, not on raw provider payloads.
+- Hosts that require human confirmation should treat `approval_required` as a first-class pause state and store the governed `operation.id`.
+- The future MCP app may add preview tools or approval-token issuance helpers, but V1 of this contract does not require them to define the response model.
+
+## Implementation Checklist
+
+- Implement the six tool names exactly as defined above.
+- Enforce policy selection before calling the provider for all mutating tools.
+- Require `idempotency_key` on all mutating tools and replay prior successful results.
+- Return only the normalized error classes from this document at the app boundary.
+- Keep the fixture corpus passing as the implementation evolves.

--- a/tools/python/README.md
+++ b/tools/python/README.md
@@ -2,6 +2,8 @@
 
 Python SDK for building AI agents with [Telnyx](https://telnyx.com) APIs. Works with **OpenAI**, **LangChain**, and **CrewAI**.
 
+For trusted in-process agents, the toolkit can expose raw Telnyx tools directly. For external, multi-tenant, or approval-sensitive agents, prefer a governed Telnyx MCP App first and only fall back to the raw toolkit when you intentionally own the broader behavior model.
+
 ## Installation
 
 ```bash
@@ -86,6 +88,20 @@ agent = Agent(
     tools=tools,
 )
 ```
+
+## Governed External-Agent Pattern
+
+Use the governed MCP App surface when you need a stable, least-privilege contract instead of raw endpoint semantics.
+
+- Use [`tools/mcp-apps`](/tools/mcp-apps) when the workflow should stay read-first or preview-first and the agent should not invent its own mutation policy.
+- Use the generic [`tools/mcp`](/tools/mcp) proxy when an expert client needs broad MCP access to the Telnyx API surface.
+- Use this toolkit directly when you control the agent code, trust boundary, and approval/idempotency rules yourself.
+
+The example directories show the governed pattern for OpenAI, LangChain, and CrewAI by discovering a focused MCP App and binding only the published tool contract:
+
+- [OpenAI governed example](/tools/python/examples/openai)
+- [LangChain governed example](/tools/python/examples/langchain)
+- [CrewAI governed example](/tools/python/examples/crewai)
 
 ## Configuration
 

--- a/tools/python/examples/crewai/README.md
+++ b/tools/python/examples/crewai/README.md
@@ -1,6 +1,6 @@
 # CrewAI Example
 
-Telecom provisioning crew using CrewAI with Telnyx tools.
+Governed external-agent example using CrewAI with a focused Telnyx MCP App. The crew gets only the tool contract published by the app instead of raw Telnyx write access.
 
 ## Setup
 
@@ -8,6 +8,7 @@ Telecom provisioning crew using CrewAI with Telnyx tools.
 pip install telnyx-agent-toolkit[crewai]
 export TELNYX_API_KEY=KEY...
 export OPENAI_API_KEY=sk-...
+export TELNYX_MCP_APPS_BASE_URL=http://localhost:3000
 ```
 
 ## Run
@@ -18,7 +19,7 @@ python main.py
 
 ## What it does
 
-1. Creates a Telnyx toolkit with messaging, numbers, and balance permissions
-2. Wraps tools as CrewAI `BaseTool` instances
-3. Creates a "Telecom Provisioning Specialist" agent
-4. Runs a task to check balance and search for phone numbers
+1. Discovers a governed MCP App such as `number-intelligence`.
+2. Wraps the app's published tools as CrewAI `BaseTool` instances.
+3. Creates a read-first telecom analyst agent.
+4. Runs a task against the governed tool surface and preserves any preview/confirm requirements.

--- a/tools/python/examples/crewai/main.py
+++ b/tools/python/examples/crewai/main.py
@@ -1,70 +1,59 @@
-"""CrewAI + Telnyx Agent Toolkit example — Telecom crew.
-
-This example creates a CrewAI agent with Telnyx tools for
-managing telecom resources.
-
-Requirements:
-    pip install telnyx-agent-toolkit[crewai]
-
-Usage:
-    export TELNYX_API_KEY=KEY...
-    export OPENAI_API_KEY=sk-...
-    python main.py
-"""
+"""CrewAI example for governed Telnyx MCP Apps."""
 
 import os
+import sys
+from pathlib import Path
 
 from crewai import Agent, Crew, Task
 
-from telnyx_agent_toolkit import TelnyxAgentToolkit
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from governed_mcp import GovernedMcpAppClient, build_crewai_tools
 
 
 def main() -> None:
     telnyx_api_key = os.environ["TELNYX_API_KEY"]
+    governed_app = os.environ.get("TELNYX_GOVERNED_APP", "number-intelligence")
 
-    toolkit = TelnyxAgentToolkit(
+    mcp_client = GovernedMcpAppClient(
         api_key=telnyx_api_key,
-        configuration={
-            "actions": {
-                "messaging": {"send_sms": True},
-                "numbers": {"list": True, "search": True, "buy": True},
-                "account": {"get_balance": True},
-            }
-        },
+        slug=governed_app,
+        client_name="telnyx-governed-crewai-example",
     )
+    tools = build_crewai_tools(mcp_client.list_tools(), mcp_client.call_tool)
 
-    tools = toolkit.get_crewai_tools()
-
-    # Create a telecom provisioning agent
     telecom_agent = Agent(
-        role="Telecom Provisioning Specialist",
-        goal="Help users manage their Telnyx phone numbers and messaging",
+        role="Telecom Readiness Analyst",
+        goal="Explain telecom readiness using governed, least-privilege Telnyx tools",
         backstory=(
-            "You are an expert in telecom provisioning. You help users "
-            "search for, purchase, and manage phone numbers on the Telnyx platform."
+            "You analyze telecom state through read-first or preview-first "
+            "governed tools before suggesting any mutating follow-up."
         ),
         tools=tools,
         verbose=True,
     )
 
-    # Create a task
     task = Task(
         description=(
-            "Check the current account balance, then search for "
-            "available local phone numbers in area code 415."
+            os.environ.get(
+                "TELNYX_EXAMPLE_PROMPT",
+                "Analyze +14155550123 and recommend the safest next action for onboarding.",
+            )
         ),
-        expected_output="A summary of the account balance and available phone numbers.",
+        expected_output=(
+            "A summary of the governed analysis, including any read-first findings "
+            "and whether a separate approval-gated action would be needed."
+        ),
         agent=telecom_agent,
     )
 
-    crew = Crew(
-        agents=[telecom_agent],
-        tasks=[task],
-        verbose=True,
-    )
+    crew = Crew(agents=[telecom_agent], tasks=[task], verbose=True)
 
-    result = crew.kickoff()
-    print(f"\nResult: {result}")
+    try:
+        result = crew.kickoff()
+        print(f"\nResult: {result}")
+    finally:
+        mcp_client.close()
 
 
 if __name__ == "__main__":

--- a/tools/python/examples/governed_mcp.py
+++ b/tools/python/examples/governed_mcp.py
@@ -1,0 +1,275 @@
+"""Helpers for governed Telnyx MCP App examples.
+
+These examples discover a focused MCP App first, then use only the tools that
+app publishes. That keeps framework examples aligned with the governed
+read-first/preview-first surface instead of exposing raw Telnyx endpoints.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Callable, Type
+from uuid import uuid4
+
+import httpx
+from pydantic import BaseModel, Field, create_model
+
+ToolDefinition = dict[str, Any]
+
+
+class GovernedMcpAppClient:
+    """Minimal MCP Apps HTTP client for examples."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        slug: str,
+        client_name: str,
+        mcp_app_url: str | None = None,
+        mcp_apps_base_url: str | None = None,
+    ) -> None:
+        self._api_key = api_key
+        self._slug = slug
+        self._client_name = client_name
+        self._mcp_app_url = mcp_app_url or os.environ.get("TELNYX_MCP_APP_URL")
+        self._mcp_apps_base_url = (
+            mcp_apps_base_url
+            or os.environ.get("TELNYX_MCP_APPS_BASE_URL")
+            or "http://localhost:3000"
+        ).rstrip("/")
+        self._session_id: str | None = None
+        self._mcp_url: str | None = None
+        self._http = httpx.Client(timeout=30.0)
+
+    def close(self) -> None:
+        self._http.close()
+
+    def list_tools(self) -> list[ToolDefinition]:
+        response = self._rpc("tools/list")
+        return response["tools"]
+
+    def call_tool(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        return self._rpc("tools/call", {"name": name, "arguments": arguments})
+
+    def _rpc(self, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        self._ensure_initialized()
+        payload: dict[str, Any] = {
+            "jsonrpc": "2.0",
+            "id": str(uuid4()),
+            "method": method,
+        }
+        if params is not None:
+            payload["params"] = params
+        response = self._http.post(self._mcp_url, headers=self._headers(), json=payload)
+        response.raise_for_status()
+        data = response.json()
+        if "error" in data:
+            raise RuntimeError(f"MCP error calling {method}: {data['error']}")
+        return data["result"]
+
+    def _ensure_initialized(self) -> None:
+        if self._session_id:
+            return
+
+        if not self._mcp_url:
+            if self._mcp_app_url:
+                self._mcp_url = self._mcp_app_url
+            else:
+                discovery = self._http.get(
+                    f"{self._mcp_apps_base_url}/apps/{self._slug}",
+                    headers={"Authorization": f"Bearer {self._api_key}"},
+                )
+                discovery.raise_for_status()
+                self._mcp_url = discovery.json()["app"]["mcp_url"]
+
+        initialize = self._http.post(
+            self._mcp_url,
+            headers=self._headers(),
+            json={
+                "jsonrpc": "2.0",
+                "id": str(uuid4()),
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": self._client_name, "version": "0.1.0"},
+                },
+            },
+        )
+        initialize.raise_for_status()
+        self._session_id = initialize.headers.get("Mcp-Session-Id")
+        init_data = initialize.json()
+        if "error" in init_data:
+            raise RuntimeError(f"MCP initialize failed: {init_data['error']}")
+
+        self._http.post(
+            self._mcp_url,
+            headers=self._headers(),
+            json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        ).raise_for_status()
+
+    def _headers(self) -> dict[str, str]:
+        headers = {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+        if self._session_id:
+            headers["Mcp-Session-Id"] = self._session_id
+        return headers
+
+
+def build_openai_tools(tool_definitions: list[ToolDefinition]) -> list[dict[str, Any]]:
+    """Convert MCP tool metadata into OpenAI function definitions."""
+    tools: list[dict[str, Any]] = []
+    for tool in tool_definitions:
+        schema = _clean_schema(tool.get("inputSchema", {"type": "object", "properties": {}}))
+        tools.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": tool["name"],
+                    "description": tool.get("description", ""),
+                    "parameters": schema,
+                },
+            }
+        )
+    return tools
+
+
+def build_langchain_tools(
+    tool_definitions: list[ToolDefinition], executor: Callable[[str, dict[str, Any]], dict[str, Any]]
+) -> list[Any]:
+    """Wrap MCP tools as LangChain BaseTool instances."""
+    from langchain_core.tools import BaseTool
+
+    result: list[Any] = []
+    for tool in tool_definitions:
+        args_schema = _build_args_schema(tool)
+        result.append(_make_langchain_tool(BaseTool, executor, tool["name"], tool.get("description", ""), args_schema))
+
+    return result
+
+
+def build_crewai_tools(
+    tool_definitions: list[ToolDefinition], executor: Callable[[str, dict[str, Any]], dict[str, Any]]
+) -> list[Any]:
+    """Wrap MCP tools as CrewAI BaseTool instances."""
+    from crewai.tools import BaseTool
+
+    result: list[Any] = []
+    for tool in tool_definitions:
+        args_schema = _build_args_schema(tool)
+        result.append(_make_crewai_tool(BaseTool, executor, tool["name"], tool.get("description", ""), args_schema))
+
+    return result
+
+
+def mcp_result_to_text(result: dict[str, Any]) -> str:
+    """Normalize MCP tool results for LLM message/tool output."""
+    if "structuredContent" in result:
+        return json.dumps(result["structuredContent"], indent=2)
+
+    content = result.get("content", [])
+    text_parts = [item.get("text", "") for item in content if item.get("type") == "text"]
+    if text_parts:
+        return "\n\n".join(part for part in text_parts if part)
+
+    return json.dumps(result, indent=2)
+
+
+def _clean_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    cleaned = dict(schema)
+    properties = cleaned.get("properties", {})
+    cleaned["properties"] = {
+        name: {key: value for key, value in prop.items() if key != "default"}
+        for name, prop in properties.items()
+    }
+    return cleaned
+
+
+def _build_args_schema(tool_def: ToolDefinition) -> Type[BaseModel]:
+    schema = tool_def.get("inputSchema", {"type": "object", "properties": {}})
+    properties = schema.get("properties", {})
+    required = set(schema.get("required", []))
+
+    fields: dict[str, Any] = {}
+    for prop_name, prop_schema in properties.items():
+        py_type, field = _json_schema_to_field(prop_schema, prop_name in required)
+        fields[prop_name] = (py_type, field)
+
+    model_name = f"{tool_def['name'].title().replace('_', '')}Input"
+    return create_model(model_name, **fields)  # type: ignore[call-overload]
+
+
+def _make_langchain_tool(
+    base_tool: Any,
+    executor: Callable[[str, dict[str, Any]], dict[str, Any]],
+    tool_name: str,
+    tool_description: str,
+    tool_args_schema: Type[BaseModel],
+) -> Any:
+    class GovernedTool(base_tool):
+        name: str = tool_name
+        description: str = tool_description
+        args_schema: Any = tool_args_schema
+
+        def _run(self, **kwargs: Any) -> str:
+            return mcp_result_to_text(executor(tool_name, kwargs))
+
+        async def _arun(self, **kwargs: Any) -> str:
+            return self._run(**kwargs)
+
+    GovernedTool.__name__ = f"Governed{tool_name.title().replace('_', '')}Tool"
+    return GovernedTool()
+
+
+def _make_crewai_tool(
+    base_tool: Any,
+    executor: Callable[[str, dict[str, Any]], dict[str, Any]],
+    tool_name: str,
+    tool_description: str,
+    tool_args_schema: Type[BaseModel],
+) -> Any:
+    def _run(self: Any, **kwargs: Any) -> str:
+        return mcp_result_to_text(executor(tool_name, kwargs))
+
+    tool_cls = type(
+        f"Governed{tool_name.title().replace('_', '')}Tool",
+        (base_tool,),
+        {
+            "name": tool_name,
+            "description": tool_description,
+            "args_schema": tool_args_schema,
+            "_run": _run,
+        },
+    )
+    return tool_cls()
+
+
+def _json_schema_to_field(schema: dict[str, Any], required: bool) -> tuple[Any, Any]:
+    type_map: dict[str, type] = {
+        "string": str,
+        "integer": int,
+        "number": float,
+        "boolean": bool,
+    }
+
+    schema_type = schema.get("type", "string")
+    if isinstance(schema_type, list):
+        py_type: Any = str
+    elif schema_type == "array":
+        item_type = schema.get("items", {}).get("type", "string")
+        inner = type_map.get(item_type, str)
+        py_type = list[inner]  # type: ignore[valid-type]
+    elif schema_type == "object":
+        py_type = dict[str, Any]
+    else:
+        py_type = type_map.get(schema_type, str)
+
+    description = schema.get("description", "")
+    if required:
+        return py_type, Field(description=description)
+
+    return py_type | None, Field(default=None, description=description)  # type: ignore[operator]

--- a/tools/python/examples/langchain/README.md
+++ b/tools/python/examples/langchain/README.md
@@ -1,6 +1,6 @@
 # LangChain Example
 
-Telecom agent using LangChain with Telnyx tools.
+Governed external-agent example using LangChain with a focused Telnyx MCP App. It binds the app's published tool contract instead of raw Telnyx endpoint tools.
 
 ## Setup
 
@@ -8,6 +8,7 @@ Telecom agent using LangChain with Telnyx tools.
 pip install telnyx-agent-toolkit[langchain] langchain-openai
 export TELNYX_API_KEY=KEY...
 export OPENAI_API_KEY=sk-...
+export TELNYX_MCP_APPS_BASE_URL=http://localhost:3000
 ```
 
 ## Run
@@ -18,7 +19,7 @@ python main.py
 
 ## What it does
 
-1. Creates a Telnyx toolkit with messaging, numbers, balance, and AI permissions
-2. Wraps tools as LangChain `BaseTool` instances
-3. Binds tools to a ChatOpenAI model
-4. Executes tool calls from the LLM response
+1. Discovers a governed MCP App such as `number-intelligence`.
+2. Wraps the app's tool schemas as LangChain tools.
+3. Binds those governed tools to a `ChatOpenAI` model.
+4. Executes only the MCP App tools returned by the model.

--- a/tools/python/examples/langchain/main.py
+++ b/tools/python/examples/langchain/main.py
@@ -1,60 +1,55 @@
-"""LangChain + Telnyx Agent Toolkit example — Telecom agent.
-
-This example creates a LangChain agent that can interact with
-Telnyx APIs to manage phone numbers and send messages.
-
-Requirements:
-    pip install telnyx-agent-toolkit[langchain] langchain-openai
-
-Usage:
-    export TELNYX_API_KEY=KEY...
-    export OPENAI_API_KEY=sk-...
-    python main.py
-"""
+"""LangChain example for governed Telnyx MCP Apps."""
 
 import os
+import sys
+from pathlib import Path
 
 from langchain_core.messages import HumanMessage
 from langchain_openai import ChatOpenAI
 
-from telnyx_agent_toolkit import TelnyxAgentToolkit
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from governed_mcp import GovernedMcpAppClient, build_langchain_tools
 
 
 def main() -> None:
     telnyx_api_key = os.environ["TELNYX_API_KEY"]
+    governed_app = os.environ.get("TELNYX_GOVERNED_APP", "number-intelligence")
 
-    toolkit = TelnyxAgentToolkit(
+    mcp_client = GovernedMcpAppClient(
         api_key=telnyx_api_key,
-        configuration={
-            "actions": {
-                "messaging": {"send_sms": True, "list_messaging_profiles": True},
-                "numbers": {"list": True, "search": True},
-                "account": {"get_balance": True},
-                "ai": {"chat": True},
-            }
-        },
+        slug=governed_app,
+        client_name="telnyx-governed-langchain-example",
     )
-
-    tools = toolkit.get_langchain_tools()
+    tools = build_langchain_tools(mcp_client.list_tools(), mcp_client.call_tool)
     llm = ChatOpenAI(model="gpt-4o", temperature=0)
     llm_with_tools = llm.bind_tools(tools)
 
-    messages = [HumanMessage(content="Search for available toll-free numbers in the US")]
+    messages = [
+        HumanMessage(
+            content=os.environ.get(
+                "TELNYX_EXAMPLE_PROMPT",
+                "Analyze +14155550123 and summarize the safest next step for messaging setup.",
+            )
+        )
+    ]
 
-    print("Sending request to LangChain agent...")
-    response = llm_with_tools.invoke(messages)
-    print(f"\nResponse: {response.content}")
+    try:
+        print(f"Sending request to LangChain with governed app '{governed_app}'...")
+        response = llm_with_tools.invoke(messages)
+        print(f"\nResponse: {response.content}")
 
-    if hasattr(response, "tool_calls") and response.tool_calls:
-        for tc in response.tool_calls:
-            print(f"\nTool call: {tc['name']}")
-            print(f"  Args: {tc['args']}")
+        if hasattr(response, "tool_calls") and response.tool_calls:
+            for tc in response.tool_calls:
+                print(f"\nGoverned tool call: {tc['name']}")
+                print(f"  Args: {tc['args']}")
 
-            # Find and execute the matching tool
-            for tool in tools:
-                if tool.name == tc["name"]:
-                    result = tool.invoke(tc["args"])
-                    print(f"  Result: {result[:200]}...")
+                for tool in tools:
+                    if tool.name == tc["name"]:
+                        result = tool.invoke(tc["args"])
+                        print(f"  Result: {result[:400]}...")
+    finally:
+        mcp_client.close()
 
 
 if __name__ == "__main__":

--- a/tools/python/examples/openai/README.md
+++ b/tools/python/examples/openai/README.md
@@ -1,6 +1,6 @@
 # OpenAI Example
 
-SMS assistant using OpenAI function calling with Telnyx tools.
+Governed external-agent example using OpenAI function calling with a focused Telnyx MCP App. By default it targets the read-first `number-intelligence` app instead of exposing raw Telnyx endpoints.
 
 ## Setup
 
@@ -8,6 +8,9 @@ SMS assistant using OpenAI function calling with Telnyx tools.
 pip install telnyx-agent-toolkit[openai]
 export TELNYX_API_KEY=KEY...
 export OPENAI_API_KEY=sk-...
+export TELNYX_MCP_APPS_BASE_URL=http://localhost:3000
+# optional: export TELNYX_MCP_APP_URL=http://localhost:3000/apps/number-intelligence/mcp
+# optional: export TELNYX_GOVERNED_APP=number-intelligence
 ```
 
 ## Run
@@ -18,8 +21,8 @@ python main.py
 
 ## What it does
 
-1. Creates a Telnyx toolkit with messaging, numbers, and balance permissions
-2. Converts tools to OpenAI function-calling format
-3. Sends a user query to GPT-4o
-4. Automatically executes any Telnyx tool calls
-5. Returns the final response
+1. Discovers the governed MCP App over `/apps/{slug}` and initializes an MCP session.
+2. Converts the app's published tool schemas into OpenAI function definitions.
+3. Sends a read-first telecom question to the model.
+4. Executes only the governed tool calls returned by the model.
+5. Preserves the MCP App contract for preview/confirm flows instead of inventing raw endpoint behavior.

--- a/tools/python/examples/openai/main.py
+++ b/tools/python/examples/openai/main.py
@@ -1,94 +1,87 @@
-"""OpenAI + Telnyx Agent Toolkit example — SMS assistant.
+"""OpenAI example for governed Telnyx MCP Apps.
 
-This example creates an AI assistant that can send SMS messages,
-search for phone numbers, and check account balance using Telnyx APIs.
-
-Requirements:
-    pip install telnyx-agent-toolkit[openai]
-
-Usage:
-    export TELNYX_API_KEY=KEY...
-    export OPENAI_API_KEY=sk-...
-    python main.py
+This example discovers a focused Telnyx MCP App and exposes only its published
+tool contract to the model. By default it uses the read-first Number
+Intelligence app instead of raw Telnyx API tools.
 """
 
 import json
 import os
+import sys
+from pathlib import Path
 
 from openai import OpenAI
 
-from telnyx_agent_toolkit import TelnyxAgentToolkit
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from governed_mcp import GovernedMcpAppClient, build_openai_tools, mcp_result_to_text
 
 
 def main() -> None:
     telnyx_api_key = os.environ["TELNYX_API_KEY"]
+    governed_app = os.environ.get("TELNYX_GOVERNED_APP", "number-intelligence")
     openai_client = OpenAI()
 
-    # Create toolkit with specific permissions
-    toolkit = TelnyxAgentToolkit(
+    mcp_client = GovernedMcpAppClient(
         api_key=telnyx_api_key,
-        configuration={
-            "actions": {
-                "messaging": {"send_sms": True},
-                "numbers": {"list": True, "search": True},
-                "account": {"get_balance": True},
-            }
-        },
+        slug=governed_app,
+        client_name="telnyx-governed-openai-example",
     )
-
-    # Get OpenAI-formatted tools
-    tools = toolkit.get_openai_tools()
-    executor = toolkit.get_openai_tool_executor()
+    tools = build_openai_tools(mcp_client.list_tools())
 
     messages = [
         {
             "role": "system",
             "content": (
-                "You are a helpful telecom assistant powered by Telnyx. "
-                "You can send SMS messages, search for phone numbers, "
-                "and check account balance."
+                "You are a careful Telnyx telecom assistant. "
+                "Use only the governed Telnyx MCP App tools that were provided. "
+                "Prefer read-first analysis. If a future tool requires a preview "
+                "token, explicit confirm flag, or operator approval before a "
+                "mutation, do not bypass that contract."
             ),
         },
         {
             "role": "user",
-            "content": "What's my current account balance?",
+            "content": os.environ.get(
+                "TELNYX_EXAMPLE_PROMPT",
+                "Analyze +14155550123 and explain whether it looks ready for SMS onboarding.",
+            ),
         },
     ]
 
-    print("Sending request to OpenAI...")
-    response = openai_client.chat.completions.create(
-        model="gpt-4o",
-        messages=messages,
-        tools=tools,
-    )
+    try:
+        while True:
+            print(f"Sending request to OpenAI with governed app '{governed_app}'...")
+            response = openai_client.chat.completions.create(
+                model="gpt-4o",
+                messages=messages,
+                tools=tools,
+            )
+            message = response.choices[0].message
 
-    message = response.choices[0].message
+            if not message.tool_calls:
+                print(f"\nAssistant: {message.content}")
+                break
 
-    # Handle tool calls
-    if message.tool_calls:
-        messages.append(message)  # type: ignore[arg-type]
+            messages.append(message)  # type: ignore[arg-type]
+            for tool_call in message.tool_calls:
+                arguments = json.loads(tool_call.function.arguments)
+                print(f"Calling governed tool: {tool_call.function.name}")
+                print(f"  Arguments: {tool_call.function.arguments}")
 
-        for tool_call in message.tool_calls:
-            print(f"Calling tool: {tool_call.function.name}")
-            print(f"  Arguments: {tool_call.function.arguments}")
+                result = mcp_client.call_tool(tool_call.function.name, arguments)
+                text_result = mcp_result_to_text(result)
+                print(f"  Result: {text_result}")
 
-            result = executor.execute(tool_call)
-            print(f"  Result: {result}")
-
-            messages.append({
-                "role": "tool",
-                "tool_call_id": tool_call.id,
-                "content": result,
-            })
-
-        # Get final response
-        final_response = openai_client.chat.completions.create(
-            model="gpt-4o",
-            messages=messages,
-        )
-        print(f"\nAssistant: {final_response.choices[0].message.content}")
-    else:
-        print(f"\nAssistant: {message.content}")
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": tool_call.id,
+                        "content": text_result,
+                    }
+                )
+    finally:
+        mcp_client.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Backfill draft PR for the recovered managed telecom agent and governed communications docs/examples work.

## Covered issues
- TEL-214
- TEL-218
- TEL-219

## Notes
Recovered from local git history ahead of `origin/main` during TEL-266 audit.
