### PR TITLE
test: verify generated skills publish from sdk metadata fix

### DIFF
--- a/providers/claude/plugin/skills/telnyx-10dlc-java/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-10dlc-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -322,7 +322,6 @@ Create or provision an additional resource when the core tasks do not cover this
 ```java
 import com.telnyx.sdk.models.messaging10dlc.phonenumbercampaigns.PhoneNumberCampaign;
 import com.telnyx.sdk.models.messaging10dlc.phonenumbercampaigns.PhoneNumberCampaignCreate;
-import com.telnyx.sdk.models.messaging10dlc.phonenumbercampaigns.PhoneNumberCampaignCreateParams;
 
 PhoneNumberCampaignCreate params = PhoneNumberCampaignCreate.builder()
     .campaignId("4b300178-131c-d902-d54e-72d90ba1620j")

--- a/providers/claude/plugin/skills/telnyx-ai-assistants-curl/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-ai-assistants-curl/SKILL.md
@@ -40,10 +40,10 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-  "name": "my-resource",
-  "model": "openai/gpt-4o",
-  "instructions": "You are a helpful assistant."
-}' \
+      "name": "my-resource",
+      "instructions": "You are a helpful assistant.",
+      "model": "openai/gpt-4o"
+  }' \
   "https://api.telnyx.com/v2/ai/assistants"
 ```
 
@@ -74,12 +74,11 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `tool_ids` | array[string] | No |  |
-| `description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```bash
 curl \
@@ -87,10 +86,10 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-  "name": "my-resource",
-  "model": "openai/gpt-4o",
-  "instructions": "You are a helpful assistant."
-}' \
+      "name": "my-resource",
+      "instructions": "You are a helpful assistant.",
+      "model": "openai/gpt-4o"
+  }' \
   "https://api.telnyx.com/v2/ai/assistants"
 ```
 
@@ -208,7 +207,7 @@ Primary response fields:
 - `.data.created_at`
 - `.data.description`
 - `.data.dynamic_variables`
-- `.data.dynamic_variables_webhook_url`
+- `.data.dynamic_variables_webhook_timeout_ms`
 
 ### Update an assistant
 
@@ -219,10 +218,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistant_id` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```bash
 curl \
@@ -238,7 +237,7 @@ Primary response fields:
 - `.data.created_at`
 - `.data.description`
 - `.data.dynamic_variables`
-- `.data.dynamic_variables_webhook_url`
+- `.data.dynamic_variables_webhook_timeout_ms`
 
 ### List assistants
 
@@ -259,7 +258,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Import assistants from external provider
 
@@ -294,7 +293,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Get All Tags
 
@@ -401,8 +400,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | HTTP only | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
 | Delete an assistant | HTTP only | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Get Canary Deploy | HTTP only | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
-| Create Canary Deploy | HTTP only | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistant_id` |
-| Update Canary Deploy | HTTP only | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistant_id` |
+| Create Canary Deploy | HTTP only | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | HTTP only | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
 | Delete Canary Deploy | HTTP only | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Assistant Sms Chat | HTTP only | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistant_id` |
 | Clone Assistant | HTTP only | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |

--- a/providers/claude/plugin/skills/telnyx-ai-assistants-curl/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-ai-assistants-curl/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -165,9 +182,15 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -228,10 +254,29 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 | `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
 
 ### Assistant Chat (BETA)
 
@@ -254,6 +299,8 @@
 | `text` | string | Required for sms scheduled events. |
 | `conversation_metadata` | object | Metadata associated with the conversation. |
 | `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
 
 ### Test Assistant Tool
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -281,9 +331,16 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server
 

--- a/providers/claude/plugin/skills/telnyx-ai-assistants-go/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-ai-assistants-go/SKILL.md
@@ -50,8 +50,8 @@ import "errors"
 
 assistant, err := client.AI.Assistants.New(context.Background(), telnyx.AIAssistantNewParams{
 		Instructions: "You are a helpful assistant.",
-		Model: "openai/gpt-4o",
 		Name: "my-resource",
+		Model: "openai/gpt-4o",
 	})
 if err != nil {
   var apiErr *telnyx.Error
@@ -97,18 +97,17 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `Name` | string | Yes |  |
-| `Model` | string | Yes | ID of the model to use. |
 | `Instructions` | string | Yes | System instructions for the assistant. |
-| `Tools` | array[object] | No | The tools that the assistant can use. |
-| `ToolIds` | array[string] | No |  |
-| `Description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `Tags` | array[string] | No | Tags associated with the assistant. |
+| `Model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `Tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```go
 	assistant, err := client.AI.Assistants.New(context.Background(), telnyx.AIAssistantNewParams{
 		Instructions: "You are a helpful assistant.",
-		Model: "openai/gpt-4o",
 		Name: "my-resource",
+		Model: "openai/gpt-4o",
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -237,7 +236,7 @@ Primary response fields:
 - `assistant.CreatedAt`
 - `assistant.Description`
 - `assistant.DynamicVariables`
-- `assistant.DynamicVariablesWebhookURL`
+- `assistant.DynamicVariablesWebhookTimeoutMs`
 
 ### Update an assistant
 
@@ -248,10 +247,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `AssistantId` | string (UUID) | Yes |  |
+| `Tags` | array[string] | No | Tags associated with the assistant. |
 | `Name` | string | No |  |
-| `Model` | string | No | ID of the model to use. |
-| `Instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `Model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```go
 	assistant, err := client.AI.Assistants.Update(
@@ -271,7 +270,7 @@ Primary response fields:
 - `assistant.CreatedAt`
 - `assistant.Description`
 - `assistant.DynamicVariables`
-- `assistant.DynamicVariablesWebhookURL`
+- `assistant.DynamicVariablesWebhookTimeoutMs`
 
 ### List assistants
 
@@ -296,7 +295,7 @@ Primary item fields:
 - `CreatedAt`
 - `Description`
 - `DynamicVariables`
-- `DynamicVariablesWebhookURL`
+- `DynamicVariablesWebhookTimeoutMs`
 
 ### Import assistants from external provider
 
@@ -330,7 +329,7 @@ Primary item fields:
 - `CreatedAt`
 - `Description`
 - `DynamicVariables`
-- `DynamicVariablesWebhookURL`
+- `DynamicVariablesWebhookTimeoutMs`
 
 ### Get All Tags
 
@@ -457,8 +456,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.AI.Assistants.Tests.Runs.Get()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `TestId`, `RunId` |
 | Delete an assistant | `client.AI.Assistants.Delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `AssistantId` |
 | Get Canary Deploy | `client.AI.Assistants.CanaryDeploys.Get()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `AssistantId` |
-| Create Canary Deploy | `client.AI.Assistants.CanaryDeploys.New()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `Versions`, `AssistantId` |
-| Update Canary Deploy | `client.AI.Assistants.CanaryDeploys.Update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `Versions`, `AssistantId` |
+| Create Canary Deploy | `client.AI.Assistants.CanaryDeploys.New()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `AssistantId` |
+| Update Canary Deploy | `client.AI.Assistants.CanaryDeploys.Update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `AssistantId` |
 | Delete Canary Deploy | `client.AI.Assistants.CanaryDeploys.Delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `AssistantId` |
 | Assistant Sms Chat | `client.AI.Assistants.SendSMS()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `From`, `To`, `AssistantId` |
 | Clone Assistant | `client.AI.Assistants.Clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `AssistantId` |

--- a/providers/claude/plugin/skills/telnyx-ai-assistants-go/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-ai-assistants-go/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `Tools` | array[object] | The tools that the assistant can use. |
-| `ToolIds` | array[string] |  |
+| `Model` | string | ID of the model to use when `external_llm` is not set. |
+| `Tools` | array[object] | Deprecated for new integrations. |
+| `McpServers` | array[object] | MCP servers attached to the assistant. |
+| `ToolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `Description` | string |  |
 | `Greeting` | string | Text that the assistant will use to start the conversation. |
-| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `ExternalLlm` | object |  |
+| `FallbackConfig` | object |  |
 | `VoiceSettings` | object |  |
 | `Transcription` | object |  |
 | `TelephonySettings` | object |  |
@@ -165,9 +182,15 @@
 | `EnabledFeatures` | array[object] |  |
 | `InsightSettings` | object |  |
 | `PrivacySettings` | object |  |
-| `DynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `DynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `DynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `DynamicVariables` | object | Map of dynamic variables and their default values |
 | `WidgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `InterruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `Integrations` | array[object] | Connected integrations attached to the assistant. |
+| `ObservabilitySettings` | object |  |
+| `Tags` | array[string] | Tags associated with the assistant. |
+| `PostConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider — `client.AI.Assistants.Imports()`
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `Name` | string |  |
-| `Model` | string | ID of the model to use. |
+| `Model` | string | ID of the model to use when `external_llm` is not set. |
 | `Instructions` | string | System instructions for the assistant. |
-| `Tools` | array[object] | The tools that the assistant can use. |
-| `ToolIds` | array[string] |  |
+| `Tools` | array[object] | Deprecated for new integrations. |
+| `McpServers` | array[object] | MCP servers attached to the assistant. |
+| `ToolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `Description` | string |  |
 | `Greeting` | string | Text that the assistant will use to start the conversation. |
-| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `ExternalLlm` | object |  |
+| `FallbackConfig` | object |  |
 | `VoiceSettings` | object |  |
 | `Transcription` | object |  |
 | `TelephonySettings` | object |  |
@@ -228,10 +254,29 @@
 | `EnabledFeatures` | array[object] |  |
 | `InsightSettings` | object |  |
 | `PrivacySettings` | object |  |
-| `DynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `DynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `DynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `DynamicVariables` | object | Map of dynamic variables and their default values |
 | `WidgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `InterruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `Integrations` | array[object] | Connected integrations attached to the assistant. |
+| `ObservabilitySettings` | object |  |
+| `Tags` | array[string] | Tags associated with the assistant. |
+| `VersionName` | string | Human-readable name for the assistant version. |
+| `PostConversationSettings` | object | Configuration for post-conversation processing. |
 | `PromoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.AI.Assistants.CanaryDeploys.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Rules` | array[object] |  |
+
+### Update Canary Deploy — `client.AI.Assistants.CanaryDeploys.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Rules` | array[object] |  |
 
 ### Assistant Chat (BETA) — `client.AI.Assistants.Chat()`
 
@@ -254,6 +299,8 @@
 | `Text` | string | Required for sms scheduled events. |
 | `ConversationMetadata` | object | Metadata associated with the conversation. |
 | `DynamicVariables` | object | A map of dynamic variable names to values. |
+| `MaxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `RetryIntervalSecs` | integer |  |
 
 ### Test Assistant Tool — `client.AI.Assistants.Tools.Test()`
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `Name` | string |  |
-| `Model` | string | ID of the model to use. |
+| `Model` | string | ID of the model to use when `external_llm` is not set. |
 | `Instructions` | string | System instructions for the assistant. |
-| `Tools` | array[object] | The tools that the assistant can use. |
-| `ToolIds` | array[string] |  |
+| `Tools` | array[object] | Deprecated for new integrations. |
+| `McpServers` | array[object] | MCP servers attached to the assistant. |
+| `ToolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `Description` | string |  |
 | `Greeting` | string | Text that the assistant will use to start the conversation. |
-| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `ExternalLlm` | object |  |
+| `FallbackConfig` | object |  |
 | `VoiceSettings` | object |  |
 | `Transcription` | object |  |
 | `TelephonySettings` | object |  |
@@ -281,9 +331,16 @@
 | `EnabledFeatures` | array[object] |  |
 | `InsightSettings` | object |  |
 | `PrivacySettings` | object |  |
-| `DynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `DynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `DynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `DynamicVariables` | object | Map of dynamic variables and their default values |
 | `WidgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `InterruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `Integrations` | array[object] | Connected integrations attached to the assistant. |
+| `ObservabilitySettings` | object |  |
+| `Tags` | array[string] | Tags associated with the assistant. |
+| `VersionName` | string | Human-readable name for the assistant version. |
+| `PostConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server — `client.AI.McpServers.New()`
 

--- a/providers/claude/plugin/skills/telnyx-ai-assistants-java/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-ai-assistants-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -50,8 +50,8 @@ import com.telnyx.sdk.models.ai.assistants.AssistantCreateParams;
 import com.telnyx.sdk.models.ai.assistants.InferenceEmbedding;
 AssistantCreateParams params = AssistantCreateParams.builder()
     .instructions("You are a helpful assistant.")
-    .model("openai/gpt-4o")
     .name("my-resource")
+    .model("openai/gpt-4o")
     .build();
 InferenceEmbedding assistant = client.ai().assistants().create(params);
 ```
@@ -83,12 +83,11 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `toolIds` | array[string] | No |  |
-| `description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```java
 import com.telnyx.sdk.models.ai.assistants.AssistantCreateParams;
@@ -96,8 +95,8 @@ import com.telnyx.sdk.models.ai.assistants.InferenceEmbedding;
 
 AssistantCreateParams params = AssistantCreateParams.builder()
     .instructions("You are a helpful assistant.")
-    .model("openai/gpt-4o")
     .name("my-resource")
+    .model("openai/gpt-4o")
     .build();
 InferenceEmbedding assistant = client.ai().assistants().create(params);
 ```
@@ -216,7 +215,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### Update an assistant
 
@@ -227,10 +226,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistantId` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```java
 import com.telnyx.sdk.models.ai.assistants.AssistantUpdateParams;
@@ -245,7 +244,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### List assistants
 
@@ -269,7 +268,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Import assistants from external provider
 
@@ -303,7 +302,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Get All Tags
 
@@ -422,8 +421,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai().assistants().tests().runs().retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId`, `runId` |
 | Delete an assistant | `client.ai().assistants().delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Get Canary Deploy | `client.ai().assistants().canaryDeploys().retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Create Canary Deploy | `client.ai().assistants().canaryDeploys().create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistantId` |
-| Update Canary Deploy | `client.ai().assistants().canaryDeploys().update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistantId` |
+| Create Canary Deploy | `client.ai().assistants().canaryDeploys().create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId` |
+| Update Canary Deploy | `client.ai().assistants().canaryDeploys().update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistantId` |
 | Delete Canary Deploy | `client.ai().assistants().canaryDeploys().delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Assistant Sms Chat | `client.ai().assistants().sendSms()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistantId` |
 | Clone Assistant | `client.ai().assistants().clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId` |

--- a/providers/claude/plugin/skills/telnyx-ai-assistants-java/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-ai-assistants-java/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -165,9 +182,15 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider — `client.ai().assistants().imports()`
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -228,10 +254,29 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 | `promoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai().assistants().canaryDeploys().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai().assistants().canaryDeploys().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
 
 ### Assistant Chat (BETA) — `client.ai().assistants().chat()`
 
@@ -254,6 +299,8 @@
 | `text` | string | Required for sms scheduled events. |
 | `conversationMetadata` | object | Metadata associated with the conversation. |
 | `dynamicVariables` | object | A map of dynamic variable names to values. |
+| `maxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retryIntervalSecs` | integer |  |
 
 ### Test Assistant Tool — `client.ai().assistants().tools().test()`
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -281,9 +331,16 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server — `client.ai().mcpServers().create()`
 

--- a/providers/claude/plugin/skills/telnyx-ai-assistants-javascript/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-ai-assistants-javascript/SKILL.md
@@ -42,8 +42,8 @@ or authentication errors (401). Always handle errors in production code:
 try {
   const assistant = await client.ai.assistants.create({
     instructions: 'You are a helpful assistant.',
-    model: 'openai/gpt-4o',
     name: 'my-resource',
+      model: 'openai/gpt-4o',
   });
 } catch (err) {
   if (err instanceof Telnyx.APIConnectionError) {
@@ -87,18 +87,17 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `toolIds` | array[string] | No |  |
-| `description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const assistant = await client.ai.assistants.create({
   instructions: 'You are a helpful assistant.',
-  model: 'openai/gpt-4o',
   name: 'my-resource',
+    model: 'openai/gpt-4o',
 });
 
 console.log(assistant.id);
@@ -209,7 +208,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### Update an assistant
 
@@ -220,10 +219,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistantId` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const assistant = await client.ai.assistants.update('550e8400-e29b-41d4-a716-446655440000');
@@ -237,7 +236,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### List assistants
 
@@ -260,7 +259,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Import assistants from external provider
 
@@ -292,7 +291,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Get All Tags
 
@@ -409,8 +408,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId`, `runId` |
 | Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Get Canary Deploy | `client.ai.assistants.canaryDeploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Create Canary Deploy | `client.ai.assistants.canaryDeploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistantId` |
-| Update Canary Deploy | `client.ai.assistants.canaryDeploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistantId` |
+| Create Canary Deploy | `client.ai.assistants.canaryDeploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId` |
+| Update Canary Deploy | `client.ai.assistants.canaryDeploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistantId` |
 | Delete Canary Deploy | `client.ai.assistants.canaryDeploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Assistant Sms Chat | `client.ai.assistants.sendSMS()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistantId` |
 | Clone Assistant | `client.ai.assistants.clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId` |

--- a/providers/claude/plugin/skills/telnyx-ai-assistants-javascript/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-ai-assistants-javascript/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -165,9 +182,15 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider — `client.ai.assistants.imports()`
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -228,10 +254,29 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 | `promoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai.assistants.canaryDeploys.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai.assistants.canaryDeploys.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
 
 ### Assistant Chat (BETA) — `client.ai.assistants.chat()`
 
@@ -254,6 +299,8 @@
 | `text` | string | Required for sms scheduled events. |
 | `conversationMetadata` | object | Metadata associated with the conversation. |
 | `dynamicVariables` | object | A map of dynamic variable names to values. |
+| `maxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retryIntervalSecs` | integer |  |
 
 ### Test Assistant Tool — `client.ai.assistants.tools.test()`
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -281,9 +331,16 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server — `client.ai.mcpServers.create()`
 

--- a/providers/claude/plugin/skills/telnyx-ai-assistants-python/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-ai-assistants-python/SKILL.md
@@ -45,8 +45,8 @@ import telnyx
 try:
     assistant = client.ai.assistants.create(
         instructions="You are a helpful assistant.",
-        model="openai/gpt-4o",
         name="my-resource",
+        model="openai/gpt-4o",
     )
 except telnyx.APIConnectionError:
     print("Network error — check connectivity and retry")
@@ -87,18 +87,17 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `tool_ids` | array[string] | No |  |
-| `description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```python
 assistant = client.ai.assistants.create(
     instructions="You are a helpful assistant.",
-    model="openai/gpt-4o",
     name="my-resource",
+    model="openai/gpt-4o",
 )
 print(assistant.id)
 ```
@@ -210,7 +209,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### Update an assistant
 
@@ -221,10 +220,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistant_id` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```python
 assistant = client.ai.assistants.update(
@@ -239,7 +238,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### List assistants
 
@@ -261,7 +260,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Import assistants from external provider
 
@@ -292,7 +291,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Get All Tags
 
@@ -407,8 +406,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
 | Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Get Canary Deploy | `client.ai.assistants.canary_deploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
-| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistant_id` |
-| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistant_id` |
+| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
 | Delete Canary Deploy | `client.ai.assistants.canary_deploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Assistant Sms Chat | `client.ai.assistants.send_sms()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from_`, `to`, `assistant_id` |
 | Clone Assistant | `client.ai.assistants.clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |

--- a/providers/claude/plugin/skills/telnyx-ai-assistants-python/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-ai-assistants-python/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -165,9 +182,15 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider — `client.ai.assistants.imports()`
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -228,10 +254,29 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 | `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai.assistants.canary_deploys.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai.assistants.canary_deploys.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
 
 ### Assistant Chat (BETA) — `client.ai.assistants.chat()`
 
@@ -254,6 +299,8 @@
 | `text` | string | Required for sms scheduled events. |
 | `conversation_metadata` | object | Metadata associated with the conversation. |
 | `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
 
 ### Test Assistant Tool — `client.ai.assistants.tools.test()`
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -281,9 +331,16 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server — `client.ai.mcp_servers.create()`
 

--- a/providers/claude/plugin/skills/telnyx-ai-assistants-ruby/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-ai-assistants-ruby/SKILL.md
@@ -39,7 +39,7 @@ All API calls can fail with network errors, rate limits (429), validation errors
 or authentication errors (401). Always handle errors in production code:
 
 ```ruby
-assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", model: "openai/gpt-4o", name: "my-resource")
+assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", name: "my-resource", model: "openai/gpt-4o")
 puts(assistant)
 ```
 
@@ -70,16 +70,14 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `tool_ids` | array[string] | No |  |
-| `description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
-assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", model: "openai/gpt-4o", name: "my-resource")
-
+assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", name: "my-resource", model: "openai/gpt-4o")
 puts(assistant)
 ```
 
@@ -188,7 +186,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### Update an assistant
 
@@ -199,10 +197,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistant_id` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
 assistant = client.ai.assistants.update("550e8400-e29b-41d4-a716-446655440000")
@@ -216,7 +214,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### List assistants
 
@@ -239,7 +237,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Import assistants from external provider
 
@@ -268,7 +266,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Get All Tags
 
@@ -383,8 +381,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
 | Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Get Canary Deploy | `client.ai.assistants.canary_deploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
-| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistant_id` |
-| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistant_id` |
+| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
 | Delete Canary Deploy | `client.ai.assistants.canary_deploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Assistant Sms Chat | `client.ai.assistants.send_sms()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistant_id` |
 | Clone Assistant | `client.ai.assistants.clone_()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |

--- a/providers/claude/plugin/skills/telnyx-ai-assistants-ruby/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-ai-assistants-ruby/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -165,9 +182,15 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider — `client.ai.assistants.imports()`
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -228,10 +254,29 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 | `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai.assistants.canary_deploys.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai.assistants.canary_deploys.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
 
 ### Assistant Chat (BETA) — `client.ai.assistants.chat()`
 
@@ -254,6 +299,8 @@
 | `text` | string | Required for sms scheduled events. |
 | `conversation_metadata` | object | Metadata associated with the conversation. |
 | `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
 
 ### Test Assistant Tool — `client.ai.assistants.tools.test_()`
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -281,9 +331,16 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server — `client.ai.mcp_servers.create()`
 

--- a/providers/claude/plugin/skills/telnyx-messaging-curl/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-messaging-curl/SKILL.md
@@ -399,6 +399,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsapp_message` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```bash
 curl \

--- a/providers/claude/plugin/skills/telnyx-messaging-curl/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-messaging-curl/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/providers/claude/plugin/skills/telnyx-messaging-go/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-messaging-go/SKILL.md
@@ -416,6 +416,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `WhatsappMessage` | object | Yes |  |
 | `Type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `WebhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `MessagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```go
 	response, err := client.Messages.SendWhatsapp(context.Background(), telnyx.MessageSendWhatsappParams{

--- a/providers/claude/plugin/skills/telnyx-messaging-go/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-messaging-go/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `Type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `WebhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `MessagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.MessagingHostedNumbers.Update()`
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/providers/claude/plugin/skills/telnyx-messaging-java/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-messaging-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -420,6 +420,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsappMessage` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```java
 import com.telnyx.sdk.models.messages.MessageSendWhatsappParams;

--- a/providers/claude/plugin/skills/telnyx-messaging-java/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-messaging-java/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messagingHostedNumbers().update()`
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/providers/claude/plugin/skills/telnyx-messaging-javascript/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-messaging-javascript/SKILL.md
@@ -392,6 +392,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsappMessage` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```javascript
 const response = await client.messages.sendWhatsapp({

--- a/providers/claude/plugin/skills/telnyx-messaging-javascript/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-messaging-javascript/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messagingHostedNumbers.update()`
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/providers/claude/plugin/skills/telnyx-messaging-python/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-messaging-python/SKILL.md
@@ -385,6 +385,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsapp_message` | object | Yes |  |
 | `type_` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```python
 response = client.messages.send_whatsapp(

--- a/providers/claude/plugin/skills/telnyx-messaging-python/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-messaging-python/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `type_` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messaging_hosted_numbers.update()`
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/providers/claude/plugin/skills/telnyx-messaging-ruby/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-messaging-ruby/SKILL.md
@@ -353,6 +353,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsapp_message` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```ruby
 response = client.messages.send_whatsapp(from: "+13125551234", to: "+13125551234", whatsapp_message: {})

--- a/providers/claude/plugin/skills/telnyx-messaging-ruby/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-messaging-ruby/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messaging_hosted_numbers.update()`
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/providers/claude/plugin/skills/telnyx-numbers-java/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-numbers-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -278,7 +278,6 @@ Create or provision an additional resource when the core tasks do not cover this
 
 ```java
 import com.telnyx.sdk.models.advancedorders.AdvancedOrder;
-import com.telnyx.sdk.models.advancedorders.AdvancedOrderCreateParams;
 import com.telnyx.sdk.models.advancedorders.AdvancedOrderCreateResponse;
 
 AdvancedOrder params = AdvancedOrder.builder().build();

--- a/providers/claude/plugin/skills/telnyx-voice-curl/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-voice-curl/SKILL.md
@@ -86,7 +86,7 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +55 optional params in [references/api-details.md](references/api-details.md) |
 
 ```bash
 curl \
@@ -121,7 +121,7 @@ Primary inbound call-control command.
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +28 optional params in [references/api-details.md](references/api-details.md) |
 
 ```bash
 curl \
@@ -148,7 +148,7 @@ Common post-answer control path with downstream webhook implications.
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```bash
 curl \
@@ -156,7 +156,7 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-  "to": "+18005550100"
+  "to": "+18005550100;secure=srtp"
 }' \
   "https://api.telnyx.com/v2/calls/v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ/actions/transfer"
 ```

--- a/providers/claude/plugin/skills/telnyx-voice-curl/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-voice-curl/references/api-details.md
@@ -128,14 +128,18 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
 | `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 | `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
 | `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +167,9 @@
 | `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
 | `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +191,7 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | Use this field to add state to every subsequent webhook. |
 | `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +221,7 @@
 | `webhook_urls` | object | A map of event types to webhook URLs. |
 | `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls
 
@@ -277,7 +286,9 @@
 |-----------|------|-------------|
 | `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/providers/claude/plugin/skills/telnyx-voice-go/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-voice-go/SKILL.md
@@ -52,7 +52,7 @@ response, err := client.Calls.Dial(context.Background(), telnyx.CallDialParams{
 		ConnectionID: "7267xxxxxxxxxxxxxx",
 		From:         "+18005550101",
 		To: telnyx.CallDialParamsToUnion{
-			OfString: telnyx.String("+18005550100"),
+			OfString: telnyx.String("+18005550100;secure=srtp"),
 		},
 	})
 if err != nil {
@@ -111,14 +111,14 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `TimeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `BillingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `ClientState` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +55 optional params in [references/api-details.md](references/api-details.md) |
 
 ```go
 	response, err := client.Calls.Dial(context.Background(), telnyx.CallDialParams{
 		ConnectionID: "7267xxxxxxxxxxxxxx",
 		From:         "+18005550101",
 		To: telnyx.CallDialParamsToUnion{
-			OfString: telnyx.String("+18005550100"),
+			OfString: telnyx.String("+18005550100;secure=srtp"),
 		},
 	})
 	if err != nil {
@@ -147,7 +147,7 @@ Primary inbound call-control command.
 | `BillingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `ClientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `WebhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +28 optional params in [references/api-details.md](references/api-details.md) |
 
 ```go
 	response, err := client.Calls.Actions.Answer(
@@ -178,14 +178,14 @@ Common post-answer control path with downstream webhook implications.
 | `TimeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `ClientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `WebhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```go
 	response, err := client.Calls.Actions.Transfer(
 		context.Background(),
 		"call_control_id",
 		telnyx.CallActionTransferParams{
-			To: "+18005550100",
+			To: "+18005550100;secure=srtp",
 		},
 	)
 	if err != nil {

--- a/providers/claude/plugin/skills/telnyx-voice-go/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-voice-go/references/api-details.md
@@ -128,14 +128,18 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `Assistant` | object | AI Assistant configuration. |
 | `FromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `Privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `AudioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `SendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
 | `MediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `PreferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `TimeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `TimeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `AnsweringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `AnsweringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `DeepfakeDetection` | object | Enables deepfake detection on the call. |
 | `ConferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
 | `CustomHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `BillingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +167,9 @@
 | `SendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
 | `WebhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `WebhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `WebhookUrls` | object | A map of event types to webhook URLs. |
+| `WebhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `WebhookRetriesPolicies` | object | A map of event types to retry policies. |
 | `Record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `RecordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `RecordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +191,7 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `Assistant` | object | AI Assistant configuration. |
 | `BillingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `ClientState` | string | Use this field to add state to every subsequent webhook. |
 | `CommandId` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +221,7 @@
 | `WebhookUrls` | object | A map of event types to webhook URLs. |
 | `WebhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `WebhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `DeepfakeDetection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.Calls.Actions.Bridge()`
 
@@ -277,7 +286,9 @@
 |-----------|------|-------------|
 | `From` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `FromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `Privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `AudioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `SendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `EarlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `MediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `TimeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/providers/claude/plugin/skills/telnyx-voice-java/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-voice-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -51,7 +51,7 @@ import com.telnyx.sdk.models.calls.CallDialResponse;
 CallDialParams params = CallDialParams.builder()
     .connectionId("7267xxxxxxxxxxxxxx")
     .from("+18005550101")
-    .to("+18005550100")
+    .to("+18005550100;secure=srtp")
     .build();
 CallDialResponse response = client.calls().dial(params);
 ```
@@ -95,7 +95,7 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +55 optional params in [references/api-details.md](references/api-details.md) |
 
 ```java
 import com.telnyx.sdk.models.calls.CallDialParams;
@@ -104,7 +104,7 @@ import com.telnyx.sdk.models.calls.CallDialResponse;
 CallDialParams params = CallDialParams.builder()
     .connectionId("7267xxxxxxxxxxxxxx")
     .from("+18005550101")
-    .to("+18005550100")
+    .to("+18005550100;secure=srtp")
     .build();
 CallDialResponse response = client.calls().dial(params);
 ```
@@ -129,7 +129,7 @@ Primary inbound call-control command.
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +28 optional params in [references/api-details.md](references/api-details.md) |
 
 ```java
 import com.telnyx.sdk.models.calls.actions.ActionAnswerParams;
@@ -155,7 +155,7 @@ Common post-answer control path with downstream webhook implications.
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```java
 import com.telnyx.sdk.models.calls.actions.ActionTransferParams;
@@ -163,7 +163,7 @@ import com.telnyx.sdk.models.calls.actions.ActionTransferResponse;
 
 ActionTransferParams params = ActionTransferParams.builder()
     .callControlId("v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ")
-    .to("+18005550100")
+    .to("+18005550100;secure=srtp")
     .build();
 ActionTransferResponse response = client.calls().actions().transfer(params);
 ```

--- a/providers/claude/plugin/skills/telnyx-voice-java/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-voice-java/references/api-details.md
@@ -128,14 +128,18 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
 | `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
 | `mediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `preferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
 | `conferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
 | `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +167,9 @@
 | `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
 | `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhookUrls` | object | A map of event types to webhook URLs. |
+| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +191,7 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
 | `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | Use this field to add state to every subsequent webhook. |
 | `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +221,7 @@
 | `webhookUrls` | object | A map of event types to webhook URLs. |
 | `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.calls().actions().bridge()`
 
@@ -277,7 +286,9 @@
 |-----------|------|-------------|
 | `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `earlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `mediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/providers/claude/plugin/skills/telnyx-voice-javascript/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-voice-javascript/SKILL.md
@@ -43,7 +43,7 @@ try {
   const response = await client.calls.dial({
     connection_id: '7267xxxxxxxxxxxxxx',
     from: '+18005550101',
-    to: '+18005550100',
+    to: '+18005550100;secure=srtp',
   });
 } catch (err) {
   if (err instanceof Telnyx.APIConnectionError) {
@@ -99,13 +99,13 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +55 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const response = await client.calls.dial({
   connection_id: '7267xxxxxxxxxxxxxx',
   from: '+18005550101',
-  to: '+18005550100',
+  to: '+18005550100;secure=srtp',
 });
 
 console.log(response.data);
@@ -131,7 +131,7 @@ Primary inbound call-control command.
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +28 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const response = await client.calls.actions.answer('v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ');
@@ -156,11 +156,11 @@ Common post-answer control path with downstream webhook implications.
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const response = await client.calls.actions.transfer('call_control_id', {
-  to: '+18005550100',
+  to: '+18005550100;secure=srtp',
 });
 
 console.log(response.data);

--- a/providers/claude/plugin/skills/telnyx-voice-javascript/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-voice-javascript/references/api-details.md
@@ -128,14 +128,18 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
 | `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
 | `mediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `preferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
 | `conferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
 | `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +167,9 @@
 | `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
 | `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhookUrls` | object | A map of event types to webhook URLs. |
+| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +191,7 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
 | `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | Use this field to add state to every subsequent webhook. |
 | `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +221,7 @@
 | `webhookUrls` | object | A map of event types to webhook URLs. |
 | `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.calls.actions.bridge()`
 
@@ -277,7 +286,9 @@
 |-----------|------|-------------|
 | `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `earlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `mediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/providers/claude/plugin/skills/telnyx-voice-python/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-voice-python/SKILL.md
@@ -46,7 +46,7 @@ try:
     response = client.calls.dial(
         connection_id="7267xxxxxxxxxxxxxx",
         from_="+18005550101",
-        to="+18005550100",
+        to="+18005550100;secure=srtp",
     )
 except telnyx.APIConnectionError:
     print("Network error — check connectivity and retry")
@@ -98,13 +98,13 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +55 optional params in [references/api-details.md](references/api-details.md) |
 
 ```python
 response = client.calls.dial(
     connection_id="7267xxxxxxxxxxxxxx",
     from_="+18005550101",
-    to="+18005550100",
+    to="+18005550100;secure=srtp",
 )
 print(response.data)
 ```
@@ -129,7 +129,7 @@ Primary inbound call-control command.
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +28 optional params in [references/api-details.md](references/api-details.md) |
 
 ```python
 response = client.calls.actions.answer(
@@ -155,12 +155,12 @@ Common post-answer control path with downstream webhook implications.
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```python
 response = client.calls.actions.transfer(
     call_control_id="550e8400-e29b-41d4-a716-446655440000",
-    to="+18005550100",
+    to="+18005550100;secure=srtp",
 )
 print(response.data)
 ```

--- a/providers/claude/plugin/skills/telnyx-voice-python/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-voice-python/references/api-details.md
@@ -128,14 +128,18 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
 | `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 | `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
 | `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +167,9 @@
 | `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
 | `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +191,7 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | Use this field to add state to every subsequent webhook. |
 | `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +221,7 @@
 | `webhook_urls` | object | A map of event types to webhook URLs. |
 | `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.calls.actions.bridge()`
 
@@ -277,7 +286,9 @@
 |-----------|------|-------------|
 | `from_` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/providers/claude/plugin/skills/telnyx-voice-ruby/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-voice-ruby/SKILL.md
@@ -42,7 +42,7 @@ or authentication errors (401). Always handle errors in production code:
 response = client.calls.dial(
   connection_id: "7267xxxxxxxxxxxxxx",
   from: "+18005550101",
-  to: "+18005550100"
+  to: "+18005550100;secure=srtp"
 )
 puts(response)
 ```
@@ -86,13 +86,13 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +55 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
 response = client.calls.dial(
   connection_id: "7267xxxxxxxxxxxxxx",
   from: "+18005550101",
-  to: "+18005550100"
+  to: "+18005550100;secure=srtp"
 )
 
 puts(response)
@@ -118,7 +118,7 @@ Primary inbound call-control command.
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +28 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
 response = client.calls.actions.answer("v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ")
@@ -143,10 +143,13 @@ Common post-answer control path with downstream webhook implications.
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
-response = client.calls.actions.transfer("call_control_id", to: "+18005550100")
+response = client.calls.actions.transfer(
+  "call_control_id",
+  to: "+18005550100;secure=srtp"
+)
 
 puts(response)
 ```

--- a/providers/claude/plugin/skills/telnyx-voice-ruby/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-voice-ruby/references/api-details.md
@@ -128,14 +128,18 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
 | `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 | `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
 | `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +167,9 @@
 | `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
 | `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +191,7 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | Use this field to add state to every subsequent webhook. |
 | `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +221,7 @@
 | `webhook_urls` | object | A map of event types to webhook URLs. |
 | `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.calls.actions.bridge()`
 
@@ -277,7 +286,9 @@
 |-----------|------|-------------|
 | `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/providers/cursor/plugin/skills/telnyx-10dlc-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-10dlc-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -322,7 +322,6 @@ Create or provision an additional resource when the core tasks do not cover this
 ```java
 import com.telnyx.sdk.models.messaging10dlc.phonenumbercampaigns.PhoneNumberCampaign;
 import com.telnyx.sdk.models.messaging10dlc.phonenumbercampaigns.PhoneNumberCampaignCreate;
-import com.telnyx.sdk.models.messaging10dlc.phonenumbercampaigns.PhoneNumberCampaignCreateParams;
 
 PhoneNumberCampaignCreate params = PhoneNumberCampaignCreate.builder()
     .campaignId("4b300178-131c-d902-d54e-72d90ba1620j")

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-curl/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-curl/SKILL.md
@@ -40,10 +40,10 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-  "name": "my-resource",
-  "model": "openai/gpt-4o",
-  "instructions": "You are a helpful assistant."
-}' \
+      "name": "my-resource",
+      "instructions": "You are a helpful assistant.",
+      "model": "openai/gpt-4o"
+  }' \
   "https://api.telnyx.com/v2/ai/assistants"
 ```
 
@@ -74,12 +74,11 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `tool_ids` | array[string] | No |  |
-| `description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```bash
 curl \
@@ -87,10 +86,10 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-  "name": "my-resource",
-  "model": "openai/gpt-4o",
-  "instructions": "You are a helpful assistant."
-}' \
+      "name": "my-resource",
+      "instructions": "You are a helpful assistant.",
+      "model": "openai/gpt-4o"
+  }' \
   "https://api.telnyx.com/v2/ai/assistants"
 ```
 
@@ -208,7 +207,7 @@ Primary response fields:
 - `.data.created_at`
 - `.data.description`
 - `.data.dynamic_variables`
-- `.data.dynamic_variables_webhook_url`
+- `.data.dynamic_variables_webhook_timeout_ms`
 
 ### Update an assistant
 
@@ -219,10 +218,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistant_id` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```bash
 curl \
@@ -238,7 +237,7 @@ Primary response fields:
 - `.data.created_at`
 - `.data.description`
 - `.data.dynamic_variables`
-- `.data.dynamic_variables_webhook_url`
+- `.data.dynamic_variables_webhook_timeout_ms`
 
 ### List assistants
 
@@ -259,7 +258,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Import assistants from external provider
 
@@ -294,7 +293,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Get All Tags
 
@@ -401,8 +400,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | HTTP only | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
 | Delete an assistant | HTTP only | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Get Canary Deploy | HTTP only | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
-| Create Canary Deploy | HTTP only | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistant_id` |
-| Update Canary Deploy | HTTP only | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistant_id` |
+| Create Canary Deploy | HTTP only | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | HTTP only | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
 | Delete Canary Deploy | HTTP only | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Assistant Sms Chat | HTTP only | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistant_id` |
 | Clone Assistant | HTTP only | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-curl/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-curl/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -165,9 +182,15 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -228,10 +254,29 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 | `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
 
 ### Assistant Chat (BETA)
 
@@ -254,6 +299,8 @@
 | `text` | string | Required for sms scheduled events. |
 | `conversation_metadata` | object | Metadata associated with the conversation. |
 | `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
 
 ### Test Assistant Tool
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -281,9 +331,16 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server
 

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-go/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-go/SKILL.md
@@ -50,8 +50,8 @@ import "errors"
 
 assistant, err := client.AI.Assistants.New(context.Background(), telnyx.AIAssistantNewParams{
 		Instructions: "You are a helpful assistant.",
-		Model: "openai/gpt-4o",
 		Name: "my-resource",
+		Model: "openai/gpt-4o",
 	})
 if err != nil {
   var apiErr *telnyx.Error
@@ -97,18 +97,17 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `Name` | string | Yes |  |
-| `Model` | string | Yes | ID of the model to use. |
 | `Instructions` | string | Yes | System instructions for the assistant. |
-| `Tools` | array[object] | No | The tools that the assistant can use. |
-| `ToolIds` | array[string] | No |  |
-| `Description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `Tags` | array[string] | No | Tags associated with the assistant. |
+| `Model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `Tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```go
 	assistant, err := client.AI.Assistants.New(context.Background(), telnyx.AIAssistantNewParams{
 		Instructions: "You are a helpful assistant.",
-		Model: "openai/gpt-4o",
 		Name: "my-resource",
+		Model: "openai/gpt-4o",
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -237,7 +236,7 @@ Primary response fields:
 - `assistant.CreatedAt`
 - `assistant.Description`
 - `assistant.DynamicVariables`
-- `assistant.DynamicVariablesWebhookURL`
+- `assistant.DynamicVariablesWebhookTimeoutMs`
 
 ### Update an assistant
 
@@ -248,10 +247,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `AssistantId` | string (UUID) | Yes |  |
+| `Tags` | array[string] | No | Tags associated with the assistant. |
 | `Name` | string | No |  |
-| `Model` | string | No | ID of the model to use. |
-| `Instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `Model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```go
 	assistant, err := client.AI.Assistants.Update(
@@ -271,7 +270,7 @@ Primary response fields:
 - `assistant.CreatedAt`
 - `assistant.Description`
 - `assistant.DynamicVariables`
-- `assistant.DynamicVariablesWebhookURL`
+- `assistant.DynamicVariablesWebhookTimeoutMs`
 
 ### List assistants
 
@@ -296,7 +295,7 @@ Primary item fields:
 - `CreatedAt`
 - `Description`
 - `DynamicVariables`
-- `DynamicVariablesWebhookURL`
+- `DynamicVariablesWebhookTimeoutMs`
 
 ### Import assistants from external provider
 
@@ -330,7 +329,7 @@ Primary item fields:
 - `CreatedAt`
 - `Description`
 - `DynamicVariables`
-- `DynamicVariablesWebhookURL`
+- `DynamicVariablesWebhookTimeoutMs`
 
 ### Get All Tags
 
@@ -457,8 +456,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.AI.Assistants.Tests.Runs.Get()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `TestId`, `RunId` |
 | Delete an assistant | `client.AI.Assistants.Delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `AssistantId` |
 | Get Canary Deploy | `client.AI.Assistants.CanaryDeploys.Get()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `AssistantId` |
-| Create Canary Deploy | `client.AI.Assistants.CanaryDeploys.New()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `Versions`, `AssistantId` |
-| Update Canary Deploy | `client.AI.Assistants.CanaryDeploys.Update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `Versions`, `AssistantId` |
+| Create Canary Deploy | `client.AI.Assistants.CanaryDeploys.New()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `AssistantId` |
+| Update Canary Deploy | `client.AI.Assistants.CanaryDeploys.Update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `AssistantId` |
 | Delete Canary Deploy | `client.AI.Assistants.CanaryDeploys.Delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `AssistantId` |
 | Assistant Sms Chat | `client.AI.Assistants.SendSMS()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `From`, `To`, `AssistantId` |
 | Clone Assistant | `client.AI.Assistants.Clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `AssistantId` |

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-go/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-go/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `Tools` | array[object] | The tools that the assistant can use. |
-| `ToolIds` | array[string] |  |
+| `Model` | string | ID of the model to use when `external_llm` is not set. |
+| `Tools` | array[object] | Deprecated for new integrations. |
+| `McpServers` | array[object] | MCP servers attached to the assistant. |
+| `ToolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `Description` | string |  |
 | `Greeting` | string | Text that the assistant will use to start the conversation. |
-| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `ExternalLlm` | object |  |
+| `FallbackConfig` | object |  |
 | `VoiceSettings` | object |  |
 | `Transcription` | object |  |
 | `TelephonySettings` | object |  |
@@ -165,9 +182,15 @@
 | `EnabledFeatures` | array[object] |  |
 | `InsightSettings` | object |  |
 | `PrivacySettings` | object |  |
-| `DynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `DynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `DynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `DynamicVariables` | object | Map of dynamic variables and their default values |
 | `WidgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `InterruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `Integrations` | array[object] | Connected integrations attached to the assistant. |
+| `ObservabilitySettings` | object |  |
+| `Tags` | array[string] | Tags associated with the assistant. |
+| `PostConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider — `client.AI.Assistants.Imports()`
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `Name` | string |  |
-| `Model` | string | ID of the model to use. |
+| `Model` | string | ID of the model to use when `external_llm` is not set. |
 | `Instructions` | string | System instructions for the assistant. |
-| `Tools` | array[object] | The tools that the assistant can use. |
-| `ToolIds` | array[string] |  |
+| `Tools` | array[object] | Deprecated for new integrations. |
+| `McpServers` | array[object] | MCP servers attached to the assistant. |
+| `ToolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `Description` | string |  |
 | `Greeting` | string | Text that the assistant will use to start the conversation. |
-| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `ExternalLlm` | object |  |
+| `FallbackConfig` | object |  |
 | `VoiceSettings` | object |  |
 | `Transcription` | object |  |
 | `TelephonySettings` | object |  |
@@ -228,10 +254,29 @@
 | `EnabledFeatures` | array[object] |  |
 | `InsightSettings` | object |  |
 | `PrivacySettings` | object |  |
-| `DynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `DynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `DynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `DynamicVariables` | object | Map of dynamic variables and their default values |
 | `WidgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `InterruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `Integrations` | array[object] | Connected integrations attached to the assistant. |
+| `ObservabilitySettings` | object |  |
+| `Tags` | array[string] | Tags associated with the assistant. |
+| `VersionName` | string | Human-readable name for the assistant version. |
+| `PostConversationSettings` | object | Configuration for post-conversation processing. |
 | `PromoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.AI.Assistants.CanaryDeploys.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Rules` | array[object] |  |
+
+### Update Canary Deploy — `client.AI.Assistants.CanaryDeploys.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Rules` | array[object] |  |
 
 ### Assistant Chat (BETA) — `client.AI.Assistants.Chat()`
 
@@ -254,6 +299,8 @@
 | `Text` | string | Required for sms scheduled events. |
 | `ConversationMetadata` | object | Metadata associated with the conversation. |
 | `DynamicVariables` | object | A map of dynamic variable names to values. |
+| `MaxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `RetryIntervalSecs` | integer |  |
 
 ### Test Assistant Tool — `client.AI.Assistants.Tools.Test()`
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `Name` | string |  |
-| `Model` | string | ID of the model to use. |
+| `Model` | string | ID of the model to use when `external_llm` is not set. |
 | `Instructions` | string | System instructions for the assistant. |
-| `Tools` | array[object] | The tools that the assistant can use. |
-| `ToolIds` | array[string] |  |
+| `Tools` | array[object] | Deprecated for new integrations. |
+| `McpServers` | array[object] | MCP servers attached to the assistant. |
+| `ToolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `Description` | string |  |
 | `Greeting` | string | Text that the assistant will use to start the conversation. |
-| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `ExternalLlm` | object |  |
+| `FallbackConfig` | object |  |
 | `VoiceSettings` | object |  |
 | `Transcription` | object |  |
 | `TelephonySettings` | object |  |
@@ -281,9 +331,16 @@
 | `EnabledFeatures` | array[object] |  |
 | `InsightSettings` | object |  |
 | `PrivacySettings` | object |  |
-| `DynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `DynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `DynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `DynamicVariables` | object | Map of dynamic variables and their default values |
 | `WidgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `InterruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `Integrations` | array[object] | Connected integrations attached to the assistant. |
+| `ObservabilitySettings` | object |  |
+| `Tags` | array[string] | Tags associated with the assistant. |
+| `VersionName` | string | Human-readable name for the assistant version. |
+| `PostConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server — `client.AI.McpServers.New()`
 

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -50,8 +50,8 @@ import com.telnyx.sdk.models.ai.assistants.AssistantCreateParams;
 import com.telnyx.sdk.models.ai.assistants.InferenceEmbedding;
 AssistantCreateParams params = AssistantCreateParams.builder()
     .instructions("You are a helpful assistant.")
-    .model("openai/gpt-4o")
     .name("my-resource")
+    .model("openai/gpt-4o")
     .build();
 InferenceEmbedding assistant = client.ai().assistants().create(params);
 ```
@@ -83,12 +83,11 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `toolIds` | array[string] | No |  |
-| `description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```java
 import com.telnyx.sdk.models.ai.assistants.AssistantCreateParams;
@@ -96,8 +95,8 @@ import com.telnyx.sdk.models.ai.assistants.InferenceEmbedding;
 
 AssistantCreateParams params = AssistantCreateParams.builder()
     .instructions("You are a helpful assistant.")
-    .model("openai/gpt-4o")
     .name("my-resource")
+    .model("openai/gpt-4o")
     .build();
 InferenceEmbedding assistant = client.ai().assistants().create(params);
 ```
@@ -216,7 +215,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### Update an assistant
 
@@ -227,10 +226,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistantId` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```java
 import com.telnyx.sdk.models.ai.assistants.AssistantUpdateParams;
@@ -245,7 +244,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### List assistants
 
@@ -269,7 +268,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Import assistants from external provider
 
@@ -303,7 +302,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Get All Tags
 
@@ -422,8 +421,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai().assistants().tests().runs().retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId`, `runId` |
 | Delete an assistant | `client.ai().assistants().delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Get Canary Deploy | `client.ai().assistants().canaryDeploys().retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Create Canary Deploy | `client.ai().assistants().canaryDeploys().create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistantId` |
-| Update Canary Deploy | `client.ai().assistants().canaryDeploys().update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistantId` |
+| Create Canary Deploy | `client.ai().assistants().canaryDeploys().create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId` |
+| Update Canary Deploy | `client.ai().assistants().canaryDeploys().update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistantId` |
 | Delete Canary Deploy | `client.ai().assistants().canaryDeploys().delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Assistant Sms Chat | `client.ai().assistants().sendSms()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistantId` |
 | Clone Assistant | `client.ai().assistants().clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId` |

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-java/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-java/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -165,9 +182,15 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider — `client.ai().assistants().imports()`
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -228,10 +254,29 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 | `promoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai().assistants().canaryDeploys().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai().assistants().canaryDeploys().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
 
 ### Assistant Chat (BETA) — `client.ai().assistants().chat()`
 
@@ -254,6 +299,8 @@
 | `text` | string | Required for sms scheduled events. |
 | `conversationMetadata` | object | Metadata associated with the conversation. |
 | `dynamicVariables` | object | A map of dynamic variable names to values. |
+| `maxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retryIntervalSecs` | integer |  |
 
 ### Test Assistant Tool — `client.ai().assistants().tools().test()`
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -281,9 +331,16 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server — `client.ai().mcpServers().create()`
 

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-javascript/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-javascript/SKILL.md
@@ -42,8 +42,8 @@ or authentication errors (401). Always handle errors in production code:
 try {
   const assistant = await client.ai.assistants.create({
     instructions: 'You are a helpful assistant.',
-    model: 'openai/gpt-4o',
     name: 'my-resource',
+      model: 'openai/gpt-4o',
   });
 } catch (err) {
   if (err instanceof Telnyx.APIConnectionError) {
@@ -87,18 +87,17 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `toolIds` | array[string] | No |  |
-| `description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const assistant = await client.ai.assistants.create({
   instructions: 'You are a helpful assistant.',
-  model: 'openai/gpt-4o',
   name: 'my-resource',
+    model: 'openai/gpt-4o',
 });
 
 console.log(assistant.id);
@@ -209,7 +208,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### Update an assistant
 
@@ -220,10 +219,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistantId` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const assistant = await client.ai.assistants.update('550e8400-e29b-41d4-a716-446655440000');
@@ -237,7 +236,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### List assistants
 
@@ -260,7 +259,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Import assistants from external provider
 
@@ -292,7 +291,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Get All Tags
 
@@ -409,8 +408,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId`, `runId` |
 | Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Get Canary Deploy | `client.ai.assistants.canaryDeploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Create Canary Deploy | `client.ai.assistants.canaryDeploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistantId` |
-| Update Canary Deploy | `client.ai.assistants.canaryDeploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistantId` |
+| Create Canary Deploy | `client.ai.assistants.canaryDeploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId` |
+| Update Canary Deploy | `client.ai.assistants.canaryDeploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistantId` |
 | Delete Canary Deploy | `client.ai.assistants.canaryDeploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Assistant Sms Chat | `client.ai.assistants.sendSMS()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistantId` |
 | Clone Assistant | `client.ai.assistants.clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId` |

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-javascript/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-javascript/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -165,9 +182,15 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider — `client.ai.assistants.imports()`
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -228,10 +254,29 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 | `promoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai.assistants.canaryDeploys.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai.assistants.canaryDeploys.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
 
 ### Assistant Chat (BETA) — `client.ai.assistants.chat()`
 
@@ -254,6 +299,8 @@
 | `text` | string | Required for sms scheduled events. |
 | `conversationMetadata` | object | Metadata associated with the conversation. |
 | `dynamicVariables` | object | A map of dynamic variable names to values. |
+| `maxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retryIntervalSecs` | integer |  |
 
 ### Test Assistant Tool — `client.ai.assistants.tools.test()`
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -281,9 +331,16 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server — `client.ai.mcpServers.create()`
 

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-python/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-python/SKILL.md
@@ -45,8 +45,8 @@ import telnyx
 try:
     assistant = client.ai.assistants.create(
         instructions="You are a helpful assistant.",
-        model="openai/gpt-4o",
         name="my-resource",
+        model="openai/gpt-4o",
     )
 except telnyx.APIConnectionError:
     print("Network error — check connectivity and retry")
@@ -87,18 +87,17 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `tool_ids` | array[string] | No |  |
-| `description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```python
 assistant = client.ai.assistants.create(
     instructions="You are a helpful assistant.",
-    model="openai/gpt-4o",
     name="my-resource",
+    model="openai/gpt-4o",
 )
 print(assistant.id)
 ```
@@ -210,7 +209,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### Update an assistant
 
@@ -221,10 +220,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistant_id` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```python
 assistant = client.ai.assistants.update(
@@ -239,7 +238,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### List assistants
 
@@ -261,7 +260,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Import assistants from external provider
 
@@ -292,7 +291,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Get All Tags
 
@@ -407,8 +406,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
 | Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Get Canary Deploy | `client.ai.assistants.canary_deploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
-| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistant_id` |
-| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistant_id` |
+| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
 | Delete Canary Deploy | `client.ai.assistants.canary_deploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Assistant Sms Chat | `client.ai.assistants.send_sms()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from_`, `to`, `assistant_id` |
 | Clone Assistant | `client.ai.assistants.clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-python/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-python/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -165,9 +182,15 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider — `client.ai.assistants.imports()`
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -228,10 +254,29 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 | `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai.assistants.canary_deploys.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai.assistants.canary_deploys.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
 
 ### Assistant Chat (BETA) — `client.ai.assistants.chat()`
 
@@ -254,6 +299,8 @@
 | `text` | string | Required for sms scheduled events. |
 | `conversation_metadata` | object | Metadata associated with the conversation. |
 | `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
 
 ### Test Assistant Tool — `client.ai.assistants.tools.test()`
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -281,9 +331,16 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server — `client.ai.mcp_servers.create()`
 

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-ruby/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-ruby/SKILL.md
@@ -39,7 +39,7 @@ All API calls can fail with network errors, rate limits (429), validation errors
 or authentication errors (401). Always handle errors in production code:
 
 ```ruby
-assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", model: "openai/gpt-4o", name: "my-resource")
+assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", name: "my-resource", model: "openai/gpt-4o")
 puts(assistant)
 ```
 
@@ -70,16 +70,14 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `tool_ids` | array[string] | No |  |
-| `description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
-assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", model: "openai/gpt-4o", name: "my-resource")
-
+assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", name: "my-resource", model: "openai/gpt-4o")
 puts(assistant)
 ```
 
@@ -188,7 +186,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### Update an assistant
 
@@ -199,10 +197,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistant_id` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
 assistant = client.ai.assistants.update("550e8400-e29b-41d4-a716-446655440000")
@@ -216,7 +214,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### List assistants
 
@@ -239,7 +237,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Import assistants from external provider
 
@@ -268,7 +266,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Get All Tags
 
@@ -383,8 +381,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
 | Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Get Canary Deploy | `client.ai.assistants.canary_deploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
-| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistant_id` |
-| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistant_id` |
+| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
 | Delete Canary Deploy | `client.ai.assistants.canary_deploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Assistant Sms Chat | `client.ai.assistants.send_sms()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistant_id` |
 | Clone Assistant | `client.ai.assistants.clone_()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-ruby/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-ruby/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -165,9 +182,15 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider — `client.ai.assistants.imports()`
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -228,10 +254,29 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 | `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai.assistants.canary_deploys.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai.assistants.canary_deploys.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
 
 ### Assistant Chat (BETA) — `client.ai.assistants.chat()`
 
@@ -254,6 +299,8 @@
 | `text` | string | Required for sms scheduled events. |
 | `conversation_metadata` | object | Metadata associated with the conversation. |
 | `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
 
 ### Test Assistant Tool — `client.ai.assistants.tools.test_()`
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -281,9 +331,16 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server — `client.ai.mcp_servers.create()`
 

--- a/providers/cursor/plugin/skills/telnyx-messaging-curl/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-curl/SKILL.md
@@ -399,6 +399,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsapp_message` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```bash
 curl \

--- a/providers/cursor/plugin/skills/telnyx-messaging-curl/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-curl/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/providers/cursor/plugin/skills/telnyx-messaging-go/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-go/SKILL.md
@@ -416,6 +416,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `WhatsappMessage` | object | Yes |  |
 | `Type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `WebhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `MessagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```go
 	response, err := client.Messages.SendWhatsapp(context.Background(), telnyx.MessageSendWhatsappParams{

--- a/providers/cursor/plugin/skills/telnyx-messaging-go/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-go/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `Type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `WebhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `MessagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.MessagingHostedNumbers.Update()`
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/providers/cursor/plugin/skills/telnyx-messaging-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -420,6 +420,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsappMessage` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```java
 import com.telnyx.sdk.models.messages.MessageSendWhatsappParams;

--- a/providers/cursor/plugin/skills/telnyx-messaging-java/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-java/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messagingHostedNumbers().update()`
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/providers/cursor/plugin/skills/telnyx-messaging-javascript/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-javascript/SKILL.md
@@ -392,6 +392,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsappMessage` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```javascript
 const response = await client.messages.sendWhatsapp({

--- a/providers/cursor/plugin/skills/telnyx-messaging-javascript/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-javascript/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messagingHostedNumbers.update()`
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/providers/cursor/plugin/skills/telnyx-messaging-python/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-python/SKILL.md
@@ -385,6 +385,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsapp_message` | object | Yes |  |
 | `type_` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```python
 response = client.messages.send_whatsapp(

--- a/providers/cursor/plugin/skills/telnyx-messaging-python/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-python/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `type_` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messaging_hosted_numbers.update()`
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/providers/cursor/plugin/skills/telnyx-messaging-ruby/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-ruby/SKILL.md
@@ -353,6 +353,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsapp_message` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```ruby
 response = client.messages.send_whatsapp(from: "+13125551234", to: "+13125551234", whatsapp_message: {})

--- a/providers/cursor/plugin/skills/telnyx-messaging-ruby/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-ruby/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messaging_hosted_numbers.update()`
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/providers/cursor/plugin/skills/telnyx-numbers-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-numbers-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -278,7 +278,6 @@ Create or provision an additional resource when the core tasks do not cover this
 
 ```java
 import com.telnyx.sdk.models.advancedorders.AdvancedOrder;
-import com.telnyx.sdk.models.advancedorders.AdvancedOrderCreateParams;
 import com.telnyx.sdk.models.advancedorders.AdvancedOrderCreateResponse;
 
 AdvancedOrder params = AdvancedOrder.builder().build();

--- a/providers/cursor/plugin/skills/telnyx-voice-curl/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-curl/SKILL.md
@@ -86,7 +86,7 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +55 optional params in [references/api-details.md](references/api-details.md) |
 
 ```bash
 curl \
@@ -121,7 +121,7 @@ Primary inbound call-control command.
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +28 optional params in [references/api-details.md](references/api-details.md) |
 
 ```bash
 curl \
@@ -148,7 +148,7 @@ Common post-answer control path with downstream webhook implications.
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```bash
 curl \
@@ -156,7 +156,7 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-  "to": "+18005550100"
+  "to": "+18005550100;secure=srtp"
 }' \
   "https://api.telnyx.com/v2/calls/v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ/actions/transfer"
 ```

--- a/providers/cursor/plugin/skills/telnyx-voice-curl/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-curl/references/api-details.md
@@ -128,14 +128,18 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
 | `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 | `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
 | `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +167,9 @@
 | `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
 | `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +191,7 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | Use this field to add state to every subsequent webhook. |
 | `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +221,7 @@
 | `webhook_urls` | object | A map of event types to webhook URLs. |
 | `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls
 
@@ -277,7 +286,9 @@
 |-----------|------|-------------|
 | `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/providers/cursor/plugin/skills/telnyx-voice-go/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-go/SKILL.md
@@ -52,7 +52,7 @@ response, err := client.Calls.Dial(context.Background(), telnyx.CallDialParams{
 		ConnectionID: "7267xxxxxxxxxxxxxx",
 		From:         "+18005550101",
 		To: telnyx.CallDialParamsToUnion{
-			OfString: telnyx.String("+18005550100"),
+			OfString: telnyx.String("+18005550100;secure=srtp"),
 		},
 	})
 if err != nil {
@@ -111,14 +111,14 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `TimeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `BillingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `ClientState` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +55 optional params in [references/api-details.md](references/api-details.md) |
 
 ```go
 	response, err := client.Calls.Dial(context.Background(), telnyx.CallDialParams{
 		ConnectionID: "7267xxxxxxxxxxxxxx",
 		From:         "+18005550101",
 		To: telnyx.CallDialParamsToUnion{
-			OfString: telnyx.String("+18005550100"),
+			OfString: telnyx.String("+18005550100;secure=srtp"),
 		},
 	})
 	if err != nil {
@@ -147,7 +147,7 @@ Primary inbound call-control command.
 | `BillingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `ClientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `WebhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +28 optional params in [references/api-details.md](references/api-details.md) |
 
 ```go
 	response, err := client.Calls.Actions.Answer(
@@ -178,14 +178,14 @@ Common post-answer control path with downstream webhook implications.
 | `TimeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `ClientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `WebhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```go
 	response, err := client.Calls.Actions.Transfer(
 		context.Background(),
 		"call_control_id",
 		telnyx.CallActionTransferParams{
-			To: "+18005550100",
+			To: "+18005550100;secure=srtp",
 		},
 	)
 	if err != nil {

--- a/providers/cursor/plugin/skills/telnyx-voice-go/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-go/references/api-details.md
@@ -128,14 +128,18 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `Assistant` | object | AI Assistant configuration. |
 | `FromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `Privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `AudioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `SendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
 | `MediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `PreferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `TimeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `TimeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `AnsweringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `AnsweringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `DeepfakeDetection` | object | Enables deepfake detection on the call. |
 | `ConferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
 | `CustomHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `BillingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +167,9 @@
 | `SendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
 | `WebhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `WebhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `WebhookUrls` | object | A map of event types to webhook URLs. |
+| `WebhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `WebhookRetriesPolicies` | object | A map of event types to retry policies. |
 | `Record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `RecordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `RecordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +191,7 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `Assistant` | object | AI Assistant configuration. |
 | `BillingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `ClientState` | string | Use this field to add state to every subsequent webhook. |
 | `CommandId` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +221,7 @@
 | `WebhookUrls` | object | A map of event types to webhook URLs. |
 | `WebhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `WebhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `DeepfakeDetection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.Calls.Actions.Bridge()`
 
@@ -277,7 +286,9 @@
 |-----------|------|-------------|
 | `From` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `FromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `Privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `AudioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `SendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `EarlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `MediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `TimeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/providers/cursor/plugin/skills/telnyx-voice-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -51,7 +51,7 @@ import com.telnyx.sdk.models.calls.CallDialResponse;
 CallDialParams params = CallDialParams.builder()
     .connectionId("7267xxxxxxxxxxxxxx")
     .from("+18005550101")
-    .to("+18005550100")
+    .to("+18005550100;secure=srtp")
     .build();
 CallDialResponse response = client.calls().dial(params);
 ```
@@ -95,7 +95,7 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +55 optional params in [references/api-details.md](references/api-details.md) |
 
 ```java
 import com.telnyx.sdk.models.calls.CallDialParams;
@@ -104,7 +104,7 @@ import com.telnyx.sdk.models.calls.CallDialResponse;
 CallDialParams params = CallDialParams.builder()
     .connectionId("7267xxxxxxxxxxxxxx")
     .from("+18005550101")
-    .to("+18005550100")
+    .to("+18005550100;secure=srtp")
     .build();
 CallDialResponse response = client.calls().dial(params);
 ```
@@ -129,7 +129,7 @@ Primary inbound call-control command.
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +28 optional params in [references/api-details.md](references/api-details.md) |
 
 ```java
 import com.telnyx.sdk.models.calls.actions.ActionAnswerParams;
@@ -155,7 +155,7 @@ Common post-answer control path with downstream webhook implications.
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```java
 import com.telnyx.sdk.models.calls.actions.ActionTransferParams;
@@ -163,7 +163,7 @@ import com.telnyx.sdk.models.calls.actions.ActionTransferResponse;
 
 ActionTransferParams params = ActionTransferParams.builder()
     .callControlId("v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ")
-    .to("+18005550100")
+    .to("+18005550100;secure=srtp")
     .build();
 ActionTransferResponse response = client.calls().actions().transfer(params);
 ```

--- a/providers/cursor/plugin/skills/telnyx-voice-java/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-java/references/api-details.md
@@ -128,14 +128,18 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
 | `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
 | `mediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `preferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
 | `conferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
 | `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +167,9 @@
 | `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
 | `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhookUrls` | object | A map of event types to webhook URLs. |
+| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +191,7 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
 | `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | Use this field to add state to every subsequent webhook. |
 | `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +221,7 @@
 | `webhookUrls` | object | A map of event types to webhook URLs. |
 | `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.calls().actions().bridge()`
 
@@ -277,7 +286,9 @@
 |-----------|------|-------------|
 | `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `earlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `mediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/providers/cursor/plugin/skills/telnyx-voice-javascript/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-javascript/SKILL.md
@@ -43,7 +43,7 @@ try {
   const response = await client.calls.dial({
     connection_id: '7267xxxxxxxxxxxxxx',
     from: '+18005550101',
-    to: '+18005550100',
+    to: '+18005550100;secure=srtp',
   });
 } catch (err) {
   if (err instanceof Telnyx.APIConnectionError) {
@@ -99,13 +99,13 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +55 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const response = await client.calls.dial({
   connection_id: '7267xxxxxxxxxxxxxx',
   from: '+18005550101',
-  to: '+18005550100',
+  to: '+18005550100;secure=srtp',
 });
 
 console.log(response.data);
@@ -131,7 +131,7 @@ Primary inbound call-control command.
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +28 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const response = await client.calls.actions.answer('v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ');
@@ -156,11 +156,11 @@ Common post-answer control path with downstream webhook implications.
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const response = await client.calls.actions.transfer('call_control_id', {
-  to: '+18005550100',
+  to: '+18005550100;secure=srtp',
 });
 
 console.log(response.data);

--- a/providers/cursor/plugin/skills/telnyx-voice-javascript/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-javascript/references/api-details.md
@@ -128,14 +128,18 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
 | `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
 | `mediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `preferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
 | `conferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
 | `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +167,9 @@
 | `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
 | `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhookUrls` | object | A map of event types to webhook URLs. |
+| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +191,7 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
 | `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | Use this field to add state to every subsequent webhook. |
 | `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +221,7 @@
 | `webhookUrls` | object | A map of event types to webhook URLs. |
 | `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.calls.actions.bridge()`
 
@@ -277,7 +286,9 @@
 |-----------|------|-------------|
 | `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `earlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `mediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/providers/cursor/plugin/skills/telnyx-voice-python/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-python/SKILL.md
@@ -46,7 +46,7 @@ try:
     response = client.calls.dial(
         connection_id="7267xxxxxxxxxxxxxx",
         from_="+18005550101",
-        to="+18005550100",
+        to="+18005550100;secure=srtp",
     )
 except telnyx.APIConnectionError:
     print("Network error — check connectivity and retry")
@@ -98,13 +98,13 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +55 optional params in [references/api-details.md](references/api-details.md) |
 
 ```python
 response = client.calls.dial(
     connection_id="7267xxxxxxxxxxxxxx",
     from_="+18005550101",
-    to="+18005550100",
+    to="+18005550100;secure=srtp",
 )
 print(response.data)
 ```
@@ -129,7 +129,7 @@ Primary inbound call-control command.
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +28 optional params in [references/api-details.md](references/api-details.md) |
 
 ```python
 response = client.calls.actions.answer(
@@ -155,12 +155,12 @@ Common post-answer control path with downstream webhook implications.
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```python
 response = client.calls.actions.transfer(
     call_control_id="550e8400-e29b-41d4-a716-446655440000",
-    to="+18005550100",
+    to="+18005550100;secure=srtp",
 )
 print(response.data)
 ```

--- a/providers/cursor/plugin/skills/telnyx-voice-python/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-python/references/api-details.md
@@ -128,14 +128,18 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
 | `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 | `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
 | `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +167,9 @@
 | `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
 | `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +191,7 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | Use this field to add state to every subsequent webhook. |
 | `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +221,7 @@
 | `webhook_urls` | object | A map of event types to webhook URLs. |
 | `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.calls.actions.bridge()`
 
@@ -277,7 +286,9 @@
 |-----------|------|-------------|
 | `from_` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/providers/cursor/plugin/skills/telnyx-voice-ruby/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-ruby/SKILL.md
@@ -42,7 +42,7 @@ or authentication errors (401). Always handle errors in production code:
 response = client.calls.dial(
   connection_id: "7267xxxxxxxxxxxxxx",
   from: "+18005550101",
-  to: "+18005550100"
+  to: "+18005550100;secure=srtp"
 )
 puts(response)
 ```
@@ -86,13 +86,13 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +55 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
 response = client.calls.dial(
   connection_id: "7267xxxxxxxxxxxxxx",
   from: "+18005550101",
-  to: "+18005550100"
+  to: "+18005550100;secure=srtp"
 )
 
 puts(response)
@@ -118,7 +118,7 @@ Primary inbound call-control command.
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +28 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
 response = client.calls.actions.answer("v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ")
@@ -143,10 +143,13 @@ Common post-answer control path with downstream webhook implications.
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
-response = client.calls.actions.transfer("call_control_id", to: "+18005550100")
+response = client.calls.actions.transfer(
+  "call_control_id",
+  to: "+18005550100;secure=srtp"
+)
 
 puts(response)
 ```

--- a/providers/cursor/plugin/skills/telnyx-voice-ruby/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-ruby/references/api-details.md
@@ -128,14 +128,18 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
 | `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 | `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
 | `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +167,9 @@
 | `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
 | `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +191,7 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | Use this field to add state to every subsequent webhook. |
 | `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +221,7 @@
 | `webhook_urls` | object | A map of event types to webhook URLs. |
 | `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.calls.actions.bridge()`
 
@@ -277,7 +286,9 @@
 |-----------|------|-------------|
 | `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/skills/telnyx-10dlc-java/SKILL.md
+++ b/skills/telnyx-10dlc-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -322,7 +322,6 @@ Create or provision an additional resource when the core tasks do not cover this
 ```java
 import com.telnyx.sdk.models.messaging10dlc.phonenumbercampaigns.PhoneNumberCampaign;
 import com.telnyx.sdk.models.messaging10dlc.phonenumbercampaigns.PhoneNumberCampaignCreate;
-import com.telnyx.sdk.models.messaging10dlc.phonenumbercampaigns.PhoneNumberCampaignCreateParams;
 
 PhoneNumberCampaignCreate params = PhoneNumberCampaignCreate.builder()
     .campaignId("4b300178-131c-d902-d54e-72d90ba1620j")

--- a/skills/telnyx-ai-assistants-curl/SKILL.md
+++ b/skills/telnyx-ai-assistants-curl/SKILL.md
@@ -40,10 +40,10 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-  "name": "my-resource",
-  "model": "openai/gpt-4o",
-  "instructions": "You are a helpful assistant."
-}' \
+      "name": "my-resource",
+      "instructions": "You are a helpful assistant.",
+      "model": "openai/gpt-4o"
+  }' \
   "https://api.telnyx.com/v2/ai/assistants"
 ```
 
@@ -74,12 +74,11 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `tool_ids` | array[string] | No |  |
-| `description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```bash
 curl \
@@ -87,10 +86,10 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-  "name": "my-resource",
-  "model": "openai/gpt-4o",
-  "instructions": "You are a helpful assistant."
-}' \
+      "name": "my-resource",
+      "instructions": "You are a helpful assistant.",
+      "model": "openai/gpt-4o"
+  }' \
   "https://api.telnyx.com/v2/ai/assistants"
 ```
 
@@ -208,7 +207,7 @@ Primary response fields:
 - `.data.created_at`
 - `.data.description`
 - `.data.dynamic_variables`
-- `.data.dynamic_variables_webhook_url`
+- `.data.dynamic_variables_webhook_timeout_ms`
 
 ### Update an assistant
 
@@ -219,10 +218,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistant_id` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```bash
 curl \
@@ -238,7 +237,7 @@ Primary response fields:
 - `.data.created_at`
 - `.data.description`
 - `.data.dynamic_variables`
-- `.data.dynamic_variables_webhook_url`
+- `.data.dynamic_variables_webhook_timeout_ms`
 
 ### List assistants
 
@@ -259,7 +258,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Import assistants from external provider
 
@@ -294,7 +293,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Get All Tags
 
@@ -401,8 +400,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | HTTP only | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
 | Delete an assistant | HTTP only | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Get Canary Deploy | HTTP only | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
-| Create Canary Deploy | HTTP only | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistant_id` |
-| Update Canary Deploy | HTTP only | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistant_id` |
+| Create Canary Deploy | HTTP only | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | HTTP only | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
 | Delete Canary Deploy | HTTP only | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Assistant Sms Chat | HTTP only | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistant_id` |
 | Clone Assistant | HTTP only | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |

--- a/skills/telnyx-ai-assistants-curl/references/api-details.md
+++ b/skills/telnyx-ai-assistants-curl/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -165,9 +182,15 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -228,10 +254,29 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 | `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
 
 ### Assistant Chat (BETA)
 
@@ -254,6 +299,8 @@
 | `text` | string | Required for sms scheduled events. |
 | `conversation_metadata` | object | Metadata associated with the conversation. |
 | `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
 
 ### Test Assistant Tool
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -281,9 +331,16 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server
 

--- a/skills/telnyx-ai-assistants-go/SKILL.md
+++ b/skills/telnyx-ai-assistants-go/SKILL.md
@@ -50,8 +50,8 @@ import "errors"
 
 assistant, err := client.AI.Assistants.New(context.Background(), telnyx.AIAssistantNewParams{
 		Instructions: "You are a helpful assistant.",
-		Model: "openai/gpt-4o",
 		Name: "my-resource",
+		Model: "openai/gpt-4o",
 	})
 if err != nil {
   var apiErr *telnyx.Error
@@ -97,18 +97,17 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `Name` | string | Yes |  |
-| `Model` | string | Yes | ID of the model to use. |
 | `Instructions` | string | Yes | System instructions for the assistant. |
-| `Tools` | array[object] | No | The tools that the assistant can use. |
-| `ToolIds` | array[string] | No |  |
-| `Description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `Tags` | array[string] | No | Tags associated with the assistant. |
+| `Model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `Tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```go
 	assistant, err := client.AI.Assistants.New(context.Background(), telnyx.AIAssistantNewParams{
 		Instructions: "You are a helpful assistant.",
-		Model: "openai/gpt-4o",
 		Name: "my-resource",
+		Model: "openai/gpt-4o",
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -237,7 +236,7 @@ Primary response fields:
 - `assistant.CreatedAt`
 - `assistant.Description`
 - `assistant.DynamicVariables`
-- `assistant.DynamicVariablesWebhookURL`
+- `assistant.DynamicVariablesWebhookTimeoutMs`
 
 ### Update an assistant
 
@@ -248,10 +247,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `AssistantId` | string (UUID) | Yes |  |
+| `Tags` | array[string] | No | Tags associated with the assistant. |
 | `Name` | string | No |  |
-| `Model` | string | No | ID of the model to use. |
-| `Instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `Model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```go
 	assistant, err := client.AI.Assistants.Update(
@@ -271,7 +270,7 @@ Primary response fields:
 - `assistant.CreatedAt`
 - `assistant.Description`
 - `assistant.DynamicVariables`
-- `assistant.DynamicVariablesWebhookURL`
+- `assistant.DynamicVariablesWebhookTimeoutMs`
 
 ### List assistants
 
@@ -296,7 +295,7 @@ Primary item fields:
 - `CreatedAt`
 - `Description`
 - `DynamicVariables`
-- `DynamicVariablesWebhookURL`
+- `DynamicVariablesWebhookTimeoutMs`
 
 ### Import assistants from external provider
 
@@ -330,7 +329,7 @@ Primary item fields:
 - `CreatedAt`
 - `Description`
 - `DynamicVariables`
-- `DynamicVariablesWebhookURL`
+- `DynamicVariablesWebhookTimeoutMs`
 
 ### Get All Tags
 
@@ -457,8 +456,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.AI.Assistants.Tests.Runs.Get()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `TestId`, `RunId` |
 | Delete an assistant | `client.AI.Assistants.Delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `AssistantId` |
 | Get Canary Deploy | `client.AI.Assistants.CanaryDeploys.Get()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `AssistantId` |
-| Create Canary Deploy | `client.AI.Assistants.CanaryDeploys.New()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `Versions`, `AssistantId` |
-| Update Canary Deploy | `client.AI.Assistants.CanaryDeploys.Update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `Versions`, `AssistantId` |
+| Create Canary Deploy | `client.AI.Assistants.CanaryDeploys.New()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `AssistantId` |
+| Update Canary Deploy | `client.AI.Assistants.CanaryDeploys.Update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `AssistantId` |
 | Delete Canary Deploy | `client.AI.Assistants.CanaryDeploys.Delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `AssistantId` |
 | Assistant Sms Chat | `client.AI.Assistants.SendSMS()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `From`, `To`, `AssistantId` |
 | Clone Assistant | `client.AI.Assistants.Clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `AssistantId` |

--- a/skills/telnyx-ai-assistants-go/references/api-details.md
+++ b/skills/telnyx-ai-assistants-go/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `Tools` | array[object] | The tools that the assistant can use. |
-| `ToolIds` | array[string] |  |
+| `Model` | string | ID of the model to use when `external_llm` is not set. |
+| `Tools` | array[object] | Deprecated for new integrations. |
+| `McpServers` | array[object] | MCP servers attached to the assistant. |
+| `ToolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `Description` | string |  |
 | `Greeting` | string | Text that the assistant will use to start the conversation. |
-| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `ExternalLlm` | object |  |
+| `FallbackConfig` | object |  |
 | `VoiceSettings` | object |  |
 | `Transcription` | object |  |
 | `TelephonySettings` | object |  |
@@ -165,9 +182,15 @@
 | `EnabledFeatures` | array[object] |  |
 | `InsightSettings` | object |  |
 | `PrivacySettings` | object |  |
-| `DynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `DynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `DynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `DynamicVariables` | object | Map of dynamic variables and their default values |
 | `WidgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `InterruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `Integrations` | array[object] | Connected integrations attached to the assistant. |
+| `ObservabilitySettings` | object |  |
+| `Tags` | array[string] | Tags associated with the assistant. |
+| `PostConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider — `client.AI.Assistants.Imports()`
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `Name` | string |  |
-| `Model` | string | ID of the model to use. |
+| `Model` | string | ID of the model to use when `external_llm` is not set. |
 | `Instructions` | string | System instructions for the assistant. |
-| `Tools` | array[object] | The tools that the assistant can use. |
-| `ToolIds` | array[string] |  |
+| `Tools` | array[object] | Deprecated for new integrations. |
+| `McpServers` | array[object] | MCP servers attached to the assistant. |
+| `ToolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `Description` | string |  |
 | `Greeting` | string | Text that the assistant will use to start the conversation. |
-| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `ExternalLlm` | object |  |
+| `FallbackConfig` | object |  |
 | `VoiceSettings` | object |  |
 | `Transcription` | object |  |
 | `TelephonySettings` | object |  |
@@ -228,10 +254,29 @@
 | `EnabledFeatures` | array[object] |  |
 | `InsightSettings` | object |  |
 | `PrivacySettings` | object |  |
-| `DynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `DynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `DynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `DynamicVariables` | object | Map of dynamic variables and their default values |
 | `WidgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `InterruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `Integrations` | array[object] | Connected integrations attached to the assistant. |
+| `ObservabilitySettings` | object |  |
+| `Tags` | array[string] | Tags associated with the assistant. |
+| `VersionName` | string | Human-readable name for the assistant version. |
+| `PostConversationSettings` | object | Configuration for post-conversation processing. |
 | `PromoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.AI.Assistants.CanaryDeploys.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Rules` | array[object] |  |
+
+### Update Canary Deploy — `client.AI.Assistants.CanaryDeploys.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Rules` | array[object] |  |
 
 ### Assistant Chat (BETA) — `client.AI.Assistants.Chat()`
 
@@ -254,6 +299,8 @@
 | `Text` | string | Required for sms scheduled events. |
 | `ConversationMetadata` | object | Metadata associated with the conversation. |
 | `DynamicVariables` | object | A map of dynamic variable names to values. |
+| `MaxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `RetryIntervalSecs` | integer |  |
 
 ### Test Assistant Tool — `client.AI.Assistants.Tools.Test()`
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `Name` | string |  |
-| `Model` | string | ID of the model to use. |
+| `Model` | string | ID of the model to use when `external_llm` is not set. |
 | `Instructions` | string | System instructions for the assistant. |
-| `Tools` | array[object] | The tools that the assistant can use. |
-| `ToolIds` | array[string] |  |
+| `Tools` | array[object] | Deprecated for new integrations. |
+| `McpServers` | array[object] | MCP servers attached to the assistant. |
+| `ToolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `Description` | string |  |
 | `Greeting` | string | Text that the assistant will use to start the conversation. |
-| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `ExternalLlm` | object |  |
+| `FallbackConfig` | object |  |
 | `VoiceSettings` | object |  |
 | `Transcription` | object |  |
 | `TelephonySettings` | object |  |
@@ -281,9 +331,16 @@
 | `EnabledFeatures` | array[object] |  |
 | `InsightSettings` | object |  |
 | `PrivacySettings` | object |  |
-| `DynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `DynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `DynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `DynamicVariables` | object | Map of dynamic variables and their default values |
 | `WidgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `InterruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `Integrations` | array[object] | Connected integrations attached to the assistant. |
+| `ObservabilitySettings` | object |  |
+| `Tags` | array[string] | Tags associated with the assistant. |
+| `VersionName` | string | Human-readable name for the assistant version. |
+| `PostConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server — `client.AI.McpServers.New()`
 

--- a/skills/telnyx-ai-assistants-java/SKILL.md
+++ b/skills/telnyx-ai-assistants-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -50,8 +50,8 @@ import com.telnyx.sdk.models.ai.assistants.AssistantCreateParams;
 import com.telnyx.sdk.models.ai.assistants.InferenceEmbedding;
 AssistantCreateParams params = AssistantCreateParams.builder()
     .instructions("You are a helpful assistant.")
-    .model("openai/gpt-4o")
     .name("my-resource")
+    .model("openai/gpt-4o")
     .build();
 InferenceEmbedding assistant = client.ai().assistants().create(params);
 ```
@@ -83,12 +83,11 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `toolIds` | array[string] | No |  |
-| `description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```java
 import com.telnyx.sdk.models.ai.assistants.AssistantCreateParams;
@@ -96,8 +95,8 @@ import com.telnyx.sdk.models.ai.assistants.InferenceEmbedding;
 
 AssistantCreateParams params = AssistantCreateParams.builder()
     .instructions("You are a helpful assistant.")
-    .model("openai/gpt-4o")
     .name("my-resource")
+    .model("openai/gpt-4o")
     .build();
 InferenceEmbedding assistant = client.ai().assistants().create(params);
 ```
@@ -216,7 +215,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### Update an assistant
 
@@ -227,10 +226,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistantId` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```java
 import com.telnyx.sdk.models.ai.assistants.AssistantUpdateParams;
@@ -245,7 +244,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### List assistants
 
@@ -269,7 +268,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Import assistants from external provider
 
@@ -303,7 +302,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Get All Tags
 
@@ -422,8 +421,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai().assistants().tests().runs().retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId`, `runId` |
 | Delete an assistant | `client.ai().assistants().delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Get Canary Deploy | `client.ai().assistants().canaryDeploys().retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Create Canary Deploy | `client.ai().assistants().canaryDeploys().create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistantId` |
-| Update Canary Deploy | `client.ai().assistants().canaryDeploys().update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistantId` |
+| Create Canary Deploy | `client.ai().assistants().canaryDeploys().create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId` |
+| Update Canary Deploy | `client.ai().assistants().canaryDeploys().update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistantId` |
 | Delete Canary Deploy | `client.ai().assistants().canaryDeploys().delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Assistant Sms Chat | `client.ai().assistants().sendSms()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistantId` |
 | Clone Assistant | `client.ai().assistants().clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId` |

--- a/skills/telnyx-ai-assistants-java/references/api-details.md
+++ b/skills/telnyx-ai-assistants-java/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -165,9 +182,15 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider — `client.ai().assistants().imports()`
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -228,10 +254,29 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 | `promoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai().assistants().canaryDeploys().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai().assistants().canaryDeploys().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
 
 ### Assistant Chat (BETA) — `client.ai().assistants().chat()`
 
@@ -254,6 +299,8 @@
 | `text` | string | Required for sms scheduled events. |
 | `conversationMetadata` | object | Metadata associated with the conversation. |
 | `dynamicVariables` | object | A map of dynamic variable names to values. |
+| `maxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retryIntervalSecs` | integer |  |
 
 ### Test Assistant Tool — `client.ai().assistants().tools().test()`
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -281,9 +331,16 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server — `client.ai().mcpServers().create()`
 

--- a/skills/telnyx-ai-assistants-javascript/SKILL.md
+++ b/skills/telnyx-ai-assistants-javascript/SKILL.md
@@ -42,8 +42,8 @@ or authentication errors (401). Always handle errors in production code:
 try {
   const assistant = await client.ai.assistants.create({
     instructions: 'You are a helpful assistant.',
-    model: 'openai/gpt-4o',
     name: 'my-resource',
+      model: 'openai/gpt-4o',
   });
 } catch (err) {
   if (err instanceof Telnyx.APIConnectionError) {
@@ -87,18 +87,17 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `toolIds` | array[string] | No |  |
-| `description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const assistant = await client.ai.assistants.create({
   instructions: 'You are a helpful assistant.',
-  model: 'openai/gpt-4o',
   name: 'my-resource',
+    model: 'openai/gpt-4o',
 });
 
 console.log(assistant.id);
@@ -209,7 +208,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### Update an assistant
 
@@ -220,10 +219,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistantId` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const assistant = await client.ai.assistants.update('550e8400-e29b-41d4-a716-446655440000');
@@ -237,7 +236,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### List assistants
 
@@ -260,7 +259,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Import assistants from external provider
 
@@ -292,7 +291,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Get All Tags
 
@@ -409,8 +408,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId`, `runId` |
 | Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Get Canary Deploy | `client.ai.assistants.canaryDeploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Create Canary Deploy | `client.ai.assistants.canaryDeploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistantId` |
-| Update Canary Deploy | `client.ai.assistants.canaryDeploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistantId` |
+| Create Canary Deploy | `client.ai.assistants.canaryDeploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId` |
+| Update Canary Deploy | `client.ai.assistants.canaryDeploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistantId` |
 | Delete Canary Deploy | `client.ai.assistants.canaryDeploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Assistant Sms Chat | `client.ai.assistants.sendSMS()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistantId` |
 | Clone Assistant | `client.ai.assistants.clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId` |

--- a/skills/telnyx-ai-assistants-javascript/references/api-details.md
+++ b/skills/telnyx-ai-assistants-javascript/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -165,9 +182,15 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider — `client.ai.assistants.imports()`
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -228,10 +254,29 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 | `promoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai.assistants.canaryDeploys.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai.assistants.canaryDeploys.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
 
 ### Assistant Chat (BETA) — `client.ai.assistants.chat()`
 
@@ -254,6 +299,8 @@
 | `text` | string | Required for sms scheduled events. |
 | `conversationMetadata` | object | Metadata associated with the conversation. |
 | `dynamicVariables` | object | A map of dynamic variable names to values. |
+| `maxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retryIntervalSecs` | integer |  |
 
 ### Test Assistant Tool — `client.ai.assistants.tools.test()`
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -281,9 +331,16 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server — `client.ai.mcpServers.create()`
 

--- a/skills/telnyx-ai-assistants-python/SKILL.md
+++ b/skills/telnyx-ai-assistants-python/SKILL.md
@@ -45,8 +45,8 @@ import telnyx
 try:
     assistant = client.ai.assistants.create(
         instructions="You are a helpful assistant.",
-        model="openai/gpt-4o",
         name="my-resource",
+        model="openai/gpt-4o",
     )
 except telnyx.APIConnectionError:
     print("Network error — check connectivity and retry")
@@ -87,18 +87,17 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `tool_ids` | array[string] | No |  |
-| `description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```python
 assistant = client.ai.assistants.create(
     instructions="You are a helpful assistant.",
-    model="openai/gpt-4o",
     name="my-resource",
+    model="openai/gpt-4o",
 )
 print(assistant.id)
 ```
@@ -210,7 +209,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### Update an assistant
 
@@ -221,10 +220,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistant_id` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```python
 assistant = client.ai.assistants.update(
@@ -239,7 +238,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### List assistants
 
@@ -261,7 +260,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Import assistants from external provider
 
@@ -292,7 +291,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Get All Tags
 
@@ -407,8 +406,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
 | Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Get Canary Deploy | `client.ai.assistants.canary_deploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
-| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistant_id` |
-| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistant_id` |
+| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
 | Delete Canary Deploy | `client.ai.assistants.canary_deploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Assistant Sms Chat | `client.ai.assistants.send_sms()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from_`, `to`, `assistant_id` |
 | Clone Assistant | `client.ai.assistants.clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |

--- a/skills/telnyx-ai-assistants-python/references/api-details.md
+++ b/skills/telnyx-ai-assistants-python/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -165,9 +182,15 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider — `client.ai.assistants.imports()`
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -228,10 +254,29 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 | `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai.assistants.canary_deploys.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai.assistants.canary_deploys.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
 
 ### Assistant Chat (BETA) — `client.ai.assistants.chat()`
 
@@ -254,6 +299,8 @@
 | `text` | string | Required for sms scheduled events. |
 | `conversation_metadata` | object | Metadata associated with the conversation. |
 | `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
 
 ### Test Assistant Tool — `client.ai.assistants.tools.test()`
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -281,9 +331,16 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server — `client.ai.mcp_servers.create()`
 

--- a/skills/telnyx-ai-assistants-ruby/SKILL.md
+++ b/skills/telnyx-ai-assistants-ruby/SKILL.md
@@ -39,7 +39,7 @@ All API calls can fail with network errors, rate limits (429), validation errors
 or authentication errors (401). Always handle errors in production code:
 
 ```ruby
-assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", model: "openai/gpt-4o", name: "my-resource")
+assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", name: "my-resource", model: "openai/gpt-4o")
 puts(assistant)
 ```
 
@@ -70,16 +70,14 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `tool_ids` | array[string] | No |  |
-| `description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
-assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", model: "openai/gpt-4o", name: "my-resource")
-
+assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", name: "my-resource", model: "openai/gpt-4o")
 puts(assistant)
 ```
 
@@ -188,7 +186,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### Update an assistant
 
@@ -199,10 +197,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistant_id` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
 assistant = client.ai.assistants.update("550e8400-e29b-41d4-a716-446655440000")
@@ -216,7 +214,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### List assistants
 
@@ -239,7 +237,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Import assistants from external provider
 
@@ -268,7 +266,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Get All Tags
 
@@ -383,8 +381,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
 | Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Get Canary Deploy | `client.ai.assistants.canary_deploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
-| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistant_id` |
-| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistant_id` |
+| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
 | Delete Canary Deploy | `client.ai.assistants.canary_deploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Assistant Sms Chat | `client.ai.assistants.send_sms()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistant_id` |
 | Clone Assistant | `client.ai.assistants.clone_()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |

--- a/skills/telnyx-ai-assistants-ruby/references/api-details.md
+++ b/skills/telnyx-ai-assistants-ruby/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -165,9 +182,15 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider — `client.ai.assistants.imports()`
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -228,10 +254,29 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 | `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai.assistants.canary_deploys.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai.assistants.canary_deploys.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
 
 ### Assistant Chat (BETA) — `client.ai.assistants.chat()`
 
@@ -254,6 +299,8 @@
 | `text` | string | Required for sms scheduled events. |
 | `conversation_metadata` | object | Metadata associated with the conversation. |
 | `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
 
 ### Test Assistant Tool — `client.ai.assistants.tools.test_()`
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -281,9 +331,16 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server — `client.ai.mcp_servers.create()`
 

--- a/skills/telnyx-messaging-curl/SKILL.md
+++ b/skills/telnyx-messaging-curl/SKILL.md
@@ -399,6 +399,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsapp_message` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```bash
 curl \

--- a/skills/telnyx-messaging-curl/references/api-details.md
+++ b/skills/telnyx-messaging-curl/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/skills/telnyx-messaging-go/SKILL.md
+++ b/skills/telnyx-messaging-go/SKILL.md
@@ -416,6 +416,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `WhatsappMessage` | object | Yes |  |
 | `Type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `WebhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `MessagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```go
 	response, err := client.Messages.SendWhatsapp(context.Background(), telnyx.MessageSendWhatsappParams{

--- a/skills/telnyx-messaging-go/references/api-details.md
+++ b/skills/telnyx-messaging-go/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `Type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `WebhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `MessagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.MessagingHostedNumbers.Update()`
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/skills/telnyx-messaging-java/SKILL.md
+++ b/skills/telnyx-messaging-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -420,6 +420,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsappMessage` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```java
 import com.telnyx.sdk.models.messages.MessageSendWhatsappParams;

--- a/skills/telnyx-messaging-java/references/api-details.md
+++ b/skills/telnyx-messaging-java/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messagingHostedNumbers().update()`
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/skills/telnyx-messaging-javascript/SKILL.md
+++ b/skills/telnyx-messaging-javascript/SKILL.md
@@ -392,6 +392,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsappMessage` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```javascript
 const response = await client.messages.sendWhatsapp({

--- a/skills/telnyx-messaging-javascript/references/api-details.md
+++ b/skills/telnyx-messaging-javascript/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messagingHostedNumbers.update()`
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/skills/telnyx-messaging-python/SKILL.md
+++ b/skills/telnyx-messaging-python/SKILL.md
@@ -385,6 +385,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsapp_message` | object | Yes |  |
 | `type_` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```python
 response = client.messages.send_whatsapp(

--- a/skills/telnyx-messaging-python/references/api-details.md
+++ b/skills/telnyx-messaging-python/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `type_` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messaging_hosted_numbers.update()`
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/skills/telnyx-messaging-ruby/SKILL.md
+++ b/skills/telnyx-messaging-ruby/SKILL.md
@@ -353,6 +353,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsapp_message` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```ruby
 response = client.messages.send_whatsapp(from: "+13125551234", to: "+13125551234", whatsapp_message: {})

--- a/skills/telnyx-messaging-ruby/references/api-details.md
+++ b/skills/telnyx-messaging-ruby/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messaging_hosted_numbers.update()`
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/skills/telnyx-numbers-java/SKILL.md
+++ b/skills/telnyx-numbers-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -278,7 +278,6 @@ Create or provision an additional resource when the core tasks do not cover this
 
 ```java
 import com.telnyx.sdk.models.advancedorders.AdvancedOrder;
-import com.telnyx.sdk.models.advancedorders.AdvancedOrderCreateParams;
 import com.telnyx.sdk.models.advancedorders.AdvancedOrderCreateResponse;
 
 AdvancedOrder params = AdvancedOrder.builder().build();

--- a/skills/telnyx-voice-curl/SKILL.md
+++ b/skills/telnyx-voice-curl/SKILL.md
@@ -86,7 +86,7 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +55 optional params in [references/api-details.md](references/api-details.md) |
 
 ```bash
 curl \
@@ -121,7 +121,7 @@ Primary inbound call-control command.
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +28 optional params in [references/api-details.md](references/api-details.md) |
 
 ```bash
 curl \
@@ -148,7 +148,7 @@ Common post-answer control path with downstream webhook implications.
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```bash
 curl \
@@ -156,7 +156,7 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-  "to": "+18005550100"
+  "to": "+18005550100;secure=srtp"
 }' \
   "https://api.telnyx.com/v2/calls/v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ/actions/transfer"
 ```

--- a/skills/telnyx-voice-curl/references/api-details.md
+++ b/skills/telnyx-voice-curl/references/api-details.md
@@ -128,14 +128,18 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
 | `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 | `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
 | `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +167,9 @@
 | `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
 | `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +191,7 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | Use this field to add state to every subsequent webhook. |
 | `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +221,7 @@
 | `webhook_urls` | object | A map of event types to webhook URLs. |
 | `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls
 
@@ -277,7 +286,9 @@
 |-----------|------|-------------|
 | `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/skills/telnyx-voice-go/SKILL.md
+++ b/skills/telnyx-voice-go/SKILL.md
@@ -52,7 +52,7 @@ response, err := client.Calls.Dial(context.Background(), telnyx.CallDialParams{
 		ConnectionID: "7267xxxxxxxxxxxxxx",
 		From:         "+18005550101",
 		To: telnyx.CallDialParamsToUnion{
-			OfString: telnyx.String("+18005550100"),
+			OfString: telnyx.String("+18005550100;secure=srtp"),
 		},
 	})
 if err != nil {
@@ -111,14 +111,14 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `TimeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `BillingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `ClientState` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +55 optional params in [references/api-details.md](references/api-details.md) |
 
 ```go
 	response, err := client.Calls.Dial(context.Background(), telnyx.CallDialParams{
 		ConnectionID: "7267xxxxxxxxxxxxxx",
 		From:         "+18005550101",
 		To: telnyx.CallDialParamsToUnion{
-			OfString: telnyx.String("+18005550100"),
+			OfString: telnyx.String("+18005550100;secure=srtp"),
 		},
 	})
 	if err != nil {
@@ -147,7 +147,7 @@ Primary inbound call-control command.
 | `BillingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `ClientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `WebhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +28 optional params in [references/api-details.md](references/api-details.md) |
 
 ```go
 	response, err := client.Calls.Actions.Answer(
@@ -178,14 +178,14 @@ Common post-answer control path with downstream webhook implications.
 | `TimeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `ClientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `WebhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```go
 	response, err := client.Calls.Actions.Transfer(
 		context.Background(),
 		"call_control_id",
 		telnyx.CallActionTransferParams{
-			To: "+18005550100",
+			To: "+18005550100;secure=srtp",
 		},
 	)
 	if err != nil {

--- a/skills/telnyx-voice-go/references/api-details.md
+++ b/skills/telnyx-voice-go/references/api-details.md
@@ -128,14 +128,18 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `Assistant` | object | AI Assistant configuration. |
 | `FromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `Privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `AudioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `SendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
 | `MediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `PreferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `TimeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `TimeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `AnsweringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `AnsweringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `DeepfakeDetection` | object | Enables deepfake detection on the call. |
 | `ConferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
 | `CustomHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `BillingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +167,9 @@
 | `SendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
 | `WebhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `WebhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `WebhookUrls` | object | A map of event types to webhook URLs. |
+| `WebhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `WebhookRetriesPolicies` | object | A map of event types to retry policies. |
 | `Record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `RecordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `RecordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +191,7 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `Assistant` | object | AI Assistant configuration. |
 | `BillingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `ClientState` | string | Use this field to add state to every subsequent webhook. |
 | `CommandId` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +221,7 @@
 | `WebhookUrls` | object | A map of event types to webhook URLs. |
 | `WebhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `WebhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `DeepfakeDetection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.Calls.Actions.Bridge()`
 
@@ -277,7 +286,9 @@
 |-----------|------|-------------|
 | `From` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `FromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `Privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `AudioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `SendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `EarlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `MediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `TimeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/skills/telnyx-voice-java/SKILL.md
+++ b/skills/telnyx-voice-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -51,7 +51,7 @@ import com.telnyx.sdk.models.calls.CallDialResponse;
 CallDialParams params = CallDialParams.builder()
     .connectionId("7267xxxxxxxxxxxxxx")
     .from("+18005550101")
-    .to("+18005550100")
+    .to("+18005550100;secure=srtp")
     .build();
 CallDialResponse response = client.calls().dial(params);
 ```
@@ -95,7 +95,7 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +55 optional params in [references/api-details.md](references/api-details.md) |
 
 ```java
 import com.telnyx.sdk.models.calls.CallDialParams;
@@ -104,7 +104,7 @@ import com.telnyx.sdk.models.calls.CallDialResponse;
 CallDialParams params = CallDialParams.builder()
     .connectionId("7267xxxxxxxxxxxxxx")
     .from("+18005550101")
-    .to("+18005550100")
+    .to("+18005550100;secure=srtp")
     .build();
 CallDialResponse response = client.calls().dial(params);
 ```
@@ -129,7 +129,7 @@ Primary inbound call-control command.
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +28 optional params in [references/api-details.md](references/api-details.md) |
 
 ```java
 import com.telnyx.sdk.models.calls.actions.ActionAnswerParams;
@@ -155,7 +155,7 @@ Common post-answer control path with downstream webhook implications.
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```java
 import com.telnyx.sdk.models.calls.actions.ActionTransferParams;
@@ -163,7 +163,7 @@ import com.telnyx.sdk.models.calls.actions.ActionTransferResponse;
 
 ActionTransferParams params = ActionTransferParams.builder()
     .callControlId("v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ")
-    .to("+18005550100")
+    .to("+18005550100;secure=srtp")
     .build();
 ActionTransferResponse response = client.calls().actions().transfer(params);
 ```

--- a/skills/telnyx-voice-java/references/api-details.md
+++ b/skills/telnyx-voice-java/references/api-details.md
@@ -128,14 +128,18 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
 | `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
 | `mediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `preferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
 | `conferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
 | `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +167,9 @@
 | `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
 | `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhookUrls` | object | A map of event types to webhook URLs. |
+| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +191,7 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
 | `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | Use this field to add state to every subsequent webhook. |
 | `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +221,7 @@
 | `webhookUrls` | object | A map of event types to webhook URLs. |
 | `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.calls().actions().bridge()`
 
@@ -277,7 +286,9 @@
 |-----------|------|-------------|
 | `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `earlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `mediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/skills/telnyx-voice-javascript/SKILL.md
+++ b/skills/telnyx-voice-javascript/SKILL.md
@@ -43,7 +43,7 @@ try {
   const response = await client.calls.dial({
     connection_id: '7267xxxxxxxxxxxxxx',
     from: '+18005550101',
-    to: '+18005550100',
+    to: '+18005550100;secure=srtp',
   });
 } catch (err) {
   if (err instanceof Telnyx.APIConnectionError) {
@@ -99,13 +99,13 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +55 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const response = await client.calls.dial({
   connection_id: '7267xxxxxxxxxxxxxx',
   from: '+18005550101',
-  to: '+18005550100',
+  to: '+18005550100;secure=srtp',
 });
 
 console.log(response.data);
@@ -131,7 +131,7 @@ Primary inbound call-control command.
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +28 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const response = await client.calls.actions.answer('v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ');
@@ -156,11 +156,11 @@ Common post-answer control path with downstream webhook implications.
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const response = await client.calls.actions.transfer('call_control_id', {
-  to: '+18005550100',
+  to: '+18005550100;secure=srtp',
 });
 
 console.log(response.data);

--- a/skills/telnyx-voice-javascript/references/api-details.md
+++ b/skills/telnyx-voice-javascript/references/api-details.md
@@ -128,14 +128,18 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
 | `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
 | `mediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `preferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
 | `conferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
 | `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +167,9 @@
 | `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
 | `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhookUrls` | object | A map of event types to webhook URLs. |
+| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +191,7 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
 | `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | Use this field to add state to every subsequent webhook. |
 | `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +221,7 @@
 | `webhookUrls` | object | A map of event types to webhook URLs. |
 | `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.calls.actions.bridge()`
 
@@ -277,7 +286,9 @@
 |-----------|------|-------------|
 | `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `earlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `mediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/skills/telnyx-voice-python/SKILL.md
+++ b/skills/telnyx-voice-python/SKILL.md
@@ -46,7 +46,7 @@ try:
     response = client.calls.dial(
         connection_id="7267xxxxxxxxxxxxxx",
         from_="+18005550101",
-        to="+18005550100",
+        to="+18005550100;secure=srtp",
     )
 except telnyx.APIConnectionError:
     print("Network error — check connectivity and retry")
@@ -98,13 +98,13 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +55 optional params in [references/api-details.md](references/api-details.md) |
 
 ```python
 response = client.calls.dial(
     connection_id="7267xxxxxxxxxxxxxx",
     from_="+18005550101",
-    to="+18005550100",
+    to="+18005550100;secure=srtp",
 )
 print(response.data)
 ```
@@ -129,7 +129,7 @@ Primary inbound call-control command.
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +28 optional params in [references/api-details.md](references/api-details.md) |
 
 ```python
 response = client.calls.actions.answer(
@@ -155,12 +155,12 @@ Common post-answer control path with downstream webhook implications.
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```python
 response = client.calls.actions.transfer(
     call_control_id="550e8400-e29b-41d4-a716-446655440000",
-    to="+18005550100",
+    to="+18005550100;secure=srtp",
 )
 print(response.data)
 ```

--- a/skills/telnyx-voice-python/references/api-details.md
+++ b/skills/telnyx-voice-python/references/api-details.md
@@ -128,14 +128,18 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
 | `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 | `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
 | `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +167,9 @@
 | `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
 | `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +191,7 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | Use this field to add state to every subsequent webhook. |
 | `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +221,7 @@
 | `webhook_urls` | object | A map of event types to webhook URLs. |
 | `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.calls.actions.bridge()`
 
@@ -277,7 +286,9 @@
 |-----------|------|-------------|
 | `from_` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/skills/telnyx-voice-ruby/SKILL.md
+++ b/skills/telnyx-voice-ruby/SKILL.md
@@ -42,7 +42,7 @@ or authentication errors (401). Always handle errors in production code:
 response = client.calls.dial(
   connection_id: "7267xxxxxxxxxxxxxx",
   from: "+18005550101",
-  to: "+18005550100"
+  to: "+18005550100;secure=srtp"
 )
 puts(response)
 ```
@@ -86,13 +86,13 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +55 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
 response = client.calls.dial(
   connection_id: "7267xxxxxxxxxxxxxx",
   from: "+18005550101",
-  to: "+18005550100"
+  to: "+18005550100;secure=srtp"
 )
 
 puts(response)
@@ -118,7 +118,7 @@ Primary inbound call-control command.
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +28 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
 response = client.calls.actions.answer("v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ")
@@ -143,10 +143,13 @@ Common post-answer control path with downstream webhook implications.
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
-response = client.calls.actions.transfer("call_control_id", to: "+18005550100")
+response = client.calls.actions.transfer(
+  "call_control_id",
+  to: "+18005550100;secure=srtp"
+)
 
 puts(response)
 ```

--- a/skills/telnyx-voice-ruby/references/api-details.md
+++ b/skills/telnyx-voice-ruby/references/api-details.md
@@ -128,14 +128,18 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
 | `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 | `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
 | `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +167,9 @@
 | `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
 | `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +191,7 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | Use this field to add state to every subsequent webhook. |
 | `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +221,7 @@
 | `webhook_urls` | object | A map of event types to webhook URLs. |
 | `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.calls.actions.bridge()`
 
@@ -277,7 +286,9 @@
 |-----------|------|-------------|
 | `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |


### PR DESCRIPTION
## Auto-generated Telnyx skills update

Verification artifact generated from source PR: https://github.com/team-telnyx/telnyx-ext-skills-generator/pull/80

Source generator commit: `080076c0b192967c099e3dd2a4df8e22aff43399`
Downstream generated commit: `69ce616304215f6c8e232d024ebc287db8fcc9a4`
Supersedes closed verification PR: https://github.com/team-telnyx/ai/pull/209

This verifies the generator branch after the Go SDK cache-selection fixes and the latest SDK metadata refresh.

## Scope

- Profile: `northstar-v2`
- Products: `messaging`, `voice`, `10dlc`, `numbers`, `ai-assistants`
- Languages: `curl`, `go`, `java`, `javascript`, `python`, `ruby`
- Generated canonical skills copied: 30
- Manual/non-target skills preserved: 204
- Canonical skills total in `team-telnyx/ai`: 234
- Provider copies refreshed via `./scripts/sync-skills.sh`

## Validation run from generator PR #80

- `./sdk-extraction/run_all.sh` — passed
  - Python 4.141.0
  - JavaScript v6.70.0
  - Ruby 5.120.0
  - Go v4.71.0
  - Java 6.58.0
- `python3 -m pytest tests/test_northstar_v2.py tests/test_publish_ai.py` — 32 passed
- `bash -n sdk-extraction/*.sh publish.sh tests/test_extract_go_cache.sh` — passed
- `./publish.sh --dry-run --scope-manifest scopes/northstar-v2-pilot.json ...` — passed; 114 expected scoped files changed
- `./publish.sh --scope-manifest scopes/northstar-v2-pilot.json ...` — passed and opened this PR

## Notes

This PR is intentionally draft while source PR #80 is unmerged. It is a generated-output verification artifact, not something to merge independently before the generator source lands.
