### PR TITLE
test: verify generated skills publish path

### DIFF
--- a/providers/claude/plugin/skills/telnyx-messaging-python/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-messaging-python/SKILL.md
@@ -442,3 +442,5 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see [references/api-details.md](references/api-details.md).
+
+<!-- TEST ONLY: publish path verification from telnyx-ext-skills-generator PR #78. Do not merge. -->

--- a/providers/cursor/plugin/skills/telnyx-messaging-python/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-python/SKILL.md
@@ -442,3 +442,5 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see [references/api-details.md](references/api-details.md).
+
+<!-- TEST ONLY: publish path verification from telnyx-ext-skills-generator PR #78. Do not merge. -->

--- a/skills/telnyx-messaging-python/SKILL.md
+++ b/skills/telnyx-messaging-python/SKILL.md
@@ -442,3 +442,5 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see [references/api-details.md](references/api-details.md).
+
+<!-- TEST ONLY: publish path verification from telnyx-ext-skills-generator PR #78. Do not merge. -->


### PR DESCRIPTION
## Auto-generated Telnyx skills update

Updates canonical `skills/` in `team-telnyx/ai` from telnyx-ext-skills-generator output and runs `./scripts/sync-skills.sh` to refresh Claude/Cursor provider copies.

- Generated canonical skills copied: 1
- Manual/non-target skills preserved: 233
- Canonical skills total: 234
