### PR TITLE
test: generated skills after PR 81 merge

### DIFF
--- a/providers/claude/plugin/skills/telnyx-10dlc-java/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-10dlc-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -322,7 +322,6 @@ Create or provision an additional resource when the core tasks do not cover this
 ```java
 import com.telnyx.sdk.models.messaging10dlc.phonenumbercampaigns.PhoneNumberCampaign;
 import com.telnyx.sdk.models.messaging10dlc.phonenumbercampaigns.PhoneNumberCampaignCreate;
-import com.telnyx.sdk.models.messaging10dlc.phonenumbercampaigns.PhoneNumberCampaignCreateParams;
 
 PhoneNumberCampaignCreate params = PhoneNumberCampaignCreate.builder()
     .campaignId("4b300178-131c-d902-d54e-72d90ba1620j")

--- a/providers/claude/plugin/skills/telnyx-ai-assistants-curl/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-ai-assistants-curl/SKILL.md
@@ -40,10 +40,10 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-  "name": "my-resource",
-  "model": "openai/gpt-4o",
-  "instructions": "You are a helpful assistant."
-}' \
+      "name": "my-resource",
+      "instructions": "You are a helpful assistant.",
+      "model": "openai/gpt-4o"
+  }' \
   "https://api.telnyx.com/v2/ai/assistants"
 ```
 
@@ -74,12 +74,11 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `tool_ids` | array[string] | No |  |
-| `description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```bash
 curl \
@@ -87,10 +86,10 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-  "name": "my-resource",
-  "model": "openai/gpt-4o",
-  "instructions": "You are a helpful assistant."
-}' \
+      "name": "my-resource",
+      "instructions": "You are a helpful assistant.",
+      "model": "openai/gpt-4o"
+  }' \
   "https://api.telnyx.com/v2/ai/assistants"
 ```
 
@@ -208,7 +207,7 @@ Primary response fields:
 - `.data.created_at`
 - `.data.description`
 - `.data.dynamic_variables`
-- `.data.dynamic_variables_webhook_url`
+- `.data.dynamic_variables_webhook_timeout_ms`
 
 ### Update an assistant
 
@@ -219,10 +218,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistant_id` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```bash
 curl \
@@ -238,7 +237,7 @@ Primary response fields:
 - `.data.created_at`
 - `.data.description`
 - `.data.dynamic_variables`
-- `.data.dynamic_variables_webhook_url`
+- `.data.dynamic_variables_webhook_timeout_ms`
 
 ### List assistants
 
@@ -259,7 +258,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Import assistants from external provider
 
@@ -294,7 +293,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Get All Tags
 
@@ -401,8 +400,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | HTTP only | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
 | Delete an assistant | HTTP only | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Get Canary Deploy | HTTP only | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
-| Create Canary Deploy | HTTP only | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistant_id` |
-| Update Canary Deploy | HTTP only | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistant_id` |
+| Create Canary Deploy | HTTP only | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | HTTP only | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
 | Delete Canary Deploy | HTTP only | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Assistant Sms Chat | HTTP only | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistant_id` |
 | Clone Assistant | HTTP only | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |

--- a/providers/claude/plugin/skills/telnyx-ai-assistants-curl/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-ai-assistants-curl/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -165,9 +182,15 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -228,10 +254,29 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 | `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
 
 ### Assistant Chat (BETA)
 
@@ -254,6 +299,8 @@
 | `text` | string | Required for sms scheduled events. |
 | `conversation_metadata` | object | Metadata associated with the conversation. |
 | `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
 
 ### Test Assistant Tool
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -281,9 +331,16 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server
 

--- a/providers/claude/plugin/skills/telnyx-ai-assistants-go/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-ai-assistants-go/SKILL.md
@@ -50,8 +50,8 @@ import "errors"
 
 assistant, err := client.AI.Assistants.New(context.Background(), telnyx.AIAssistantNewParams{
 		Instructions: "You are a helpful assistant.",
-		Model: "openai/gpt-4o",
 		Name: "my-resource",
+		Model: "openai/gpt-4o",
 	})
 if err != nil {
   var apiErr *telnyx.Error
@@ -97,18 +97,17 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `Name` | string | Yes |  |
-| `Model` | string | Yes | ID of the model to use. |
 | `Instructions` | string | Yes | System instructions for the assistant. |
-| `Tools` | array[object] | No | The tools that the assistant can use. |
-| `ToolIds` | array[string] | No |  |
-| `Description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `Tags` | array[string] | No | Tags associated with the assistant. |
+| `Model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `Tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```go
 	assistant, err := client.AI.Assistants.New(context.Background(), telnyx.AIAssistantNewParams{
 		Instructions: "You are a helpful assistant.",
-		Model: "openai/gpt-4o",
 		Name: "my-resource",
+		Model: "openai/gpt-4o",
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -237,7 +236,7 @@ Primary response fields:
 - `assistant.CreatedAt`
 - `assistant.Description`
 - `assistant.DynamicVariables`
-- `assistant.DynamicVariablesWebhookURL`
+- `assistant.DynamicVariablesWebhookTimeoutMs`
 
 ### Update an assistant
 
@@ -248,10 +247,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `AssistantId` | string (UUID) | Yes |  |
+| `Tags` | array[string] | No | Tags associated with the assistant. |
 | `Name` | string | No |  |
-| `Model` | string | No | ID of the model to use. |
-| `Instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `Model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```go
 	assistant, err := client.AI.Assistants.Update(
@@ -271,7 +270,7 @@ Primary response fields:
 - `assistant.CreatedAt`
 - `assistant.Description`
 - `assistant.DynamicVariables`
-- `assistant.DynamicVariablesWebhookURL`
+- `assistant.DynamicVariablesWebhookTimeoutMs`
 
 ### List assistants
 
@@ -296,7 +295,7 @@ Primary item fields:
 - `CreatedAt`
 - `Description`
 - `DynamicVariables`
-- `DynamicVariablesWebhookURL`
+- `DynamicVariablesWebhookTimeoutMs`
 
 ### Import assistants from external provider
 
@@ -330,7 +329,7 @@ Primary item fields:
 - `CreatedAt`
 - `Description`
 - `DynamicVariables`
-- `DynamicVariablesWebhookURL`
+- `DynamicVariablesWebhookTimeoutMs`
 
 ### Get All Tags
 
@@ -457,8 +456,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.AI.Assistants.Tests.Runs.Get()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `TestId`, `RunId` |
 | Delete an assistant | `client.AI.Assistants.Delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `AssistantId` |
 | Get Canary Deploy | `client.AI.Assistants.CanaryDeploys.Get()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `AssistantId` |
-| Create Canary Deploy | `client.AI.Assistants.CanaryDeploys.New()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `Versions`, `AssistantId` |
-| Update Canary Deploy | `client.AI.Assistants.CanaryDeploys.Update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `Versions`, `AssistantId` |
+| Create Canary Deploy | `client.AI.Assistants.CanaryDeploys.New()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `AssistantId` |
+| Update Canary Deploy | `client.AI.Assistants.CanaryDeploys.Update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `AssistantId` |
 | Delete Canary Deploy | `client.AI.Assistants.CanaryDeploys.Delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `AssistantId` |
 | Assistant Sms Chat | `client.AI.Assistants.SendSMS()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `From`, `To`, `AssistantId` |
 | Clone Assistant | `client.AI.Assistants.Clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `AssistantId` |

--- a/providers/claude/plugin/skills/telnyx-ai-assistants-go/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-ai-assistants-go/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `Tools` | array[object] | The tools that the assistant can use. |
-| `ToolIds` | array[string] |  |
+| `Model` | string | ID of the model to use when `external_llm` is not set. |
+| `Tools` | array[object] | Deprecated for new integrations. |
+| `McpServers` | array[object] | MCP servers attached to the assistant. |
+| `ToolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `Description` | string |  |
 | `Greeting` | string | Text that the assistant will use to start the conversation. |
-| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `ExternalLlm` | object |  |
+| `FallbackConfig` | object |  |
 | `VoiceSettings` | object |  |
 | `Transcription` | object |  |
 | `TelephonySettings` | object |  |
@@ -165,9 +182,15 @@
 | `EnabledFeatures` | array[object] |  |
 | `InsightSettings` | object |  |
 | `PrivacySettings` | object |  |
-| `DynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `DynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `DynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `DynamicVariables` | object | Map of dynamic variables and their default values |
 | `WidgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `InterruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `Integrations` | array[object] | Connected integrations attached to the assistant. |
+| `ObservabilitySettings` | object |  |
+| `Tags` | array[string] | Tags associated with the assistant. |
+| `PostConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider — `client.AI.Assistants.Imports()`
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `Name` | string |  |
-| `Model` | string | ID of the model to use. |
+| `Model` | string | ID of the model to use when `external_llm` is not set. |
 | `Instructions` | string | System instructions for the assistant. |
-| `Tools` | array[object] | The tools that the assistant can use. |
-| `ToolIds` | array[string] |  |
+| `Tools` | array[object] | Deprecated for new integrations. |
+| `McpServers` | array[object] | MCP servers attached to the assistant. |
+| `ToolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `Description` | string |  |
 | `Greeting` | string | Text that the assistant will use to start the conversation. |
-| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `ExternalLlm` | object |  |
+| `FallbackConfig` | object |  |
 | `VoiceSettings` | object |  |
 | `Transcription` | object |  |
 | `TelephonySettings` | object |  |
@@ -228,10 +254,29 @@
 | `EnabledFeatures` | array[object] |  |
 | `InsightSettings` | object |  |
 | `PrivacySettings` | object |  |
-| `DynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `DynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `DynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `DynamicVariables` | object | Map of dynamic variables and their default values |
 | `WidgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `InterruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `Integrations` | array[object] | Connected integrations attached to the assistant. |
+| `ObservabilitySettings` | object |  |
+| `Tags` | array[string] | Tags associated with the assistant. |
+| `VersionName` | string | Human-readable name for the assistant version. |
+| `PostConversationSettings` | object | Configuration for post-conversation processing. |
 | `PromoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.AI.Assistants.CanaryDeploys.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Rules` | array[object] |  |
+
+### Update Canary Deploy — `client.AI.Assistants.CanaryDeploys.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Rules` | array[object] |  |
 
 ### Assistant Chat (BETA) — `client.AI.Assistants.Chat()`
 
@@ -254,6 +299,8 @@
 | `Text` | string | Required for sms scheduled events. |
 | `ConversationMetadata` | object | Metadata associated with the conversation. |
 | `DynamicVariables` | object | A map of dynamic variable names to values. |
+| `MaxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `RetryIntervalSecs` | integer |  |
 
 ### Test Assistant Tool — `client.AI.Assistants.Tools.Test()`
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `Name` | string |  |
-| `Model` | string | ID of the model to use. |
+| `Model` | string | ID of the model to use when `external_llm` is not set. |
 | `Instructions` | string | System instructions for the assistant. |
-| `Tools` | array[object] | The tools that the assistant can use. |
-| `ToolIds` | array[string] |  |
+| `Tools` | array[object] | Deprecated for new integrations. |
+| `McpServers` | array[object] | MCP servers attached to the assistant. |
+| `ToolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `Description` | string |  |
 | `Greeting` | string | Text that the assistant will use to start the conversation. |
-| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `ExternalLlm` | object |  |
+| `FallbackConfig` | object |  |
 | `VoiceSettings` | object |  |
 | `Transcription` | object |  |
 | `TelephonySettings` | object |  |
@@ -281,9 +331,16 @@
 | `EnabledFeatures` | array[object] |  |
 | `InsightSettings` | object |  |
 | `PrivacySettings` | object |  |
-| `DynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `DynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `DynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `DynamicVariables` | object | Map of dynamic variables and their default values |
 | `WidgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `InterruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `Integrations` | array[object] | Connected integrations attached to the assistant. |
+| `ObservabilitySettings` | object |  |
+| `Tags` | array[string] | Tags associated with the assistant. |
+| `VersionName` | string | Human-readable name for the assistant version. |
+| `PostConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server — `client.AI.McpServers.New()`
 

--- a/providers/claude/plugin/skills/telnyx-ai-assistants-java/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-ai-assistants-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -50,8 +50,8 @@ import com.telnyx.sdk.models.ai.assistants.AssistantCreateParams;
 import com.telnyx.sdk.models.ai.assistants.InferenceEmbedding;
 AssistantCreateParams params = AssistantCreateParams.builder()
     .instructions("You are a helpful assistant.")
-    .model("openai/gpt-4o")
     .name("my-resource")
+    .model("openai/gpt-4o")
     .build();
 InferenceEmbedding assistant = client.ai().assistants().create(params);
 ```
@@ -83,12 +83,11 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `toolIds` | array[string] | No |  |
-| `description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```java
 import com.telnyx.sdk.models.ai.assistants.AssistantCreateParams;
@@ -96,8 +95,8 @@ import com.telnyx.sdk.models.ai.assistants.InferenceEmbedding;
 
 AssistantCreateParams params = AssistantCreateParams.builder()
     .instructions("You are a helpful assistant.")
-    .model("openai/gpt-4o")
     .name("my-resource")
+    .model("openai/gpt-4o")
     .build();
 InferenceEmbedding assistant = client.ai().assistants().create(params);
 ```
@@ -216,7 +215,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### Update an assistant
 
@@ -227,10 +226,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistantId` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```java
 import com.telnyx.sdk.models.ai.assistants.AssistantUpdateParams;
@@ -245,7 +244,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### List assistants
 
@@ -269,7 +268,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Import assistants from external provider
 
@@ -303,7 +302,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Get All Tags
 
@@ -422,8 +421,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai().assistants().tests().runs().retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId`, `runId` |
 | Delete an assistant | `client.ai().assistants().delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Get Canary Deploy | `client.ai().assistants().canaryDeploys().retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Create Canary Deploy | `client.ai().assistants().canaryDeploys().create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistantId` |
-| Update Canary Deploy | `client.ai().assistants().canaryDeploys().update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistantId` |
+| Create Canary Deploy | `client.ai().assistants().canaryDeploys().create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId` |
+| Update Canary Deploy | `client.ai().assistants().canaryDeploys().update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistantId` |
 | Delete Canary Deploy | `client.ai().assistants().canaryDeploys().delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Assistant Sms Chat | `client.ai().assistants().sendSms()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistantId` |
 | Clone Assistant | `client.ai().assistants().clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId` |

--- a/providers/claude/plugin/skills/telnyx-ai-assistants-java/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-ai-assistants-java/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -165,9 +182,15 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider — `client.ai().assistants().imports()`
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -228,10 +254,29 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 | `promoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai().assistants().canaryDeploys().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai().assistants().canaryDeploys().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
 
 ### Assistant Chat (BETA) — `client.ai().assistants().chat()`
 
@@ -254,6 +299,8 @@
 | `text` | string | Required for sms scheduled events. |
 | `conversationMetadata` | object | Metadata associated with the conversation. |
 | `dynamicVariables` | object | A map of dynamic variable names to values. |
+| `maxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retryIntervalSecs` | integer |  |
 
 ### Test Assistant Tool — `client.ai().assistants().tools().test()`
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -281,9 +331,16 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server — `client.ai().mcpServers().create()`
 

--- a/providers/claude/plugin/skills/telnyx-ai-assistants-javascript/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-ai-assistants-javascript/SKILL.md
@@ -42,8 +42,8 @@ or authentication errors (401). Always handle errors in production code:
 try {
   const assistant = await client.ai.assistants.create({
     instructions: 'You are a helpful assistant.',
-    model: 'openai/gpt-4o',
     name: 'my-resource',
+      model: 'openai/gpt-4o',
   });
 } catch (err) {
   if (err instanceof Telnyx.APIConnectionError) {
@@ -87,18 +87,17 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `toolIds` | array[string] | No |  |
-| `description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const assistant = await client.ai.assistants.create({
   instructions: 'You are a helpful assistant.',
-  model: 'openai/gpt-4o',
   name: 'my-resource',
+    model: 'openai/gpt-4o',
 });
 
 console.log(assistant.id);
@@ -209,7 +208,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### Update an assistant
 
@@ -220,10 +219,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistantId` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const assistant = await client.ai.assistants.update('550e8400-e29b-41d4-a716-446655440000');
@@ -237,7 +236,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### List assistants
 
@@ -260,7 +259,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Import assistants from external provider
 
@@ -292,7 +291,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Get All Tags
 
@@ -409,8 +408,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId`, `runId` |
 | Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Get Canary Deploy | `client.ai.assistants.canaryDeploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Create Canary Deploy | `client.ai.assistants.canaryDeploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistantId` |
-| Update Canary Deploy | `client.ai.assistants.canaryDeploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistantId` |
+| Create Canary Deploy | `client.ai.assistants.canaryDeploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId` |
+| Update Canary Deploy | `client.ai.assistants.canaryDeploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistantId` |
 | Delete Canary Deploy | `client.ai.assistants.canaryDeploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Assistant Sms Chat | `client.ai.assistants.sendSMS()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistantId` |
 | Clone Assistant | `client.ai.assistants.clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId` |

--- a/providers/claude/plugin/skills/telnyx-ai-assistants-javascript/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-ai-assistants-javascript/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -165,9 +182,15 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider — `client.ai.assistants.imports()`
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -228,10 +254,29 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 | `promoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai.assistants.canaryDeploys.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai.assistants.canaryDeploys.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
 
 ### Assistant Chat (BETA) — `client.ai.assistants.chat()`
 
@@ -254,6 +299,8 @@
 | `text` | string | Required for sms scheduled events. |
 | `conversationMetadata` | object | Metadata associated with the conversation. |
 | `dynamicVariables` | object | A map of dynamic variable names to values. |
+| `maxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retryIntervalSecs` | integer |  |
 
 ### Test Assistant Tool — `client.ai.assistants.tools.test()`
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -281,9 +331,16 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server — `client.ai.mcpServers.create()`
 

--- a/providers/claude/plugin/skills/telnyx-ai-assistants-python/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-ai-assistants-python/SKILL.md
@@ -45,8 +45,8 @@ import telnyx
 try:
     assistant = client.ai.assistants.create(
         instructions="You are a helpful assistant.",
-        model="openai/gpt-4o",
         name="my-resource",
+        model="openai/gpt-4o",
     )
 except telnyx.APIConnectionError:
     print("Network error — check connectivity and retry")
@@ -87,18 +87,17 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `tool_ids` | array[string] | No |  |
-| `description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```python
 assistant = client.ai.assistants.create(
     instructions="You are a helpful assistant.",
-    model="openai/gpt-4o",
     name="my-resource",
+    model="openai/gpt-4o",
 )
 print(assistant.id)
 ```
@@ -210,7 +209,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### Update an assistant
 
@@ -221,10 +220,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistant_id` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```python
 assistant = client.ai.assistants.update(
@@ -239,7 +238,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### List assistants
 
@@ -261,7 +260,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Import assistants from external provider
 
@@ -292,7 +291,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Get All Tags
 
@@ -407,8 +406,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
 | Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Get Canary Deploy | `client.ai.assistants.canary_deploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
-| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistant_id` |
-| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistant_id` |
+| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
 | Delete Canary Deploy | `client.ai.assistants.canary_deploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Assistant Sms Chat | `client.ai.assistants.send_sms()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from_`, `to`, `assistant_id` |
 | Clone Assistant | `client.ai.assistants.clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |

--- a/providers/claude/plugin/skills/telnyx-ai-assistants-python/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-ai-assistants-python/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -165,9 +182,15 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider — `client.ai.assistants.imports()`
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -228,10 +254,29 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 | `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai.assistants.canary_deploys.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai.assistants.canary_deploys.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
 
 ### Assistant Chat (BETA) — `client.ai.assistants.chat()`
 
@@ -254,6 +299,8 @@
 | `text` | string | Required for sms scheduled events. |
 | `conversation_metadata` | object | Metadata associated with the conversation. |
 | `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
 
 ### Test Assistant Tool — `client.ai.assistants.tools.test()`
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -281,9 +331,16 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server — `client.ai.mcp_servers.create()`
 

--- a/providers/claude/plugin/skills/telnyx-ai-assistants-ruby/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-ai-assistants-ruby/SKILL.md
@@ -39,7 +39,7 @@ All API calls can fail with network errors, rate limits (429), validation errors
 or authentication errors (401). Always handle errors in production code:
 
 ```ruby
-assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", model: "openai/gpt-4o", name: "my-resource")
+assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", name: "my-resource", model: "openai/gpt-4o")
 puts(assistant)
 ```
 
@@ -70,16 +70,14 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `tool_ids` | array[string] | No |  |
-| `description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
-assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", model: "openai/gpt-4o", name: "my-resource")
-
+assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", name: "my-resource", model: "openai/gpt-4o")
 puts(assistant)
 ```
 
@@ -188,7 +186,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### Update an assistant
 
@@ -199,10 +197,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistant_id` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
 assistant = client.ai.assistants.update("550e8400-e29b-41d4-a716-446655440000")
@@ -216,7 +214,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### List assistants
 
@@ -239,7 +237,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Import assistants from external provider
 
@@ -268,7 +266,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Get All Tags
 
@@ -383,8 +381,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
 | Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Get Canary Deploy | `client.ai.assistants.canary_deploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
-| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistant_id` |
-| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistant_id` |
+| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
 | Delete Canary Deploy | `client.ai.assistants.canary_deploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Assistant Sms Chat | `client.ai.assistants.send_sms()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistant_id` |
 | Clone Assistant | `client.ai.assistants.clone_()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |

--- a/providers/claude/plugin/skills/telnyx-ai-assistants-ruby/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-ai-assistants-ruby/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -165,9 +182,15 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider — `client.ai.assistants.imports()`
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -228,10 +254,29 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 | `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai.assistants.canary_deploys.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai.assistants.canary_deploys.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
 
 ### Assistant Chat (BETA) — `client.ai.assistants.chat()`
 
@@ -254,6 +299,8 @@
 | `text` | string | Required for sms scheduled events. |
 | `conversation_metadata` | object | Metadata associated with the conversation. |
 | `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
 
 ### Test Assistant Tool — `client.ai.assistants.tools.test_()`
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -281,9 +331,16 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server — `client.ai.mcp_servers.create()`
 

--- a/providers/claude/plugin/skills/telnyx-messaging-curl/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-messaging-curl/SKILL.md
@@ -399,6 +399,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsapp_message` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```bash
 curl \

--- a/providers/claude/plugin/skills/telnyx-messaging-curl/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-messaging-curl/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/providers/claude/plugin/skills/telnyx-messaging-go/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-messaging-go/SKILL.md
@@ -416,6 +416,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `WhatsappMessage` | object | Yes |  |
 | `Type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `WebhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `MessagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```go
 	response, err := client.Messages.SendWhatsapp(context.Background(), telnyx.MessageSendWhatsappParams{

--- a/providers/claude/plugin/skills/telnyx-messaging-go/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-messaging-go/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `Type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `WebhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `MessagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.MessagingHostedNumbers.Update()`
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/providers/claude/plugin/skills/telnyx-messaging-java/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-messaging-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -420,6 +420,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsappMessage` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```java
 import com.telnyx.sdk.models.messages.MessageSendWhatsappParams;

--- a/providers/claude/plugin/skills/telnyx-messaging-java/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-messaging-java/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messagingHostedNumbers().update()`
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/providers/claude/plugin/skills/telnyx-messaging-javascript/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-messaging-javascript/SKILL.md
@@ -392,6 +392,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsappMessage` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```javascript
 const response = await client.messages.sendWhatsapp({

--- a/providers/claude/plugin/skills/telnyx-messaging-javascript/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-messaging-javascript/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messagingHostedNumbers.update()`
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/providers/claude/plugin/skills/telnyx-messaging-python/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-messaging-python/SKILL.md
@@ -385,6 +385,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsapp_message` | object | Yes |  |
 | `type_` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```python
 response = client.messages.send_whatsapp(

--- a/providers/claude/plugin/skills/telnyx-messaging-python/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-messaging-python/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `type_` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messaging_hosted_numbers.update()`
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/providers/claude/plugin/skills/telnyx-messaging-ruby/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-messaging-ruby/SKILL.md
@@ -353,6 +353,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsapp_message` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```ruby
 response = client.messages.send_whatsapp(from: "+13125551234", to: "+13125551234", whatsapp_message: {})

--- a/providers/claude/plugin/skills/telnyx-messaging-ruby/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-messaging-ruby/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messaging_hosted_numbers.update()`
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/providers/claude/plugin/skills/telnyx-numbers-java/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-numbers-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -278,7 +278,6 @@ Create or provision an additional resource when the core tasks do not cover this
 
 ```java
 import com.telnyx.sdk.models.advancedorders.AdvancedOrder;
-import com.telnyx.sdk.models.advancedorders.AdvancedOrderCreateParams;
 import com.telnyx.sdk.models.advancedorders.AdvancedOrderCreateResponse;
 
 AdvancedOrder params = AdvancedOrder.builder().build();

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/curl/10dlc.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/curl/10dlc.md
@@ -55,8 +55,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -207,7 +207,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `description` | string | Description of the event. |
 | `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -358,7 +358,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -398,3 +398,471 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# 10DLC (curl) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Brands, List Campaigns, List shared partner campaigns, List Shared Campaigns, List phone number campaigns
+
+| Field | Type |
+|-------|------|
+| `page` | integer |
+| `records` | array[object] |
+| `totalRecords` | integer |
+
+**Returned by:** Create Brand, Update Brand, Revet Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Get Brand Feedback By Id
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `category` | array[object] |
+
+**Returned by:** Get Brand SMS OTP Status, Get Brand SMS OTP Status by Brand ID
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `deliveryStatus` | string |
+| `deliveryStatusDate` | date-time |
+| `deliveryStatusDetails` | string |
+| `mobilePhone` | string |
+| `referenceId` | string |
+| `requestDate` | date-time |
+| `verifyDate` | date-time |
+
+**Returned by:** Get Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `assignedCampaignsCount` | number |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Order Brand External Vetting, Import External Vetting Record
+
+| Field | Type |
+|-------|------|
+| `createDate` | string |
+| `evpId` | string |
+| `vettedDate` | string |
+| `vettingClass` | string |
+| `vettingId` | string |
+| `vettingScore` | integer |
+| `vettingToken` | string |
+
+**Returned by:** Trigger Brand SMS OTP
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `referenceId` | string |
+
+**Returned by:** Get Campaign Cost
+
+| Field | Type |
+|-------|------|
+| `campaignUsecase` | string |
+| `description` | string |
+| `monthlyCost` | string |
+| `upFrontCost` | string |
+
+**Returned by:** Get campaign, Update campaign, Submit Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `autoRenewal` | boolean |
+| `billedDate` | string |
+| `brandDisplayName` | string |
+| `brandId` | string |
+| `campaignId` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createDate` | string |
+| `cspId` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isTMobileNumberPoolingEnabled` | boolean |
+| `isTMobileRegistered` | boolean |
+| `isTMobileSuspended` | boolean |
+| `messageFlow` | string |
+| `mock` | boolean |
+| `nextRenewalOrExpirationDate` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `referenceId` | string |
+| `resellerId` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `status` | string |
+| `subUsecases` | array[string] |
+| `submissionStatus` | enum: CREATED, FAILED, PENDING |
+| `subscriberHelp` | boolean |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `usecase` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Deactivate campaign
+
+| Field | Type |
+|-------|------|
+| `message` | string |
+| `record_type` | string |
+| `time` | number |
+
+**Returned by:** Submit campaign appeal for manual review
+
+| Field | Type |
+|-------|------|
+| `appealed_at` | date-time |
+
+**Returned by:** Get Campaign Mno Metadata
+
+| Field | Type |
+|-------|------|
+| `10999` | object |
+
+**Returned by:** Get Sharing Status
+
+| Field | Type |
+|-------|------|
+| `sharedByMe` | object |
+| `sharedWithMe` | object |
+
+**Returned by:** Qualify By Usecase
+
+| Field | Type |
+|-------|------|
+| `annualFee` | number |
+| `maxSubUsecases` | integer |
+| `minSubUsecases` | integer |
+| `mnoMetadata` | object |
+| `monthlyFee` | number |
+| `quarterlyFee` | number |
+| `usecase` | string |
+
+**Returned by:** Get Single Shared Campaign, Update Single Shared Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `assignedPhoneNumbersCount` | number |
+| `brandDisplayName` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createdAt` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isNumberPoolingEnabled` | boolean |
+| `messageFlow` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `subUsecases` | array[string] |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `updatedAt` | string |
+| `usecase` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Assign Messaging Profile To Campaign
+
+| Field | Type |
+|-------|------|
+| `campaignId` | string |
+| `messagingProfileId` | string |
+| `taskId` | string |
+| `tcrCampaignId` | string |
+
+**Returned by:** Get Assignment Task Status
+
+| Field | Type |
+|-------|------|
+| `createdAt` | date-time |
+| `status` | string |
+| `taskId` | string |
+| `updatedAt` | date-time |
+
+**Returned by:** Get Phone Number Status
+
+| Field | Type |
+|-------|------|
+| `records` | array[object] |
+
+**Returned by:** Create New Phone Number Campaign, Get Single Phone Number Campaign, Create New Phone Number Campaign, Delete Phone Number Campaign
+
+| Field | Type |
+|-------|------|
+| `assignmentStatus` | enum: FAILED_ASSIGNMENT, PENDING_ASSIGNMENT, ASSIGNED, PENDING_UNASSIGNMENT, FAILED_UNASSIGNMENT |
+| `brandId` | string |
+| `campaignId` | string |
+| `createdAt` | string |
+| `failureReasons` | string |
+| `phoneNumber` | string |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `telnyxCampaignId` | string |
+| `updatedAt` | string |
+
+## Optional Parameters
+
+### Create Brand
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `companyName` | string | (Required for Non-profit/private/public) Legal company name. |
+| `firstName` | string | First name of business contact. |
+| `lastName` | string | Last name of business contact. |
+| `ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `phone` | string | Valid phone number in e.164 international format. |
+| `street` | string | Street number and name. |
+| `city` | string | City name |
+| `state` | string | State. |
+| `postalCode` | string | Postal codes. |
+| `stockSymbol` | string | (Required for public company) stock symbol. |
+| `stockExchange` | object | (Required for public company) stock exchange. |
+| `ipAddress` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `website` | string | Brand website URL. |
+| `isReseller` | boolean |  |
+| `mock` | boolean | Mock brand for testing purposes. |
+| `mobilePhone` | string | Valid mobile phone number in e.164 international format. |
+| `businessContactEmail` | string | Business contact email. |
+| `webhookURL` | string | Webhook URL for brand status updates. |
+| `webhookFailoverURL` | string | Webhook failover URL for brand status updates. |
+
+### Update Brand
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `companyName` | string | (Required for Non-profit/private/public) Legal company name. |
+| `firstName` | string | First name of business contact. |
+| `lastName` | string | Last name of business contact. |
+| `ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `phone` | string | Valid phone number in e.164 international format. |
+| `street` | string | Street number and name. |
+| `city` | string | City name |
+| `state` | string | State. |
+| `postalCode` | string | Postal codes. |
+| `stockSymbol` | string | (Required for public company) stock symbol. |
+| `stockExchange` | object | (Required for public company) stock exchange. |
+| `ipAddress` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `website` | string | Brand website URL. |
+| `altBusinessIdType` | enum (NONE, DUNS, GIIN, LEI) | An enumeration. |
+| `isReseller` | boolean |  |
+| `identityStatus` | enum (VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED) | The verification status of an active brand |
+| `businessContactEmail` | string | Business contact email. |
+| `webhookURL` | string | Webhook URL for brand status updates. |
+| `webhookFailoverURL` | string | Webhook failover URL for brand status updates. |
+| `altBusinessId` | string (UUID) | Alternate business identifier such as DUNS, LEI, or GIIN |
+
+### Import External Vetting Record
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `vettingToken` | string | Required by some providers for vetting record confirmation. |
+
+### Update campaign
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `resellerId` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `sample1` | string | Message sample. |
+| `sample2` | string | Message sample. |
+| `sample3` | string | Message sample. |
+| `sample4` | string | Message sample. |
+| `sample5` | string | Message sample. |
+| `messageFlow` | string | Message flow description. |
+| `helpMessage` | string | Help message of the campaign. |
+| `autoRenewal` | boolean | Help message of the campaign. |
+| `webhookURL` | string | Webhook to which campaign status updates are sent. |
+| `webhookFailoverURL` | string | Webhook failover to which campaign status updates are sent. |
+
+### Submit Campaign
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ageGated` | boolean | Age gated message content in campaign. |
+| `autoRenewal` | boolean | Campaign subscription auto-renewal option. |
+| `directLending` | boolean | Direct lending or loan arrangement |
+| `embeddedLink` | boolean | Does message generated by the campaign include URL link in SMS? |
+| `embeddedPhone` | boolean | Does message generated by the campaign include phone number in SMS? |
+| `helpKeywords` | string | Subscriber help keywords. |
+| `helpMessage` | string | Help message of the campaign. |
+| `messageFlow` | string | Message flow description. |
+| `mnoIds` | array[integer] | Submit campaign to given list of MNOs by MNO's network ID. |
+| `numberPool` | boolean | Does campaign utilize pool of phone numbers? |
+| `optinKeywords` | string | Subscriber opt-in keywords. |
+| `optinMessage` | string | Subscriber opt-in message. |
+| `optoutKeywords` | string | Subscriber opt-out keywords. |
+| `optoutMessage` | string | Subscriber opt-out message. |
+| `referenceId` | string (UUID) | Caller supplied campaign reference ID. |
+| `resellerId` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `sample1` | string | Message sample. |
+| `sample2` | string | Message sample. |
+| `sample3` | string | Message sample. |
+| `sample4` | string | Message sample. |
+| `sample5` | string | Message sample. |
+| `subUsecases` | array[string] | Campaign sub-usecases. |
+| `subscriberHelp` | boolean | Does campaign responds to help keyword(s)? |
+| `subscriberOptin` | boolean | Does campaign require subscriber to opt-in before SMS is sent to subscriber? |
+| `subscriberOptout` | boolean | Does campaign support subscriber opt-out keyword(s)? |
+| `tag` | array[string] | Tags to be set on the Campaign. |
+| `termsAndConditions` | boolean | Is terms and conditions accepted? |
+| `privacyPolicyLink` | string | Link to the campaign's privacy policy. |
+| `termsAndConditionsLink` | string | Link to the campaign's terms and conditions. |
+| `embeddedLinkSample` | string | Sample of an embedded link that will be sent to subscribers. |
+| `webhookURL` | string | Webhook to which campaign status updates are sent. |
+| `webhookFailoverURL` | string | Failover webhook to which campaign status updates are sent. |
+
+### Update Single Shared Campaign
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `webhookURL` | string | Webhook to which campaign status updates are sent. |
+| `webhookFailoverURL` | string | Webhook failover to which campaign status updates are sent. |
+
+### Assign Messaging Profile To Campaign
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `tcrCampaignId` | string (UUID) | The TCR ID of the shared campaign you want to link to the specified messaging... |
+| `campaignId` | string (UUID) | The ID of the campaign you want to link to the specified messaging profile. |
+
+## Webhook Payload Fields
+
+### `campaignStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `brandId` | string | Brand ID associated with the campaign. |
+| `campaignId` | string | The ID of the campaign. |
+| `createDate` | string | Unix timestamp when campaign was created. |
+| `cspId` | string | Alphanumeric identifier of the CSP associated with this campaign. |
+| `isTMobileRegistered` | boolean | Indicates whether the campaign is registered with T-Mobile. |
+| `type` | enum: TELNYX_EVENT, REGISTRATION, MNO_REVIEW, TELNYX_REVIEW, NUMBER_POOL_PROVISIONED, NUMBER_POOL_DEPROVISIONED, TCR_EVENT, VERIFIED |  |
+| `description` | string | Description of the event. |
+| `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/curl/ai-assistants.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/curl/ai-assistants.md
@@ -27,10 +27,10 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-  "name": "my-resource",
-  "model": "openai/gpt-4o",
-  "instructions": "You are a helpful assistant."
-}' \
+      "name": "my-resource",
+      "instructions": "You are a helpful assistant.",
+      "model": "openai/gpt-4o"
+  }' \
   "https://api.telnyx.com/v2/ai/assistants"
 ```
 
@@ -48,7 +48,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -61,12 +61,11 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `description` | string | No |  |
-| `greeting` | string | No | Text that the assistant will use to start the conversation. |
-| ... | | | +11 optional params in the API Details section below |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in the API Details section below |
 
 ```bash
 curl \
@@ -74,10 +73,10 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-  "name": "my-resource",
-  "model": "openai/gpt-4o",
-  "instructions": "You are a helpful assistant."
-}' \
+      "name": "my-resource",
+      "instructions": "You are a helpful assistant.",
+      "model": "openai/gpt-4o"
+  }' \
   "https://api.telnyx.com/v2/ai/assistants"
 ```
 
@@ -195,7 +194,7 @@ Primary response fields:
 - `.data.created_at`
 - `.data.description`
 - `.data.dynamic_variables`
-- `.data.dynamic_variables_webhook_url`
+- `.data.dynamic_variables_webhook_timeout_ms`
 
 ### Update an assistant
 
@@ -206,10 +205,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistant_id` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +15 optional params in the API Details section below |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in the API Details section below |
 
 ```bash
 curl \
@@ -225,7 +224,7 @@ Primary response fields:
 - `.data.created_at`
 - `.data.description`
 - `.data.dynamic_variables`
-- `.data.dynamic_variables_webhook_url`
+- `.data.dynamic_variables_webhook_timeout_ms`
 
 ### List assistants
 
@@ -246,7 +245,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Import assistants from external provider
 
@@ -281,7 +280,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Get All Tags
 
@@ -375,7 +374,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -388,8 +387,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | HTTP only | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
 | Delete an assistant | HTTP only | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Get Canary Deploy | HTTP only | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
-| Create Canary Deploy | HTTP only | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistant_id` |
-| Update Canary Deploy | HTTP only | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistant_id` |
+| Create Canary Deploy | HTTP only | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | HTTP only | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
 | Delete Canary Deploy | HTTP only | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Assistant Sms Chat | HTTP only | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistant_id` |
 | Clone Assistant | HTTP only | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |
@@ -400,6 +399,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Add Assistant Tag | HTTP only | `POST /ai/assistants/{assistant_id}/tags` | Create or provision an additional resource when the core tasks do not cover this flow. | `tag`, `assistant_id` |
 | Remove Assistant Tag | HTTP only | `DELETE /ai/assistants/{assistant_id}/tags/{tag}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `tag` |
 | Get assistant texml | HTTP only | `GET /ai/assistants/{assistant_id}/texml` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Add Assistant Tool | HTTP only | `PUT /ai/assistants/{assistant_id}/tools/{tool_id}` | Modify an existing resource without recreating it. | `assistant_id`, `tool_id` |
+| Remove Assistant Tool | HTTP only | `DELETE /ai/assistants/{assistant_id}/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `tool_id` |
 | Test Assistant Tool | HTTP only | `POST /ai/assistants/{assistant_id}/tools/{tool_id}/test` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id`, `tool_id` |
 | Get all versions of an assistant | HTTP only | `GET /ai/assistants/{assistant_id}/versions` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
 | Get a specific assistant version | HTTP only | `GET /ai/assistants/{assistant_id}/versions/{version_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id`, `version_id` |
@@ -411,7 +412,398 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get MCP Server | HTTP only | `GET /ai/mcp_servers/{mcp_server_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `mcp_server_id` |
 | Update MCP Server | HTTP only | `PUT /ai/mcp_servers/{mcp_server_id}` | Modify an existing resource without recreating it. | `mcp_server_id` |
 | Delete MCP Server | HTTP only | `DELETE /ai/mcp_servers/{mcp_server_id}` | Remove, detach, or clean up an existing resource. | `mcp_server_id` |
+| List Tools | HTTP only | `GET /ai/tools` | Inspect available resources or choose an existing resource before mutating it. | None |
+| Create Tool | HTTP only | `POST /ai/tools` | Create or provision an additional resource when the core tasks do not cover this flow. | `type`, `display_name` |
+| Get Tool | HTTP only | `GET /ai/tools/{tool_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `tool_id` |
+| Update Tool | HTTP only | `PATCH /ai/tools/{tool_id}` | Modify an existing resource without recreating it. | `tool_id` |
+| Delete Tool | HTTP only | `DELETE /ai/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `tool_id` |
 
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# AI Assistants (curl) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+
+## Response Schemas
+
+**Returned by:** List assistants, Create an assistant, Import assistants from external provider, Get an assistant, Update an assistant, Clone Assistant, Get all versions of an assistant, Get a specific assistant version, Update a specific assistant version, Promote an assistant version to main
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
+| `dynamic_variables_webhook_url` | string |
+| `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
+| `greeting` | string |
+| `id` | string |
+| `import_metadata` | object |
+| `insight_settings` | object |
+| `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
+| `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
+| `messaging_settings` | object |
+| `model` | string |
+| `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
+| `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
+| `telephony_settings` | object |
+| `tools` | array[object] |
+| `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
+| `voice_settings` | object |
+| `widget_settings` | object |
+
+**Returned by:** Get All Tags, Add Assistant Tag, Remove Assistant Tag
+
+| Field | Type |
+|-------|------|
+| `tags` | array[string] |
+
+**Returned by:** List assistant tests with pagination, Create a new assistant test, Get assistant test by ID, Update an assistant test
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `destination` | string |
+| `instructions` | string |
+| `max_duration_seconds` | integer |
+| `name` | string |
+| `rubric` | array[object] |
+| `telnyx_conversation_channel` | object |
+| `test_id` | uuid |
+| `test_suite` | string |
+
+**Returned by:** Get all test suite names
+
+| Field | Type |
+|-------|------|
+| `data` | array[string] |
+
+**Returned by:** Get test suite run history, Get test run history for a specific test, Trigger a manual test run, Get specific test run details
+
+| Field | Type |
+|-------|------|
+| `completed_at` | date-time |
+| `conversation_id` | string |
+| `conversation_insights_id` | string |
+| `created_at` | date-time |
+| `detail_status` | array[object] |
+| `logs` | string |
+| `run_id` | uuid |
+| `status` | enum: pending, starting, running, passed, failed, error |
+| `test_id` | uuid |
+| `test_suite_run_id` | uuid |
+| `triggered_by` | string |
+| `updated_at` | date-time |
+
+**Returned by:** Delete an assistant
+
+| Field | Type |
+|-------|------|
+| `deleted` | boolean |
+| `id` | string |
+| `object` | string |
+
+**Returned by:** Get Canary Deploy, Create Canary Deploy, Update Canary Deploy
+
+| Field | Type |
+|-------|------|
+| `assistant_id` | string |
+| `created_at` | date-time |
+| `rules` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Assistant Chat (BETA)
+
+| Field | Type |
+|-------|------|
+| `content` | string |
+
+**Returned by:** Assistant Sms Chat
+
+| Field | Type |
+|-------|------|
+| `conversation_id` | string |
+
+**Returned by:** List scheduled events
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Test Assistant Tool
+
+| Field | Type |
+|-------|------|
+| `content_type` | string |
+| `request` | object |
+| `response` | string |
+| `status_code` | integer |
+| `success` | boolean |
+
+**Returned by:** Create MCP Server, Get MCP Server, Update MCP Server
+
+| Field | Type |
+|-------|------|
+| `allowed_tools` | array \| null |
+| `api_key_ref` | string \| null |
+| `created_at` | date-time |
+| `id` | string |
+| `name` | string |
+| `type` | string |
+| `url` | string |
+
+**Returned by:** List Tools, Create Tool, Get Tool, Update Tool
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `display_name` | string |
+| `id` | string |
+| `timeout_ms` | integer |
+| `tool_definition` | object |
+| `type` | string |
+
+## Optional Parameters
+
+### Create an assistant
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
+| `transcription` | object |  |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+
+### Import assistants from external provider
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `import_ids` | array[string] | Optional list of assistant IDs to import from the external provider. |
+
+### Create a new assistant test
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `description` | string | Optional detailed description of what this test evaluates and its purpose. |
+| `telnyx_conversation_channel` | object | The communication channel through which the test will be conducted. |
+| `max_duration_seconds` | integer | Maximum duration in seconds that the test conversation should run before timi... |
+| `test_suite` | string | Optional test suite name to group related tests together. |
+
+### Trigger test suite execution
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `destination_version_id` | string (UUID) | Optional assistant version ID to use for all test runs in this suite. |
+
+### Update an assistant test
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | Updated name for the assistant test. |
+| `description` | string | Updated description of the test's purpose and evaluation criteria. |
+| `telnyx_conversation_channel` | enum (phone_call, web_call, sms_chat, web_chat) |  |
+| `destination` | string | Updated target destination for test conversations. |
+| `max_duration_seconds` | integer | Updated maximum test duration in seconds. |
+| `test_suite` | string | Updated test suite assignment for better organization. |
+| `instructions` | string | Updated test scenario instructions and objectives. |
+| `rubric` | array[object] | Updated evaluation criteria for assessing assistant performance. |
+
+### Trigger a manual test run
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `destination_version_id` | string (UUID) | Optional assistant version ID to use for this test run. |
+
+### Update an assistant
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `instructions` | string | System instructions for the assistant. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
+| `transcription` | object |  |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+| `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Assistant Chat (BETA)
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | The optional display name of the user sending the message |
+
+### Assistant Sms Chat
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string |  |
+| `conversation_metadata` | object |  |
+| `should_create_conversation` | boolean |  |
+
+### Create a scheduled event
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Required for sms scheduled events. |
+| `conversation_metadata` | object | Metadata associated with the conversation. |
+| `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
+
+### Test Assistant Tool
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `arguments` | object | Key-value arguments to use for the webhook test |
+| `dynamic_variables` | object | Key-value dynamic variables to use for the webhook test |
+
+### Update a specific assistant version
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `instructions` | string | System instructions for the assistant. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
+| `transcription` | object |  |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+
+### Create MCP Server
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `api_key_ref` | string |  |
+| `allowed_tools` | array[string] |  |
+
+### Update MCP Server
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `name` | string |  |
+| `type` | string |  |
+| `url` | string (URL) |  |
+| `api_key_ref` | string |  |
+| `allowed_tools` | array[string] |  |
+| `created_at` | string (date-time) |  |
+
+### Create Tool
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `function` | object |  |
+| `retrieval` | object |  |
+| `handoff` | object |  |
+| `invite` | object |  |
+| `webhook` | object |  |
+| `timeout_ms` | integer |  |
+
+### Update Tool
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type` | string |  |
+| `display_name` | string |  |
+| `function` | object |  |
+| `retrieval` | object |  |
+| `handoff` | object |  |
+| `invite` | object |  |
+| `webhook` | object |  |
+| `timeout_ms` | integer |  |

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/curl/messaging.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/curl/messaging.md
@@ -54,8 +54,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -183,7 +183,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.media` | array[object] |  |
 | `data.record_type` | enum: event | Identifies the type of the resource. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -386,6 +386,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsapp_message` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```bash
 curl \
@@ -413,7 +414,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -447,3 +448,425 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Messaging (curl) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List alphanumeric sender IDs, Create an alphanumeric sender ID, Retrieve an alphanumeric sender ID, Delete an alphanumeric sender ID, List alphanumeric sender IDs for a messaging profile
+
+| Field | Type |
+|-------|------|
+| `alphanumeric_sender_id` | string |
+| `id` | uuid |
+| `messaging_profile_id` | uuid |
+| `organization_id` | string |
+| `record_type` | enum: alphanumeric_sender_id |
+| `us_long_code_fallback` | string |
+
+**Returned by:** Send a message, Send a message using an alphanumeric sender ID, Retrieve group MMS messages, Send a group MMS message, Send a long code message, Send a message using number pool, Schedule a message, Send a short code message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `wait_seconds` | float |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** Send a WhatsApp message
+
+| Field | Type |
+|-------|------|
+| `body` | object |
+| `direction` | string |
+| `encoding` | string |
+| `from` | object |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `organization_id` | string |
+| `received_at` | date-time |
+| `record_type` | string |
+| `to` | array[object] |
+| `type` | string |
+| `wait_seconds` | float |
+
+**Returned by:** Retrieve a message, Get detailed messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Cancel a scheduled message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** List messaging hosted numbers, Retrieve a messaging hosted number, Update a messaging hosted number
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `eligible_messaging_products` | array[string] |
+| `features` | object |
+| `health` | object |
+| `id` | string |
+| `messaging_product` | string |
+| `messaging_profile_id` | string \| null |
+| `organization_id` | string |
+| `phone_number` | string |
+| `record_type` | enum: messaging_phone_number, messaging_settings |
+| `tags` | array[string] |
+| `traffic_type` | string |
+| `type` | enum: long-code, toll-free, short-code, longcode, tollfree, shortcode |
+| `updated_at` | date-time |
+
+**Returned by:** List opt-outs
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `from` | string |
+| `keyword` | string \| null |
+| `messaging_profile_id` | string \| null |
+| `to` | string |
+
+**Returned by:** List high-level messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Regenerate messaging profile secret
+
+| Field | Type |
+|-------|------|
+| `ai_assistant_id` | string \| null |
+| `alpha_sender` | string \| null |
+| `created_at` | date-time |
+| `daily_spend_limit` | string |
+| `daily_spend_limit_enabled` | boolean |
+| `enabled` | boolean |
+| `health_webhook_url` | url |
+| `id` | uuid |
+| `mms_fall_back_to_sms` | boolean |
+| `mms_transcoding` | boolean |
+| `mobile_only` | boolean |
+| `name` | string |
+| `number_pool_settings` | object \| null |
+| `organization_id` | string |
+| `record_type` | enum: messaging_profile |
+| `redaction_enabled` | boolean |
+| `redaction_level` | integer |
+| `resource_group_id` | string \| null |
+| `smart_encoding` | boolean |
+| `updated_at` | date-time |
+| `url_shortener_settings` | object \| null |
+| `v1_secret` | string |
+| `webhook_api_version` | enum: 1, 2, 2010-04-01 |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+| `whitelisted_destinations` | array[string] |
+
+**Returned by:** List Auto-Response Settings, Create auto-response setting, Get Auto-Response Setting, Update Auto-Response Setting
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `id` | string |
+| `keywords` | array[string] |
+| `op` | enum: start, stop, info |
+| `resp_text` | string |
+| `updated_at` | date-time |
+
+## Optional Parameters
+
+### Create an alphanumeric sender ID
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `us_long_code_fallback` | string | A US long code number to use as fallback when sending to US destinations. |
+
+### Send a message
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using an alphanumeric sender ID
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `webhook_url` | string (URL) | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | If true, use the messaging profile's webhook settings. |
+
+### Send a group MMS message
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+
+### Send a long code message
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using number pool
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Schedule a message
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+
+### Send a short code message
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a WhatsApp message
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
+
+### Update a messaging hosted number
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `messaging_profile_id` | string (UUID) | Configure the messaging profile this phone number is assigned to:
+
+* Omit thi... |
+| `messaging_product` | string | Configure the messaging product for this number:
+
+* Omit this field or set it... |
+| `tags` | array[string] | Tags to set on this phone number. |
+
+### Create auto-response setting
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `resp_text` | string |  |
+
+### Update Auto-Response Setting
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `resp_text` | string |  |
+
+## Webhook Payload Fields
+
+### `deliveryUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.sent, message.finalized | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: outbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | uuid | The id of the organization the messaging profile belongs to. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Subject of multimedia message |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | ISO 8601 formatted date indicating when the message was sent. |
+| `data.payload.completed_at` | date-time | ISO 8601 formatted date indicating when the message was finalized. |
+| `data.payload.valid_until` | date-time | Message must be out of the queue by this time or else it will be discarded and marked as 'sending_failed'. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+| `data.payload.smart_encoding_applied` | boolean | Indicates whether smart encoding was applied to this message. |
+| `data.payload.wait_seconds` | float | Seconds the message is queued due to rate limiting before being sent to the carrier. |
+| `meta.attempt` | integer | Number of attempts to deliver the webhook event. |
+| `meta.delivered_to` | url | The webhook URL the event was delivered to. |
+
+### `inboundMessage`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.received | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: inbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Message subject. |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | Not used for inbound messages. |
+| `data.payload.completed_at` | date-time | Not used for inbound messages. |
+| `data.payload.valid_until` | date-time | Not used for inbound messages. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+
+### `replacedLinkClick`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | string | Identifies the type of the resource. |
+| `data.url` | string | The original link that was sent in the message. |
+| `data.to` | string | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or short code). |
+| `data.message_id` | uuid | The message ID associated with the clicked link. |
+| `data.time_clicked` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+
+### Field Type Notes
+
+- `from` in responses/webhooks: object with sub-fields `phone_number` (string), `carrier` (string), `line_type` (string)
+- `to` in responses/webhooks: array of objects, each with `phone_number` (string), `carrier` (string), `line_type` (string), `status` (string)
+- `cost`: object with `amount` (string, decimal), `currency` (string, e.g., 'USD')

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/curl/numbers.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/curl/numbers.md
@@ -39,7 +39,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -352,7 +352,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -402,3 +402,433 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Numbers (curl) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Advanced Orders, Create Advanced Order, Update Advanced Order, Get Advanced Order
+
+| Field | Type |
+|-------|------|
+| `area_code` | string |
+| `comments` | string |
+| `country_code` | string |
+| `customer_reference` | string |
+| `features` | array[object] |
+| `id` | uuid |
+| `orders` | array[string] |
+| `phone_number_type` | object |
+| `quantity` | integer |
+| `requirement_group_id` | uuid |
+| `status` | object |
+
+**Returned by:** List available phone number blocks
+
+| Field | Type |
+|-------|------|
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `range` | integer |
+| `record_type` | enum: available_phone_number_block |
+| `region_information` | array[object] |
+
+**Returned by:** List available phone numbers
+
+| Field | Type |
+|-------|------|
+| `best_effort` | boolean |
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `quickship` | boolean |
+| `record_type` | enum: available_phone_number |
+| `region_information` | array[object] |
+| `reservable` | boolean |
+| `vanity_format` | string |
+
+**Returned by:** Retrieve all comments
+
+| Field | Type |
+|-------|------|
+| `body` | string |
+| `comment_record_id` | uuid |
+| `comment_record_type` | enum: sub_number_order, requirement_group |
+| `commenter` | string |
+| `commenter_type` | enum: admin, user |
+| `created_at` | date-time |
+| `id` | uuid |
+| `read_at` | date-time |
+| `updated_at` | date-time |
+
+**Returned by:** Create a comment, Retrieve a comment, Mark a comment as read, Get country coverage
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Get coverage for a specific country
+
+| Field | Type |
+|-------|------|
+| `code` | string |
+| `features` | array[string] |
+| `international_sms` | boolean |
+| `inventory_coverage` | boolean |
+| `local` | object |
+| `mobile` | object |
+| `national` | object |
+| `numbers` | boolean |
+| `p2p` | boolean |
+| `phone_number_type` | array[string] |
+| `quickship` | boolean |
+| `region` | string \| null |
+| `reservable` | boolean |
+| `shared_cost` | object |
+| `toll_free` | object |
+
+**Returned by:** List customer service records, Create a customer service record, Get a customer service record
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `error_message` | string \| null |
+| `id` | uuid |
+| `phone_number` | string |
+| `record_type` | string |
+| `result` | object \| null |
+| `status` | enum: pending, completed, failed |
+| `updated_at` | date-time |
+| `webhook_url` | string |
+
+**Returned by:** Verify CSR phone number coverage
+
+| Field | Type |
+|-------|------|
+| `additional_data_required` | array[string] |
+| `has_csr_coverage` | boolean |
+| `phone_number` | string |
+| `reason` | string |
+| `record_type` | string |
+
+**Returned by:** List inexplicit number orders, Create an inexplicit number order, Retrieve an inexplicit number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `ordering_groups` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Create an inventory coverage request
+
+| Field | Type |
+|-------|------|
+| `administrative_area` | string |
+| `advance_requirements` | boolean |
+| `count` | integer |
+| `coverage_type` | enum: number, block |
+| `group` | string |
+| `group_type` | string |
+| `number_range` | integer |
+| `number_type` | enum: did, toll-free |
+| `phone_number_type` | enum: local, toll_free, national, landline, shared_cost, mobile |
+| `record_type` | string |
+
+**Returned by:** List mobile network operators
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `id` | uuid |
+| `mcc` | string |
+| `mnc` | string |
+| `name` | string |
+| `network_preferences_enabled` | boolean |
+| `record_type` | string |
+| `tadig` | string |
+
+**Returned by:** List network coverage locations
+
+| Field | Type |
+|-------|------|
+| `available_services` | array[object] |
+| `location` | object |
+| `record_type` | string |
+
+**Returned by:** List number block orders, Create a number block order, Retrieve a number block order
+
+| Field | Type |
+|-------|------|
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers_count` | integer |
+| `range` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `starting_number` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve a list of phone numbers associated to orders, Retrieve a single phone number within a number order., Update requirements for a single phone number within a number order.
+
+| Field | Type |
+|-------|------|
+| `bundle_id` | uuid |
+| `country_code` | string |
+| `deadline` | date-time |
+| `id` | uuid |
+| `is_block_number` | boolean |
+| `locality` | string |
+| `order_request_id` | uuid |
+| `phone_number` | string |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `requirements_status` | enum: pending, approved, cancelled, deleted, requirement-info-exception, requirement-info-pending, requirement-info-under-review |
+| `status` | enum: pending, success, failure |
+| `sub_number_order_id` | uuid |
+
+**Returned by:** List number orders, Create a number order, Retrieve a number order, Update a number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers` | array[object] |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `sub_number_orders_ids` | array[string] |
+| `updated_at` | date-time |
+
+**Returned by:** List number reservations, Create a number reservation, Retrieve a number reservation, Extend a number reservation
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `errors` | string |
+| `id` | uuid |
+| `phone_numbers` | array[object] |
+| `record_type` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve the features for a list of numbers
+
+| Field | Type |
+|-------|------|
+| `features` | array[string] |
+| `phone_number` | string |
+
+**Returned by:** Lists the phone number blocks jobs, Deletes all numbers associated with a phone number block, Retrieves a phone number blocks job
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `etc` | date-time |
+| `failed_operations` | array[object] |
+| `id` | uuid |
+| `record_type` | string |
+| `status` | enum: pending, in_progress, completed, failed |
+| `successful_operations` | array[object] |
+| `type` | enum: delete_phone_number_block |
+| `updated_at` | string |
+
+**Returned by:** List sub number orders, Retrieve a sub number order, Update a sub number order's requirements, Cancel a sub number order
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `is_block_sub_number_order` | boolean |
+| `order_request_id` | uuid |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+**Returned by:** Create a sub number orders report, Retrieve a sub number orders report
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `filters` | object |
+| `id` | uuid |
+| `order_type` | string |
+| `status` | enum: pending, success, failed, expired |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+## Optional Parameters
+
+### Create Advanced Order
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `country_code` | string (ISO 3166-1 alpha-2) |  |
+| `comments` | string |  |
+| `quantity` | integer |  |
+| `area_code` | string |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `features` | array[object] |  |
+| `customer_reference` | string |  |
+| `requirement_group_id` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Update Advanced Order
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `country_code` | string (ISO 3166-1 alpha-2) |  |
+| `comments` | string |  |
+| `quantity` | integer |  |
+| `area_code` | string |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `features` | array[object] |  |
+| `customer_reference` | string |  |
+| `requirement_group_id` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Create a comment
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `body` | string |  |
+| `commenter` | string |  |
+| `commenter_type` | enum (admin, user) |  |
+| `comment_record_type` | enum (sub_number_order, requirement_group) |  |
+| `comment_record_id` | string (UUID) |  |
+| `read_at` | string (date-time) | An ISO 8901 datetime string for when the comment was read. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the comment was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the comment was updated. |
+
+### Create an inexplicit number order
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `connection_id` | string (UUID) | Connection id to apply to phone numbers that are purchased |
+| `messaging_profile_id` | string (UUID) | Messaging profile id to apply to phone numbers that are purchased |
+| `customer_reference` | string | Reference label for the customer |
+| `billing_group_id` | string (UUID) | Billing group id to apply to phone numbers that are purchased |
+
+### Create a number block order
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `record_type` | string |  |
+| `phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `connection_id` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `status` | enum (pending, success, failure) | The status of the order. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the number order was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the number order was updated. |
+| `requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `errors` | string | Errors the reservation could happen upon |
+
+### Update requirements for a single phone number within a number order.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatory_requirements` | array[object] |  |
+
+### Create a number order
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `phone_numbers` | array[object] |  |
+| `connection_id` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `billing_group_id` | string (UUID) | Identifies the billing group associated with the phone number. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+
+### Update a number order
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatory_requirements` | array[object] |  |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+
+### Create a number reservation
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `record_type` | string |  |
+| `phone_numbers` | array[object] |  |
+| `status` | enum (pending, success, failure) | The status of the entire reservation. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the numbers reservation was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the number reservation was updated. |
+
+### Update a sub number order's requirements
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatory_requirements` | array[object] |  |
+
+### Create a sub number orders report
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `status` | enum (pending, success, failure) | Filter by order status |
+| `country_code` | string (ISO 3166-1 alpha-2) | Filter by country code |
+| `created_at_gt` | string (date-time) | Filter for orders created after this date |
+| `created_at_lt` | string (date-time) | Filter for orders created before this date |
+| `order_request_id` | string (UUID) | Filter by specific order request ID |
+| `customer_reference` | string | Filter by customer reference |
+
+## Webhook Payload Fields
+
+### `numberOrderStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.event_type` | string | The type of event being sent |
+| `data.id` | uuid | Unique identifier for the event |
+| `data.occurred_at` | date-time | ISO 8601 timestamp of when the event occurred |
+| `data.payload.id` | uuid |  |
+| `data.payload.record_type` | string |  |
+| `data.payload.phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `data.payload.connection_id` | string | Identifies the connection associated with this phone number. |
+| `data.payload.messaging_profile_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.billing_group_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.phone_numbers` | array[object] |  |
+| `data.payload.sub_number_orders_ids` | array[string] |  |
+| `data.payload.status` | enum: pending, success, failure | The status of the order. |
+| `data.payload.customer_reference` | string | A customer reference string for customer look ups. |
+| `data.payload.created_at` | date-time | An ISO 8901 datetime string denoting when the number order was created. |
+| `data.payload.updated_at` | date-time | An ISO 8901 datetime string for when the number order was updated. |
+| `data.payload.requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `data.record_type` | string | Type of record |
+| `meta.attempt` | integer | Webhook delivery attempt number |
+| `meta.delivered_to` | uri | URL where the webhook was delivered |

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/curl/voice.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/curl/voice.md
@@ -54,8 +54,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -73,7 +73,7 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in the API Details section below |
+| ... | | | +56 optional params in the API Details section below |
 
 ```bash
 curl \
@@ -108,7 +108,7 @@ Primary inbound call-control command.
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in the API Details section below |
+| ... | | | +29 optional params in the API Details section below |
 
 ```bash
 curl \
@@ -135,7 +135,7 @@ Common post-answer control path with downstream webhook implications.
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in the API Details section below |
+| ... | | | +35 optional params in the API Details section below |
 
 ```bash
 curl \
@@ -143,7 +143,7 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-  "to": "+18005550100"
+  "to": "+18005550100;secure=srtp"
 }' \
   "https://api.telnyx.com/v2/calls/v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ/actions/transfer"
 ```
@@ -213,7 +213,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
 | `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -383,7 +383,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -403,3 +403,427 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Voice (curl) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List call control applications, Create a call control application, Retrieve a call control application, Update a call control application, Delete a call control application
+
+| Field | Type |
+|-------|------|
+| `active` | boolean |
+| `anchorsite_override` | enum: Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, Chennai, IN, Amsterdam, Netherlands, Toronto, Canada, Sydney, Australia |
+| `application_name` | string |
+| `call_cost_in_webhooks` | boolean |
+| `created_at` | string |
+| `dtmf_type` | enum: RFC 2833, Inband, SIP INFO |
+| `first_command_timeout` | boolean |
+| `first_command_timeout_secs` | integer |
+| `id` | string |
+| `inbound` | object |
+| `outbound` | object |
+| `record_type` | enum: call_control_application |
+| `redact_dtmf_debug_logging` | boolean |
+| `tags` | array[string] |
+| `updated_at` | string |
+| `webhook_api_version` | enum: 1, 2 |
+| `webhook_event_failover_url` | url |
+| `webhook_event_url` | url |
+| `webhook_timeout_secs` | integer \| null |
+
+**Returned by:** Dial
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `recording_id` | uuid |
+| `start_time` | string |
+
+**Returned by:** Retrieve a call status
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `start_time` | string |
+
+**Returned by:** Answer call
+
+| Field | Type |
+|-------|------|
+| `recording_id` | uuid |
+| `result` | string |
+
+**Returned by:** Bridge calls, Hangup call, SIP Refer a call, Reject a call, Send SIP info, Transfer call
+
+| Field | Type |
+|-------|------|
+| `result` | string |
+
+**Returned by:** List all active calls for given connection
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `record_type` | enum: call |
+
+## Optional Parameters
+
+### Create a call control application
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `active` | boolean | Specifies whether the connection can be used. |
+| `anchorsite_override` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmf_type` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `first_command_timeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `first_command_timeout_secs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `inbound` | object |  |
+| `outbound` | object |  |
+| `webhook_api_version` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhook_event_failover_url` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhook_timeout_secs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `call_cost_in_webhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `redact_dtmf_debug_logging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Update a call control application
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `call_cost_in_webhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `active` | boolean | Specifies whether the connection can be used. |
+| `anchorsite_override` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmf_type` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `first_command_timeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `first_command_timeout_secs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `tags` | array[string] | Tags assigned to the Call Control Application. |
+| `inbound` | object |  |
+| `outbound` | object |  |
+| `webhook_api_version` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhook_event_failover_url` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhook_timeout_secs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `redact_dtmf_debug_logging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Dial
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
+| `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
+| `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
+| `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `link_to` | string | Use another call's control id for sharing the same call session id |
+| `bridge_intent` | boolean | Indicates the intent to bridge this call with the call specified in link_to. |
+| `bridge_on_answer` | boolean | Whether to automatically bridge answered call to the call specified in link_to. |
+| `prevent_double_bridge` | boolean | Prevents bridging and hangs up the call if the target is already bridged. |
+| `park_after_unbridge` | string | If supplied with the value `self`, the current leg will be parked after unbri... |
+| `media_encryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the call. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE request. |
+| `sip_transport_protocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `stream_url` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `stream_track` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `stream_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `stream_bidirectional_mode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `stream_bidirectional_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `stream_bidirectional_target_legs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `stream_bidirectional_sampling_rate` | enum (8000, 16000, 22050, 24000, 48000) | Audio sampling rate. |
+| `stream_establish_before_call_originate` | boolean | Establish websocket connection before dialing the destination. |
+| `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `supervise_call_control_id` | string (UUID) | The call leg which will be supervised by the new call. |
+| `supervisor_role` | enum (barge, whisper, monitor) | The role of the supervisor call. |
+| `enable_dialogflow` | boolean | Enables Dialogflow for the current call. |
+| `dialogflow_config` | object |  |
+| `transcription` | boolean | Enable transcription upon call answer. |
+| `transcription_config` | object |  |
+| `sip_region` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `stream_auth_token` | string | An authentication token to be sent as part of the WebSocket connection when u... |
+
+### Answer call
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE response. |
+| `preferred_codecs` | enum (G722,PCMU,PCMA,G729,OPUS,VP8,H264) | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE response. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `stream_url` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `stream_track` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `stream_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `stream_bidirectional_mode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `stream_bidirectional_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `stream_bidirectional_target_legs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `transcription` | boolean | Enable transcription upon call answer. |
+| `transcription_config` | object |  |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
+
+### Bridge calls
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `queue` | string | The name of the queue you want to bridge with, can't be used together with ca... |
+| `video_room_id` | string (UUID) | The ID of the video room you want to bridge with, can't be used together with... |
+| `video_room_context` | string | The additional parameter that will be passed to the video conference. |
+| `prevent_double_bridge` | boolean | When set to `true`, it prevents bridging if the target call is already bridge... |
+| `park_after_unbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `play_ringtone` | boolean | Specifies whether to play a ringtone if the call you want to bridge with has ... |
+| `ringtone` | enum (at, au, be, bg, br, ...) | Specifies which country ringtone to play when `play_ringtone` is set to `true`. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `mute_dtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `hold_after_unbridge` | boolean | Specifies behavior after the bridge ends. |
+
+### Hangup call
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP BYE message. |
+
+### SIP Refer a call
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid execution of duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the request. |
+
+### Reject a call
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Send SIP info
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Transfer call
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
+| `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
+| `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
+| `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
+| `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `park_after_unbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `target_leg_client_state` | string | Use this field to add state to every subsequent webhook for the new leg. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `media_encryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the new call leg. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE. |
+| `sip_transport_protocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `mute_dtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `sip_region` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `preferred_codecs` | string | The list of comma-separated codecs in order of preference to be used during t... |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+
+## Webhook Payload Fields
+
+### `callAnswered`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.answered | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: answered | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### `callBridged`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.bridged | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+
+### `callHangup`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.hangup | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: hangup | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+| `data.payload.hangup_cause` | enum: call_rejected, normal_clearing, originator_cancel, timeout, time_limit, user_busy, not_found, no_answer, unspecified | The reason the call was ended (`call_rejected`, `normal_clearing`, `originator_cancel`, `timeout`, `time_limit`, `use... |
+| `data.payload.hangup_source` | enum: caller, callee, unknown | The party who ended the call (`callee`, `caller`, `unknown`). |
+| `data.payload.sip_hangup_cause` | string | The reason the call was ended (SIP response code). |
+| `data.payload.call_quality_stats` | object \| null | Call quality statistics aggregated from the CHANNEL_HANGUP_COMPLETE event. |
+
+### `callInitiated`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.initiated | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
+| `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.custom_headers` | array[object] | Custom headers from sip invite |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.shaken_stir_attestation` | string | SHAKEN/STIR attestation level. |
+| `data.payload.shaken_stir_validated` | boolean | Whether attestation was successfully validated or not. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.caller_id_name` | string | Caller id. |
+| `data.payload.call_screening_result` | string | Call screening result. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.direction` | enum: incoming, outgoing | Whether the call is `incoming` or `outgoing`. |
+| `data.payload.state` | enum: parked, bridging | State received from a command. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### Field Type Notes
+
+- `from` in webhook payloads: string (E.164 phone number)
+- `to` in webhook payloads: string (E.164 phone number)
+- The return value of `client.webhooks.unwrap()` is a parsed event object — access fields via `event.data.event_type`, `event.data.payload.call_control_id`, etc.

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/go/10dlc.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/go/10dlc.md
@@ -78,8 +78,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -228,7 +228,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `description` | string | Description of the event. |
 | `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -406,7 +406,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -446,3 +446,471 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# 10DLC (Go) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Brands, List Campaigns, List shared partner campaigns, List Shared Campaigns, List phone number campaigns
+
+| Field | Type |
+|-------|------|
+| `page` | integer |
+| `records` | array[object] |
+| `totalRecords` | integer |
+
+**Returned by:** Create Brand, Update Brand, Revet Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Get Brand Feedback By Id
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `category` | array[object] |
+
+**Returned by:** Get Brand SMS OTP Status, Get Brand SMS OTP Status by Brand ID
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `deliveryStatus` | string |
+| `deliveryStatusDate` | date-time |
+| `deliveryStatusDetails` | string |
+| `mobilePhone` | string |
+| `referenceId` | string |
+| `requestDate` | date-time |
+| `verifyDate` | date-time |
+
+**Returned by:** Get Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `assignedCampaignsCount` | number |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Order Brand External Vetting, Import External Vetting Record
+
+| Field | Type |
+|-------|------|
+| `createDate` | string |
+| `evpId` | string |
+| `vettedDate` | string |
+| `vettingClass` | string |
+| `vettingId` | string |
+| `vettingScore` | integer |
+| `vettingToken` | string |
+
+**Returned by:** Trigger Brand SMS OTP
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `referenceId` | string |
+
+**Returned by:** Get Campaign Cost
+
+| Field | Type |
+|-------|------|
+| `campaignUsecase` | string |
+| `description` | string |
+| `monthlyCost` | string |
+| `upFrontCost` | string |
+
+**Returned by:** Get campaign, Update campaign, Submit Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `autoRenewal` | boolean |
+| `billedDate` | string |
+| `brandDisplayName` | string |
+| `brandId` | string |
+| `campaignId` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createDate` | string |
+| `cspId` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isTMobileNumberPoolingEnabled` | boolean |
+| `isTMobileRegistered` | boolean |
+| `isTMobileSuspended` | boolean |
+| `messageFlow` | string |
+| `mock` | boolean |
+| `nextRenewalOrExpirationDate` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `referenceId` | string |
+| `resellerId` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `status` | string |
+| `subUsecases` | array[string] |
+| `submissionStatus` | enum: CREATED, FAILED, PENDING |
+| `subscriberHelp` | boolean |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `usecase` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Deactivate campaign
+
+| Field | Type |
+|-------|------|
+| `message` | string |
+| `record_type` | string |
+| `time` | number |
+
+**Returned by:** Submit campaign appeal for manual review
+
+| Field | Type |
+|-------|------|
+| `appealed_at` | date-time |
+
+**Returned by:** Get Campaign Mno Metadata
+
+| Field | Type |
+|-------|------|
+| `10999` | object |
+
+**Returned by:** Get Sharing Status
+
+| Field | Type |
+|-------|------|
+| `sharedByMe` | object |
+| `sharedWithMe` | object |
+
+**Returned by:** Qualify By Usecase
+
+| Field | Type |
+|-------|------|
+| `annualFee` | number |
+| `maxSubUsecases` | integer |
+| `minSubUsecases` | integer |
+| `mnoMetadata` | object |
+| `monthlyFee` | number |
+| `quarterlyFee` | number |
+| `usecase` | string |
+
+**Returned by:** Get Single Shared Campaign, Update Single Shared Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `assignedPhoneNumbersCount` | number |
+| `brandDisplayName` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createdAt` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isNumberPoolingEnabled` | boolean |
+| `messageFlow` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `subUsecases` | array[string] |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `updatedAt` | string |
+| `usecase` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Assign Messaging Profile To Campaign
+
+| Field | Type |
+|-------|------|
+| `campaignId` | string |
+| `messagingProfileId` | string |
+| `taskId` | string |
+| `tcrCampaignId` | string |
+
+**Returned by:** Get Assignment Task Status
+
+| Field | Type |
+|-------|------|
+| `createdAt` | date-time |
+| `status` | string |
+| `taskId` | string |
+| `updatedAt` | date-time |
+
+**Returned by:** Get Phone Number Status
+
+| Field | Type |
+|-------|------|
+| `records` | array[object] |
+
+**Returned by:** Create New Phone Number Campaign, Get Single Phone Number Campaign, Create New Phone Number Campaign, Delete Phone Number Campaign
+
+| Field | Type |
+|-------|------|
+| `assignmentStatus` | enum: FAILED_ASSIGNMENT, PENDING_ASSIGNMENT, ASSIGNED, PENDING_UNASSIGNMENT, FAILED_UNASSIGNMENT |
+| `brandId` | string |
+| `campaignId` | string |
+| `createdAt` | string |
+| `failureReasons` | string |
+| `phoneNumber` | string |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `telnyxCampaignId` | string |
+| `updatedAt` | string |
+
+## Optional Parameters
+
+### Create Brand — `client.Messaging10dlc.Brand.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `CompanyName` | string | (Required for Non-profit/private/public) Legal company name. |
+| `FirstName` | string | First name of business contact. |
+| `LastName` | string | Last name of business contact. |
+| `Ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `Phone` | string | Valid phone number in e.164 international format. |
+| `Street` | string | Street number and name. |
+| `City` | string | City name |
+| `State` | string | State. |
+| `PostalCode` | string | Postal codes. |
+| `StockSymbol` | string | (Required for public company) stock symbol. |
+| `StockExchange` | object | (Required for public company) stock exchange. |
+| `IpAddress` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `Website` | string | Brand website URL. |
+| `IsReseller` | boolean |  |
+| `Mock` | boolean | Mock brand for testing purposes. |
+| `MobilePhone` | string | Valid mobile phone number in e.164 international format. |
+| `BusinessContactEmail` | string | Business contact email. |
+| `WebhookURL` | string | Webhook URL for brand status updates. |
+| `WebhookFailoverURL` | string | Webhook failover URL for brand status updates. |
+
+### Update Brand — `client.Messaging10dlc.Brand.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `CompanyName` | string | (Required for Non-profit/private/public) Legal company name. |
+| `FirstName` | string | First name of business contact. |
+| `LastName` | string | Last name of business contact. |
+| `Ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `Phone` | string | Valid phone number in e.164 international format. |
+| `Street` | string | Street number and name. |
+| `City` | string | City name |
+| `State` | string | State. |
+| `PostalCode` | string | Postal codes. |
+| `StockSymbol` | string | (Required for public company) stock symbol. |
+| `StockExchange` | object | (Required for public company) stock exchange. |
+| `IpAddress` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `Website` | string | Brand website URL. |
+| `AltBusinessIdType` | enum (NONE, DUNS, GIIN, LEI) | An enumeration. |
+| `IsReseller` | boolean |  |
+| `IdentityStatus` | enum (VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED) | The verification status of an active brand |
+| `BusinessContactEmail` | string | Business contact email. |
+| `WebhookURL` | string | Webhook URL for brand status updates. |
+| `WebhookFailoverURL` | string | Webhook failover URL for brand status updates. |
+| `AltBusinessId` | string (UUID) | Alternate business identifier such as DUNS, LEI, or GIIN |
+
+### Import External Vetting Record — `client.Messaging10dlc.Brand.ExternalVetting.Imports()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `VettingToken` | string | Required by some providers for vetting record confirmation. |
+
+### Update campaign — `client.Messaging10dlc.Campaign.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ResellerId` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `Sample1` | string | Message sample. |
+| `Sample2` | string | Message sample. |
+| `Sample3` | string | Message sample. |
+| `Sample4` | string | Message sample. |
+| `Sample5` | string | Message sample. |
+| `MessageFlow` | string | Message flow description. |
+| `HelpMessage` | string | Help message of the campaign. |
+| `AutoRenewal` | boolean | Help message of the campaign. |
+| `WebhookURL` | string | Webhook to which campaign status updates are sent. |
+| `WebhookFailoverURL` | string | Webhook failover to which campaign status updates are sent. |
+
+### Submit Campaign — `client.Messaging10dlc.CampaignBuilder.Submit()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `AgeGated` | boolean | Age gated message content in campaign. |
+| `AutoRenewal` | boolean | Campaign subscription auto-renewal option. |
+| `DirectLending` | boolean | Direct lending or loan arrangement |
+| `EmbeddedLink` | boolean | Does message generated by the campaign include URL link in SMS? |
+| `EmbeddedPhone` | boolean | Does message generated by the campaign include phone number in SMS? |
+| `HelpKeywords` | string | Subscriber help keywords. |
+| `HelpMessage` | string | Help message of the campaign. |
+| `MessageFlow` | string | Message flow description. |
+| `MnoIds` | array[integer] | Submit campaign to given list of MNOs by MNO's network ID. |
+| `NumberPool` | boolean | Does campaign utilize pool of phone numbers? |
+| `OptinKeywords` | string | Subscriber opt-in keywords. |
+| `OptinMessage` | string | Subscriber opt-in message. |
+| `OptoutKeywords` | string | Subscriber opt-out keywords. |
+| `OptoutMessage` | string | Subscriber opt-out message. |
+| `ReferenceId` | string (UUID) | Caller supplied campaign reference ID. |
+| `ResellerId` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `Sample1` | string | Message sample. |
+| `Sample2` | string | Message sample. |
+| `Sample3` | string | Message sample. |
+| `Sample4` | string | Message sample. |
+| `Sample5` | string | Message sample. |
+| `SubUsecases` | array[string] | Campaign sub-usecases. |
+| `SubscriberHelp` | boolean | Does campaign responds to help keyword(s)? |
+| `SubscriberOptin` | boolean | Does campaign require subscriber to opt-in before SMS is sent to subscriber? |
+| `SubscriberOptout` | boolean | Does campaign support subscriber opt-out keyword(s)? |
+| `Tag` | array[string] | Tags to be set on the Campaign. |
+| `TermsAndConditions` | boolean | Is terms and conditions accepted? |
+| `PrivacyPolicyLink` | string | Link to the campaign's privacy policy. |
+| `TermsAndConditionsLink` | string | Link to the campaign's terms and conditions. |
+| `EmbeddedLinkSample` | string | Sample of an embedded link that will be sent to subscribers. |
+| `WebhookURL` | string | Webhook to which campaign status updates are sent. |
+| `WebhookFailoverURL` | string | Failover webhook to which campaign status updates are sent. |
+
+### Update Single Shared Campaign — `client.Messaging10dlc.PartnerCampaigns.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `WebhookURL` | string | Webhook to which campaign status updates are sent. |
+| `WebhookFailoverURL` | string | Webhook failover to which campaign status updates are sent. |
+
+### Assign Messaging Profile To Campaign — `client.Messaging10dlc.PhoneNumberAssignmentByProfile.Assign()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `TcrCampaignId` | string (UUID) | The TCR ID of the shared campaign you want to link to the specified messaging... |
+| `CampaignId` | string (UUID) | The ID of the campaign you want to link to the specified messaging profile. |
+
+## Webhook Payload Fields
+
+### `campaignStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `brandId` | string | Brand ID associated with the campaign. |
+| `campaignId` | string | The ID of the campaign. |
+| `createDate` | string | Unix timestamp when campaign was created. |
+| `cspId` | string | Alphanumeric identifier of the CSP associated with this campaign. |
+| `isTMobileRegistered` | boolean | Indicates whether the campaign is registered with T-Mobile. |
+| `type` | enum: TELNYX_EVENT, REGISTRATION, MNO_REVIEW, TELNYX_REVIEW, NUMBER_POOL_PROVISIONED, NUMBER_POOL_DEPROVISIONED, TCR_EVENT, VERIFIED |  |
+| `description` | string | Description of the event. |
+| `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/go/ai-assistants.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/go/ai-assistants.md
@@ -37,8 +37,8 @@ import "errors"
 
 assistant, err := client.AI.Assistants.New(context.Background(), telnyx.AIAssistantNewParams{
 		Instructions: "You are a helpful assistant.",
-		Model: "openai/gpt-4o",
 		Name: "my-resource",
+		Model: "openai/gpt-4o",
 	})
 if err != nil {
   var apiErr *telnyx.Error
@@ -71,7 +71,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -84,18 +84,17 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `Name` | string | Yes |  |
-| `Model` | string | Yes | ID of the model to use. |
 | `Instructions` | string | Yes | System instructions for the assistant. |
-| `Tools` | array[object] | No | The tools that the assistant can use. |
-| `Description` | string | No |  |
-| `Greeting` | string | No | Text that the assistant will use to start the conversation. |
-| ... | | | +11 optional params in the API Details section below |
+| `Tags` | array[string] | No | Tags associated with the assistant. |
+| `Model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `Tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in the API Details section below |
 
 ```go
 	assistant, err := client.AI.Assistants.New(context.Background(), telnyx.AIAssistantNewParams{
 		Instructions: "You are a helpful assistant.",
-		Model: "openai/gpt-4o",
 		Name: "my-resource",
+		Model: "openai/gpt-4o",
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -224,7 +223,7 @@ Primary response fields:
 - `assistant.CreatedAt`
 - `assistant.Description`
 - `assistant.DynamicVariables`
-- `assistant.DynamicVariablesWebhookURL`
+- `assistant.DynamicVariablesWebhookTimeoutMs`
 
 ### Update an assistant
 
@@ -235,10 +234,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `AssistantId` | string (UUID) | Yes |  |
+| `Tags` | array[string] | No | Tags associated with the assistant. |
 | `Name` | string | No |  |
-| `Model` | string | No | ID of the model to use. |
-| `Instructions` | string | No | System instructions for the assistant. |
-| ... | | | +15 optional params in the API Details section below |
+| `Model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in the API Details section below |
 
 ```go
 	assistant, err := client.AI.Assistants.Update(
@@ -258,7 +257,7 @@ Primary response fields:
 - `assistant.CreatedAt`
 - `assistant.Description`
 - `assistant.DynamicVariables`
-- `assistant.DynamicVariablesWebhookURL`
+- `assistant.DynamicVariablesWebhookTimeoutMs`
 
 ### List assistants
 
@@ -283,7 +282,7 @@ Primary item fields:
 - `CreatedAt`
 - `Description`
 - `DynamicVariables`
-- `DynamicVariablesWebhookURL`
+- `DynamicVariablesWebhookTimeoutMs`
 
 ### Import assistants from external provider
 
@@ -317,7 +316,7 @@ Primary item fields:
 - `CreatedAt`
 - `Description`
 - `DynamicVariables`
-- `DynamicVariablesWebhookURL`
+- `DynamicVariablesWebhookTimeoutMs`
 
 ### Get All Tags
 
@@ -431,7 +430,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -444,8 +443,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.AI.Assistants.Tests.Runs.Get()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `TestId`, `RunId` |
 | Delete an assistant | `client.AI.Assistants.Delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `AssistantId` |
 | Get Canary Deploy | `client.AI.Assistants.CanaryDeploys.Get()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `AssistantId` |
-| Create Canary Deploy | `client.AI.Assistants.CanaryDeploys.New()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `Versions`, `AssistantId` |
-| Update Canary Deploy | `client.AI.Assistants.CanaryDeploys.Update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `Versions`, `AssistantId` |
+| Create Canary Deploy | `client.AI.Assistants.CanaryDeploys.New()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `AssistantId` |
+| Update Canary Deploy | `client.AI.Assistants.CanaryDeploys.Update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `AssistantId` |
 | Delete Canary Deploy | `client.AI.Assistants.CanaryDeploys.Delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `AssistantId` |
 | Assistant Sms Chat | `client.AI.Assistants.SendSMS()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `From`, `To`, `AssistantId` |
 | Clone Assistant | `client.AI.Assistants.Clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `AssistantId` |
@@ -456,6 +455,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Add Assistant Tag | `client.AI.Assistants.Tags.Add()` | `POST /ai/assistants/{assistant_id}/tags` | Create or provision an additional resource when the core tasks do not cover this flow. | `Tag`, `AssistantId` |
 | Remove Assistant Tag | `client.AI.Assistants.Tags.Remove()` | `DELETE /ai/assistants/{assistant_id}/tags/{tag}` | Remove, detach, or clean up an existing resource. | `AssistantId`, `Tag` |
 | Get assistant texml | `client.AI.Assistants.GetTexml()` | `GET /ai/assistants/{assistant_id}/texml` | Fetch the current state before updating, deleting, or making control-flow decisions. | `AssistantId` |
+| Add Assistant Tool | `client.AI.Assistants.Tools.Add()` | `PUT /ai/assistants/{assistant_id}/tools/{tool_id}` | Modify an existing resource without recreating it. | `AssistantId`, `ToolId` |
+| Remove Assistant Tool | `client.AI.Assistants.Tools.Remove()` | `DELETE /ai/assistants/{assistant_id}/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `AssistantId`, `ToolId` |
 | Test Assistant Tool | `client.AI.Assistants.Tools.Test()` | `POST /ai/assistants/{assistant_id}/tools/{tool_id}/test` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `AssistantId`, `ToolId` |
 | Get all versions of an assistant | `client.AI.Assistants.Versions.List()` | `GET /ai/assistants/{assistant_id}/versions` | Fetch the current state before updating, deleting, or making control-flow decisions. | `AssistantId` |
 | Get a specific assistant version | `client.AI.Assistants.Versions.Get()` | `GET /ai/assistants/{assistant_id}/versions/{version_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `AssistantId`, `VersionId` |
@@ -467,7 +468,398 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get MCP Server | `client.AI.McpServers.Get()` | `GET /ai/mcp_servers/{mcp_server_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `McpServerId` |
 | Update MCP Server | `client.AI.McpServers.Update()` | `PUT /ai/mcp_servers/{mcp_server_id}` | Modify an existing resource without recreating it. | `McpServerId` |
 | Delete MCP Server | `client.AI.McpServers.Delete()` | `DELETE /ai/mcp_servers/{mcp_server_id}` | Remove, detach, or clean up an existing resource. | `McpServerId` |
+| List Tools | `client.AI.Tools.List()` | `GET /ai/tools` | Inspect available resources or choose an existing resource before mutating it. | None |
+| Create Tool | `client.AI.Tools.New()` | `POST /ai/tools` | Create or provision an additional resource when the core tasks do not cover this flow. | `Type`, `DisplayName` |
+| Get Tool | `client.AI.Tools.Get()` | `GET /ai/tools/{tool_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `ToolId` |
+| Update Tool | `client.AI.Tools.Update()` | `PATCH /ai/tools/{tool_id}` | Modify an existing resource without recreating it. | `ToolId` |
+| Delete Tool | `client.AI.Tools.Delete()` | `DELETE /ai/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `ToolId` |
 
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# AI Assistants (Go) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+
+## Response Schemas
+
+**Returned by:** List assistants, Create an assistant, Import assistants from external provider, Get an assistant, Update an assistant, Clone Assistant, Get all versions of an assistant, Get a specific assistant version, Update a specific assistant version, Promote an assistant version to main
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
+| `dynamic_variables_webhook_url` | string |
+| `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
+| `greeting` | string |
+| `id` | string |
+| `import_metadata` | object |
+| `insight_settings` | object |
+| `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
+| `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
+| `messaging_settings` | object |
+| `model` | string |
+| `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
+| `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
+| `telephony_settings` | object |
+| `tools` | array[object] |
+| `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
+| `voice_settings` | object |
+| `widget_settings` | object |
+
+**Returned by:** Get All Tags, Add Assistant Tag, Remove Assistant Tag
+
+| Field | Type |
+|-------|------|
+| `tags` | array[string] |
+
+**Returned by:** List assistant tests with pagination, Create a new assistant test, Get assistant test by ID, Update an assistant test
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `destination` | string |
+| `instructions` | string |
+| `max_duration_seconds` | integer |
+| `name` | string |
+| `rubric` | array[object] |
+| `telnyx_conversation_channel` | object |
+| `test_id` | uuid |
+| `test_suite` | string |
+
+**Returned by:** Get all test suite names
+
+| Field | Type |
+|-------|------|
+| `data` | array[string] |
+
+**Returned by:** Get test suite run history, Get test run history for a specific test, Trigger a manual test run, Get specific test run details
+
+| Field | Type |
+|-------|------|
+| `completed_at` | date-time |
+| `conversation_id` | string |
+| `conversation_insights_id` | string |
+| `created_at` | date-time |
+| `detail_status` | array[object] |
+| `logs` | string |
+| `run_id` | uuid |
+| `status` | enum: pending, starting, running, passed, failed, error |
+| `test_id` | uuid |
+| `test_suite_run_id` | uuid |
+| `triggered_by` | string |
+| `updated_at` | date-time |
+
+**Returned by:** Delete an assistant
+
+| Field | Type |
+|-------|------|
+| `deleted` | boolean |
+| `id` | string |
+| `object` | string |
+
+**Returned by:** Get Canary Deploy, Create Canary Deploy, Update Canary Deploy
+
+| Field | Type |
+|-------|------|
+| `assistant_id` | string |
+| `created_at` | date-time |
+| `rules` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Assistant Chat (BETA)
+
+| Field | Type |
+|-------|------|
+| `content` | string |
+
+**Returned by:** Assistant Sms Chat
+
+| Field | Type |
+|-------|------|
+| `conversation_id` | string |
+
+**Returned by:** List scheduled events
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Test Assistant Tool
+
+| Field | Type |
+|-------|------|
+| `content_type` | string |
+| `request` | object |
+| `response` | string |
+| `status_code` | integer |
+| `success` | boolean |
+
+**Returned by:** Create MCP Server, Get MCP Server, Update MCP Server
+
+| Field | Type |
+|-------|------|
+| `allowed_tools` | array \| null |
+| `api_key_ref` | string \| null |
+| `created_at` | date-time |
+| `id` | string |
+| `name` | string |
+| `type` | string |
+| `url` | string |
+
+**Returned by:** List Tools, Create Tool, Get Tool, Update Tool
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `display_name` | string |
+| `id` | string |
+| `timeout_ms` | integer |
+| `tool_definition` | object |
+| `type` | string |
+
+## Optional Parameters
+
+### Create an assistant — `client.AI.Assistants.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Model` | string | ID of the model to use when `external_llm` is not set. |
+| `Tools` | array[object] | Deprecated for new integrations. |
+| `McpServers` | array[object] | MCP servers attached to the assistant. |
+| `ToolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `Description` | string |  |
+| `Greeting` | string | Text that the assistant will use to start the conversation. |
+| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `ExternalLlm` | object |  |
+| `FallbackConfig` | object |  |
+| `VoiceSettings` | object |  |
+| `Transcription` | object |  |
+| `TelephonySettings` | object |  |
+| `MessagingSettings` | object |  |
+| `EnabledFeatures` | array[object] |  |
+| `InsightSettings` | object |  |
+| `PrivacySettings` | object |  |
+| `DynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `DynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `DynamicVariables` | object | Map of dynamic variables and their default values |
+| `WidgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `InterruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `Integrations` | array[object] | Connected integrations attached to the assistant. |
+| `ObservabilitySettings` | object |  |
+| `Tags` | array[string] | Tags associated with the assistant. |
+| `PostConversationSettings` | object | Configuration for post-conversation processing. |
+
+### Import assistants from external provider — `client.AI.Assistants.Imports()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ImportIds` | array[string] | Optional list of assistant IDs to import from the external provider. |
+
+### Create a new assistant test — `client.AI.Assistants.Tests.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Description` | string | Optional detailed description of what this test evaluates and its purpose. |
+| `TelnyxConversationChannel` | object | The communication channel through which the test will be conducted. |
+| `MaxDurationSeconds` | integer | Maximum duration in seconds that the test conversation should run before timi... |
+| `TestSuite` | string | Optional test suite name to group related tests together. |
+
+### Trigger test suite execution — `client.AI.Assistants.Tests.TestSuites.Runs.Trigger()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `DestinationVersionId` | string (UUID) | Optional assistant version ID to use for all test runs in this suite. |
+
+### Update an assistant test — `client.AI.Assistants.Tests.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Name` | string | Updated name for the assistant test. |
+| `Description` | string | Updated description of the test's purpose and evaluation criteria. |
+| `TelnyxConversationChannel` | enum (phone_call, web_call, sms_chat, web_chat) |  |
+| `Destination` | string | Updated target destination for test conversations. |
+| `MaxDurationSeconds` | integer | Updated maximum test duration in seconds. |
+| `TestSuite` | string | Updated test suite assignment for better organization. |
+| `Instructions` | string | Updated test scenario instructions and objectives. |
+| `Rubric` | array[object] | Updated evaluation criteria for assessing assistant performance. |
+
+### Trigger a manual test run — `client.AI.Assistants.Tests.Runs.Trigger()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `DestinationVersionId` | string (UUID) | Optional assistant version ID to use for this test run. |
+
+### Update an assistant — `client.AI.Assistants.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Name` | string |  |
+| `Model` | string | ID of the model to use when `external_llm` is not set. |
+| `Instructions` | string | System instructions for the assistant. |
+| `Tools` | array[object] | Deprecated for new integrations. |
+| `McpServers` | array[object] | MCP servers attached to the assistant. |
+| `ToolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `Description` | string |  |
+| `Greeting` | string | Text that the assistant will use to start the conversation. |
+| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `ExternalLlm` | object |  |
+| `FallbackConfig` | object |  |
+| `VoiceSettings` | object |  |
+| `Transcription` | object |  |
+| `TelephonySettings` | object |  |
+| `MessagingSettings` | object |  |
+| `EnabledFeatures` | array[object] |  |
+| `InsightSettings` | object |  |
+| `PrivacySettings` | object |  |
+| `DynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `DynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `DynamicVariables` | object | Map of dynamic variables and their default values |
+| `WidgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `InterruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `Integrations` | array[object] | Connected integrations attached to the assistant. |
+| `ObservabilitySettings` | object |  |
+| `Tags` | array[string] | Tags associated with the assistant. |
+| `VersionName` | string | Human-readable name for the assistant version. |
+| `PostConversationSettings` | object | Configuration for post-conversation processing. |
+| `PromoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.AI.Assistants.CanaryDeploys.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Rules` | array[object] |  |
+
+### Update Canary Deploy — `client.AI.Assistants.CanaryDeploys.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Rules` | array[object] |  |
+
+### Assistant Chat (BETA) — `client.AI.Assistants.Chat()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Name` | string | The optional display name of the user sending the message |
+
+### Assistant Sms Chat — `client.AI.Assistants.SendSMS()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Text` | string |  |
+| `ConversationMetadata` | object |  |
+| `ShouldCreateConversation` | boolean |  |
+
+### Create a scheduled event — `client.AI.Assistants.ScheduledEvents.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Text` | string | Required for sms scheduled events. |
+| `ConversationMetadata` | object | Metadata associated with the conversation. |
+| `DynamicVariables` | object | A map of dynamic variable names to values. |
+| `MaxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `RetryIntervalSecs` | integer |  |
+
+### Test Assistant Tool — `client.AI.Assistants.Tools.Test()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Arguments` | object | Key-value arguments to use for the webhook test |
+| `DynamicVariables` | object | Key-value dynamic variables to use for the webhook test |
+
+### Update a specific assistant version — `client.AI.Assistants.Versions.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Name` | string |  |
+| `Model` | string | ID of the model to use when `external_llm` is not set. |
+| `Instructions` | string | System instructions for the assistant. |
+| `Tools` | array[object] | Deprecated for new integrations. |
+| `McpServers` | array[object] | MCP servers attached to the assistant. |
+| `ToolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `Description` | string |  |
+| `Greeting` | string | Text that the assistant will use to start the conversation. |
+| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `ExternalLlm` | object |  |
+| `FallbackConfig` | object |  |
+| `VoiceSettings` | object |  |
+| `Transcription` | object |  |
+| `TelephonySettings` | object |  |
+| `MessagingSettings` | object |  |
+| `EnabledFeatures` | array[object] |  |
+| `InsightSettings` | object |  |
+| `PrivacySettings` | object |  |
+| `DynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `DynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `DynamicVariables` | object | Map of dynamic variables and their default values |
+| `WidgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `InterruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `Integrations` | array[object] | Connected integrations attached to the assistant. |
+| `ObservabilitySettings` | object |  |
+| `Tags` | array[string] | Tags associated with the assistant. |
+| `VersionName` | string | Human-readable name for the assistant version. |
+| `PostConversationSettings` | object | Configuration for post-conversation processing. |
+
+### Create MCP Server — `client.AI.McpServers.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ApiKeyRef` | string |  |
+| `AllowedTools` | array[string] |  |
+
+### Update MCP Server — `client.AI.McpServers.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Id` | string (UUID) |  |
+| `Name` | string |  |
+| `Type` | string |  |
+| `Url` | string (URL) |  |
+| `ApiKeyRef` | string |  |
+| `AllowedTools` | array[string] |  |
+| `CreatedAt` | string (date-time) |  |
+
+### Create Tool — `client.AI.Tools.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Function` | object |  |
+| `Retrieval` | object |  |
+| `Handoff` | object |  |
+| `Invite` | object |  |
+| `Webhook` | object |  |
+| `TimeoutMs` | integer |  |
+
+### Update Tool — `client.AI.Tools.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Type` | string |  |
+| `DisplayName` | string |  |
+| `Function` | object |  |
+| `Retrieval` | object |  |
+| `Handoff` | object |  |
+| `Invite` | object |  |
+| `Webhook` | object |  |
+| `TimeoutMs` | integer |  |

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/go/messaging.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/go/messaging.md
@@ -77,8 +77,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -207,7 +207,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.media` | array[object] |  |
 | `data.record_type` | enum: event | Identifies the type of the resource. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -403,6 +403,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `WhatsappMessage` | object | Yes |  |
 | `Type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `WebhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `MessagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```go
 	response, err := client.Messages.SendWhatsapp(context.Background(), telnyx.MessageSendWhatsappParams{
@@ -429,7 +430,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -463,3 +464,425 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Messaging (Go) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List alphanumeric sender IDs, Create an alphanumeric sender ID, Retrieve an alphanumeric sender ID, Delete an alphanumeric sender ID, List alphanumeric sender IDs for a messaging profile
+
+| Field | Type |
+|-------|------|
+| `alphanumeric_sender_id` | string |
+| `id` | uuid |
+| `messaging_profile_id` | uuid |
+| `organization_id` | string |
+| `record_type` | enum: alphanumeric_sender_id |
+| `us_long_code_fallback` | string |
+
+**Returned by:** Send a message, Send a message using an alphanumeric sender ID, Retrieve group MMS messages, Send a group MMS message, Send a long code message, Send a message using number pool, Schedule a message, Send a short code message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `wait_seconds` | float |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** Send a WhatsApp message
+
+| Field | Type |
+|-------|------|
+| `body` | object |
+| `direction` | string |
+| `encoding` | string |
+| `from` | object |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `organization_id` | string |
+| `received_at` | date-time |
+| `record_type` | string |
+| `to` | array[object] |
+| `type` | string |
+| `wait_seconds` | float |
+
+**Returned by:** Retrieve a message, Get detailed messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Cancel a scheduled message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** List messaging hosted numbers, Retrieve a messaging hosted number, Update a messaging hosted number
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `eligible_messaging_products` | array[string] |
+| `features` | object |
+| `health` | object |
+| `id` | string |
+| `messaging_product` | string |
+| `messaging_profile_id` | string \| null |
+| `organization_id` | string |
+| `phone_number` | string |
+| `record_type` | enum: messaging_phone_number, messaging_settings |
+| `tags` | array[string] |
+| `traffic_type` | string |
+| `type` | enum: long-code, toll-free, short-code, longcode, tollfree, shortcode |
+| `updated_at` | date-time |
+
+**Returned by:** List opt-outs
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `from` | string |
+| `keyword` | string \| null |
+| `messaging_profile_id` | string \| null |
+| `to` | string |
+
+**Returned by:** List high-level messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Regenerate messaging profile secret
+
+| Field | Type |
+|-------|------|
+| `ai_assistant_id` | string \| null |
+| `alpha_sender` | string \| null |
+| `created_at` | date-time |
+| `daily_spend_limit` | string |
+| `daily_spend_limit_enabled` | boolean |
+| `enabled` | boolean |
+| `health_webhook_url` | url |
+| `id` | uuid |
+| `mms_fall_back_to_sms` | boolean |
+| `mms_transcoding` | boolean |
+| `mobile_only` | boolean |
+| `name` | string |
+| `number_pool_settings` | object \| null |
+| `organization_id` | string |
+| `record_type` | enum: messaging_profile |
+| `redaction_enabled` | boolean |
+| `redaction_level` | integer |
+| `resource_group_id` | string \| null |
+| `smart_encoding` | boolean |
+| `updated_at` | date-time |
+| `url_shortener_settings` | object \| null |
+| `v1_secret` | string |
+| `webhook_api_version` | enum: 1, 2, 2010-04-01 |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+| `whitelisted_destinations` | array[string] |
+
+**Returned by:** List Auto-Response Settings, Create auto-response setting, Get Auto-Response Setting, Update Auto-Response Setting
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `id` | string |
+| `keywords` | array[string] |
+| `op` | enum: start, stop, info |
+| `resp_text` | string |
+| `updated_at` | date-time |
+
+## Optional Parameters
+
+### Create an alphanumeric sender ID — `client.AlphanumericSenderIDs.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `UsLongCodeFallback` | string | A US long code number to use as fallback when sending to US destinations. |
+
+### Send a message — `client.Messages.Send()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `From` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `MessagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `Text` | string | Message body (i.e., content) as a non-empty string. |
+| `Subject` | string | Subject of multimedia message |
+| `MediaUrls` | array[string] | A list of media URLs. |
+| `WebhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `WebhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `UseProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `Type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `AutoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `SendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `Encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using an alphanumeric sender ID — `client.Messages.SendWithAlphanumericSender()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `WebhookUrl` | string (URL) | Callback URL for delivery status updates. |
+| `WebhookFailoverUrl` | string (URL) | Failover callback URL for delivery status updates. |
+| `UseProfileWebhooks` | boolean | If true, use the messaging profile's webhook settings. |
+
+### Send a group MMS message — `client.Messages.SendGroupMms()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Text` | string | Message body (i.e., content) as a non-empty string. |
+| `Subject` | string | Subject of multimedia message |
+| `MediaUrls` | array[string] | A list of media URLs. |
+| `WebhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `WebhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `UseProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+
+### Send a long code message — `client.Messages.SendLongCode()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Text` | string | Message body (i.e., content) as a non-empty string. |
+| `Subject` | string | Subject of multimedia message |
+| `MediaUrls` | array[string] | A list of media URLs. |
+| `WebhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `WebhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `UseProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `Type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `AutoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `Encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using number pool — `client.Messages.SendNumberPool()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Text` | string | Message body (i.e., content) as a non-empty string. |
+| `Subject` | string | Subject of multimedia message |
+| `MediaUrls` | array[string] | A list of media URLs. |
+| `WebhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `WebhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `UseProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `Type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `AutoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `Encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Schedule a message — `client.Messages.Schedule()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `From` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `MessagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `Text` | string | Message body (i.e., content) as a non-empty string. |
+| `Subject` | string | Subject of multimedia message |
+| `MediaUrls` | array[string] | A list of media URLs. |
+| `WebhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `WebhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `UseProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `Type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `AutoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `SendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+
+### Send a short code message — `client.Messages.SendShortCode()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Text` | string | Message body (i.e., content) as a non-empty string. |
+| `Subject` | string | Subject of multimedia message |
+| `MediaUrls` | array[string] | A list of media URLs. |
+| `WebhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `WebhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `UseProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `Type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `AutoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `Encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a WhatsApp message — `client.Messages.SendWhatsapp()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
+| `WebhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `MessagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
+
+### Update a messaging hosted number — `client.MessagingHostedNumbers.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `MessagingProfileId` | string (UUID) | Configure the messaging profile this phone number is assigned to:
+
+* Omit thi... |
+| `MessagingProduct` | string | Configure the messaging product for this number:
+
+* Omit this field or set it... |
+| `Tags` | array[string] | Tags to set on this phone number. |
+
+### Create auto-response setting — `client.MessagingProfiles.AutorespConfigs.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `RespText` | string |  |
+
+### Update Auto-Response Setting — `client.MessagingProfiles.AutorespConfigs.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `RespText` | string |  |
+
+## Webhook Payload Fields
+
+### `deliveryUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.sent, message.finalized | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: outbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | uuid | The id of the organization the messaging profile belongs to. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Subject of multimedia message |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | ISO 8601 formatted date indicating when the message was sent. |
+| `data.payload.completed_at` | date-time | ISO 8601 formatted date indicating when the message was finalized. |
+| `data.payload.valid_until` | date-time | Message must be out of the queue by this time or else it will be discarded and marked as 'sending_failed'. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+| `data.payload.smart_encoding_applied` | boolean | Indicates whether smart encoding was applied to this message. |
+| `data.payload.wait_seconds` | float | Seconds the message is queued due to rate limiting before being sent to the carrier. |
+| `meta.attempt` | integer | Number of attempts to deliver the webhook event. |
+| `meta.delivered_to` | url | The webhook URL the event was delivered to. |
+
+### `inboundMessage`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.received | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: inbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Message subject. |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | Not used for inbound messages. |
+| `data.payload.completed_at` | date-time | Not used for inbound messages. |
+| `data.payload.valid_until` | date-time | Not used for inbound messages. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+
+### `replacedLinkClick`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | string | Identifies the type of the resource. |
+| `data.url` | string | The original link that was sent in the message. |
+| `data.to` | string | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or short code). |
+| `data.message_id` | uuid | The message ID associated with the clicked link. |
+| `data.time_clicked` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+
+### Field Type Notes
+
+- `from` in responses/webhooks: object with sub-fields `phone_number` (string), `carrier` (string), `line_type` (string)
+- `to` in responses/webhooks: array of objects, each with `phone_number` (string), `carrier` (string), `line_type` (string), `status` (string)
+- `cost`: object with `amount` (string, decimal), `currency` (string, e.g., 'USD')

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/go/numbers.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/go/numbers.md
@@ -67,7 +67,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -406,7 +406,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -456,3 +456,433 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Numbers (Go) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Advanced Orders, Create Advanced Order, Update Advanced Order, Get Advanced Order
+
+| Field | Type |
+|-------|------|
+| `area_code` | string |
+| `comments` | string |
+| `country_code` | string |
+| `customer_reference` | string |
+| `features` | array[object] |
+| `id` | uuid |
+| `orders` | array[string] |
+| `phone_number_type` | object |
+| `quantity` | integer |
+| `requirement_group_id` | uuid |
+| `status` | object |
+
+**Returned by:** List available phone number blocks
+
+| Field | Type |
+|-------|------|
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `range` | integer |
+| `record_type` | enum: available_phone_number_block |
+| `region_information` | array[object] |
+
+**Returned by:** List available phone numbers
+
+| Field | Type |
+|-------|------|
+| `best_effort` | boolean |
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `quickship` | boolean |
+| `record_type` | enum: available_phone_number |
+| `region_information` | array[object] |
+| `reservable` | boolean |
+| `vanity_format` | string |
+
+**Returned by:** Retrieve all comments
+
+| Field | Type |
+|-------|------|
+| `body` | string |
+| `comment_record_id` | uuid |
+| `comment_record_type` | enum: sub_number_order, requirement_group |
+| `commenter` | string |
+| `commenter_type` | enum: admin, user |
+| `created_at` | date-time |
+| `id` | uuid |
+| `read_at` | date-time |
+| `updated_at` | date-time |
+
+**Returned by:** Create a comment, Retrieve a comment, Mark a comment as read, Get country coverage
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Get coverage for a specific country
+
+| Field | Type |
+|-------|------|
+| `code` | string |
+| `features` | array[string] |
+| `international_sms` | boolean |
+| `inventory_coverage` | boolean |
+| `local` | object |
+| `mobile` | object |
+| `national` | object |
+| `numbers` | boolean |
+| `p2p` | boolean |
+| `phone_number_type` | array[string] |
+| `quickship` | boolean |
+| `region` | string \| null |
+| `reservable` | boolean |
+| `shared_cost` | object |
+| `toll_free` | object |
+
+**Returned by:** List customer service records, Create a customer service record, Get a customer service record
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `error_message` | string \| null |
+| `id` | uuid |
+| `phone_number` | string |
+| `record_type` | string |
+| `result` | object \| null |
+| `status` | enum: pending, completed, failed |
+| `updated_at` | date-time |
+| `webhook_url` | string |
+
+**Returned by:** Verify CSR phone number coverage
+
+| Field | Type |
+|-------|------|
+| `additional_data_required` | array[string] |
+| `has_csr_coverage` | boolean |
+| `phone_number` | string |
+| `reason` | string |
+| `record_type` | string |
+
+**Returned by:** List inexplicit number orders, Create an inexplicit number order, Retrieve an inexplicit number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `ordering_groups` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Create an inventory coverage request
+
+| Field | Type |
+|-------|------|
+| `administrative_area` | string |
+| `advance_requirements` | boolean |
+| `count` | integer |
+| `coverage_type` | enum: number, block |
+| `group` | string |
+| `group_type` | string |
+| `number_range` | integer |
+| `number_type` | enum: did, toll-free |
+| `phone_number_type` | enum: local, toll_free, national, landline, shared_cost, mobile |
+| `record_type` | string |
+
+**Returned by:** List mobile network operators
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `id` | uuid |
+| `mcc` | string |
+| `mnc` | string |
+| `name` | string |
+| `network_preferences_enabled` | boolean |
+| `record_type` | string |
+| `tadig` | string |
+
+**Returned by:** List network coverage locations
+
+| Field | Type |
+|-------|------|
+| `available_services` | array[object] |
+| `location` | object |
+| `record_type` | string |
+
+**Returned by:** List number block orders, Create a number block order, Retrieve a number block order
+
+| Field | Type |
+|-------|------|
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers_count` | integer |
+| `range` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `starting_number` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve a list of phone numbers associated to orders, Retrieve a single phone number within a number order., Update requirements for a single phone number within a number order.
+
+| Field | Type |
+|-------|------|
+| `bundle_id` | uuid |
+| `country_code` | string |
+| `deadline` | date-time |
+| `id` | uuid |
+| `is_block_number` | boolean |
+| `locality` | string |
+| `order_request_id` | uuid |
+| `phone_number` | string |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `requirements_status` | enum: pending, approved, cancelled, deleted, requirement-info-exception, requirement-info-pending, requirement-info-under-review |
+| `status` | enum: pending, success, failure |
+| `sub_number_order_id` | uuid |
+
+**Returned by:** List number orders, Create a number order, Retrieve a number order, Update a number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers` | array[object] |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `sub_number_orders_ids` | array[string] |
+| `updated_at` | date-time |
+
+**Returned by:** List number reservations, Create a number reservation, Retrieve a number reservation, Extend a number reservation
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `errors` | string |
+| `id` | uuid |
+| `phone_numbers` | array[object] |
+| `record_type` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve the features for a list of numbers
+
+| Field | Type |
+|-------|------|
+| `features` | array[string] |
+| `phone_number` | string |
+
+**Returned by:** Lists the phone number blocks jobs, Deletes all numbers associated with a phone number block, Retrieves a phone number blocks job
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `etc` | date-time |
+| `failed_operations` | array[object] |
+| `id` | uuid |
+| `record_type` | string |
+| `status` | enum: pending, in_progress, completed, failed |
+| `successful_operations` | array[object] |
+| `type` | enum: delete_phone_number_block |
+| `updated_at` | string |
+
+**Returned by:** List sub number orders, Retrieve a sub number order, Update a sub number order's requirements, Cancel a sub number order
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `is_block_sub_number_order` | boolean |
+| `order_request_id` | uuid |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+**Returned by:** Create a sub number orders report, Retrieve a sub number orders report
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `filters` | object |
+| `id` | uuid |
+| `order_type` | string |
+| `status` | enum: pending, success, failed, expired |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+## Optional Parameters
+
+### Create Advanced Order — `client.AdvancedOrders.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `CountryCode` | string (ISO 3166-1 alpha-2) |  |
+| `Comments` | string |  |
+| `Quantity` | integer |  |
+| `AreaCode` | string |  |
+| `PhoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `Features` | array[object] |  |
+| `CustomerReference` | string |  |
+| `RequirementGroupId` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Update Advanced Order — `client.AdvancedOrders.UpdateRequirementGroup()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `CountryCode` | string (ISO 3166-1 alpha-2) |  |
+| `Comments` | string |  |
+| `Quantity` | integer |  |
+| `AreaCode` | string |  |
+| `PhoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `Features` | array[object] |  |
+| `CustomerReference` | string |  |
+| `RequirementGroupId` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Create a comment — `client.Comments.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Id` | string (UUID) |  |
+| `Body` | string |  |
+| `Commenter` | string |  |
+| `CommenterType` | enum (admin, user) |  |
+| `CommentRecordType` | enum (sub_number_order, requirement_group) |  |
+| `CommentRecordId` | string (UUID) |  |
+| `ReadAt` | string (date-time) | An ISO 8901 datetime string for when the comment was read. |
+| `CreatedAt` | string (date-time) | An ISO 8901 datetime string denoting when the comment was created. |
+| `UpdatedAt` | string (date-time) | An ISO 8901 datetime string for when the comment was updated. |
+
+### Create an inexplicit number order — `client.InexplicitNumberOrders.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ConnectionId` | string (UUID) | Connection id to apply to phone numbers that are purchased |
+| `MessagingProfileId` | string (UUID) | Messaging profile id to apply to phone numbers that are purchased |
+| `CustomerReference` | string | Reference label for the customer |
+| `BillingGroupId` | string (UUID) | Billing group id to apply to phone numbers that are purchased |
+
+### Create a number block order — `client.NumberBlockOrders.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Id` | string (UUID) |  |
+| `RecordType` | string |  |
+| `PhoneNumbersCount` | integer | The count of phone numbers in the number order. |
+| `ConnectionId` | string (UUID) | Identifies the connection associated with this phone number. |
+| `MessagingProfileId` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `Status` | enum (pending, success, failure) | The status of the order. |
+| `CustomerReference` | string | A customer reference string for customer look ups. |
+| `CreatedAt` | string (date-time) | An ISO 8901 datetime string denoting when the number order was created. |
+| `UpdatedAt` | string (date-time) | An ISO 8901 datetime string for when the number order was updated. |
+| `RequirementsMet` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `Errors` | string | Errors the reservation could happen upon |
+
+### Update requirements for a single phone number within a number order. — `client.NumberOrderPhoneNumbers.UpdateRequirements()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `RegulatoryRequirements` | array[object] |  |
+
+### Create a number order — `client.NumberOrders.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `PhoneNumbers` | array[object] |  |
+| `ConnectionId` | string (UUID) | Identifies the connection associated with this phone number. |
+| `MessagingProfileId` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `BillingGroupId` | string (UUID) | Identifies the billing group associated with the phone number. |
+| `CustomerReference` | string | A customer reference string for customer look ups. |
+
+### Update a number order — `client.NumberOrders.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `RegulatoryRequirements` | array[object] |  |
+| `CustomerReference` | string | A customer reference string for customer look ups. |
+
+### Create a number reservation — `client.NumberReservations.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Id` | string (UUID) |  |
+| `RecordType` | string |  |
+| `PhoneNumbers` | array[object] |  |
+| `Status` | enum (pending, success, failure) | The status of the entire reservation. |
+| `CustomerReference` | string | A customer reference string for customer look ups. |
+| `CreatedAt` | string (date-time) | An ISO 8901 datetime string denoting when the numbers reservation was created. |
+| `UpdatedAt` | string (date-time) | An ISO 8901 datetime string for when the number reservation was updated. |
+
+### Update a sub number order's requirements — `client.SubNumberOrders.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `RegulatoryRequirements` | array[object] |  |
+
+### Create a sub number orders report — `client.SubNumberOrdersReport.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Status` | enum (pending, success, failure) | Filter by order status |
+| `CountryCode` | string (ISO 3166-1 alpha-2) | Filter by country code |
+| `CreatedAtGt` | string (date-time) | Filter for orders created after this date |
+| `CreatedAtLt` | string (date-time) | Filter for orders created before this date |
+| `OrderRequestId` | string (UUID) | Filter by specific order request ID |
+| `CustomerReference` | string | Filter by customer reference |
+
+## Webhook Payload Fields
+
+### `numberOrderStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.event_type` | string | The type of event being sent |
+| `data.id` | uuid | Unique identifier for the event |
+| `data.occurred_at` | date-time | ISO 8601 timestamp of when the event occurred |
+| `data.payload.id` | uuid |  |
+| `data.payload.record_type` | string |  |
+| `data.payload.phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `data.payload.connection_id` | string | Identifies the connection associated with this phone number. |
+| `data.payload.messaging_profile_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.billing_group_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.phone_numbers` | array[object] |  |
+| `data.payload.sub_number_orders_ids` | array[string] |  |
+| `data.payload.status` | enum: pending, success, failure | The status of the order. |
+| `data.payload.customer_reference` | string | A customer reference string for customer look ups. |
+| `data.payload.created_at` | date-time | An ISO 8901 datetime string denoting when the number order was created. |
+| `data.payload.updated_at` | date-time | An ISO 8901 datetime string for when the number order was updated. |
+| `data.payload.requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `data.record_type` | string | Type of record |
+| `meta.attempt` | integer | Webhook delivery attempt number |
+| `meta.delivered_to` | uri | URL where the webhook was delivered |

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/go/voice.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/go/voice.md
@@ -39,7 +39,7 @@ response, err := client.Calls.Dial(context.Background(), telnyx.CallDialParams{
 		ConnectionID: "7267xxxxxxxxxxxxxx",
 		From:         "+18005550101",
 		To: telnyx.CallDialParamsToUnion{
-			OfString: telnyx.String("+18005550100"),
+			OfString: telnyx.String("+18005550100;secure=srtp"),
 		},
 	})
 if err != nil {
@@ -79,8 +79,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -98,14 +98,14 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `TimeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `BillingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `ClientState` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in the API Details section below |
+| ... | | | +56 optional params in the API Details section below |
 
 ```go
 	response, err := client.Calls.Dial(context.Background(), telnyx.CallDialParams{
 		ConnectionID: "7267xxxxxxxxxxxxxx",
 		From:         "+18005550101",
 		To: telnyx.CallDialParamsToUnion{
-			OfString: telnyx.String("+18005550100"),
+			OfString: telnyx.String("+18005550100;secure=srtp"),
 		},
 	})
 	if err != nil {
@@ -134,7 +134,7 @@ Primary inbound call-control command.
 | `BillingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `ClientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `WebhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in the API Details section below |
+| ... | | | +29 optional params in the API Details section below |
 
 ```go
 	response, err := client.Calls.Actions.Answer(
@@ -165,14 +165,14 @@ Common post-answer control path with downstream webhook implications.
 | `TimeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `ClientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `WebhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in the API Details section below |
+| ... | | | +35 optional params in the API Details section below |
 
 ```go
 	response, err := client.Calls.Actions.Transfer(
 		context.Background(),
 		"call_control_id",
 		telnyx.CallActionTransferParams{
-			To: "+18005550100",
+			To: "+18005550100;secure=srtp",
 		},
 	)
 	if err != nil {
@@ -249,7 +249,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
 | `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -445,7 +445,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -465,3 +465,427 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Voice (Go) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List call control applications, Create a call control application, Retrieve a call control application, Update a call control application, Delete a call control application
+
+| Field | Type |
+|-------|------|
+| `active` | boolean |
+| `anchorsite_override` | enum: Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, Chennai, IN, Amsterdam, Netherlands, Toronto, Canada, Sydney, Australia |
+| `application_name` | string |
+| `call_cost_in_webhooks` | boolean |
+| `created_at` | string |
+| `dtmf_type` | enum: RFC 2833, Inband, SIP INFO |
+| `first_command_timeout` | boolean |
+| `first_command_timeout_secs` | integer |
+| `id` | string |
+| `inbound` | object |
+| `outbound` | object |
+| `record_type` | enum: call_control_application |
+| `redact_dtmf_debug_logging` | boolean |
+| `tags` | array[string] |
+| `updated_at` | string |
+| `webhook_api_version` | enum: 1, 2 |
+| `webhook_event_failover_url` | url |
+| `webhook_event_url` | url |
+| `webhook_timeout_secs` | integer \| null |
+
+**Returned by:** Dial
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `recording_id` | uuid |
+| `start_time` | string |
+
+**Returned by:** Retrieve a call status
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `start_time` | string |
+
+**Returned by:** Answer call
+
+| Field | Type |
+|-------|------|
+| `recording_id` | uuid |
+| `result` | string |
+
+**Returned by:** Bridge calls, Hangup call, SIP Refer a call, Reject a call, Send SIP info, Transfer call
+
+| Field | Type |
+|-------|------|
+| `result` | string |
+
+**Returned by:** List all active calls for given connection
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `record_type` | enum: call |
+
+## Optional Parameters
+
+### Create a call control application — `client.CallControlApplications.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Active` | boolean | Specifies whether the connection can be used. |
+| `AnchorsiteOverride` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `DtmfType` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `FirstCommandTimeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `FirstCommandTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `Inbound` | object |  |
+| `Outbound` | object |  |
+| `WebhookApiVersion` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `WebhookEventFailoverUrl` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `WebhookTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `CallCostInWebhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `RedactDtmfDebugLogging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Update a call control application — `client.CallControlApplications.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `CallCostInWebhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `Active` | boolean | Specifies whether the connection can be used. |
+| `AnchorsiteOverride` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `DtmfType` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `FirstCommandTimeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `FirstCommandTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `Tags` | array[string] | Tags assigned to the Call Control Application. |
+| `Inbound` | object |  |
+| `Outbound` | object |  |
+| `WebhookApiVersion` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `WebhookEventFailoverUrl` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `WebhookTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `RedactDtmfDebugLogging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Dial — `client.Calls.Dial()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Assistant` | object | AI Assistant configuration. |
+| `ConversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `FromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `Privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `AudioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `SendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
+| `MediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
+| `PreferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `TimeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `TimeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `AnsweringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `AnsweringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `DeepfakeDetection` | object | Enables deepfake detection on the call. |
+| `ConferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
+| `CustomHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `BillingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `ClientState` | string | Use this field to add state to every subsequent webhook. |
+| `CommandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `LinkTo` | string | Use another call's control id for sharing the same call session id |
+| `BridgeIntent` | boolean | Indicates the intent to bridge this call with the call specified in link_to. |
+| `BridgeOnAnswer` | boolean | Whether to automatically bridge answered call to the call specified in link_to. |
+| `PreventDoubleBridge` | boolean | Prevents bridging and hangs up the call if the target is already bridged. |
+| `ParkAfterUnbridge` | string | If supplied with the value `self`, the current leg will be parked after unbri... |
+| `MediaEncryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the call. |
+| `SipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
+| `SipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
+| `SipHeaders` | array[object] | SIP headers to be added to the SIP INVITE request. |
+| `SipTransportProtocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `SoundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `StreamUrl` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `StreamTrack` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `StreamCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `StreamBidirectionalMode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `StreamBidirectionalCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `StreamBidirectionalTargetLegs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `StreamBidirectionalSamplingRate` | enum (8000, 16000, 22050, 24000, 48000) | Audio sampling rate. |
+| `StreamEstablishBeforeCallOriginate` | boolean | Establish websocket connection before dialing the destination. |
+| `SendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
+| `WebhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `WebhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `WebhookUrls` | object | A map of event types to webhook URLs. |
+| `WebhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `WebhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `Record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `RecordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `RecordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `RecordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `RecordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `RecordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `RecordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `RecordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `SuperviseCallControlId` | string (UUID) | The call leg which will be supervised by the new call. |
+| `SupervisorRole` | enum (barge, whisper, monitor) | The role of the supervisor call. |
+| `EnableDialogflow` | boolean | Enables Dialogflow for the current call. |
+| `DialogflowConfig` | object |  |
+| `Transcription` | boolean | Enable transcription upon call answer. |
+| `TranscriptionConfig` | object |  |
+| `SipRegion` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `StreamAuthToken` | string | An authentication token to be sent as part of the WebSocket connection when u... |
+
+### Answer call — `client.Calls.Actions.Answer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Assistant` | object | AI Assistant configuration. |
+| `ConversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `BillingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `ClientState` | string | Use this field to add state to every subsequent webhook. |
+| `CommandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `CustomHeaders` | array[object] | Custom headers to be added to the SIP INVITE response. |
+| `PreferredCodecs` | enum (G722,PCMU,PCMA,G729,OPUS,VP8,H264) | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `SipHeaders` | array[object] | SIP headers to be added to the SIP INVITE response. |
+| `SoundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `StreamUrl` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `StreamTrack` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `StreamCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `StreamBidirectionalMode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `StreamBidirectionalCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `StreamBidirectionalTargetLegs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `SendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
+| `WebhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `WebhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `Transcription` | boolean | Enable transcription upon call answer. |
+| `TranscriptionConfig` | object |  |
+| `Record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `RecordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `RecordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `RecordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `RecordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `RecordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `RecordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `RecordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `WebhookUrls` | object | A map of event types to webhook URLs. |
+| `WebhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `WebhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `DeepfakeDetection` | object | Enables deepfake detection on the call. |
+
+### Bridge calls — `client.Calls.Actions.Bridge()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ClientState` | string | Use this field to add state to every subsequent webhook. |
+| `CommandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `Queue` | string | The name of the queue you want to bridge with, can't be used together with ca... |
+| `VideoRoomId` | string (UUID) | The ID of the video room you want to bridge with, can't be used together with... |
+| `VideoRoomContext` | string | The additional parameter that will be passed to the video conference. |
+| `PreventDoubleBridge` | boolean | When set to `true`, it prevents bridging if the target call is already bridge... |
+| `ParkAfterUnbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `PlayRingtone` | boolean | Specifies whether to play a ringtone if the call you want to bridge with has ... |
+| `Ringtone` | enum (at, au, be, bg, br, ...) | Specifies which country ringtone to play when `play_ringtone` is set to `true`. |
+| `Record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `RecordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `RecordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `RecordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `RecordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `RecordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `RecordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `RecordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `MuteDtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `HoldAfterUnbridge` | boolean | Specifies behavior after the bridge ends. |
+
+### Hangup call — `client.Calls.Actions.Hangup()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ClientState` | string | Use this field to add state to every subsequent webhook. |
+| `CommandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `CustomHeaders` | array[object] | Custom headers to be added to the SIP BYE message. |
+
+### SIP Refer a call — `client.Calls.Actions.Refer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ClientState` | string | Use this field to add state to every subsequent webhook. |
+| `CommandId` | string (UUID) | Use this field to avoid execution of duplicate commands. |
+| `CustomHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `SipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
+| `SipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
+| `SipHeaders` | array[object] | SIP headers to be added to the request. |
+
+### Reject a call — `client.Calls.Actions.Reject()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ClientState` | string | Use this field to add state to every subsequent webhook. |
+| `CommandId` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Send SIP info — `client.Calls.Actions.SendSipInfo()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ClientState` | string | Use this field to add state to every subsequent webhook. |
+| `CommandId` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Transfer call — `client.Calls.Actions.Transfer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `From` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
+| `FromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `Privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `AudioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `SendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
+| `EarlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
+| `MediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
+| `TimeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `TimeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `ParkAfterUnbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `AnsweringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `AnsweringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `CustomHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `ClientState` | string | Use this field to add state to every subsequent webhook. |
+| `TargetLegClientState` | string | Use this field to add state to every subsequent webhook for the new leg. |
+| `CommandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `MediaEncryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the new call leg. |
+| `SipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
+| `SipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
+| `SipHeaders` | array[object] | SIP headers to be added to the SIP INVITE. |
+| `SipTransportProtocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `SoundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `WebhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `WebhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `MuteDtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `Record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `RecordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `RecordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `RecordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `RecordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `RecordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `RecordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `RecordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `SipRegion` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `PreferredCodecs` | string | The list of comma-separated codecs in order of preference to be used during t... |
+| `WebhookUrls` | object | A map of event types to webhook URLs. |
+| `WebhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `WebhookRetriesPolicies` | object | A map of event types to retry policies. |
+
+## Webhook Payload Fields
+
+### `callAnswered`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.answered | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: answered | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### `callBridged`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.bridged | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+
+### `callHangup`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.hangup | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: hangup | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+| `data.payload.hangup_cause` | enum: call_rejected, normal_clearing, originator_cancel, timeout, time_limit, user_busy, not_found, no_answer, unspecified | The reason the call was ended (`call_rejected`, `normal_clearing`, `originator_cancel`, `timeout`, `time_limit`, `use... |
+| `data.payload.hangup_source` | enum: caller, callee, unknown | The party who ended the call (`callee`, `caller`, `unknown`). |
+| `data.payload.sip_hangup_cause` | string | The reason the call was ended (SIP response code). |
+| `data.payload.call_quality_stats` | object \| null | Call quality statistics aggregated from the CHANNEL_HANGUP_COMPLETE event. |
+
+### `callInitiated`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.initiated | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
+| `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.custom_headers` | array[object] | Custom headers from sip invite |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.shaken_stir_attestation` | string | SHAKEN/STIR attestation level. |
+| `data.payload.shaken_stir_validated` | boolean | Whether attestation was successfully validated or not. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.caller_id_name` | string | Caller id. |
+| `data.payload.call_screening_result` | string | Call screening result. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.direction` | enum: incoming, outgoing | Whether the call is `incoming` or `outgoing`. |
+| `data.payload.state` | enum: parked, bridging | State received from a command. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### Field Type Notes
+
+- `from` in webhook payloads: string (E.164 phone number)
+- `to` in webhook payloads: string (E.164 phone number)
+- The return value of `client.webhooks.unwrap()` is a parsed event object — access fields via `event.data.event_type`, `event.data.payload.call_control_id`, etc.

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/java/10dlc.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/java/10dlc.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -66,8 +66,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -232,7 +232,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `description` | string | Description of the event. |
 | `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -309,7 +309,6 @@ Create or provision an additional resource when the core tasks do not cover this
 ```java
 import com.telnyx.sdk.models.messaging10dlc.phonenumbercampaigns.PhoneNumberCampaign;
 import com.telnyx.sdk.models.messaging10dlc.phonenumbercampaigns.PhoneNumberCampaignCreate;
-import com.telnyx.sdk.models.messaging10dlc.phonenumbercampaigns.PhoneNumberCampaignCreateParams;
 
 PhoneNumberCampaignCreate params = PhoneNumberCampaignCreate.builder()
     .campaignId("4b300178-131c-d902-d54e-72d90ba1620j")
@@ -402,7 +401,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -442,3 +441,471 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# 10DLC (Java) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Brands, List Campaigns, List shared partner campaigns, List Shared Campaigns, List phone number campaigns
+
+| Field | Type |
+|-------|------|
+| `page` | integer |
+| `records` | array[object] |
+| `totalRecords` | integer |
+
+**Returned by:** Create Brand, Update Brand, Revet Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Get Brand Feedback By Id
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `category` | array[object] |
+
+**Returned by:** Get Brand SMS OTP Status, Get Brand SMS OTP Status by Brand ID
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `deliveryStatus` | string |
+| `deliveryStatusDate` | date-time |
+| `deliveryStatusDetails` | string |
+| `mobilePhone` | string |
+| `referenceId` | string |
+| `requestDate` | date-time |
+| `verifyDate` | date-time |
+
+**Returned by:** Get Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `assignedCampaignsCount` | number |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Order Brand External Vetting, Import External Vetting Record
+
+| Field | Type |
+|-------|------|
+| `createDate` | string |
+| `evpId` | string |
+| `vettedDate` | string |
+| `vettingClass` | string |
+| `vettingId` | string |
+| `vettingScore` | integer |
+| `vettingToken` | string |
+
+**Returned by:** Trigger Brand SMS OTP
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `referenceId` | string |
+
+**Returned by:** Get Campaign Cost
+
+| Field | Type |
+|-------|------|
+| `campaignUsecase` | string |
+| `description` | string |
+| `monthlyCost` | string |
+| `upFrontCost` | string |
+
+**Returned by:** Get campaign, Update campaign, Submit Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `autoRenewal` | boolean |
+| `billedDate` | string |
+| `brandDisplayName` | string |
+| `brandId` | string |
+| `campaignId` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createDate` | string |
+| `cspId` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isTMobileNumberPoolingEnabled` | boolean |
+| `isTMobileRegistered` | boolean |
+| `isTMobileSuspended` | boolean |
+| `messageFlow` | string |
+| `mock` | boolean |
+| `nextRenewalOrExpirationDate` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `referenceId` | string |
+| `resellerId` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `status` | string |
+| `subUsecases` | array[string] |
+| `submissionStatus` | enum: CREATED, FAILED, PENDING |
+| `subscriberHelp` | boolean |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `usecase` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Deactivate campaign
+
+| Field | Type |
+|-------|------|
+| `message` | string |
+| `record_type` | string |
+| `time` | number |
+
+**Returned by:** Submit campaign appeal for manual review
+
+| Field | Type |
+|-------|------|
+| `appealed_at` | date-time |
+
+**Returned by:** Get Campaign Mno Metadata
+
+| Field | Type |
+|-------|------|
+| `10999` | object |
+
+**Returned by:** Get Sharing Status
+
+| Field | Type |
+|-------|------|
+| `sharedByMe` | object |
+| `sharedWithMe` | object |
+
+**Returned by:** Qualify By Usecase
+
+| Field | Type |
+|-------|------|
+| `annualFee` | number |
+| `maxSubUsecases` | integer |
+| `minSubUsecases` | integer |
+| `mnoMetadata` | object |
+| `monthlyFee` | number |
+| `quarterlyFee` | number |
+| `usecase` | string |
+
+**Returned by:** Get Single Shared Campaign, Update Single Shared Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `assignedPhoneNumbersCount` | number |
+| `brandDisplayName` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createdAt` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isNumberPoolingEnabled` | boolean |
+| `messageFlow` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `subUsecases` | array[string] |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `updatedAt` | string |
+| `usecase` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Assign Messaging Profile To Campaign
+
+| Field | Type |
+|-------|------|
+| `campaignId` | string |
+| `messagingProfileId` | string |
+| `taskId` | string |
+| `tcrCampaignId` | string |
+
+**Returned by:** Get Assignment Task Status
+
+| Field | Type |
+|-------|------|
+| `createdAt` | date-time |
+| `status` | string |
+| `taskId` | string |
+| `updatedAt` | date-time |
+
+**Returned by:** Get Phone Number Status
+
+| Field | Type |
+|-------|------|
+| `records` | array[object] |
+
+**Returned by:** Create New Phone Number Campaign, Get Single Phone Number Campaign, Create New Phone Number Campaign, Delete Phone Number Campaign
+
+| Field | Type |
+|-------|------|
+| `assignmentStatus` | enum: FAILED_ASSIGNMENT, PENDING_ASSIGNMENT, ASSIGNED, PENDING_UNASSIGNMENT, FAILED_UNASSIGNMENT |
+| `brandId` | string |
+| `campaignId` | string |
+| `createdAt` | string |
+| `failureReasons` | string |
+| `phoneNumber` | string |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `telnyxCampaignId` | string |
+| `updatedAt` | string |
+
+## Optional Parameters
+
+### Create Brand — `client.messaging10dlc().brand().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `companyName` | string | (Required for Non-profit/private/public) Legal company name. |
+| `firstName` | string | First name of business contact. |
+| `lastName` | string | Last name of business contact. |
+| `ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `phone` | string | Valid phone number in e.164 international format. |
+| `street` | string | Street number and name. |
+| `city` | string | City name |
+| `state` | string | State. |
+| `postalCode` | string | Postal codes. |
+| `stockSymbol` | string | (Required for public company) stock symbol. |
+| `stockExchange` | object | (Required for public company) stock exchange. |
+| `ipAddress` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `website` | string | Brand website URL. |
+| `isReseller` | boolean |  |
+| `mock` | boolean | Mock brand for testing purposes. |
+| `mobilePhone` | string | Valid mobile phone number in e.164 international format. |
+| `businessContactEmail` | string | Business contact email. |
+| `webhookURL` | string | Webhook URL for brand status updates. |
+| `webhookFailoverURL` | string | Webhook failover URL for brand status updates. |
+
+### Update Brand — `client.messaging10dlc().brand().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `companyName` | string | (Required for Non-profit/private/public) Legal company name. |
+| `firstName` | string | First name of business contact. |
+| `lastName` | string | Last name of business contact. |
+| `ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `phone` | string | Valid phone number in e.164 international format. |
+| `street` | string | Street number and name. |
+| `city` | string | City name |
+| `state` | string | State. |
+| `postalCode` | string | Postal codes. |
+| `stockSymbol` | string | (Required for public company) stock symbol. |
+| `stockExchange` | object | (Required for public company) stock exchange. |
+| `ipAddress` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `website` | string | Brand website URL. |
+| `altBusinessIdType` | enum (NONE, DUNS, GIIN, LEI) | An enumeration. |
+| `isReseller` | boolean |  |
+| `identityStatus` | enum (VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED) | The verification status of an active brand |
+| `businessContactEmail` | string | Business contact email. |
+| `webhookURL` | string | Webhook URL for brand status updates. |
+| `webhookFailoverURL` | string | Webhook failover URL for brand status updates. |
+| `altBusinessId` | string (UUID) | Alternate business identifier such as DUNS, LEI, or GIIN |
+
+### Import External Vetting Record — `client.messaging10dlc().brand().externalVetting().imports()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `vettingToken` | string | Required by some providers for vetting record confirmation. |
+
+### Update campaign — `client.messaging10dlc().campaign().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `resellerId` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `sample1` | string | Message sample. |
+| `sample2` | string | Message sample. |
+| `sample3` | string | Message sample. |
+| `sample4` | string | Message sample. |
+| `sample5` | string | Message sample. |
+| `messageFlow` | string | Message flow description. |
+| `helpMessage` | string | Help message of the campaign. |
+| `autoRenewal` | boolean | Help message of the campaign. |
+| `webhookURL` | string | Webhook to which campaign status updates are sent. |
+| `webhookFailoverURL` | string | Webhook failover to which campaign status updates are sent. |
+
+### Submit Campaign — `client.messaging10dlc().campaignBuilder().submit()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ageGated` | boolean | Age gated message content in campaign. |
+| `autoRenewal` | boolean | Campaign subscription auto-renewal option. |
+| `directLending` | boolean | Direct lending or loan arrangement |
+| `embeddedLink` | boolean | Does message generated by the campaign include URL link in SMS? |
+| `embeddedPhone` | boolean | Does message generated by the campaign include phone number in SMS? |
+| `helpKeywords` | string | Subscriber help keywords. |
+| `helpMessage` | string | Help message of the campaign. |
+| `messageFlow` | string | Message flow description. |
+| `mnoIds` | array[integer] | Submit campaign to given list of MNOs by MNO's network ID. |
+| `numberPool` | boolean | Does campaign utilize pool of phone numbers? |
+| `optinKeywords` | string | Subscriber opt-in keywords. |
+| `optinMessage` | string | Subscriber opt-in message. |
+| `optoutKeywords` | string | Subscriber opt-out keywords. |
+| `optoutMessage` | string | Subscriber opt-out message. |
+| `referenceId` | string (UUID) | Caller supplied campaign reference ID. |
+| `resellerId` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `sample1` | string | Message sample. |
+| `sample2` | string | Message sample. |
+| `sample3` | string | Message sample. |
+| `sample4` | string | Message sample. |
+| `sample5` | string | Message sample. |
+| `subUsecases` | array[string] | Campaign sub-usecases. |
+| `subscriberHelp` | boolean | Does campaign responds to help keyword(s)? |
+| `subscriberOptin` | boolean | Does campaign require subscriber to opt-in before SMS is sent to subscriber? |
+| `subscriberOptout` | boolean | Does campaign support subscriber opt-out keyword(s)? |
+| `tag` | array[string] | Tags to be set on the Campaign. |
+| `termsAndConditions` | boolean | Is terms and conditions accepted? |
+| `privacyPolicyLink` | string | Link to the campaign's privacy policy. |
+| `termsAndConditionsLink` | string | Link to the campaign's terms and conditions. |
+| `embeddedLinkSample` | string | Sample of an embedded link that will be sent to subscribers. |
+| `webhookURL` | string | Webhook to which campaign status updates are sent. |
+| `webhookFailoverURL` | string | Failover webhook to which campaign status updates are sent. |
+
+### Update Single Shared Campaign — `client.messaging10dlc().partnerCampaigns().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `webhookURL` | string | Webhook to which campaign status updates are sent. |
+| `webhookFailoverURL` | string | Webhook failover to which campaign status updates are sent. |
+
+### Assign Messaging Profile To Campaign — `client.messaging10dlc().phoneNumberAssignmentByProfile().assign()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `tcrCampaignId` | string (UUID) | The TCR ID of the shared campaign you want to link to the specified messaging... |
+| `campaignId` | string (UUID) | The ID of the campaign you want to link to the specified messaging profile. |
+
+## Webhook Payload Fields
+
+### `campaignStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `brandId` | string | Brand ID associated with the campaign. |
+| `campaignId` | string | The ID of the campaign. |
+| `createDate` | string | Unix timestamp when campaign was created. |
+| `cspId` | string | Alphanumeric identifier of the CSP associated with this campaign. |
+| `isTMobileRegistered` | boolean | Indicates whether the campaign is registered with T-Mobile. |
+| `type` | enum: TELNYX_EVENT, REGISTRATION, MNO_REVIEW, TELNYX_REVIEW, NUMBER_POOL_PROVISIONED, NUMBER_POOL_DEPROVISIONED, TCR_EVENT, VERIFIED |  |
+| `description` | string | Description of the event. |
+| `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/java/ai-assistants.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/java/ai-assistants.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -37,8 +37,8 @@ import com.telnyx.sdk.models.ai.assistants.AssistantCreateParams;
 import com.telnyx.sdk.models.ai.assistants.InferenceEmbedding;
 AssistantCreateParams params = AssistantCreateParams.builder()
     .instructions("You are a helpful assistant.")
-    .model("openai/gpt-4o")
     .name("my-resource")
+    .model("openai/gpt-4o")
     .build();
 InferenceEmbedding assistant = client.ai().assistants().create(params);
 ```
@@ -57,7 +57,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -70,12 +70,11 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `description` | string | No |  |
-| `greeting` | string | No | Text that the assistant will use to start the conversation. |
-| ... | | | +11 optional params in the API Details section below |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in the API Details section below |
 
 ```java
 import com.telnyx.sdk.models.ai.assistants.AssistantCreateParams;
@@ -83,8 +82,8 @@ import com.telnyx.sdk.models.ai.assistants.InferenceEmbedding;
 
 AssistantCreateParams params = AssistantCreateParams.builder()
     .instructions("You are a helpful assistant.")
-    .model("openai/gpt-4o")
     .name("my-resource")
+    .model("openai/gpt-4o")
     .build();
 InferenceEmbedding assistant = client.ai().assistants().create(params);
 ```
@@ -203,7 +202,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### Update an assistant
 
@@ -214,10 +213,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistantId` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +15 optional params in the API Details section below |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in the API Details section below |
 
 ```java
 import com.telnyx.sdk.models.ai.assistants.AssistantUpdateParams;
@@ -232,7 +231,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### List assistants
 
@@ -256,7 +255,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Import assistants from external provider
 
@@ -290,7 +289,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Get All Tags
 
@@ -396,7 +395,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -409,8 +408,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai().assistants().tests().runs().retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId`, `runId` |
 | Delete an assistant | `client.ai().assistants().delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Get Canary Deploy | `client.ai().assistants().canaryDeploys().retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Create Canary Deploy | `client.ai().assistants().canaryDeploys().create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistantId` |
-| Update Canary Deploy | `client.ai().assistants().canaryDeploys().update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistantId` |
+| Create Canary Deploy | `client.ai().assistants().canaryDeploys().create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId` |
+| Update Canary Deploy | `client.ai().assistants().canaryDeploys().update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistantId` |
 | Delete Canary Deploy | `client.ai().assistants().canaryDeploys().delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Assistant Sms Chat | `client.ai().assistants().sendSms()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistantId` |
 | Clone Assistant | `client.ai().assistants().clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId` |
@@ -421,6 +420,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Add Assistant Tag | `client.ai().assistants().tags().add()` | `POST /ai/assistants/{assistant_id}/tags` | Create or provision an additional resource when the core tasks do not cover this flow. | `tag`, `assistantId` |
 | Remove Assistant Tag | `client.ai().assistants().tags().remove()` | `DELETE /ai/assistants/{assistant_id}/tags/{tag}` | Remove, detach, or clean up an existing resource. | `assistantId`, `tag` |
 | Get assistant texml | `client.ai().assistants().getTexml()` | `GET /ai/assistants/{assistant_id}/texml` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
+| Add Assistant Tool | `client.ai().assistants().tools().add()` | `PUT /ai/assistants/{assistant_id}/tools/{tool_id}` | Modify an existing resource without recreating it. | `assistantId`, `toolId` |
+| Remove Assistant Tool | `client.ai().assistants().tools().remove()` | `DELETE /ai/assistants/{assistant_id}/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `assistantId`, `toolId` |
 | Test Assistant Tool | `client.ai().assistants().tools().test()` | `POST /ai/assistants/{assistant_id}/tools/{tool_id}/test` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId`, `toolId` |
 | Get all versions of an assistant | `client.ai().assistants().versions().list()` | `GET /ai/assistants/{assistant_id}/versions` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
 | Get a specific assistant version | `client.ai().assistants().versions().retrieve()` | `GET /ai/assistants/{assistant_id}/versions/{version_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId`, `versionId` |
@@ -432,7 +433,398 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get MCP Server | `client.ai().mcpServers().retrieve()` | `GET /ai/mcp_servers/{mcp_server_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `mcpServerId` |
 | Update MCP Server | `client.ai().mcpServers().update()` | `PUT /ai/mcp_servers/{mcp_server_id}` | Modify an existing resource without recreating it. | `mcpServerId` |
 | Delete MCP Server | `client.ai().mcpServers().delete()` | `DELETE /ai/mcp_servers/{mcp_server_id}` | Remove, detach, or clean up an existing resource. | `mcpServerId` |
+| List Tools | `client.ai().tools().list()` | `GET /ai/tools` | Inspect available resources or choose an existing resource before mutating it. | None |
+| Create Tool | `client.ai().tools().create()` | `POST /ai/tools` | Create or provision an additional resource when the core tasks do not cover this flow. | `type`, `displayName` |
+| Get Tool | `client.ai().tools().retrieve()` | `GET /ai/tools/{tool_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `toolId` |
+| Update Tool | `client.ai().tools().update()` | `PATCH /ai/tools/{tool_id}` | Modify an existing resource without recreating it. | `toolId` |
+| Delete Tool | `client.ai().tools().delete()` | `DELETE /ai/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `toolId` |
 
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# AI Assistants (Java) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+
+## Response Schemas
+
+**Returned by:** List assistants, Create an assistant, Import assistants from external provider, Get an assistant, Update an assistant, Clone Assistant, Get all versions of an assistant, Get a specific assistant version, Update a specific assistant version, Promote an assistant version to main
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
+| `dynamic_variables_webhook_url` | string |
+| `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
+| `greeting` | string |
+| `id` | string |
+| `import_metadata` | object |
+| `insight_settings` | object |
+| `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
+| `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
+| `messaging_settings` | object |
+| `model` | string |
+| `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
+| `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
+| `telephony_settings` | object |
+| `tools` | array[object] |
+| `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
+| `voice_settings` | object |
+| `widget_settings` | object |
+
+**Returned by:** Get All Tags, Add Assistant Tag, Remove Assistant Tag
+
+| Field | Type |
+|-------|------|
+| `tags` | array[string] |
+
+**Returned by:** List assistant tests with pagination, Create a new assistant test, Get assistant test by ID, Update an assistant test
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `destination` | string |
+| `instructions` | string |
+| `max_duration_seconds` | integer |
+| `name` | string |
+| `rubric` | array[object] |
+| `telnyx_conversation_channel` | object |
+| `test_id` | uuid |
+| `test_suite` | string |
+
+**Returned by:** Get all test suite names
+
+| Field | Type |
+|-------|------|
+| `data` | array[string] |
+
+**Returned by:** Get test suite run history, Get test run history for a specific test, Trigger a manual test run, Get specific test run details
+
+| Field | Type |
+|-------|------|
+| `completed_at` | date-time |
+| `conversation_id` | string |
+| `conversation_insights_id` | string |
+| `created_at` | date-time |
+| `detail_status` | array[object] |
+| `logs` | string |
+| `run_id` | uuid |
+| `status` | enum: pending, starting, running, passed, failed, error |
+| `test_id` | uuid |
+| `test_suite_run_id` | uuid |
+| `triggered_by` | string |
+| `updated_at` | date-time |
+
+**Returned by:** Delete an assistant
+
+| Field | Type |
+|-------|------|
+| `deleted` | boolean |
+| `id` | string |
+| `object` | string |
+
+**Returned by:** Get Canary Deploy, Create Canary Deploy, Update Canary Deploy
+
+| Field | Type |
+|-------|------|
+| `assistant_id` | string |
+| `created_at` | date-time |
+| `rules` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Assistant Chat (BETA)
+
+| Field | Type |
+|-------|------|
+| `content` | string |
+
+**Returned by:** Assistant Sms Chat
+
+| Field | Type |
+|-------|------|
+| `conversation_id` | string |
+
+**Returned by:** List scheduled events
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Test Assistant Tool
+
+| Field | Type |
+|-------|------|
+| `content_type` | string |
+| `request` | object |
+| `response` | string |
+| `status_code` | integer |
+| `success` | boolean |
+
+**Returned by:** Create MCP Server, Get MCP Server, Update MCP Server
+
+| Field | Type |
+|-------|------|
+| `allowed_tools` | array \| null |
+| `api_key_ref` | string \| null |
+| `created_at` | date-time |
+| `id` | string |
+| `name` | string |
+| `type` | string |
+| `url` | string |
+
+**Returned by:** List Tools, Create Tool, Get Tool, Update Tool
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `display_name` | string |
+| `id` | string |
+| `timeout_ms` | integer |
+| `tool_definition` | object |
+| `type` | string |
+
+## Optional Parameters
+
+### Create an assistant — `client.ai().assistants().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
+| `voiceSettings` | object |  |
+| `transcription` | object |  |
+| `telephonySettings` | object |  |
+| `messagingSettings` | object |  |
+| `enabledFeatures` | array[object] |  |
+| `insightSettings` | object |  |
+| `privacySettings` | object |  |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamicVariables` | object | Map of dynamic variables and their default values |
+| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
+
+### Import assistants from external provider — `client.ai().assistants().imports()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `importIds` | array[string] | Optional list of assistant IDs to import from the external provider. |
+
+### Create a new assistant test — `client.ai().assistants().tests().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `description` | string | Optional detailed description of what this test evaluates and its purpose. |
+| `telnyxConversationChannel` | object | The communication channel through which the test will be conducted. |
+| `maxDurationSeconds` | integer | Maximum duration in seconds that the test conversation should run before timi... |
+| `testSuite` | string | Optional test suite name to group related tests together. |
+
+### Trigger test suite execution — `client.ai().assistants().tests().testSuites().runs().trigger()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `destinationVersionId` | string (UUID) | Optional assistant version ID to use for all test runs in this suite. |
+
+### Update an assistant test — `client.ai().assistants().tests().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | Updated name for the assistant test. |
+| `description` | string | Updated description of the test's purpose and evaluation criteria. |
+| `telnyxConversationChannel` | enum (phone_call, web_call, sms_chat, web_chat) |  |
+| `destination` | string | Updated target destination for test conversations. |
+| `maxDurationSeconds` | integer | Updated maximum test duration in seconds. |
+| `testSuite` | string | Updated test suite assignment for better organization. |
+| `instructions` | string | Updated test scenario instructions and objectives. |
+| `rubric` | array[object] | Updated evaluation criteria for assessing assistant performance. |
+
+### Trigger a manual test run — `client.ai().assistants().tests().runs().trigger()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `destinationVersionId` | string (UUID) | Optional assistant version ID to use for this test run. |
+
+### Update an assistant — `client.ai().assistants().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `instructions` | string | System instructions for the assistant. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
+| `voiceSettings` | object |  |
+| `transcription` | object |  |
+| `telephonySettings` | object |  |
+| `messagingSettings` | object |  |
+| `enabledFeatures` | array[object] |  |
+| `insightSettings` | object |  |
+| `privacySettings` | object |  |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamicVariables` | object | Map of dynamic variables and their default values |
+| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
+| `promoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai().assistants().canaryDeploys().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai().assistants().canaryDeploys().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Assistant Chat (BETA) — `client.ai().assistants().chat()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | The optional display name of the user sending the message |
+
+### Assistant Sms Chat — `client.ai().assistants().sendSms()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string |  |
+| `conversationMetadata` | object |  |
+| `shouldCreateConversation` | boolean |  |
+
+### Create a scheduled event — `client.ai().assistants().scheduledEvents().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Required for sms scheduled events. |
+| `conversationMetadata` | object | Metadata associated with the conversation. |
+| `dynamicVariables` | object | A map of dynamic variable names to values. |
+| `maxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retryIntervalSecs` | integer |  |
+
+### Test Assistant Tool — `client.ai().assistants().tools().test()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `arguments` | object | Key-value arguments to use for the webhook test |
+| `dynamicVariables` | object | Key-value dynamic variables to use for the webhook test |
+
+### Update a specific assistant version — `client.ai().assistants().versions().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `instructions` | string | System instructions for the assistant. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
+| `voiceSettings` | object |  |
+| `transcription` | object |  |
+| `telephonySettings` | object |  |
+| `messagingSettings` | object |  |
+| `enabledFeatures` | array[object] |  |
+| `insightSettings` | object |  |
+| `privacySettings` | object |  |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamicVariables` | object | Map of dynamic variables and their default values |
+| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
+
+### Create MCP Server — `client.ai().mcpServers().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `apiKeyRef` | string |  |
+| `allowedTools` | array[string] |  |
+
+### Update MCP Server — `client.ai().mcpServers().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `name` | string |  |
+| `type` | string |  |
+| `url` | string (URL) |  |
+| `apiKeyRef` | string |  |
+| `allowedTools` | array[string] |  |
+| `createdAt` | string (date-time) |  |
+
+### Create Tool — `client.ai().tools().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `function` | object |  |
+| `retrieval` | object |  |
+| `handoff` | object |  |
+| `invite` | object |  |
+| `webhook` | object |  |
+| `timeoutMs` | integer |  |
+
+### Update Tool — `client.ai().tools().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type` | string |  |
+| `displayName` | string |  |
+| `function` | object |  |
+| `retrieval` | object |  |
+| `handoff` | object |  |
+| `invite` | object |  |
+| `webhook` | object |  |
+| `timeoutMs` | integer |  |

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/java/messaging.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/java/messaging.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -63,8 +63,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -208,7 +208,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.media` | array[object] |  |
 | `data.record_type` | enum: event | Identifies the type of the resource. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -407,6 +407,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsappMessage` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```java
 import com.telnyx.sdk.models.messages.MessageSendWhatsappParams;
@@ -434,7 +435,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -468,3 +469,425 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Messaging (Java) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List alphanumeric sender IDs, Create an alphanumeric sender ID, Retrieve an alphanumeric sender ID, Delete an alphanumeric sender ID, List alphanumeric sender IDs for a messaging profile
+
+| Field | Type |
+|-------|------|
+| `alphanumeric_sender_id` | string |
+| `id` | uuid |
+| `messaging_profile_id` | uuid |
+| `organization_id` | string |
+| `record_type` | enum: alphanumeric_sender_id |
+| `us_long_code_fallback` | string |
+
+**Returned by:** Send a message, Send a message using an alphanumeric sender ID, Retrieve group MMS messages, Send a group MMS message, Send a long code message, Send a message using number pool, Schedule a message, Send a short code message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `wait_seconds` | float |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** Send a WhatsApp message
+
+| Field | Type |
+|-------|------|
+| `body` | object |
+| `direction` | string |
+| `encoding` | string |
+| `from` | object |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `organization_id` | string |
+| `received_at` | date-time |
+| `record_type` | string |
+| `to` | array[object] |
+| `type` | string |
+| `wait_seconds` | float |
+
+**Returned by:** Retrieve a message, Get detailed messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Cancel a scheduled message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** List messaging hosted numbers, Retrieve a messaging hosted number, Update a messaging hosted number
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `eligible_messaging_products` | array[string] |
+| `features` | object |
+| `health` | object |
+| `id` | string |
+| `messaging_product` | string |
+| `messaging_profile_id` | string \| null |
+| `organization_id` | string |
+| `phone_number` | string |
+| `record_type` | enum: messaging_phone_number, messaging_settings |
+| `tags` | array[string] |
+| `traffic_type` | string |
+| `type` | enum: long-code, toll-free, short-code, longcode, tollfree, shortcode |
+| `updated_at` | date-time |
+
+**Returned by:** List opt-outs
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `from` | string |
+| `keyword` | string \| null |
+| `messaging_profile_id` | string \| null |
+| `to` | string |
+
+**Returned by:** List high-level messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Regenerate messaging profile secret
+
+| Field | Type |
+|-------|------|
+| `ai_assistant_id` | string \| null |
+| `alpha_sender` | string \| null |
+| `created_at` | date-time |
+| `daily_spend_limit` | string |
+| `daily_spend_limit_enabled` | boolean |
+| `enabled` | boolean |
+| `health_webhook_url` | url |
+| `id` | uuid |
+| `mms_fall_back_to_sms` | boolean |
+| `mms_transcoding` | boolean |
+| `mobile_only` | boolean |
+| `name` | string |
+| `number_pool_settings` | object \| null |
+| `organization_id` | string |
+| `record_type` | enum: messaging_profile |
+| `redaction_enabled` | boolean |
+| `redaction_level` | integer |
+| `resource_group_id` | string \| null |
+| `smart_encoding` | boolean |
+| `updated_at` | date-time |
+| `url_shortener_settings` | object \| null |
+| `v1_secret` | string |
+| `webhook_api_version` | enum: 1, 2, 2010-04-01 |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+| `whitelisted_destinations` | array[string] |
+
+**Returned by:** List Auto-Response Settings, Create auto-response setting, Get Auto-Response Setting, Update Auto-Response Setting
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `id` | string |
+| `keywords` | array[string] |
+| `op` | enum: start, stop, info |
+| `resp_text` | string |
+| `updated_at` | date-time |
+
+## Optional Parameters
+
+### Create an alphanumeric sender ID — `client.alphanumericSenderIds().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `usLongCodeFallback` | string | A US long code number to use as fallback when sending to US destinations. |
+
+### Send a message — `client.messages().send()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using an alphanumeric sender ID — `client.messages().sendWithAlphanumericSender()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `webhookUrl` | string (URL) | Callback URL for delivery status updates. |
+| `webhookFailoverUrl` | string (URL) | Failover callback URL for delivery status updates. |
+| `useProfileWebhooks` | boolean | If true, use the messaging profile's webhook settings. |
+
+### Send a group MMS message — `client.messages().sendGroupMms()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+
+### Send a long code message — `client.messages().sendLongCode()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using number pool — `client.messages().sendNumberPool()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Schedule a message — `client.messages().schedule()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+
+### Send a short code message — `client.messages().sendShortCode()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a WhatsApp message — `client.messages().sendWhatsapp()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
+
+### Update a messaging hosted number — `client.messagingHostedNumbers().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `messagingProfileId` | string (UUID) | Configure the messaging profile this phone number is assigned to:
+
+* Omit thi... |
+| `messagingProduct` | string | Configure the messaging product for this number:
+
+* Omit this field or set it... |
+| `tags` | array[string] | Tags to set on this phone number. |
+
+### Create auto-response setting — `client.messagingProfiles().autorespConfigs().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `respText` | string |  |
+
+### Update Auto-Response Setting — `client.messagingProfiles().autorespConfigs().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `respText` | string |  |
+
+## Webhook Payload Fields
+
+### `deliveryUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.sent, message.finalized | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: outbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | uuid | The id of the organization the messaging profile belongs to. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Subject of multimedia message |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | ISO 8601 formatted date indicating when the message was sent. |
+| `data.payload.completed_at` | date-time | ISO 8601 formatted date indicating when the message was finalized. |
+| `data.payload.valid_until` | date-time | Message must be out of the queue by this time or else it will be discarded and marked as 'sending_failed'. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+| `data.payload.smart_encoding_applied` | boolean | Indicates whether smart encoding was applied to this message. |
+| `data.payload.wait_seconds` | float | Seconds the message is queued due to rate limiting before being sent to the carrier. |
+| `meta.attempt` | integer | Number of attempts to deliver the webhook event. |
+| `meta.delivered_to` | url | The webhook URL the event was delivered to. |
+
+### `inboundMessage`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.received | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: inbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Message subject. |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | Not used for inbound messages. |
+| `data.payload.completed_at` | date-time | Not used for inbound messages. |
+| `data.payload.valid_until` | date-time | Not used for inbound messages. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+
+### `replacedLinkClick`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | string | Identifies the type of the resource. |
+| `data.url` | string | The original link that was sent in the message. |
+| `data.to` | string | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or short code). |
+| `data.message_id` | uuid | The message ID associated with the clicked link. |
+| `data.time_clicked` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+
+### Field Type Notes
+
+- `from` in responses/webhooks: object with sub-fields `phone_number` (string), `carrier` (string), `line_type` (string)
+- `to` in responses/webhooks: array of objects, each with `phone_number` (string), `carrier` (string), `line_type` (string), `status` (string)
+- `cost`: object with `amount` (string, decimal), `currency` (string, e.g., 'USD')

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/java/numbers.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/java/numbers.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -52,7 +52,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -266,7 +266,6 @@ Create or provision an additional resource when the core tasks do not cover this
 
 ```java
 import com.telnyx.sdk.models.advancedorders.AdvancedOrder;
-import com.telnyx.sdk.models.advancedorders.AdvancedOrderCreateParams;
 import com.telnyx.sdk.models.advancedorders.AdvancedOrderCreateResponse;
 
 AdvancedOrder params = AdvancedOrder.builder().build();
@@ -403,7 +402,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -453,3 +452,433 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Numbers (Java) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Advanced Orders, Create Advanced Order, Update Advanced Order, Get Advanced Order
+
+| Field | Type |
+|-------|------|
+| `area_code` | string |
+| `comments` | string |
+| `country_code` | string |
+| `customer_reference` | string |
+| `features` | array[object] |
+| `id` | uuid |
+| `orders` | array[string] |
+| `phone_number_type` | object |
+| `quantity` | integer |
+| `requirement_group_id` | uuid |
+| `status` | object |
+
+**Returned by:** List available phone number blocks
+
+| Field | Type |
+|-------|------|
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `range` | integer |
+| `record_type` | enum: available_phone_number_block |
+| `region_information` | array[object] |
+
+**Returned by:** List available phone numbers
+
+| Field | Type |
+|-------|------|
+| `best_effort` | boolean |
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `quickship` | boolean |
+| `record_type` | enum: available_phone_number |
+| `region_information` | array[object] |
+| `reservable` | boolean |
+| `vanity_format` | string |
+
+**Returned by:** Retrieve all comments
+
+| Field | Type |
+|-------|------|
+| `body` | string |
+| `comment_record_id` | uuid |
+| `comment_record_type` | enum: sub_number_order, requirement_group |
+| `commenter` | string |
+| `commenter_type` | enum: admin, user |
+| `created_at` | date-time |
+| `id` | uuid |
+| `read_at` | date-time |
+| `updated_at` | date-time |
+
+**Returned by:** Create a comment, Retrieve a comment, Mark a comment as read, Get country coverage
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Get coverage for a specific country
+
+| Field | Type |
+|-------|------|
+| `code` | string |
+| `features` | array[string] |
+| `international_sms` | boolean |
+| `inventory_coverage` | boolean |
+| `local` | object |
+| `mobile` | object |
+| `national` | object |
+| `numbers` | boolean |
+| `p2p` | boolean |
+| `phone_number_type` | array[string] |
+| `quickship` | boolean |
+| `region` | string \| null |
+| `reservable` | boolean |
+| `shared_cost` | object |
+| `toll_free` | object |
+
+**Returned by:** List customer service records, Create a customer service record, Get a customer service record
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `error_message` | string \| null |
+| `id` | uuid |
+| `phone_number` | string |
+| `record_type` | string |
+| `result` | object \| null |
+| `status` | enum: pending, completed, failed |
+| `updated_at` | date-time |
+| `webhook_url` | string |
+
+**Returned by:** Verify CSR phone number coverage
+
+| Field | Type |
+|-------|------|
+| `additional_data_required` | array[string] |
+| `has_csr_coverage` | boolean |
+| `phone_number` | string |
+| `reason` | string |
+| `record_type` | string |
+
+**Returned by:** List inexplicit number orders, Create an inexplicit number order, Retrieve an inexplicit number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `ordering_groups` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Create an inventory coverage request
+
+| Field | Type |
+|-------|------|
+| `administrative_area` | string |
+| `advance_requirements` | boolean |
+| `count` | integer |
+| `coverage_type` | enum: number, block |
+| `group` | string |
+| `group_type` | string |
+| `number_range` | integer |
+| `number_type` | enum: did, toll-free |
+| `phone_number_type` | enum: local, toll_free, national, landline, shared_cost, mobile |
+| `record_type` | string |
+
+**Returned by:** List mobile network operators
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `id` | uuid |
+| `mcc` | string |
+| `mnc` | string |
+| `name` | string |
+| `network_preferences_enabled` | boolean |
+| `record_type` | string |
+| `tadig` | string |
+
+**Returned by:** List network coverage locations
+
+| Field | Type |
+|-------|------|
+| `available_services` | array[object] |
+| `location` | object |
+| `record_type` | string |
+
+**Returned by:** List number block orders, Create a number block order, Retrieve a number block order
+
+| Field | Type |
+|-------|------|
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers_count` | integer |
+| `range` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `starting_number` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve a list of phone numbers associated to orders, Retrieve a single phone number within a number order., Update requirements for a single phone number within a number order.
+
+| Field | Type |
+|-------|------|
+| `bundle_id` | uuid |
+| `country_code` | string |
+| `deadline` | date-time |
+| `id` | uuid |
+| `is_block_number` | boolean |
+| `locality` | string |
+| `order_request_id` | uuid |
+| `phone_number` | string |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `requirements_status` | enum: pending, approved, cancelled, deleted, requirement-info-exception, requirement-info-pending, requirement-info-under-review |
+| `status` | enum: pending, success, failure |
+| `sub_number_order_id` | uuid |
+
+**Returned by:** List number orders, Create a number order, Retrieve a number order, Update a number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers` | array[object] |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `sub_number_orders_ids` | array[string] |
+| `updated_at` | date-time |
+
+**Returned by:** List number reservations, Create a number reservation, Retrieve a number reservation, Extend a number reservation
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `errors` | string |
+| `id` | uuid |
+| `phone_numbers` | array[object] |
+| `record_type` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve the features for a list of numbers
+
+| Field | Type |
+|-------|------|
+| `features` | array[string] |
+| `phone_number` | string |
+
+**Returned by:** Lists the phone number blocks jobs, Deletes all numbers associated with a phone number block, Retrieves a phone number blocks job
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `etc` | date-time |
+| `failed_operations` | array[object] |
+| `id` | uuid |
+| `record_type` | string |
+| `status` | enum: pending, in_progress, completed, failed |
+| `successful_operations` | array[object] |
+| `type` | enum: delete_phone_number_block |
+| `updated_at` | string |
+
+**Returned by:** List sub number orders, Retrieve a sub number order, Update a sub number order's requirements, Cancel a sub number order
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `is_block_sub_number_order` | boolean |
+| `order_request_id` | uuid |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+**Returned by:** Create a sub number orders report, Retrieve a sub number orders report
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `filters` | object |
+| `id` | uuid |
+| `order_type` | string |
+| `status` | enum: pending, success, failed, expired |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+## Optional Parameters
+
+### Create Advanced Order — `client.advancedOrders().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `countryCode` | string (ISO 3166-1 alpha-2) |  |
+| `comments` | string |  |
+| `quantity` | integer |  |
+| `areaCode` | string |  |
+| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `features` | array[object] |  |
+| `customerReference` | string |  |
+| `requirementGroupId` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Update Advanced Order — `client.advancedOrders().updateRequirementGroup()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `countryCode` | string (ISO 3166-1 alpha-2) |  |
+| `comments` | string |  |
+| `quantity` | integer |  |
+| `areaCode` | string |  |
+| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `features` | array[object] |  |
+| `customerReference` | string |  |
+| `requirementGroupId` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Create a comment — `client.comments().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `body` | string |  |
+| `commenter` | string |  |
+| `commenterType` | enum (admin, user) |  |
+| `commentRecordType` | enum (sub_number_order, requirement_group) |  |
+| `commentRecordId` | string (UUID) |  |
+| `readAt` | string (date-time) | An ISO 8901 datetime string for when the comment was read. |
+| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the comment was created. |
+| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the comment was updated. |
+
+### Create an inexplicit number order — `client.inexplicitNumberOrders().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `connectionId` | string (UUID) | Connection id to apply to phone numbers that are purchased |
+| `messagingProfileId` | string (UUID) | Messaging profile id to apply to phone numbers that are purchased |
+| `customerReference` | string | Reference label for the customer |
+| `billingGroupId` | string (UUID) | Billing group id to apply to phone numbers that are purchased |
+
+### Create a number block order — `client.numberBlockOrders().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `recordType` | string |  |
+| `phoneNumbersCount` | integer | The count of phone numbers in the number order. |
+| `connectionId` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messagingProfileId` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `status` | enum (pending, success, failure) | The status of the order. |
+| `customerReference` | string | A customer reference string for customer look ups. |
+| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the number order was created. |
+| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the number order was updated. |
+| `requirementsMet` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `errors` | string | Errors the reservation could happen upon |
+
+### Update requirements for a single phone number within a number order. — `client.numberOrderPhoneNumbers().updateRequirements()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatoryRequirements` | array[object] |  |
+
+### Create a number order — `client.numberOrders().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `phoneNumbers` | array[object] |  |
+| `connectionId` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messagingProfileId` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `billingGroupId` | string (UUID) | Identifies the billing group associated with the phone number. |
+| `customerReference` | string | A customer reference string for customer look ups. |
+
+### Update a number order — `client.numberOrders().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatoryRequirements` | array[object] |  |
+| `customerReference` | string | A customer reference string for customer look ups. |
+
+### Create a number reservation — `client.numberReservations().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `recordType` | string |  |
+| `phoneNumbers` | array[object] |  |
+| `status` | enum (pending, success, failure) | The status of the entire reservation. |
+| `customerReference` | string | A customer reference string for customer look ups. |
+| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the numbers reservation was created. |
+| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the number reservation was updated. |
+
+### Update a sub number order's requirements — `client.subNumberOrders().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatoryRequirements` | array[object] |  |
+
+### Create a sub number orders report — `client.subNumberOrdersReport().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `status` | enum (pending, success, failure) | Filter by order status |
+| `countryCode` | string (ISO 3166-1 alpha-2) | Filter by country code |
+| `createdAtGt` | string (date-time) | Filter for orders created after this date |
+| `createdAtLt` | string (date-time) | Filter for orders created before this date |
+| `orderRequestId` | string (UUID) | Filter by specific order request ID |
+| `customerReference` | string | Filter by customer reference |
+
+## Webhook Payload Fields
+
+### `numberOrderStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.event_type` | string | The type of event being sent |
+| `data.id` | uuid | Unique identifier for the event |
+| `data.occurred_at` | date-time | ISO 8601 timestamp of when the event occurred |
+| `data.payload.id` | uuid |  |
+| `data.payload.record_type` | string |  |
+| `data.payload.phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `data.payload.connection_id` | string | Identifies the connection associated with this phone number. |
+| `data.payload.messaging_profile_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.billing_group_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.phone_numbers` | array[object] |  |
+| `data.payload.sub_number_orders_ids` | array[string] |  |
+| `data.payload.status` | enum: pending, success, failure | The status of the order. |
+| `data.payload.customer_reference` | string | A customer reference string for customer look ups. |
+| `data.payload.created_at` | date-time | An ISO 8901 datetime string denoting when the number order was created. |
+| `data.payload.updated_at` | date-time | An ISO 8901 datetime string for when the number order was updated. |
+| `data.payload.requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `data.record_type` | string | Type of record |
+| `meta.attempt` | integer | Webhook delivery attempt number |
+| `meta.delivered_to` | uri | URL where the webhook was delivered |

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/java/voice.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/java/voice.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -38,7 +38,7 @@ import com.telnyx.sdk.models.calls.CallDialResponse;
 CallDialParams params = CallDialParams.builder()
     .connectionId("7267xxxxxxxxxxxxxx")
     .from("+18005550101")
-    .to("+18005550100")
+    .to("+18005550100;secure=srtp")
     .build();
 CallDialResponse response = client.calls().dial(params);
 ```
@@ -63,8 +63,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -82,7 +82,7 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in the API Details section below |
+| ... | | | +56 optional params in the API Details section below |
 
 ```java
 import com.telnyx.sdk.models.calls.CallDialParams;
@@ -91,7 +91,7 @@ import com.telnyx.sdk.models.calls.CallDialResponse;
 CallDialParams params = CallDialParams.builder()
     .connectionId("7267xxxxxxxxxxxxxx")
     .from("+18005550101")
-    .to("+18005550100")
+    .to("+18005550100;secure=srtp")
     .build();
 CallDialResponse response = client.calls().dial(params);
 ```
@@ -116,7 +116,7 @@ Primary inbound call-control command.
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in the API Details section below |
+| ... | | | +29 optional params in the API Details section below |
 
 ```java
 import com.telnyx.sdk.models.calls.actions.ActionAnswerParams;
@@ -142,7 +142,7 @@ Common post-answer control path with downstream webhook implications.
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in the API Details section below |
+| ... | | | +35 optional params in the API Details section below |
 
 ```java
 import com.telnyx.sdk.models.calls.actions.ActionTransferParams;
@@ -150,7 +150,7 @@ import com.telnyx.sdk.models.calls.actions.ActionTransferResponse;
 
 ActionTransferParams params = ActionTransferParams.builder()
     .callControlId("v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ")
-    .to("+18005550100")
+    .to("+18005550100;secure=srtp")
     .build();
 ActionTransferResponse response = client.calls().actions().transfer(params);
 ```
@@ -237,7 +237,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
 | `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -415,7 +415,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -435,3 +435,427 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Voice (Java) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List call control applications, Create a call control application, Retrieve a call control application, Update a call control application, Delete a call control application
+
+| Field | Type |
+|-------|------|
+| `active` | boolean |
+| `anchorsite_override` | enum: Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, Chennai, IN, Amsterdam, Netherlands, Toronto, Canada, Sydney, Australia |
+| `application_name` | string |
+| `call_cost_in_webhooks` | boolean |
+| `created_at` | string |
+| `dtmf_type` | enum: RFC 2833, Inband, SIP INFO |
+| `first_command_timeout` | boolean |
+| `first_command_timeout_secs` | integer |
+| `id` | string |
+| `inbound` | object |
+| `outbound` | object |
+| `record_type` | enum: call_control_application |
+| `redact_dtmf_debug_logging` | boolean |
+| `tags` | array[string] |
+| `updated_at` | string |
+| `webhook_api_version` | enum: 1, 2 |
+| `webhook_event_failover_url` | url |
+| `webhook_event_url` | url |
+| `webhook_timeout_secs` | integer \| null |
+
+**Returned by:** Dial
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `recording_id` | uuid |
+| `start_time` | string |
+
+**Returned by:** Retrieve a call status
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `start_time` | string |
+
+**Returned by:** Answer call
+
+| Field | Type |
+|-------|------|
+| `recording_id` | uuid |
+| `result` | string |
+
+**Returned by:** Bridge calls, Hangup call, SIP Refer a call, Reject a call, Send SIP info, Transfer call
+
+| Field | Type |
+|-------|------|
+| `result` | string |
+
+**Returned by:** List all active calls for given connection
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `record_type` | enum: call |
+
+## Optional Parameters
+
+### Create a call control application — `client.callControlApplications().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `active` | boolean | Specifies whether the connection can be used. |
+| `anchorsiteOverride` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmfType` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `firstCommandTimeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `firstCommandTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `inbound` | object |  |
+| `outbound` | object |  |
+| `webhookApiVersion` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhookEventFailoverUrl` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhookTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `callCostInWebhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `redactDtmfDebugLogging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Update a call control application — `client.callControlApplications().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `callCostInWebhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `active` | boolean | Specifies whether the connection can be used. |
+| `anchorsiteOverride` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmfType` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `firstCommandTimeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `firstCommandTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `tags` | array[string] | Tags assigned to the Call Control Application. |
+| `inbound` | object |  |
+| `outbound` | object |  |
+| `webhookApiVersion` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhookEventFailoverUrl` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhookTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `redactDtmfDebugLogging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Dial — `client.calls().dial()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `audioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
+| `mediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
+| `preferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
+| `conferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
+| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `linkTo` | string | Use another call's control id for sharing the same call session id |
+| `bridgeIntent` | boolean | Indicates the intent to bridge this call with the call specified in link_to. |
+| `bridgeOnAnswer` | boolean | Whether to automatically bridge answered call to the call specified in link_to. |
+| `preventDoubleBridge` | boolean | Prevents bridging and hangs up the call if the target is already bridged. |
+| `parkAfterUnbridge` | string | If supplied with the value `self`, the current leg will be parked after unbri... |
+| `mediaEncryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the call. |
+| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
+| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
+| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE request. |
+| `sipTransportProtocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `streamUrl` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `streamTrack` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `streamCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `streamBidirectionalMode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `streamBidirectionalCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `streamBidirectionalTargetLegs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `streamBidirectionalSamplingRate` | enum (8000, 16000, 22050, 24000, 48000) | Audio sampling rate. |
+| `streamEstablishBeforeCallOriginate` | boolean | Establish websocket connection before dialing the destination. |
+| `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhookUrls` | object | A map of event types to webhook URLs. |
+| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `superviseCallControlId` | string (UUID) | The call leg which will be supervised by the new call. |
+| `supervisorRole` | enum (barge, whisper, monitor) | The role of the supervisor call. |
+| `enableDialogflow` | boolean | Enables Dialogflow for the current call. |
+| `dialogflowConfig` | object |  |
+| `transcription` | boolean | Enable transcription upon call answer. |
+| `transcriptionConfig` | object |  |
+| `sipRegion` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `streamAuthToken` | string | An authentication token to be sent as part of the WebSocket connection when u... |
+
+### Answer call — `client.calls().actions().answer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE response. |
+| `preferredCodecs` | enum (G722,PCMU,PCMA,G729,OPUS,VP8,H264) | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE response. |
+| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `streamUrl` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `streamTrack` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `streamCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `streamBidirectionalMode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `streamBidirectionalCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `streamBidirectionalTargetLegs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `transcription` | boolean | Enable transcription upon call answer. |
+| `transcriptionConfig` | object |  |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `webhookUrls` | object | A map of event types to webhook URLs. |
+| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
+
+### Bridge calls — `client.calls().actions().bridge()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `queue` | string | The name of the queue you want to bridge with, can't be used together with ca... |
+| `videoRoomId` | string (UUID) | The ID of the video room you want to bridge with, can't be used together with... |
+| `videoRoomContext` | string | The additional parameter that will be passed to the video conference. |
+| `preventDoubleBridge` | boolean | When set to `true`, it prevents bridging if the target call is already bridge... |
+| `parkAfterUnbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `playRingtone` | boolean | Specifies whether to play a ringtone if the call you want to bridge with has ... |
+| `ringtone` | enum (at, au, be, bg, br, ...) | Specifies which country ringtone to play when `play_ringtone` is set to `true`. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `muteDtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `holdAfterUnbridge` | boolean | Specifies behavior after the bridge ends. |
+
+### Hangup call — `client.calls().actions().hangup()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `customHeaders` | array[object] | Custom headers to be added to the SIP BYE message. |
+
+### SIP Refer a call — `client.calls().actions().refer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid execution of duplicate commands. |
+| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
+| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
+| `sipHeaders` | array[object] | SIP headers to be added to the request. |
+
+### Reject a call — `client.calls().actions().reject()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Send SIP info — `client.calls().actions().sendSipInfo()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Transfer call — `client.calls().actions().transfer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
+| `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `audioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
+| `earlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
+| `mediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
+| `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `parkAfterUnbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `targetLegClientState` | string | Use this field to add state to every subsequent webhook for the new leg. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `mediaEncryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the new call leg. |
+| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
+| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
+| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE. |
+| `sipTransportProtocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `muteDtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `sipRegion` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `preferredCodecs` | string | The list of comma-separated codecs in order of preference to be used during t... |
+| `webhookUrls` | object | A map of event types to webhook URLs. |
+| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+
+## Webhook Payload Fields
+
+### `callAnswered`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.answered | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: answered | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### `callBridged`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.bridged | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+
+### `callHangup`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.hangup | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: hangup | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+| `data.payload.hangup_cause` | enum: call_rejected, normal_clearing, originator_cancel, timeout, time_limit, user_busy, not_found, no_answer, unspecified | The reason the call was ended (`call_rejected`, `normal_clearing`, `originator_cancel`, `timeout`, `time_limit`, `use... |
+| `data.payload.hangup_source` | enum: caller, callee, unknown | The party who ended the call (`callee`, `caller`, `unknown`). |
+| `data.payload.sip_hangup_cause` | string | The reason the call was ended (SIP response code). |
+| `data.payload.call_quality_stats` | object \| null | Call quality statistics aggregated from the CHANNEL_HANGUP_COMPLETE event. |
+
+### `callInitiated`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.initiated | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
+| `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.custom_headers` | array[object] | Custom headers from sip invite |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.shaken_stir_attestation` | string | SHAKEN/STIR attestation level. |
+| `data.payload.shaken_stir_validated` | boolean | Whether attestation was successfully validated or not. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.caller_id_name` | string | Caller id. |
+| `data.payload.call_screening_result` | string | Call screening result. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.direction` | enum: incoming, outgoing | Whether the call is `incoming` or `outgoing`. |
+| `data.payload.state` | enum: parked, bridging | State received from a command. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### Field Type Notes
+
+- `from` in webhook payloads: string (E.164 phone number)
+- `to` in webhook payloads: string (E.164 phone number)
+- The return value of `client.webhooks.unwrap()` is a parsed event object — access fields via `event.data.event_type`, `event.data.payload.call_control_id`, etc.

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/10dlc.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/10dlc.md
@@ -68,8 +68,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -214,7 +214,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `description` | string | Description of the event. |
 | `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -375,7 +375,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -415,3 +415,471 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# 10DLC (JavaScript) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Brands, List Campaigns, List shared partner campaigns, List Shared Campaigns, List phone number campaigns
+
+| Field | Type |
+|-------|------|
+| `page` | integer |
+| `records` | array[object] |
+| `totalRecords` | integer |
+
+**Returned by:** Create Brand, Update Brand, Revet Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Get Brand Feedback By Id
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `category` | array[object] |
+
+**Returned by:** Get Brand SMS OTP Status, Get Brand SMS OTP Status by Brand ID
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `deliveryStatus` | string |
+| `deliveryStatusDate` | date-time |
+| `deliveryStatusDetails` | string |
+| `mobilePhone` | string |
+| `referenceId` | string |
+| `requestDate` | date-time |
+| `verifyDate` | date-time |
+
+**Returned by:** Get Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `assignedCampaignsCount` | number |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Order Brand External Vetting, Import External Vetting Record
+
+| Field | Type |
+|-------|------|
+| `createDate` | string |
+| `evpId` | string |
+| `vettedDate` | string |
+| `vettingClass` | string |
+| `vettingId` | string |
+| `vettingScore` | integer |
+| `vettingToken` | string |
+
+**Returned by:** Trigger Brand SMS OTP
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `referenceId` | string |
+
+**Returned by:** Get Campaign Cost
+
+| Field | Type |
+|-------|------|
+| `campaignUsecase` | string |
+| `description` | string |
+| `monthlyCost` | string |
+| `upFrontCost` | string |
+
+**Returned by:** Get campaign, Update campaign, Submit Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `autoRenewal` | boolean |
+| `billedDate` | string |
+| `brandDisplayName` | string |
+| `brandId` | string |
+| `campaignId` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createDate` | string |
+| `cspId` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isTMobileNumberPoolingEnabled` | boolean |
+| `isTMobileRegistered` | boolean |
+| `isTMobileSuspended` | boolean |
+| `messageFlow` | string |
+| `mock` | boolean |
+| `nextRenewalOrExpirationDate` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `referenceId` | string |
+| `resellerId` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `status` | string |
+| `subUsecases` | array[string] |
+| `submissionStatus` | enum: CREATED, FAILED, PENDING |
+| `subscriberHelp` | boolean |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `usecase` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Deactivate campaign
+
+| Field | Type |
+|-------|------|
+| `message` | string |
+| `record_type` | string |
+| `time` | number |
+
+**Returned by:** Submit campaign appeal for manual review
+
+| Field | Type |
+|-------|------|
+| `appealed_at` | date-time |
+
+**Returned by:** Get Campaign Mno Metadata
+
+| Field | Type |
+|-------|------|
+| `10999` | object |
+
+**Returned by:** Get Sharing Status
+
+| Field | Type |
+|-------|------|
+| `sharedByMe` | object |
+| `sharedWithMe` | object |
+
+**Returned by:** Qualify By Usecase
+
+| Field | Type |
+|-------|------|
+| `annualFee` | number |
+| `maxSubUsecases` | integer |
+| `minSubUsecases` | integer |
+| `mnoMetadata` | object |
+| `monthlyFee` | number |
+| `quarterlyFee` | number |
+| `usecase` | string |
+
+**Returned by:** Get Single Shared Campaign, Update Single Shared Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `assignedPhoneNumbersCount` | number |
+| `brandDisplayName` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createdAt` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isNumberPoolingEnabled` | boolean |
+| `messageFlow` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `subUsecases` | array[string] |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `updatedAt` | string |
+| `usecase` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Assign Messaging Profile To Campaign
+
+| Field | Type |
+|-------|------|
+| `campaignId` | string |
+| `messagingProfileId` | string |
+| `taskId` | string |
+| `tcrCampaignId` | string |
+
+**Returned by:** Get Assignment Task Status
+
+| Field | Type |
+|-------|------|
+| `createdAt` | date-time |
+| `status` | string |
+| `taskId` | string |
+| `updatedAt` | date-time |
+
+**Returned by:** Get Phone Number Status
+
+| Field | Type |
+|-------|------|
+| `records` | array[object] |
+
+**Returned by:** Create New Phone Number Campaign, Get Single Phone Number Campaign, Create New Phone Number Campaign, Delete Phone Number Campaign
+
+| Field | Type |
+|-------|------|
+| `assignmentStatus` | enum: FAILED_ASSIGNMENT, PENDING_ASSIGNMENT, ASSIGNED, PENDING_UNASSIGNMENT, FAILED_UNASSIGNMENT |
+| `brandId` | string |
+| `campaignId` | string |
+| `createdAt` | string |
+| `failureReasons` | string |
+| `phoneNumber` | string |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `telnyxCampaignId` | string |
+| `updatedAt` | string |
+
+## Optional Parameters
+
+### Create Brand — `client.messaging10dlc.brand.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `companyName` | string | (Required for Non-profit/private/public) Legal company name. |
+| `firstName` | string | First name of business contact. |
+| `lastName` | string | Last name of business contact. |
+| `ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `phone` | string | Valid phone number in e.164 international format. |
+| `street` | string | Street number and name. |
+| `city` | string | City name |
+| `state` | string | State. |
+| `postalCode` | string | Postal codes. |
+| `stockSymbol` | string | (Required for public company) stock symbol. |
+| `stockExchange` | object | (Required for public company) stock exchange. |
+| `ipAddress` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `website` | string | Brand website URL. |
+| `isReseller` | boolean |  |
+| `mock` | boolean | Mock brand for testing purposes. |
+| `mobilePhone` | string | Valid mobile phone number in e.164 international format. |
+| `businessContactEmail` | string | Business contact email. |
+| `webhookURL` | string | Webhook URL for brand status updates. |
+| `webhookFailoverURL` | string | Webhook failover URL for brand status updates. |
+
+### Update Brand — `client.messaging10dlc.brand.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `companyName` | string | (Required for Non-profit/private/public) Legal company name. |
+| `firstName` | string | First name of business contact. |
+| `lastName` | string | Last name of business contact. |
+| `ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `phone` | string | Valid phone number in e.164 international format. |
+| `street` | string | Street number and name. |
+| `city` | string | City name |
+| `state` | string | State. |
+| `postalCode` | string | Postal codes. |
+| `stockSymbol` | string | (Required for public company) stock symbol. |
+| `stockExchange` | object | (Required for public company) stock exchange. |
+| `ipAddress` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `website` | string | Brand website URL. |
+| `altBusinessIdType` | enum (NONE, DUNS, GIIN, LEI) | An enumeration. |
+| `isReseller` | boolean |  |
+| `identityStatus` | enum (VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED) | The verification status of an active brand |
+| `businessContactEmail` | string | Business contact email. |
+| `webhookURL` | string | Webhook URL for brand status updates. |
+| `webhookFailoverURL` | string | Webhook failover URL for brand status updates. |
+| `altBusinessId` | string (UUID) | Alternate business identifier such as DUNS, LEI, or GIIN |
+
+### Import External Vetting Record — `client.messaging10dlc.brand.externalVetting.imports()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `vettingToken` | string | Required by some providers for vetting record confirmation. |
+
+### Update campaign — `client.messaging10dlc.campaign.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `resellerId` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `sample1` | string | Message sample. |
+| `sample2` | string | Message sample. |
+| `sample3` | string | Message sample. |
+| `sample4` | string | Message sample. |
+| `sample5` | string | Message sample. |
+| `messageFlow` | string | Message flow description. |
+| `helpMessage` | string | Help message of the campaign. |
+| `autoRenewal` | boolean | Help message of the campaign. |
+| `webhookURL` | string | Webhook to which campaign status updates are sent. |
+| `webhookFailoverURL` | string | Webhook failover to which campaign status updates are sent. |
+
+### Submit Campaign — `client.messaging10dlc.campaignBuilder.submit()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ageGated` | boolean | Age gated message content in campaign. |
+| `autoRenewal` | boolean | Campaign subscription auto-renewal option. |
+| `directLending` | boolean | Direct lending or loan arrangement |
+| `embeddedLink` | boolean | Does message generated by the campaign include URL link in SMS? |
+| `embeddedPhone` | boolean | Does message generated by the campaign include phone number in SMS? |
+| `helpKeywords` | string | Subscriber help keywords. |
+| `helpMessage` | string | Help message of the campaign. |
+| `messageFlow` | string | Message flow description. |
+| `mnoIds` | array[integer] | Submit campaign to given list of MNOs by MNO's network ID. |
+| `numberPool` | boolean | Does campaign utilize pool of phone numbers? |
+| `optinKeywords` | string | Subscriber opt-in keywords. |
+| `optinMessage` | string | Subscriber opt-in message. |
+| `optoutKeywords` | string | Subscriber opt-out keywords. |
+| `optoutMessage` | string | Subscriber opt-out message. |
+| `referenceId` | string (UUID) | Caller supplied campaign reference ID. |
+| `resellerId` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `sample1` | string | Message sample. |
+| `sample2` | string | Message sample. |
+| `sample3` | string | Message sample. |
+| `sample4` | string | Message sample. |
+| `sample5` | string | Message sample. |
+| `subUsecases` | array[string] | Campaign sub-usecases. |
+| `subscriberHelp` | boolean | Does campaign responds to help keyword(s)? |
+| `subscriberOptin` | boolean | Does campaign require subscriber to opt-in before SMS is sent to subscriber? |
+| `subscriberOptout` | boolean | Does campaign support subscriber opt-out keyword(s)? |
+| `tag` | array[string] | Tags to be set on the Campaign. |
+| `termsAndConditions` | boolean | Is terms and conditions accepted? |
+| `privacyPolicyLink` | string | Link to the campaign's privacy policy. |
+| `termsAndConditionsLink` | string | Link to the campaign's terms and conditions. |
+| `embeddedLinkSample` | string | Sample of an embedded link that will be sent to subscribers. |
+| `webhookURL` | string | Webhook to which campaign status updates are sent. |
+| `webhookFailoverURL` | string | Failover webhook to which campaign status updates are sent. |
+
+### Update Single Shared Campaign — `client.messaging10dlc.partnerCampaigns.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `webhookURL` | string | Webhook to which campaign status updates are sent. |
+| `webhookFailoverURL` | string | Webhook failover to which campaign status updates are sent. |
+
+### Assign Messaging Profile To Campaign — `client.messaging10dlc.phoneNumberAssignmentByProfile.assign()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `tcrCampaignId` | string (UUID) | The TCR ID of the shared campaign you want to link to the specified messaging... |
+| `campaignId` | string (UUID) | The ID of the campaign you want to link to the specified messaging profile. |
+
+## Webhook Payload Fields
+
+### `campaignStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `brandId` | string | Brand ID associated with the campaign. |
+| `campaignId` | string | The ID of the campaign. |
+| `createDate` | string | Unix timestamp when campaign was created. |
+| `cspId` | string | Alphanumeric identifier of the CSP associated with this campaign. |
+| `isTMobileRegistered` | boolean | Indicates whether the campaign is registered with T-Mobile. |
+| `type` | enum: TELNYX_EVENT, REGISTRATION, MNO_REVIEW, TELNYX_REVIEW, NUMBER_POOL_PROVISIONED, NUMBER_POOL_DEPROVISIONED, TCR_EVENT, VERIFIED |  |
+| `description` | string | Description of the event. |
+| `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/ai-assistants.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/ai-assistants.md
@@ -29,8 +29,8 @@ or authentication errors (401). Always handle errors in production code:
 try {
   const assistant = await client.ai.assistants.create({
     instructions: 'You are a helpful assistant.',
-    model: 'openai/gpt-4o',
     name: 'my-resource',
+      model: 'openai/gpt-4o',
   });
 } catch (err) {
   if (err instanceof Telnyx.APIConnectionError) {
@@ -61,7 +61,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -74,18 +74,17 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `description` | string | No |  |
-| `greeting` | string | No | Text that the assistant will use to start the conversation. |
-| ... | | | +11 optional params in the API Details section below |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in the API Details section below |
 
 ```javascript
 const assistant = await client.ai.assistants.create({
   instructions: 'You are a helpful assistant.',
-  model: 'openai/gpt-4o',
   name: 'my-resource',
+    model: 'openai/gpt-4o',
 });
 
 console.log(assistant.id);
@@ -196,7 +195,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### Update an assistant
 
@@ -207,10 +206,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistantId` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +15 optional params in the API Details section below |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in the API Details section below |
 
 ```javascript
 const assistant = await client.ai.assistants.update('550e8400-e29b-41d4-a716-446655440000');
@@ -224,7 +223,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### List assistants
 
@@ -247,7 +246,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Import assistants from external provider
 
@@ -279,7 +278,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Get All Tags
 
@@ -383,7 +382,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -396,8 +395,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId`, `runId` |
 | Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Get Canary Deploy | `client.ai.assistants.canaryDeploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Create Canary Deploy | `client.ai.assistants.canaryDeploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistantId` |
-| Update Canary Deploy | `client.ai.assistants.canaryDeploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistantId` |
+| Create Canary Deploy | `client.ai.assistants.canaryDeploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId` |
+| Update Canary Deploy | `client.ai.assistants.canaryDeploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistantId` |
 | Delete Canary Deploy | `client.ai.assistants.canaryDeploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Assistant Sms Chat | `client.ai.assistants.sendSMS()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistantId` |
 | Clone Assistant | `client.ai.assistants.clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId` |
@@ -408,6 +407,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Add Assistant Tag | `client.ai.assistants.tags.add()` | `POST /ai/assistants/{assistant_id}/tags` | Create or provision an additional resource when the core tasks do not cover this flow. | `tag`, `assistantId` |
 | Remove Assistant Tag | `client.ai.assistants.tags.remove()` | `DELETE /ai/assistants/{assistant_id}/tags/{tag}` | Remove, detach, or clean up an existing resource. | `assistantId`, `tag` |
 | Get assistant texml | `client.ai.assistants.getTexml()` | `GET /ai/assistants/{assistant_id}/texml` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
+| Add Assistant Tool | `client.ai.assistants.tools.add()` | `PUT /ai/assistants/{assistant_id}/tools/{tool_id}` | Modify an existing resource without recreating it. | `assistantId`, `toolId` |
+| Remove Assistant Tool | `client.ai.assistants.tools.remove()` | `DELETE /ai/assistants/{assistant_id}/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `assistantId`, `toolId` |
 | Test Assistant Tool | `client.ai.assistants.tools.test()` | `POST /ai/assistants/{assistant_id}/tools/{tool_id}/test` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId`, `toolId` |
 | Get all versions of an assistant | `client.ai.assistants.versions.list()` | `GET /ai/assistants/{assistant_id}/versions` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
 | Get a specific assistant version | `client.ai.assistants.versions.retrieve()` | `GET /ai/assistants/{assistant_id}/versions/{version_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId`, `versionId` |
@@ -419,7 +420,398 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get MCP Server | `client.ai.mcpServers.retrieve()` | `GET /ai/mcp_servers/{mcp_server_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `mcpServerId` |
 | Update MCP Server | `client.ai.mcpServers.update()` | `PUT /ai/mcp_servers/{mcp_server_id}` | Modify an existing resource without recreating it. | `mcpServerId` |
 | Delete MCP Server | `client.ai.mcpServers.delete()` | `DELETE /ai/mcp_servers/{mcp_server_id}` | Remove, detach, or clean up an existing resource. | `mcpServerId` |
+| List Tools | `client.ai.tools.list()` | `GET /ai/tools` | Inspect available resources or choose an existing resource before mutating it. | None |
+| Create Tool | `client.ai.tools.create()` | `POST /ai/tools` | Create or provision an additional resource when the core tasks do not cover this flow. | `type`, `displayName` |
+| Get Tool | `client.ai.tools.retrieve()` | `GET /ai/tools/{tool_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `toolId` |
+| Update Tool | `client.ai.tools.update()` | `PATCH /ai/tools/{tool_id}` | Modify an existing resource without recreating it. | `toolId` |
+| Delete Tool | `client.ai.tools.delete()` | `DELETE /ai/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `toolId` |
 
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# AI Assistants (JavaScript) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+
+## Response Schemas
+
+**Returned by:** List assistants, Create an assistant, Import assistants from external provider, Get an assistant, Update an assistant, Clone Assistant, Get all versions of an assistant, Get a specific assistant version, Update a specific assistant version, Promote an assistant version to main
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
+| `dynamic_variables_webhook_url` | string |
+| `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
+| `greeting` | string |
+| `id` | string |
+| `import_metadata` | object |
+| `insight_settings` | object |
+| `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
+| `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
+| `messaging_settings` | object |
+| `model` | string |
+| `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
+| `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
+| `telephony_settings` | object |
+| `tools` | array[object] |
+| `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
+| `voice_settings` | object |
+| `widget_settings` | object |
+
+**Returned by:** Get All Tags, Add Assistant Tag, Remove Assistant Tag
+
+| Field | Type |
+|-------|------|
+| `tags` | array[string] |
+
+**Returned by:** List assistant tests with pagination, Create a new assistant test, Get assistant test by ID, Update an assistant test
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `destination` | string |
+| `instructions` | string |
+| `max_duration_seconds` | integer |
+| `name` | string |
+| `rubric` | array[object] |
+| `telnyx_conversation_channel` | object |
+| `test_id` | uuid |
+| `test_suite` | string |
+
+**Returned by:** Get all test suite names
+
+| Field | Type |
+|-------|------|
+| `data` | array[string] |
+
+**Returned by:** Get test suite run history, Get test run history for a specific test, Trigger a manual test run, Get specific test run details
+
+| Field | Type |
+|-------|------|
+| `completed_at` | date-time |
+| `conversation_id` | string |
+| `conversation_insights_id` | string |
+| `created_at` | date-time |
+| `detail_status` | array[object] |
+| `logs` | string |
+| `run_id` | uuid |
+| `status` | enum: pending, starting, running, passed, failed, error |
+| `test_id` | uuid |
+| `test_suite_run_id` | uuid |
+| `triggered_by` | string |
+| `updated_at` | date-time |
+
+**Returned by:** Delete an assistant
+
+| Field | Type |
+|-------|------|
+| `deleted` | boolean |
+| `id` | string |
+| `object` | string |
+
+**Returned by:** Get Canary Deploy, Create Canary Deploy, Update Canary Deploy
+
+| Field | Type |
+|-------|------|
+| `assistant_id` | string |
+| `created_at` | date-time |
+| `rules` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Assistant Chat (BETA)
+
+| Field | Type |
+|-------|------|
+| `content` | string |
+
+**Returned by:** Assistant Sms Chat
+
+| Field | Type |
+|-------|------|
+| `conversation_id` | string |
+
+**Returned by:** List scheduled events
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Test Assistant Tool
+
+| Field | Type |
+|-------|------|
+| `content_type` | string |
+| `request` | object |
+| `response` | string |
+| `status_code` | integer |
+| `success` | boolean |
+
+**Returned by:** Create MCP Server, Get MCP Server, Update MCP Server
+
+| Field | Type |
+|-------|------|
+| `allowed_tools` | array \| null |
+| `api_key_ref` | string \| null |
+| `created_at` | date-time |
+| `id` | string |
+| `name` | string |
+| `type` | string |
+| `url` | string |
+
+**Returned by:** List Tools, Create Tool, Get Tool, Update Tool
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `display_name` | string |
+| `id` | string |
+| `timeout_ms` | integer |
+| `tool_definition` | object |
+| `type` | string |
+
+## Optional Parameters
+
+### Create an assistant — `client.ai.assistants.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
+| `voiceSettings` | object |  |
+| `transcription` | object |  |
+| `telephonySettings` | object |  |
+| `messagingSettings` | object |  |
+| `enabledFeatures` | array[object] |  |
+| `insightSettings` | object |  |
+| `privacySettings` | object |  |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamicVariables` | object | Map of dynamic variables and their default values |
+| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
+
+### Import assistants from external provider — `client.ai.assistants.imports()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `importIds` | array[string] | Optional list of assistant IDs to import from the external provider. |
+
+### Create a new assistant test — `client.ai.assistants.tests.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `description` | string | Optional detailed description of what this test evaluates and its purpose. |
+| `telnyxConversationChannel` | object | The communication channel through which the test will be conducted. |
+| `maxDurationSeconds` | integer | Maximum duration in seconds that the test conversation should run before timi... |
+| `testSuite` | string | Optional test suite name to group related tests together. |
+
+### Trigger test suite execution — `client.ai.assistants.tests.testSuites.runs.trigger()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `destinationVersionId` | string (UUID) | Optional assistant version ID to use for all test runs in this suite. |
+
+### Update an assistant test — `client.ai.assistants.tests.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | Updated name for the assistant test. |
+| `description` | string | Updated description of the test's purpose and evaluation criteria. |
+| `telnyxConversationChannel` | enum (phone_call, web_call, sms_chat, web_chat) |  |
+| `destination` | string | Updated target destination for test conversations. |
+| `maxDurationSeconds` | integer | Updated maximum test duration in seconds. |
+| `testSuite` | string | Updated test suite assignment for better organization. |
+| `instructions` | string | Updated test scenario instructions and objectives. |
+| `rubric` | array[object] | Updated evaluation criteria for assessing assistant performance. |
+
+### Trigger a manual test run — `client.ai.assistants.tests.runs.trigger()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `destinationVersionId` | string (UUID) | Optional assistant version ID to use for this test run. |
+
+### Update an assistant — `client.ai.assistants.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `instructions` | string | System instructions for the assistant. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
+| `voiceSettings` | object |  |
+| `transcription` | object |  |
+| `telephonySettings` | object |  |
+| `messagingSettings` | object |  |
+| `enabledFeatures` | array[object] |  |
+| `insightSettings` | object |  |
+| `privacySettings` | object |  |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamicVariables` | object | Map of dynamic variables and their default values |
+| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
+| `promoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai.assistants.canaryDeploys.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai.assistants.canaryDeploys.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Assistant Chat (BETA) — `client.ai.assistants.chat()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | The optional display name of the user sending the message |
+
+### Assistant Sms Chat — `client.ai.assistants.sendSMS()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string |  |
+| `conversationMetadata` | object |  |
+| `shouldCreateConversation` | boolean |  |
+
+### Create a scheduled event — `client.ai.assistants.scheduledEvents.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Required for sms scheduled events. |
+| `conversationMetadata` | object | Metadata associated with the conversation. |
+| `dynamicVariables` | object | A map of dynamic variable names to values. |
+| `maxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retryIntervalSecs` | integer |  |
+
+### Test Assistant Tool — `client.ai.assistants.tools.test()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `arguments` | object | Key-value arguments to use for the webhook test |
+| `dynamicVariables` | object | Key-value dynamic variables to use for the webhook test |
+
+### Update a specific assistant version — `client.ai.assistants.versions.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `instructions` | string | System instructions for the assistant. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
+| `voiceSettings` | object |  |
+| `transcription` | object |  |
+| `telephonySettings` | object |  |
+| `messagingSettings` | object |  |
+| `enabledFeatures` | array[object] |  |
+| `insightSettings` | object |  |
+| `privacySettings` | object |  |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamicVariables` | object | Map of dynamic variables and their default values |
+| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
+
+### Create MCP Server — `client.ai.mcpServers.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `apiKeyRef` | string |  |
+| `allowedTools` | array[string] |  |
+
+### Update MCP Server — `client.ai.mcpServers.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `name` | string |  |
+| `type` | string |  |
+| `url` | string (URL) |  |
+| `apiKeyRef` | string |  |
+| `allowedTools` | array[string] |  |
+| `createdAt` | string (date-time) |  |
+
+### Create Tool — `client.ai.tools.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `function` | object |  |
+| `retrieval` | object |  |
+| `handoff` | object |  |
+| `invite` | object |  |
+| `webhook` | object |  |
+| `timeoutMs` | integer |  |
+
+### Update Tool — `client.ai.tools.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type` | string |  |
+| `displayName` | string |  |
+| `function` | object |  |
+| `retrieval` | object |  |
+| `handoff` | object |  |
+| `invite` | object |  |
+| `webhook` | object |  |
+| `timeoutMs` | integer |  |

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/messaging.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/messaging.md
@@ -67,8 +67,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -195,7 +195,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.media` | array[object] |  |
 | `data.record_type` | enum: event | Identifies the type of the resource. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -379,6 +379,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsappMessage` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```javascript
 const response = await client.messages.sendWhatsapp({
@@ -403,7 +404,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -437,3 +438,425 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Messaging (JavaScript) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List alphanumeric sender IDs, Create an alphanumeric sender ID, Retrieve an alphanumeric sender ID, Delete an alphanumeric sender ID, List alphanumeric sender IDs for a messaging profile
+
+| Field | Type |
+|-------|------|
+| `alphanumeric_sender_id` | string |
+| `id` | uuid |
+| `messaging_profile_id` | uuid |
+| `organization_id` | string |
+| `record_type` | enum: alphanumeric_sender_id |
+| `us_long_code_fallback` | string |
+
+**Returned by:** Send a message, Send a message using an alphanumeric sender ID, Retrieve group MMS messages, Send a group MMS message, Send a long code message, Send a message using number pool, Schedule a message, Send a short code message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `wait_seconds` | float |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** Send a WhatsApp message
+
+| Field | Type |
+|-------|------|
+| `body` | object |
+| `direction` | string |
+| `encoding` | string |
+| `from` | object |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `organization_id` | string |
+| `received_at` | date-time |
+| `record_type` | string |
+| `to` | array[object] |
+| `type` | string |
+| `wait_seconds` | float |
+
+**Returned by:** Retrieve a message, Get detailed messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Cancel a scheduled message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** List messaging hosted numbers, Retrieve a messaging hosted number, Update a messaging hosted number
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `eligible_messaging_products` | array[string] |
+| `features` | object |
+| `health` | object |
+| `id` | string |
+| `messaging_product` | string |
+| `messaging_profile_id` | string \| null |
+| `organization_id` | string |
+| `phone_number` | string |
+| `record_type` | enum: messaging_phone_number, messaging_settings |
+| `tags` | array[string] |
+| `traffic_type` | string |
+| `type` | enum: long-code, toll-free, short-code, longcode, tollfree, shortcode |
+| `updated_at` | date-time |
+
+**Returned by:** List opt-outs
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `from` | string |
+| `keyword` | string \| null |
+| `messaging_profile_id` | string \| null |
+| `to` | string |
+
+**Returned by:** List high-level messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Regenerate messaging profile secret
+
+| Field | Type |
+|-------|------|
+| `ai_assistant_id` | string \| null |
+| `alpha_sender` | string \| null |
+| `created_at` | date-time |
+| `daily_spend_limit` | string |
+| `daily_spend_limit_enabled` | boolean |
+| `enabled` | boolean |
+| `health_webhook_url` | url |
+| `id` | uuid |
+| `mms_fall_back_to_sms` | boolean |
+| `mms_transcoding` | boolean |
+| `mobile_only` | boolean |
+| `name` | string |
+| `number_pool_settings` | object \| null |
+| `organization_id` | string |
+| `record_type` | enum: messaging_profile |
+| `redaction_enabled` | boolean |
+| `redaction_level` | integer |
+| `resource_group_id` | string \| null |
+| `smart_encoding` | boolean |
+| `updated_at` | date-time |
+| `url_shortener_settings` | object \| null |
+| `v1_secret` | string |
+| `webhook_api_version` | enum: 1, 2, 2010-04-01 |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+| `whitelisted_destinations` | array[string] |
+
+**Returned by:** List Auto-Response Settings, Create auto-response setting, Get Auto-Response Setting, Update Auto-Response Setting
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `id` | string |
+| `keywords` | array[string] |
+| `op` | enum: start, stop, info |
+| `resp_text` | string |
+| `updated_at` | date-time |
+
+## Optional Parameters
+
+### Create an alphanumeric sender ID — `client.alphanumericSenderIDs.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `usLongCodeFallback` | string | A US long code number to use as fallback when sending to US destinations. |
+
+### Send a message — `client.messages.send()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using an alphanumeric sender ID — `client.messages.sendWithAlphanumericSender()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `webhookUrl` | string (URL) | Callback URL for delivery status updates. |
+| `webhookFailoverUrl` | string (URL) | Failover callback URL for delivery status updates. |
+| `useProfileWebhooks` | boolean | If true, use the messaging profile's webhook settings. |
+
+### Send a group MMS message — `client.messages.sendGroupMms()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+
+### Send a long code message — `client.messages.sendLongCode()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using number pool — `client.messages.sendNumberPool()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Schedule a message — `client.messages.schedule()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+
+### Send a short code message — `client.messages.sendShortCode()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a WhatsApp message — `client.messages.sendWhatsapp()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
+
+### Update a messaging hosted number — `client.messagingHostedNumbers.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `messagingProfileId` | string (UUID) | Configure the messaging profile this phone number is assigned to:
+
+* Omit thi... |
+| `messagingProduct` | string | Configure the messaging product for this number:
+
+* Omit this field or set it... |
+| `tags` | array[string] | Tags to set on this phone number. |
+
+### Create auto-response setting — `client.messagingProfiles.autorespConfigs.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `respText` | string |  |
+
+### Update Auto-Response Setting — `client.messagingProfiles.autorespConfigs.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `respText` | string |  |
+
+## Webhook Payload Fields
+
+### `deliveryUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.sent, message.finalized | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: outbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | uuid | The id of the organization the messaging profile belongs to. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Subject of multimedia message |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | ISO 8601 formatted date indicating when the message was sent. |
+| `data.payload.completed_at` | date-time | ISO 8601 formatted date indicating when the message was finalized. |
+| `data.payload.valid_until` | date-time | Message must be out of the queue by this time or else it will be discarded and marked as 'sending_failed'. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+| `data.payload.smart_encoding_applied` | boolean | Indicates whether smart encoding was applied to this message. |
+| `data.payload.wait_seconds` | float | Seconds the message is queued due to rate limiting before being sent to the carrier. |
+| `meta.attempt` | integer | Number of attempts to deliver the webhook event. |
+| `meta.delivered_to` | url | The webhook URL the event was delivered to. |
+
+### `inboundMessage`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.received | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: inbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Message subject. |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | Not used for inbound messages. |
+| `data.payload.completed_at` | date-time | Not used for inbound messages. |
+| `data.payload.valid_until` | date-time | Not used for inbound messages. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+
+### `replacedLinkClick`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | string | Identifies the type of the resource. |
+| `data.url` | string | The original link that was sent in the message. |
+| `data.to` | string | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or short code). |
+| `data.message_id` | uuid | The message ID associated with the clicked link. |
+| `data.time_clicked` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+
+### Field Type Notes
+
+- `from` in responses/webhooks: object with sub-fields `phone_number` (string), `carrier` (string), `line_type` (string)
+- `to` in responses/webhooks: array of objects, each with `phone_number` (string), `carrier` (string), `line_type` (string), `status` (string)
+- `cost`: object with `amount` (string, decimal), `currency` (string, e.g., 'USD')

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/numbers.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/numbers.md
@@ -57,7 +57,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -368,7 +368,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -418,3 +418,433 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Numbers (JavaScript) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Advanced Orders, Create Advanced Order, Update Advanced Order, Get Advanced Order
+
+| Field | Type |
+|-------|------|
+| `area_code` | string |
+| `comments` | string |
+| `country_code` | string |
+| `customer_reference` | string |
+| `features` | array[object] |
+| `id` | uuid |
+| `orders` | array[string] |
+| `phone_number_type` | object |
+| `quantity` | integer |
+| `requirement_group_id` | uuid |
+| `status` | object |
+
+**Returned by:** List available phone number blocks
+
+| Field | Type |
+|-------|------|
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `range` | integer |
+| `record_type` | enum: available_phone_number_block |
+| `region_information` | array[object] |
+
+**Returned by:** List available phone numbers
+
+| Field | Type |
+|-------|------|
+| `best_effort` | boolean |
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `quickship` | boolean |
+| `record_type` | enum: available_phone_number |
+| `region_information` | array[object] |
+| `reservable` | boolean |
+| `vanity_format` | string |
+
+**Returned by:** Retrieve all comments
+
+| Field | Type |
+|-------|------|
+| `body` | string |
+| `comment_record_id` | uuid |
+| `comment_record_type` | enum: sub_number_order, requirement_group |
+| `commenter` | string |
+| `commenter_type` | enum: admin, user |
+| `created_at` | date-time |
+| `id` | uuid |
+| `read_at` | date-time |
+| `updated_at` | date-time |
+
+**Returned by:** Create a comment, Retrieve a comment, Mark a comment as read, Get country coverage
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Get coverage for a specific country
+
+| Field | Type |
+|-------|------|
+| `code` | string |
+| `features` | array[string] |
+| `international_sms` | boolean |
+| `inventory_coverage` | boolean |
+| `local` | object |
+| `mobile` | object |
+| `national` | object |
+| `numbers` | boolean |
+| `p2p` | boolean |
+| `phone_number_type` | array[string] |
+| `quickship` | boolean |
+| `region` | string \| null |
+| `reservable` | boolean |
+| `shared_cost` | object |
+| `toll_free` | object |
+
+**Returned by:** List customer service records, Create a customer service record, Get a customer service record
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `error_message` | string \| null |
+| `id` | uuid |
+| `phone_number` | string |
+| `record_type` | string |
+| `result` | object \| null |
+| `status` | enum: pending, completed, failed |
+| `updated_at` | date-time |
+| `webhook_url` | string |
+
+**Returned by:** Verify CSR phone number coverage
+
+| Field | Type |
+|-------|------|
+| `additional_data_required` | array[string] |
+| `has_csr_coverage` | boolean |
+| `phone_number` | string |
+| `reason` | string |
+| `record_type` | string |
+
+**Returned by:** List inexplicit number orders, Create an inexplicit number order, Retrieve an inexplicit number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `ordering_groups` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Create an inventory coverage request
+
+| Field | Type |
+|-------|------|
+| `administrative_area` | string |
+| `advance_requirements` | boolean |
+| `count` | integer |
+| `coverage_type` | enum: number, block |
+| `group` | string |
+| `group_type` | string |
+| `number_range` | integer |
+| `number_type` | enum: did, toll-free |
+| `phone_number_type` | enum: local, toll_free, national, landline, shared_cost, mobile |
+| `record_type` | string |
+
+**Returned by:** List mobile network operators
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `id` | uuid |
+| `mcc` | string |
+| `mnc` | string |
+| `name` | string |
+| `network_preferences_enabled` | boolean |
+| `record_type` | string |
+| `tadig` | string |
+
+**Returned by:** List network coverage locations
+
+| Field | Type |
+|-------|------|
+| `available_services` | array[object] |
+| `location` | object |
+| `record_type` | string |
+
+**Returned by:** List number block orders, Create a number block order, Retrieve a number block order
+
+| Field | Type |
+|-------|------|
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers_count` | integer |
+| `range` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `starting_number` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve a list of phone numbers associated to orders, Retrieve a single phone number within a number order., Update requirements for a single phone number within a number order.
+
+| Field | Type |
+|-------|------|
+| `bundle_id` | uuid |
+| `country_code` | string |
+| `deadline` | date-time |
+| `id` | uuid |
+| `is_block_number` | boolean |
+| `locality` | string |
+| `order_request_id` | uuid |
+| `phone_number` | string |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `requirements_status` | enum: pending, approved, cancelled, deleted, requirement-info-exception, requirement-info-pending, requirement-info-under-review |
+| `status` | enum: pending, success, failure |
+| `sub_number_order_id` | uuid |
+
+**Returned by:** List number orders, Create a number order, Retrieve a number order, Update a number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers` | array[object] |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `sub_number_orders_ids` | array[string] |
+| `updated_at` | date-time |
+
+**Returned by:** List number reservations, Create a number reservation, Retrieve a number reservation, Extend a number reservation
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `errors` | string |
+| `id` | uuid |
+| `phone_numbers` | array[object] |
+| `record_type` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve the features for a list of numbers
+
+| Field | Type |
+|-------|------|
+| `features` | array[string] |
+| `phone_number` | string |
+
+**Returned by:** Lists the phone number blocks jobs, Deletes all numbers associated with a phone number block, Retrieves a phone number blocks job
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `etc` | date-time |
+| `failed_operations` | array[object] |
+| `id` | uuid |
+| `record_type` | string |
+| `status` | enum: pending, in_progress, completed, failed |
+| `successful_operations` | array[object] |
+| `type` | enum: delete_phone_number_block |
+| `updated_at` | string |
+
+**Returned by:** List sub number orders, Retrieve a sub number order, Update a sub number order's requirements, Cancel a sub number order
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `is_block_sub_number_order` | boolean |
+| `order_request_id` | uuid |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+**Returned by:** Create a sub number orders report, Retrieve a sub number orders report
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `filters` | object |
+| `id` | uuid |
+| `order_type` | string |
+| `status` | enum: pending, success, failed, expired |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+## Optional Parameters
+
+### Create Advanced Order — `client.advancedOrders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `countryCode` | string (ISO 3166-1 alpha-2) |  |
+| `comments` | string |  |
+| `quantity` | integer |  |
+| `areaCode` | string |  |
+| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `features` | array[object] |  |
+| `customerReference` | string |  |
+| `requirementGroupId` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Update Advanced Order — `client.advancedOrders.updateRequirementGroup()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `countryCode` | string (ISO 3166-1 alpha-2) |  |
+| `comments` | string |  |
+| `quantity` | integer |  |
+| `areaCode` | string |  |
+| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `features` | array[object] |  |
+| `customerReference` | string |  |
+| `requirementGroupId` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Create a comment — `client.comments.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `body` | string |  |
+| `commenter` | string |  |
+| `commenterType` | enum (admin, user) |  |
+| `commentRecordType` | enum (sub_number_order, requirement_group) |  |
+| `commentRecordId` | string (UUID) |  |
+| `readAt` | string (date-time) | An ISO 8901 datetime string for when the comment was read. |
+| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the comment was created. |
+| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the comment was updated. |
+
+### Create an inexplicit number order — `client.inexplicitNumberOrders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `connectionId` | string (UUID) | Connection id to apply to phone numbers that are purchased |
+| `messagingProfileId` | string (UUID) | Messaging profile id to apply to phone numbers that are purchased |
+| `customerReference` | string | Reference label for the customer |
+| `billingGroupId` | string (UUID) | Billing group id to apply to phone numbers that are purchased |
+
+### Create a number block order — `client.numberBlockOrders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `recordType` | string |  |
+| `phoneNumbersCount` | integer | The count of phone numbers in the number order. |
+| `connectionId` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messagingProfileId` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `status` | enum (pending, success, failure) | The status of the order. |
+| `customerReference` | string | A customer reference string for customer look ups. |
+| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the number order was created. |
+| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the number order was updated. |
+| `requirementsMet` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `errors` | string | Errors the reservation could happen upon |
+
+### Update requirements for a single phone number within a number order. — `client.numberOrderPhoneNumbers.updateRequirements()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatoryRequirements` | array[object] |  |
+
+### Create a number order — `client.numberOrders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `phoneNumbers` | array[object] |  |
+| `connectionId` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messagingProfileId` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `billingGroupId` | string (UUID) | Identifies the billing group associated with the phone number. |
+| `customerReference` | string | A customer reference string for customer look ups. |
+
+### Update a number order — `client.numberOrders.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatoryRequirements` | array[object] |  |
+| `customerReference` | string | A customer reference string for customer look ups. |
+
+### Create a number reservation — `client.numberReservations.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `recordType` | string |  |
+| `phoneNumbers` | array[object] |  |
+| `status` | enum (pending, success, failure) | The status of the entire reservation. |
+| `customerReference` | string | A customer reference string for customer look ups. |
+| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the numbers reservation was created. |
+| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the number reservation was updated. |
+
+### Update a sub number order's requirements — `client.subNumberOrders.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatoryRequirements` | array[object] |  |
+
+### Create a sub number orders report — `client.subNumberOrdersReport.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `status` | enum (pending, success, failure) | Filter by order status |
+| `countryCode` | string (ISO 3166-1 alpha-2) | Filter by country code |
+| `createdAtGt` | string (date-time) | Filter for orders created after this date |
+| `createdAtLt` | string (date-time) | Filter for orders created before this date |
+| `orderRequestId` | string (UUID) | Filter by specific order request ID |
+| `customerReference` | string | Filter by customer reference |
+
+## Webhook Payload Fields
+
+### `numberOrderStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.event_type` | string | The type of event being sent |
+| `data.id` | uuid | Unique identifier for the event |
+| `data.occurred_at` | date-time | ISO 8601 timestamp of when the event occurred |
+| `data.payload.id` | uuid |  |
+| `data.payload.record_type` | string |  |
+| `data.payload.phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `data.payload.connection_id` | string | Identifies the connection associated with this phone number. |
+| `data.payload.messaging_profile_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.billing_group_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.phone_numbers` | array[object] |  |
+| `data.payload.sub_number_orders_ids` | array[string] |  |
+| `data.payload.status` | enum: pending, success, failure | The status of the order. |
+| `data.payload.customer_reference` | string | A customer reference string for customer look ups. |
+| `data.payload.created_at` | date-time | An ISO 8901 datetime string denoting when the number order was created. |
+| `data.payload.updated_at` | date-time | An ISO 8901 datetime string for when the number order was updated. |
+| `data.payload.requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `data.record_type` | string | Type of record |
+| `meta.attempt` | integer | Webhook delivery attempt number |
+| `meta.delivered_to` | uri | URL where the webhook was delivered |

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/voice.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/voice.md
@@ -30,7 +30,7 @@ try {
   const response = await client.calls.dial({
     connection_id: '7267xxxxxxxxxxxxxx',
     from: '+18005550101',
-    to: '+18005550100',
+    to: '+18005550100;secure=srtp',
   });
 } catch (err) {
   if (err instanceof Telnyx.APIConnectionError) {
@@ -67,8 +67,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -86,13 +86,13 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in the API Details section below |
+| ... | | | +56 optional params in the API Details section below |
 
 ```javascript
 const response = await client.calls.dial({
   connection_id: '7267xxxxxxxxxxxxxx',
   from: '+18005550101',
-  to: '+18005550100',
+  to: '+18005550100;secure=srtp',
 });
 
 console.log(response.data);
@@ -118,7 +118,7 @@ Primary inbound call-control command.
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in the API Details section below |
+| ... | | | +29 optional params in the API Details section below |
 
 ```javascript
 const response = await client.calls.actions.answer('v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ');
@@ -143,11 +143,11 @@ Common post-answer control path with downstream webhook implications.
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in the API Details section below |
+| ... | | | +35 optional params in the API Details section below |
 
 ```javascript
 const response = await client.calls.actions.transfer('call_control_id', {
-  to: '+18005550100',
+  to: '+18005550100;secure=srtp',
 });
 
 console.log(response.data);
@@ -223,7 +223,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
 | `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -393,7 +393,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -413,3 +413,427 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Voice (JavaScript) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List call control applications, Create a call control application, Retrieve a call control application, Update a call control application, Delete a call control application
+
+| Field | Type |
+|-------|------|
+| `active` | boolean |
+| `anchorsite_override` | enum: Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, Chennai, IN, Amsterdam, Netherlands, Toronto, Canada, Sydney, Australia |
+| `application_name` | string |
+| `call_cost_in_webhooks` | boolean |
+| `created_at` | string |
+| `dtmf_type` | enum: RFC 2833, Inband, SIP INFO |
+| `first_command_timeout` | boolean |
+| `first_command_timeout_secs` | integer |
+| `id` | string |
+| `inbound` | object |
+| `outbound` | object |
+| `record_type` | enum: call_control_application |
+| `redact_dtmf_debug_logging` | boolean |
+| `tags` | array[string] |
+| `updated_at` | string |
+| `webhook_api_version` | enum: 1, 2 |
+| `webhook_event_failover_url` | url |
+| `webhook_event_url` | url |
+| `webhook_timeout_secs` | integer \| null |
+
+**Returned by:** Dial
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `recording_id` | uuid |
+| `start_time` | string |
+
+**Returned by:** Retrieve a call status
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `start_time` | string |
+
+**Returned by:** Answer call
+
+| Field | Type |
+|-------|------|
+| `recording_id` | uuid |
+| `result` | string |
+
+**Returned by:** Bridge calls, Hangup call, SIP Refer a call, Reject a call, Send SIP info, Transfer call
+
+| Field | Type |
+|-------|------|
+| `result` | string |
+
+**Returned by:** List all active calls for given connection
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `record_type` | enum: call |
+
+## Optional Parameters
+
+### Create a call control application — `client.callControlApplications.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `active` | boolean | Specifies whether the connection can be used. |
+| `anchorsiteOverride` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmfType` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `firstCommandTimeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `firstCommandTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `inbound` | object |  |
+| `outbound` | object |  |
+| `webhookApiVersion` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhookEventFailoverUrl` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhookTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `callCostInWebhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `redactDtmfDebugLogging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Update a call control application — `client.callControlApplications.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `callCostInWebhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `active` | boolean | Specifies whether the connection can be used. |
+| `anchorsiteOverride` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmfType` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `firstCommandTimeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `firstCommandTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `tags` | array[string] | Tags assigned to the Call Control Application. |
+| `inbound` | object |  |
+| `outbound` | object |  |
+| `webhookApiVersion` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhookEventFailoverUrl` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhookTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `redactDtmfDebugLogging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Dial — `client.calls.dial()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `audioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
+| `mediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
+| `preferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
+| `conferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
+| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `linkTo` | string | Use another call's control id for sharing the same call session id |
+| `bridgeIntent` | boolean | Indicates the intent to bridge this call with the call specified in link_to. |
+| `bridgeOnAnswer` | boolean | Whether to automatically bridge answered call to the call specified in link_to. |
+| `preventDoubleBridge` | boolean | Prevents bridging and hangs up the call if the target is already bridged. |
+| `parkAfterUnbridge` | string | If supplied with the value `self`, the current leg will be parked after unbri... |
+| `mediaEncryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the call. |
+| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
+| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
+| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE request. |
+| `sipTransportProtocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `streamUrl` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `streamTrack` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `streamCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `streamBidirectionalMode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `streamBidirectionalCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `streamBidirectionalTargetLegs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `streamBidirectionalSamplingRate` | enum (8000, 16000, 22050, 24000, 48000) | Audio sampling rate. |
+| `streamEstablishBeforeCallOriginate` | boolean | Establish websocket connection before dialing the destination. |
+| `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhookUrls` | object | A map of event types to webhook URLs. |
+| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `superviseCallControlId` | string (UUID) | The call leg which will be supervised by the new call. |
+| `supervisorRole` | enum (barge, whisper, monitor) | The role of the supervisor call. |
+| `enableDialogflow` | boolean | Enables Dialogflow for the current call. |
+| `dialogflowConfig` | object |  |
+| `transcription` | boolean | Enable transcription upon call answer. |
+| `transcriptionConfig` | object |  |
+| `sipRegion` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `streamAuthToken` | string | An authentication token to be sent as part of the WebSocket connection when u... |
+
+### Answer call — `client.calls.actions.answer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE response. |
+| `preferredCodecs` | enum (G722,PCMU,PCMA,G729,OPUS,VP8,H264) | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE response. |
+| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `streamUrl` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `streamTrack` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `streamCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `streamBidirectionalMode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `streamBidirectionalCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `streamBidirectionalTargetLegs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `transcription` | boolean | Enable transcription upon call answer. |
+| `transcriptionConfig` | object |  |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `webhookUrls` | object | A map of event types to webhook URLs. |
+| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
+
+### Bridge calls — `client.calls.actions.bridge()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `queue` | string | The name of the queue you want to bridge with, can't be used together with ca... |
+| `videoRoomId` | string (UUID) | The ID of the video room you want to bridge with, can't be used together with... |
+| `videoRoomContext` | string | The additional parameter that will be passed to the video conference. |
+| `preventDoubleBridge` | boolean | When set to `true`, it prevents bridging if the target call is already bridge... |
+| `parkAfterUnbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `playRingtone` | boolean | Specifies whether to play a ringtone if the call you want to bridge with has ... |
+| `ringtone` | enum (at, au, be, bg, br, ...) | Specifies which country ringtone to play when `play_ringtone` is set to `true`. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `muteDtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `holdAfterUnbridge` | boolean | Specifies behavior after the bridge ends. |
+
+### Hangup call — `client.calls.actions.hangup()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `customHeaders` | array[object] | Custom headers to be added to the SIP BYE message. |
+
+### SIP Refer a call — `client.calls.actions.refer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid execution of duplicate commands. |
+| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
+| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
+| `sipHeaders` | array[object] | SIP headers to be added to the request. |
+
+### Reject a call — `client.calls.actions.reject()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Send SIP info — `client.calls.actions.sendSipInfo()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Transfer call — `client.calls.actions.transfer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
+| `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `audioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
+| `earlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
+| `mediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
+| `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `parkAfterUnbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `targetLegClientState` | string | Use this field to add state to every subsequent webhook for the new leg. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `mediaEncryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the new call leg. |
+| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
+| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
+| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE. |
+| `sipTransportProtocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `muteDtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `sipRegion` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `preferredCodecs` | string | The list of comma-separated codecs in order of preference to be used during t... |
+| `webhookUrls` | object | A map of event types to webhook URLs. |
+| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+
+## Webhook Payload Fields
+
+### `callAnswered`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.answered | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: answered | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### `callBridged`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.bridged | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+
+### `callHangup`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.hangup | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: hangup | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+| `data.payload.hangup_cause` | enum: call_rejected, normal_clearing, originator_cancel, timeout, time_limit, user_busy, not_found, no_answer, unspecified | The reason the call was ended (`call_rejected`, `normal_clearing`, `originator_cancel`, `timeout`, `time_limit`, `use... |
+| `data.payload.hangup_source` | enum: caller, callee, unknown | The party who ended the call (`callee`, `caller`, `unknown`). |
+| `data.payload.sip_hangup_cause` | string | The reason the call was ended (SIP response code). |
+| `data.payload.call_quality_stats` | object \| null | Call quality statistics aggregated from the CHANNEL_HANGUP_COMPLETE event. |
+
+### `callInitiated`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.initiated | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
+| `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.custom_headers` | array[object] | Custom headers from sip invite |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.shaken_stir_attestation` | string | SHAKEN/STIR attestation level. |
+| `data.payload.shaken_stir_validated` | boolean | Whether attestation was successfully validated or not. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.caller_id_name` | string | Caller id. |
+| `data.payload.call_screening_result` | string | Call screening result. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.direction` | enum: incoming, outgoing | Whether the call is `incoming` or `outgoing`. |
+| `data.payload.state` | enum: parked, bridging | State received from a command. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### Field Type Notes
+
+- `from` in webhook payloads: string (E.164 phone number)
+- `to` in webhook payloads: string (E.164 phone number)
+- The return value of `client.webhooks.unwrap()` is a parsed event object — access fields via `event.data.event_type`, `event.data.payload.call_control_id`, etc.

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/python/10dlc.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/python/10dlc.md
@@ -67,8 +67,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -209,7 +209,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `description` | string | Description of the event. |
 | `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -371,7 +371,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -411,3 +411,471 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# 10DLC (Python) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Brands, List Campaigns, List shared partner campaigns, List Shared Campaigns, List phone number campaigns
+
+| Field | Type |
+|-------|------|
+| `page` | integer |
+| `records` | array[object] |
+| `totalRecords` | integer |
+
+**Returned by:** Create Brand, Update Brand, Revet Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Get Brand Feedback By Id
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `category` | array[object] |
+
+**Returned by:** Get Brand SMS OTP Status, Get Brand SMS OTP Status by Brand ID
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `deliveryStatus` | string |
+| `deliveryStatusDate` | date-time |
+| `deliveryStatusDetails` | string |
+| `mobilePhone` | string |
+| `referenceId` | string |
+| `requestDate` | date-time |
+| `verifyDate` | date-time |
+
+**Returned by:** Get Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `assignedCampaignsCount` | number |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Order Brand External Vetting, Import External Vetting Record
+
+| Field | Type |
+|-------|------|
+| `createDate` | string |
+| `evpId` | string |
+| `vettedDate` | string |
+| `vettingClass` | string |
+| `vettingId` | string |
+| `vettingScore` | integer |
+| `vettingToken` | string |
+
+**Returned by:** Trigger Brand SMS OTP
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `referenceId` | string |
+
+**Returned by:** Get Campaign Cost
+
+| Field | Type |
+|-------|------|
+| `campaignUsecase` | string |
+| `description` | string |
+| `monthlyCost` | string |
+| `upFrontCost` | string |
+
+**Returned by:** Get campaign, Update campaign, Submit Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `autoRenewal` | boolean |
+| `billedDate` | string |
+| `brandDisplayName` | string |
+| `brandId` | string |
+| `campaignId` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createDate` | string |
+| `cspId` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isTMobileNumberPoolingEnabled` | boolean |
+| `isTMobileRegistered` | boolean |
+| `isTMobileSuspended` | boolean |
+| `messageFlow` | string |
+| `mock` | boolean |
+| `nextRenewalOrExpirationDate` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `referenceId` | string |
+| `resellerId` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `status` | string |
+| `subUsecases` | array[string] |
+| `submissionStatus` | enum: CREATED, FAILED, PENDING |
+| `subscriberHelp` | boolean |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `usecase` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Deactivate campaign
+
+| Field | Type |
+|-------|------|
+| `message` | string |
+| `record_type` | string |
+| `time` | number |
+
+**Returned by:** Submit campaign appeal for manual review
+
+| Field | Type |
+|-------|------|
+| `appealed_at` | date-time |
+
+**Returned by:** Get Campaign Mno Metadata
+
+| Field | Type |
+|-------|------|
+| `10999` | object |
+
+**Returned by:** Get Sharing Status
+
+| Field | Type |
+|-------|------|
+| `sharedByMe` | object |
+| `sharedWithMe` | object |
+
+**Returned by:** Qualify By Usecase
+
+| Field | Type |
+|-------|------|
+| `annualFee` | number |
+| `maxSubUsecases` | integer |
+| `minSubUsecases` | integer |
+| `mnoMetadata` | object |
+| `monthlyFee` | number |
+| `quarterlyFee` | number |
+| `usecase` | string |
+
+**Returned by:** Get Single Shared Campaign, Update Single Shared Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `assignedPhoneNumbersCount` | number |
+| `brandDisplayName` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createdAt` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isNumberPoolingEnabled` | boolean |
+| `messageFlow` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `subUsecases` | array[string] |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `updatedAt` | string |
+| `usecase` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Assign Messaging Profile To Campaign
+
+| Field | Type |
+|-------|------|
+| `campaignId` | string |
+| `messagingProfileId` | string |
+| `taskId` | string |
+| `tcrCampaignId` | string |
+
+**Returned by:** Get Assignment Task Status
+
+| Field | Type |
+|-------|------|
+| `createdAt` | date-time |
+| `status` | string |
+| `taskId` | string |
+| `updatedAt` | date-time |
+
+**Returned by:** Get Phone Number Status
+
+| Field | Type |
+|-------|------|
+| `records` | array[object] |
+
+**Returned by:** Create New Phone Number Campaign, Get Single Phone Number Campaign, Create New Phone Number Campaign, Delete Phone Number Campaign
+
+| Field | Type |
+|-------|------|
+| `assignmentStatus` | enum: FAILED_ASSIGNMENT, PENDING_ASSIGNMENT, ASSIGNED, PENDING_UNASSIGNMENT, FAILED_UNASSIGNMENT |
+| `brandId` | string |
+| `campaignId` | string |
+| `createdAt` | string |
+| `failureReasons` | string |
+| `phoneNumber` | string |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `telnyxCampaignId` | string |
+| `updatedAt` | string |
+
+## Optional Parameters
+
+### Create Brand — `client.messaging_10dlc.brand.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `company_name` | string | (Required for Non-profit/private/public) Legal company name. |
+| `first_name` | string | First name of business contact. |
+| `last_name` | string | Last name of business contact. |
+| `ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `phone` | string | Valid phone number in e.164 international format. |
+| `street` | string | Street number and name. |
+| `city` | string | City name |
+| `state` | string | State. |
+| `postal_code` | string | Postal codes. |
+| `stock_symbol` | string | (Required for public company) stock symbol. |
+| `stock_exchange` | object | (Required for public company) stock exchange. |
+| `ip_address` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `website` | string | Brand website URL. |
+| `is_reseller` | boolean |  |
+| `mock` | boolean | Mock brand for testing purposes. |
+| `mobile_phone` | string | Valid mobile phone number in e.164 international format. |
+| `business_contact_email` | string | Business contact email. |
+| `webhook_url` | string | Webhook URL for brand status updates. |
+| `webhook_failover_url` | string | Webhook failover URL for brand status updates. |
+
+### Update Brand — `client.messaging_10dlc.brand.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `company_name` | string | (Required for Non-profit/private/public) Legal company name. |
+| `first_name` | string | First name of business contact. |
+| `last_name` | string | Last name of business contact. |
+| `ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `phone` | string | Valid phone number in e.164 international format. |
+| `street` | string | Street number and name. |
+| `city` | string | City name |
+| `state` | string | State. |
+| `postal_code` | string | Postal codes. |
+| `stock_symbol` | string | (Required for public company) stock symbol. |
+| `stock_exchange` | object | (Required for public company) stock exchange. |
+| `ip_address` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `website` | string | Brand website URL. |
+| `alt_business_id_type` | enum (NONE, DUNS, GIIN, LEI) | An enumeration. |
+| `is_reseller` | boolean |  |
+| `identity_status` | enum (VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED) | The verification status of an active brand |
+| `business_contact_email` | string | Business contact email. |
+| `webhook_url` | string | Webhook URL for brand status updates. |
+| `webhook_failover_url` | string | Webhook failover URL for brand status updates. |
+| `alt_business_id` | string (UUID) | Alternate business identifier such as DUNS, LEI, or GIIN |
+
+### Import External Vetting Record — `client.messaging_10dlc.brand.external_vetting.imports()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `vetting_token` | string | Required by some providers for vetting record confirmation. |
+
+### Update campaign — `client.messaging_10dlc.campaign.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `reseller_id` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `sample1` | string | Message sample. |
+| `sample2` | string | Message sample. |
+| `sample3` | string | Message sample. |
+| `sample4` | string | Message sample. |
+| `sample5` | string | Message sample. |
+| `message_flow` | string | Message flow description. |
+| `help_message` | string | Help message of the campaign. |
+| `auto_renewal` | boolean | Help message of the campaign. |
+| `webhook_url` | string | Webhook to which campaign status updates are sent. |
+| `webhook_failover_url` | string | Webhook failover to which campaign status updates are sent. |
+
+### Submit Campaign — `client.messaging_10dlc.campaign_builder.submit()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `age_gated` | boolean | Age gated message content in campaign. |
+| `auto_renewal` | boolean | Campaign subscription auto-renewal option. |
+| `direct_lending` | boolean | Direct lending or loan arrangement |
+| `embedded_link` | boolean | Does message generated by the campaign include URL link in SMS? |
+| `embedded_phone` | boolean | Does message generated by the campaign include phone number in SMS? |
+| `help_keywords` | string | Subscriber help keywords. |
+| `help_message` | string | Help message of the campaign. |
+| `message_flow` | string | Message flow description. |
+| `mno_ids` | array[integer] | Submit campaign to given list of MNOs by MNO's network ID. |
+| `number_pool` | boolean | Does campaign utilize pool of phone numbers? |
+| `optin_keywords` | string | Subscriber opt-in keywords. |
+| `optin_message` | string | Subscriber opt-in message. |
+| `optout_keywords` | string | Subscriber opt-out keywords. |
+| `optout_message` | string | Subscriber opt-out message. |
+| `reference_id` | string (UUID) | Caller supplied campaign reference ID. |
+| `reseller_id` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `sample1` | string | Message sample. |
+| `sample2` | string | Message sample. |
+| `sample3` | string | Message sample. |
+| `sample4` | string | Message sample. |
+| `sample5` | string | Message sample. |
+| `sub_usecases` | array[string] | Campaign sub-usecases. |
+| `subscriber_help` | boolean | Does campaign responds to help keyword(s)? |
+| `subscriber_optin` | boolean | Does campaign require subscriber to opt-in before SMS is sent to subscriber? |
+| `subscriber_optout` | boolean | Does campaign support subscriber opt-out keyword(s)? |
+| `tag` | array[string] | Tags to be set on the Campaign. |
+| `terms_and_conditions` | boolean | Is terms and conditions accepted? |
+| `privacy_policy_link` | string | Link to the campaign's privacy policy. |
+| `terms_and_conditions_link` | string | Link to the campaign's terms and conditions. |
+| `embedded_link_sample` | string | Sample of an embedded link that will be sent to subscribers. |
+| `webhook_url` | string | Webhook to which campaign status updates are sent. |
+| `webhook_failover_url` | string | Failover webhook to which campaign status updates are sent. |
+
+### Update Single Shared Campaign — `client.messaging_10dlc.partner_campaigns.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `webhook_url` | string | Webhook to which campaign status updates are sent. |
+| `webhook_failover_url` | string | Webhook failover to which campaign status updates are sent. |
+
+### Assign Messaging Profile To Campaign — `client.messaging_10dlc.phone_number_assignment_by_profile.assign()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `tcr_campaign_id` | string (UUID) | The TCR ID of the shared campaign you want to link to the specified messaging... |
+| `campaign_id` | string (UUID) | The ID of the campaign you want to link to the specified messaging profile. |
+
+## Webhook Payload Fields
+
+### `campaignStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `brandId` | string | Brand ID associated with the campaign. |
+| `campaignId` | string | The ID of the campaign. |
+| `createDate` | string | Unix timestamp when campaign was created. |
+| `cspId` | string | Alphanumeric identifier of the CSP associated with this campaign. |
+| `isTMobileRegistered` | boolean | Indicates whether the campaign is registered with T-Mobile. |
+| `type` | enum: TELNYX_EVENT, REGISTRATION, MNO_REVIEW, TELNYX_REVIEW, NUMBER_POOL_PROVISIONED, NUMBER_POOL_DEPROVISIONED, TCR_EVENT, VERIFIED |  |
+| `description` | string | Description of the event. |
+| `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/python/ai-assistants.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/python/ai-assistants.md
@@ -32,8 +32,8 @@ import telnyx
 try:
     assistant = client.ai.assistants.create(
         instructions="You are a helpful assistant.",
-        model="openai/gpt-4o",
         name="my-resource",
+        model="openai/gpt-4o",
     )
 except telnyx.APIConnectionError:
     print("Network error — check connectivity and retry")
@@ -61,7 +61,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -74,18 +74,17 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `description` | string | No |  |
-| `greeting` | string | No | Text that the assistant will use to start the conversation. |
-| ... | | | +11 optional params in the API Details section below |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in the API Details section below |
 
 ```python
 assistant = client.ai.assistants.create(
     instructions="You are a helpful assistant.",
-    model="openai/gpt-4o",
     name="my-resource",
+    model="openai/gpt-4o",
 )
 print(assistant.id)
 ```
@@ -197,7 +196,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### Update an assistant
 
@@ -208,10 +207,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistant_id` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +15 optional params in the API Details section below |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in the API Details section below |
 
 ```python
 assistant = client.ai.assistants.update(
@@ -226,7 +225,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### List assistants
 
@@ -248,7 +247,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Import assistants from external provider
 
@@ -279,7 +278,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Get All Tags
 
@@ -381,7 +380,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -394,8 +393,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
 | Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Get Canary Deploy | `client.ai.assistants.canary_deploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
-| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistant_id` |
-| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistant_id` |
+| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
 | Delete Canary Deploy | `client.ai.assistants.canary_deploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Assistant Sms Chat | `client.ai.assistants.send_sms()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from_`, `to`, `assistant_id` |
 | Clone Assistant | `client.ai.assistants.clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |
@@ -406,6 +405,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Add Assistant Tag | `client.ai.assistants.tags.add()` | `POST /ai/assistants/{assistant_id}/tags` | Create or provision an additional resource when the core tasks do not cover this flow. | `tag`, `assistant_id` |
 | Remove Assistant Tag | `client.ai.assistants.tags.remove()` | `DELETE /ai/assistants/{assistant_id}/tags/{tag}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `tag` |
 | Get assistant texml | `client.ai.assistants.get_texml()` | `GET /ai/assistants/{assistant_id}/texml` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Add Assistant Tool | `client.ai.assistants.tools.add()` | `PUT /ai/assistants/{assistant_id}/tools/{tool_id}` | Modify an existing resource without recreating it. | `assistant_id`, `tool_id` |
+| Remove Assistant Tool | `client.ai.assistants.tools.remove()` | `DELETE /ai/assistants/{assistant_id}/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `tool_id` |
 | Test Assistant Tool | `client.ai.assistants.tools.test()` | `POST /ai/assistants/{assistant_id}/tools/{tool_id}/test` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id`, `tool_id` |
 | Get all versions of an assistant | `client.ai.assistants.versions.list()` | `GET /ai/assistants/{assistant_id}/versions` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
 | Get a specific assistant version | `client.ai.assistants.versions.retrieve()` | `GET /ai/assistants/{assistant_id}/versions/{version_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id`, `version_id` |
@@ -417,7 +418,398 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get MCP Server | `client.ai.mcp_servers.retrieve()` | `GET /ai/mcp_servers/{mcp_server_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `mcp_server_id` |
 | Update MCP Server | `client.ai.mcp_servers.update()` | `PUT /ai/mcp_servers/{mcp_server_id}` | Modify an existing resource without recreating it. | `mcp_server_id` |
 | Delete MCP Server | `client.ai.mcp_servers.delete()` | `DELETE /ai/mcp_servers/{mcp_server_id}` | Remove, detach, or clean up an existing resource. | `mcp_server_id` |
+| List Tools | `client.ai.tools.list()` | `GET /ai/tools` | Inspect available resources or choose an existing resource before mutating it. | None |
+| Create Tool | `client.ai.tools.create()` | `POST /ai/tools` | Create or provision an additional resource when the core tasks do not cover this flow. | `type_`, `display_name` |
+| Get Tool | `client.ai.tools.retrieve()` | `GET /ai/tools/{tool_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `tool_id` |
+| Update Tool | `client.ai.tools.update()` | `PATCH /ai/tools/{tool_id}` | Modify an existing resource without recreating it. | `tool_id` |
+| Delete Tool | `client.ai.tools.delete()` | `DELETE /ai/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `tool_id` |
 
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# AI Assistants (Python) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+
+## Response Schemas
+
+**Returned by:** List assistants, Create an assistant, Import assistants from external provider, Get an assistant, Update an assistant, Clone Assistant, Get all versions of an assistant, Get a specific assistant version, Update a specific assistant version, Promote an assistant version to main
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
+| `dynamic_variables_webhook_url` | string |
+| `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
+| `greeting` | string |
+| `id` | string |
+| `import_metadata` | object |
+| `insight_settings` | object |
+| `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
+| `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
+| `messaging_settings` | object |
+| `model` | string |
+| `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
+| `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
+| `telephony_settings` | object |
+| `tools` | array[object] |
+| `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
+| `voice_settings` | object |
+| `widget_settings` | object |
+
+**Returned by:** Get All Tags, Add Assistant Tag, Remove Assistant Tag
+
+| Field | Type |
+|-------|------|
+| `tags` | array[string] |
+
+**Returned by:** List assistant tests with pagination, Create a new assistant test, Get assistant test by ID, Update an assistant test
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `destination` | string |
+| `instructions` | string |
+| `max_duration_seconds` | integer |
+| `name` | string |
+| `rubric` | array[object] |
+| `telnyx_conversation_channel` | object |
+| `test_id` | uuid |
+| `test_suite` | string |
+
+**Returned by:** Get all test suite names
+
+| Field | Type |
+|-------|------|
+| `data` | array[string] |
+
+**Returned by:** Get test suite run history, Get test run history for a specific test, Trigger a manual test run, Get specific test run details
+
+| Field | Type |
+|-------|------|
+| `completed_at` | date-time |
+| `conversation_id` | string |
+| `conversation_insights_id` | string |
+| `created_at` | date-time |
+| `detail_status` | array[object] |
+| `logs` | string |
+| `run_id` | uuid |
+| `status` | enum: pending, starting, running, passed, failed, error |
+| `test_id` | uuid |
+| `test_suite_run_id` | uuid |
+| `triggered_by` | string |
+| `updated_at` | date-time |
+
+**Returned by:** Delete an assistant
+
+| Field | Type |
+|-------|------|
+| `deleted` | boolean |
+| `id` | string |
+| `object` | string |
+
+**Returned by:** Get Canary Deploy, Create Canary Deploy, Update Canary Deploy
+
+| Field | Type |
+|-------|------|
+| `assistant_id` | string |
+| `created_at` | date-time |
+| `rules` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Assistant Chat (BETA)
+
+| Field | Type |
+|-------|------|
+| `content` | string |
+
+**Returned by:** Assistant Sms Chat
+
+| Field | Type |
+|-------|------|
+| `conversation_id` | string |
+
+**Returned by:** List scheduled events
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Test Assistant Tool
+
+| Field | Type |
+|-------|------|
+| `content_type` | string |
+| `request` | object |
+| `response` | string |
+| `status_code` | integer |
+| `success` | boolean |
+
+**Returned by:** Create MCP Server, Get MCP Server, Update MCP Server
+
+| Field | Type |
+|-------|------|
+| `allowed_tools` | array \| null |
+| `api_key_ref` | string \| null |
+| `created_at` | date-time |
+| `id` | string |
+| `name` | string |
+| `type` | string |
+| `url` | string |
+
+**Returned by:** List Tools, Create Tool, Get Tool, Update Tool
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `display_name` | string |
+| `id` | string |
+| `timeout_ms` | integer |
+| `tool_definition` | object |
+| `type` | string |
+
+## Optional Parameters
+
+### Create an assistant — `client.ai.assistants.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
+| `transcription` | object |  |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+
+### Import assistants from external provider — `client.ai.assistants.imports()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `import_ids` | array[string] | Optional list of assistant IDs to import from the external provider. |
+
+### Create a new assistant test — `client.ai.assistants.tests.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `description` | string | Optional detailed description of what this test evaluates and its purpose. |
+| `telnyx_conversation_channel` | object | The communication channel through which the test will be conducted. |
+| `max_duration_seconds` | integer | Maximum duration in seconds that the test conversation should run before timi... |
+| `test_suite` | string | Optional test suite name to group related tests together. |
+
+### Trigger test suite execution — `client.ai.assistants.tests.test_suites.runs.trigger()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `destination_version_id` | string (UUID) | Optional assistant version ID to use for all test runs in this suite. |
+
+### Update an assistant test — `client.ai.assistants.tests.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | Updated name for the assistant test. |
+| `description` | string | Updated description of the test's purpose and evaluation criteria. |
+| `telnyx_conversation_channel` | enum (phone_call, web_call, sms_chat, web_chat) |  |
+| `destination` | string | Updated target destination for test conversations. |
+| `max_duration_seconds` | integer | Updated maximum test duration in seconds. |
+| `test_suite` | string | Updated test suite assignment for better organization. |
+| `instructions` | string | Updated test scenario instructions and objectives. |
+| `rubric` | array[object] | Updated evaluation criteria for assessing assistant performance. |
+
+### Trigger a manual test run — `client.ai.assistants.tests.runs.trigger()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `destination_version_id` | string (UUID) | Optional assistant version ID to use for this test run. |
+
+### Update an assistant — `client.ai.assistants.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `instructions` | string | System instructions for the assistant. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
+| `transcription` | object |  |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+| `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai.assistants.canary_deploys.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai.assistants.canary_deploys.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Assistant Chat (BETA) — `client.ai.assistants.chat()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | The optional display name of the user sending the message |
+
+### Assistant Sms Chat — `client.ai.assistants.send_sms()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string |  |
+| `conversation_metadata` | object |  |
+| `should_create_conversation` | boolean |  |
+
+### Create a scheduled event — `client.ai.assistants.scheduled_events.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Required for sms scheduled events. |
+| `conversation_metadata` | object | Metadata associated with the conversation. |
+| `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
+
+### Test Assistant Tool — `client.ai.assistants.tools.test()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `arguments` | object | Key-value arguments to use for the webhook test |
+| `dynamic_variables` | object | Key-value dynamic variables to use for the webhook test |
+
+### Update a specific assistant version — `client.ai.assistants.versions.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `instructions` | string | System instructions for the assistant. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
+| `transcription` | object |  |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+
+### Create MCP Server — `client.ai.mcp_servers.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `api_key_ref` | string |  |
+| `allowed_tools` | array[string] |  |
+
+### Update MCP Server — `client.ai.mcp_servers.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `name` | string |  |
+| `type_` | string |  |
+| `url` | string (URL) |  |
+| `api_key_ref` | string |  |
+| `allowed_tools` | array[string] |  |
+| `created_at` | string (date-time) |  |
+
+### Create Tool — `client.ai.tools.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `function` | object |  |
+| `retrieval` | object |  |
+| `handoff` | object |  |
+| `invite` | object |  |
+| `webhook` | object |  |
+| `timeout_ms` | integer |  |
+
+### Update Tool — `client.ai.tools.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type_` | string |  |
+| `display_name` | string |  |
+| `function` | object |  |
+| `retrieval` | object |  |
+| `handoff` | object |  |
+| `invite` | object |  |
+| `webhook` | object |  |
+| `timeout_ms` | integer |  |

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/python/messaging.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/python/messaging.md
@@ -66,8 +66,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -191,7 +191,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.media` | array[object] |  |
 | `data.record_type` | enum: event | Identifies the type of the resource. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -372,6 +372,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsapp_message` | object | Yes |  |
 | `type_` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```python
 response = client.messages.send_whatsapp(
@@ -395,7 +396,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -429,3 +430,425 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Messaging (Python) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List alphanumeric sender IDs, Create an alphanumeric sender ID, Retrieve an alphanumeric sender ID, Delete an alphanumeric sender ID, List alphanumeric sender IDs for a messaging profile
+
+| Field | Type |
+|-------|------|
+| `alphanumeric_sender_id` | string |
+| `id` | uuid |
+| `messaging_profile_id` | uuid |
+| `organization_id` | string |
+| `record_type` | enum: alphanumeric_sender_id |
+| `us_long_code_fallback` | string |
+
+**Returned by:** Send a message, Send a message using an alphanumeric sender ID, Retrieve group MMS messages, Send a group MMS message, Send a long code message, Send a message using number pool, Schedule a message, Send a short code message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `wait_seconds` | float |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** Send a WhatsApp message
+
+| Field | Type |
+|-------|------|
+| `body` | object |
+| `direction` | string |
+| `encoding` | string |
+| `from` | object |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `organization_id` | string |
+| `received_at` | date-time |
+| `record_type` | string |
+| `to` | array[object] |
+| `type` | string |
+| `wait_seconds` | float |
+
+**Returned by:** Retrieve a message, Get detailed messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Cancel a scheduled message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** List messaging hosted numbers, Retrieve a messaging hosted number, Update a messaging hosted number
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `eligible_messaging_products` | array[string] |
+| `features` | object |
+| `health` | object |
+| `id` | string |
+| `messaging_product` | string |
+| `messaging_profile_id` | string \| null |
+| `organization_id` | string |
+| `phone_number` | string |
+| `record_type` | enum: messaging_phone_number, messaging_settings |
+| `tags` | array[string] |
+| `traffic_type` | string |
+| `type` | enum: long-code, toll-free, short-code, longcode, tollfree, shortcode |
+| `updated_at` | date-time |
+
+**Returned by:** List opt-outs
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `from` | string |
+| `keyword` | string \| null |
+| `messaging_profile_id` | string \| null |
+| `to` | string |
+
+**Returned by:** List high-level messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Regenerate messaging profile secret
+
+| Field | Type |
+|-------|------|
+| `ai_assistant_id` | string \| null |
+| `alpha_sender` | string \| null |
+| `created_at` | date-time |
+| `daily_spend_limit` | string |
+| `daily_spend_limit_enabled` | boolean |
+| `enabled` | boolean |
+| `health_webhook_url` | url |
+| `id` | uuid |
+| `mms_fall_back_to_sms` | boolean |
+| `mms_transcoding` | boolean |
+| `mobile_only` | boolean |
+| `name` | string |
+| `number_pool_settings` | object \| null |
+| `organization_id` | string |
+| `record_type` | enum: messaging_profile |
+| `redaction_enabled` | boolean |
+| `redaction_level` | integer |
+| `resource_group_id` | string \| null |
+| `smart_encoding` | boolean |
+| `updated_at` | date-time |
+| `url_shortener_settings` | object \| null |
+| `v1_secret` | string |
+| `webhook_api_version` | enum: 1, 2, 2010-04-01 |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+| `whitelisted_destinations` | array[string] |
+
+**Returned by:** List Auto-Response Settings, Create auto-response setting, Get Auto-Response Setting, Update Auto-Response Setting
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `id` | string |
+| `keywords` | array[string] |
+| `op` | enum: start, stop, info |
+| `resp_text` | string |
+| `updated_at` | date-time |
+
+## Optional Parameters
+
+### Create an alphanumeric sender ID — `client.alphanumeric_sender_ids.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `us_long_code_fallback` | string | A US long code number to use as fallback when sending to US destinations. |
+
+### Send a message — `client.messages.send()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from_` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type_` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using an alphanumeric sender ID — `client.messages.send_with_alphanumeric_sender()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `webhook_url` | string (URL) | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | If true, use the messaging profile's webhook settings. |
+
+### Send a group MMS message — `client.messages.send_group_mms()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+
+### Send a long code message — `client.messages.send_long_code()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type_` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using number pool — `client.messages.send_number_pool()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type_` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Schedule a message — `client.messages.schedule()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from_` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type_` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+
+### Send a short code message — `client.messages.send_short_code()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type_` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a WhatsApp message — `client.messages.send_whatsapp()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type_` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
+
+### Update a messaging hosted number — `client.messaging_hosted_numbers.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `messaging_profile_id` | string (UUID) | Configure the messaging profile this phone number is assigned to:
+
+* Omit thi... |
+| `messaging_product` | string | Configure the messaging product for this number:
+
+* Omit this field or set it... |
+| `tags` | array[string] | Tags to set on this phone number. |
+
+### Create auto-response setting — `client.messaging_profiles.autoresp_configs.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `resp_text` | string |  |
+
+### Update Auto-Response Setting — `client.messaging_profiles.autoresp_configs.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `resp_text` | string |  |
+
+## Webhook Payload Fields
+
+### `deliveryUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.sent, message.finalized | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: outbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | uuid | The id of the organization the messaging profile belongs to. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Subject of multimedia message |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | ISO 8601 formatted date indicating when the message was sent. |
+| `data.payload.completed_at` | date-time | ISO 8601 formatted date indicating when the message was finalized. |
+| `data.payload.valid_until` | date-time | Message must be out of the queue by this time or else it will be discarded and marked as 'sending_failed'. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+| `data.payload.smart_encoding_applied` | boolean | Indicates whether smart encoding was applied to this message. |
+| `data.payload.wait_seconds` | float | Seconds the message is queued due to rate limiting before being sent to the carrier. |
+| `meta.attempt` | integer | Number of attempts to deliver the webhook event. |
+| `meta.delivered_to` | url | The webhook URL the event was delivered to. |
+
+### `inboundMessage`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.received | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: inbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Message subject. |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | Not used for inbound messages. |
+| `data.payload.completed_at` | date-time | Not used for inbound messages. |
+| `data.payload.valid_until` | date-time | Not used for inbound messages. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+
+### `replacedLinkClick`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | string | Identifies the type of the resource. |
+| `data.url` | string | The original link that was sent in the message. |
+| `data.to` | string | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or short code). |
+| `data.message_id` | uuid | The message ID associated with the clicked link. |
+| `data.time_clicked` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+
+### Field Type Notes
+
+- `from` in responses/webhooks: object with sub-fields `phone_number` (string), `carrier` (string), `line_type` (string)
+- `to` in responses/webhooks: array of objects, each with `phone_number` (string), `carrier` (string), `line_type` (string), `status` (string)
+- `cost`: object with `amount` (string, decimal), `currency` (string, e.g., 'USD')

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/python/numbers.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/python/numbers.md
@@ -56,7 +56,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -362,7 +362,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -412,3 +412,433 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Numbers (Python) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Advanced Orders, Create Advanced Order, Update Advanced Order, Get Advanced Order
+
+| Field | Type |
+|-------|------|
+| `area_code` | string |
+| `comments` | string |
+| `country_code` | string |
+| `customer_reference` | string |
+| `features` | array[object] |
+| `id` | uuid |
+| `orders` | array[string] |
+| `phone_number_type` | object |
+| `quantity` | integer |
+| `requirement_group_id` | uuid |
+| `status` | object |
+
+**Returned by:** List available phone number blocks
+
+| Field | Type |
+|-------|------|
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `range` | integer |
+| `record_type` | enum: available_phone_number_block |
+| `region_information` | array[object] |
+
+**Returned by:** List available phone numbers
+
+| Field | Type |
+|-------|------|
+| `best_effort` | boolean |
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `quickship` | boolean |
+| `record_type` | enum: available_phone_number |
+| `region_information` | array[object] |
+| `reservable` | boolean |
+| `vanity_format` | string |
+
+**Returned by:** Retrieve all comments
+
+| Field | Type |
+|-------|------|
+| `body` | string |
+| `comment_record_id` | uuid |
+| `comment_record_type` | enum: sub_number_order, requirement_group |
+| `commenter` | string |
+| `commenter_type` | enum: admin, user |
+| `created_at` | date-time |
+| `id` | uuid |
+| `read_at` | date-time |
+| `updated_at` | date-time |
+
+**Returned by:** Create a comment, Retrieve a comment, Mark a comment as read, Get country coverage
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Get coverage for a specific country
+
+| Field | Type |
+|-------|------|
+| `code` | string |
+| `features` | array[string] |
+| `international_sms` | boolean |
+| `inventory_coverage` | boolean |
+| `local` | object |
+| `mobile` | object |
+| `national` | object |
+| `numbers` | boolean |
+| `p2p` | boolean |
+| `phone_number_type` | array[string] |
+| `quickship` | boolean |
+| `region` | string \| null |
+| `reservable` | boolean |
+| `shared_cost` | object |
+| `toll_free` | object |
+
+**Returned by:** List customer service records, Create a customer service record, Get a customer service record
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `error_message` | string \| null |
+| `id` | uuid |
+| `phone_number` | string |
+| `record_type` | string |
+| `result` | object \| null |
+| `status` | enum: pending, completed, failed |
+| `updated_at` | date-time |
+| `webhook_url` | string |
+
+**Returned by:** Verify CSR phone number coverage
+
+| Field | Type |
+|-------|------|
+| `additional_data_required` | array[string] |
+| `has_csr_coverage` | boolean |
+| `phone_number` | string |
+| `reason` | string |
+| `record_type` | string |
+
+**Returned by:** List inexplicit number orders, Create an inexplicit number order, Retrieve an inexplicit number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `ordering_groups` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Create an inventory coverage request
+
+| Field | Type |
+|-------|------|
+| `administrative_area` | string |
+| `advance_requirements` | boolean |
+| `count` | integer |
+| `coverage_type` | enum: number, block |
+| `group` | string |
+| `group_type` | string |
+| `number_range` | integer |
+| `number_type` | enum: did, toll-free |
+| `phone_number_type` | enum: local, toll_free, national, landline, shared_cost, mobile |
+| `record_type` | string |
+
+**Returned by:** List mobile network operators
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `id` | uuid |
+| `mcc` | string |
+| `mnc` | string |
+| `name` | string |
+| `network_preferences_enabled` | boolean |
+| `record_type` | string |
+| `tadig` | string |
+
+**Returned by:** List network coverage locations
+
+| Field | Type |
+|-------|------|
+| `available_services` | array[object] |
+| `location` | object |
+| `record_type` | string |
+
+**Returned by:** List number block orders, Create a number block order, Retrieve a number block order
+
+| Field | Type |
+|-------|------|
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers_count` | integer |
+| `range` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `starting_number` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve a list of phone numbers associated to orders, Retrieve a single phone number within a number order., Update requirements for a single phone number within a number order.
+
+| Field | Type |
+|-------|------|
+| `bundle_id` | uuid |
+| `country_code` | string |
+| `deadline` | date-time |
+| `id` | uuid |
+| `is_block_number` | boolean |
+| `locality` | string |
+| `order_request_id` | uuid |
+| `phone_number` | string |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `requirements_status` | enum: pending, approved, cancelled, deleted, requirement-info-exception, requirement-info-pending, requirement-info-under-review |
+| `status` | enum: pending, success, failure |
+| `sub_number_order_id` | uuid |
+
+**Returned by:** List number orders, Create a number order, Retrieve a number order, Update a number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers` | array[object] |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `sub_number_orders_ids` | array[string] |
+| `updated_at` | date-time |
+
+**Returned by:** List number reservations, Create a number reservation, Retrieve a number reservation, Extend a number reservation
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `errors` | string |
+| `id` | uuid |
+| `phone_numbers` | array[object] |
+| `record_type` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve the features for a list of numbers
+
+| Field | Type |
+|-------|------|
+| `features` | array[string] |
+| `phone_number` | string |
+
+**Returned by:** Lists the phone number blocks jobs, Deletes all numbers associated with a phone number block, Retrieves a phone number blocks job
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `etc` | date-time |
+| `failed_operations` | array[object] |
+| `id` | uuid |
+| `record_type` | string |
+| `status` | enum: pending, in_progress, completed, failed |
+| `successful_operations` | array[object] |
+| `type` | enum: delete_phone_number_block |
+| `updated_at` | string |
+
+**Returned by:** List sub number orders, Retrieve a sub number order, Update a sub number order's requirements, Cancel a sub number order
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `is_block_sub_number_order` | boolean |
+| `order_request_id` | uuid |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+**Returned by:** Create a sub number orders report, Retrieve a sub number orders report
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `filters` | object |
+| `id` | uuid |
+| `order_type` | string |
+| `status` | enum: pending, success, failed, expired |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+## Optional Parameters
+
+### Create Advanced Order — `client.advanced_orders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `country_code` | string (ISO 3166-1 alpha-2) |  |
+| `comments` | string |  |
+| `quantity` | integer |  |
+| `area_code` | string |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `features` | array[object] |  |
+| `customer_reference` | string |  |
+| `requirement_group_id` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Update Advanced Order — `client.advanced_orders.update_requirement_group()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `country_code` | string (ISO 3166-1 alpha-2) |  |
+| `comments` | string |  |
+| `quantity` | integer |  |
+| `area_code` | string |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `features` | array[object] |  |
+| `customer_reference` | string |  |
+| `requirement_group_id` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Create a comment — `client.comments.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `body` | string |  |
+| `commenter` | string |  |
+| `commenter_type` | enum (admin, user) |  |
+| `comment_record_type` | enum (sub_number_order, requirement_group) |  |
+| `comment_record_id` | string (UUID) |  |
+| `read_at` | string (date-time) | An ISO 8901 datetime string for when the comment was read. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the comment was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the comment was updated. |
+
+### Create an inexplicit number order — `client.inexplicit_number_orders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `connection_id` | string (UUID) | Connection id to apply to phone numbers that are purchased |
+| `messaging_profile_id` | string (UUID) | Messaging profile id to apply to phone numbers that are purchased |
+| `customer_reference` | string | Reference label for the customer |
+| `billing_group_id` | string (UUID) | Billing group id to apply to phone numbers that are purchased |
+
+### Create a number block order — `client.number_block_orders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `record_type` | string |  |
+| `phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `connection_id` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `status` | enum (pending, success, failure) | The status of the order. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the number order was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the number order was updated. |
+| `requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `errors` | string | Errors the reservation could happen upon |
+
+### Update requirements for a single phone number within a number order. — `client.number_order_phone_numbers.update_requirements()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatory_requirements` | array[object] |  |
+
+### Create a number order — `client.number_orders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `phone_numbers` | array[object] |  |
+| `connection_id` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `billing_group_id` | string (UUID) | Identifies the billing group associated with the phone number. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+
+### Update a number order — `client.number_orders.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatory_requirements` | array[object] |  |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+
+### Create a number reservation — `client.number_reservations.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `record_type` | string |  |
+| `phone_numbers` | array[object] |  |
+| `status` | enum (pending, success, failure) | The status of the entire reservation. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the numbers reservation was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the number reservation was updated. |
+
+### Update a sub number order's requirements — `client.sub_number_orders.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatory_requirements` | array[object] |  |
+
+### Create a sub number orders report — `client.sub_number_orders_report.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `status` | enum (pending, success, failure) | Filter by order status |
+| `country_code` | string (ISO 3166-1 alpha-2) | Filter by country code |
+| `created_at_gt` | string (date-time) | Filter for orders created after this date |
+| `created_at_lt` | string (date-time) | Filter for orders created before this date |
+| `order_request_id` | string (UUID) | Filter by specific order request ID |
+| `customer_reference` | string | Filter by customer reference |
+
+## Webhook Payload Fields
+
+### `numberOrderStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.event_type` | string | The type of event being sent |
+| `data.id` | uuid | Unique identifier for the event |
+| `data.occurred_at` | date-time | ISO 8601 timestamp of when the event occurred |
+| `data.payload.id` | uuid |  |
+| `data.payload.record_type` | string |  |
+| `data.payload.phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `data.payload.connection_id` | string | Identifies the connection associated with this phone number. |
+| `data.payload.messaging_profile_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.billing_group_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.phone_numbers` | array[object] |  |
+| `data.payload.sub_number_orders_ids` | array[string] |  |
+| `data.payload.status` | enum: pending, success, failure | The status of the order. |
+| `data.payload.customer_reference` | string | A customer reference string for customer look ups. |
+| `data.payload.created_at` | date-time | An ISO 8901 datetime string denoting when the number order was created. |
+| `data.payload.updated_at` | date-time | An ISO 8901 datetime string for when the number order was updated. |
+| `data.payload.requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `data.record_type` | string | Type of record |
+| `meta.attempt` | integer | Webhook delivery attempt number |
+| `meta.delivered_to` | uri | URL where the webhook was delivered |

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/python/voice.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/python/voice.md
@@ -33,7 +33,7 @@ try:
     response = client.calls.dial(
         connection_id="7267xxxxxxxxxxxxxx",
         from_="+18005550101",
-        to="+18005550100",
+        to="+18005550100;secure=srtp",
     )
 except telnyx.APIConnectionError:
     print("Network error — check connectivity and retry")
@@ -66,8 +66,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -85,13 +85,13 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in the API Details section below |
+| ... | | | +56 optional params in the API Details section below |
 
 ```python
 response = client.calls.dial(
     connection_id="7267xxxxxxxxxxxxxx",
     from_="+18005550101",
-    to="+18005550100",
+    to="+18005550100;secure=srtp",
 )
 print(response.data)
 ```
@@ -116,7 +116,7 @@ Primary inbound call-control command.
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in the API Details section below |
+| ... | | | +29 optional params in the API Details section below |
 
 ```python
 response = client.calls.actions.answer(
@@ -142,12 +142,12 @@ Common post-answer control path with downstream webhook implications.
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in the API Details section below |
+| ... | | | +35 optional params in the API Details section below |
 
 ```python
 response = client.calls.actions.transfer(
     call_control_id="550e8400-e29b-41d4-a716-446655440000",
-    to="+18005550100",
+    to="+18005550100;secure=srtp",
 )
 print(response.data)
 ```
@@ -221,7 +221,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
 | `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -393,7 +393,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -413,3 +413,427 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Voice (Python) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List call control applications, Create a call control application, Retrieve a call control application, Update a call control application, Delete a call control application
+
+| Field | Type |
+|-------|------|
+| `active` | boolean |
+| `anchorsite_override` | enum: Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, Chennai, IN, Amsterdam, Netherlands, Toronto, Canada, Sydney, Australia |
+| `application_name` | string |
+| `call_cost_in_webhooks` | boolean |
+| `created_at` | string |
+| `dtmf_type` | enum: RFC 2833, Inband, SIP INFO |
+| `first_command_timeout` | boolean |
+| `first_command_timeout_secs` | integer |
+| `id` | string |
+| `inbound` | object |
+| `outbound` | object |
+| `record_type` | enum: call_control_application |
+| `redact_dtmf_debug_logging` | boolean |
+| `tags` | array[string] |
+| `updated_at` | string |
+| `webhook_api_version` | enum: 1, 2 |
+| `webhook_event_failover_url` | url |
+| `webhook_event_url` | url |
+| `webhook_timeout_secs` | integer \| null |
+
+**Returned by:** Dial
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `recording_id` | uuid |
+| `start_time` | string |
+
+**Returned by:** Retrieve a call status
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `start_time` | string |
+
+**Returned by:** Answer call
+
+| Field | Type |
+|-------|------|
+| `recording_id` | uuid |
+| `result` | string |
+
+**Returned by:** Bridge calls, Hangup call, SIP Refer a call, Reject a call, Send SIP info, Transfer call
+
+| Field | Type |
+|-------|------|
+| `result` | string |
+
+**Returned by:** List all active calls for given connection
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `record_type` | enum: call |
+
+## Optional Parameters
+
+### Create a call control application — `client.call_control_applications.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `active` | boolean | Specifies whether the connection can be used. |
+| `anchorsite_override` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmf_type` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `first_command_timeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `first_command_timeout_secs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `inbound` | object |  |
+| `outbound` | object |  |
+| `webhook_api_version` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhook_event_failover_url` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhook_timeout_secs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `call_cost_in_webhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `redact_dtmf_debug_logging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Update a call control application — `client.call_control_applications.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `call_cost_in_webhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `active` | boolean | Specifies whether the connection can be used. |
+| `anchorsite_override` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmf_type` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `first_command_timeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `first_command_timeout_secs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `tags` | array[string] | Tags assigned to the Call Control Application. |
+| `inbound` | object |  |
+| `outbound` | object |  |
+| `webhook_api_version` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhook_event_failover_url` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhook_timeout_secs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `redact_dtmf_debug_logging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Dial — `client.calls.dial()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
+| `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
+| `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
+| `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `link_to` | string | Use another call's control id for sharing the same call session id |
+| `bridge_intent` | boolean | Indicates the intent to bridge this call with the call specified in link_to. |
+| `bridge_on_answer` | boolean | Whether to automatically bridge answered call to the call specified in link_to. |
+| `prevent_double_bridge` | boolean | Prevents bridging and hangs up the call if the target is already bridged. |
+| `park_after_unbridge` | string | If supplied with the value `self`, the current leg will be parked after unbri... |
+| `media_encryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the call. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE request. |
+| `sip_transport_protocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `stream_url` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `stream_track` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `stream_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `stream_bidirectional_mode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `stream_bidirectional_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `stream_bidirectional_target_legs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `stream_bidirectional_sampling_rate` | enum (8000, 16000, 22050, 24000, 48000) | Audio sampling rate. |
+| `stream_establish_before_call_originate` | boolean | Establish websocket connection before dialing the destination. |
+| `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `supervise_call_control_id` | string (UUID) | The call leg which will be supervised by the new call. |
+| `supervisor_role` | enum (barge, whisper, monitor) | The role of the supervisor call. |
+| `enable_dialogflow` | boolean | Enables Dialogflow for the current call. |
+| `dialogflow_config` | object |  |
+| `transcription` | boolean | Enable transcription upon call answer. |
+| `transcription_config` | object |  |
+| `sip_region` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `stream_auth_token` | string | An authentication token to be sent as part of the WebSocket connection when u... |
+
+### Answer call — `client.calls.actions.answer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE response. |
+| `preferred_codecs` | enum (G722,PCMU,PCMA,G729,OPUS,VP8,H264) | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE response. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `stream_url` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `stream_track` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `stream_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `stream_bidirectional_mode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `stream_bidirectional_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `stream_bidirectional_target_legs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `transcription` | boolean | Enable transcription upon call answer. |
+| `transcription_config` | object |  |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
+
+### Bridge calls — `client.calls.actions.bridge()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `queue` | string | The name of the queue you want to bridge with, can't be used together with ca... |
+| `video_room_id` | string (UUID) | The ID of the video room you want to bridge with, can't be used together with... |
+| `video_room_context` | string | The additional parameter that will be passed to the video conference. |
+| `prevent_double_bridge` | boolean | When set to `true`, it prevents bridging if the target call is already bridge... |
+| `park_after_unbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `play_ringtone` | boolean | Specifies whether to play a ringtone if the call you want to bridge with has ... |
+| `ringtone` | enum (at, au, be, bg, br, ...) | Specifies which country ringtone to play when `play_ringtone` is set to `true`. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `mute_dtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `hold_after_unbridge` | boolean | Specifies behavior after the bridge ends. |
+
+### Hangup call — `client.calls.actions.hangup()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP BYE message. |
+
+### SIP Refer a call — `client.calls.actions.refer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid execution of duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the request. |
+
+### Reject a call — `client.calls.actions.reject()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Send SIP info — `client.calls.actions.send_sip_info()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Transfer call — `client.calls.actions.transfer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from_` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
+| `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
+| `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
+| `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
+| `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `park_after_unbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `target_leg_client_state` | string | Use this field to add state to every subsequent webhook for the new leg. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `media_encryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the new call leg. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE. |
+| `sip_transport_protocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `mute_dtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `sip_region` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `preferred_codecs` | string | The list of comma-separated codecs in order of preference to be used during t... |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+
+## Webhook Payload Fields
+
+### `callAnswered`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.answered | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: answered | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### `callBridged`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.bridged | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+
+### `callHangup`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.hangup | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: hangup | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+| `data.payload.hangup_cause` | enum: call_rejected, normal_clearing, originator_cancel, timeout, time_limit, user_busy, not_found, no_answer, unspecified | The reason the call was ended (`call_rejected`, `normal_clearing`, `originator_cancel`, `timeout`, `time_limit`, `use... |
+| `data.payload.hangup_source` | enum: caller, callee, unknown | The party who ended the call (`callee`, `caller`, `unknown`). |
+| `data.payload.sip_hangup_cause` | string | The reason the call was ended (SIP response code). |
+| `data.payload.call_quality_stats` | object \| null | Call quality statistics aggregated from the CHANNEL_HANGUP_COMPLETE event. |
+
+### `callInitiated`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.initiated | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
+| `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.custom_headers` | array[object] | Custom headers from sip invite |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.shaken_stir_attestation` | string | SHAKEN/STIR attestation level. |
+| `data.payload.shaken_stir_validated` | boolean | Whether attestation was successfully validated or not. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.caller_id_name` | string | Caller id. |
+| `data.payload.call_screening_result` | string | Call screening result. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.direction` | enum: incoming, outgoing | Whether the call is `incoming` or `outgoing`. |
+| `data.payload.state` | enum: parked, bridging | State received from a command. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### Field Type Notes
+
+- `from` in webhook payloads: string (E.164 phone number)
+- `to` in webhook payloads: string (E.164 phone number)
+- The return value of `client.webhooks.unwrap()` is a parsed event object — access fields via `event.data.event_type`, `event.data.payload.call_control_id`, etc.

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/ruby/10dlc.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/ruby/10dlc.md
@@ -55,8 +55,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -203,7 +203,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `description` | string | Description of the event. |
 | `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -361,7 +361,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -401,3 +401,471 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# 10DLC (Ruby) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Brands, List Campaigns, List shared partner campaigns, List Shared Campaigns, List phone number campaigns
+
+| Field | Type |
+|-------|------|
+| `page` | integer |
+| `records` | array[object] |
+| `totalRecords` | integer |
+
+**Returned by:** Create Brand, Update Brand, Revet Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Get Brand Feedback By Id
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `category` | array[object] |
+
+**Returned by:** Get Brand SMS OTP Status, Get Brand SMS OTP Status by Brand ID
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `deliveryStatus` | string |
+| `deliveryStatusDate` | date-time |
+| `deliveryStatusDetails` | string |
+| `mobilePhone` | string |
+| `referenceId` | string |
+| `requestDate` | date-time |
+| `verifyDate` | date-time |
+
+**Returned by:** Get Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `assignedCampaignsCount` | number |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Order Brand External Vetting, Import External Vetting Record
+
+| Field | Type |
+|-------|------|
+| `createDate` | string |
+| `evpId` | string |
+| `vettedDate` | string |
+| `vettingClass` | string |
+| `vettingId` | string |
+| `vettingScore` | integer |
+| `vettingToken` | string |
+
+**Returned by:** Trigger Brand SMS OTP
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `referenceId` | string |
+
+**Returned by:** Get Campaign Cost
+
+| Field | Type |
+|-------|------|
+| `campaignUsecase` | string |
+| `description` | string |
+| `monthlyCost` | string |
+| `upFrontCost` | string |
+
+**Returned by:** Get campaign, Update campaign, Submit Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `autoRenewal` | boolean |
+| `billedDate` | string |
+| `brandDisplayName` | string |
+| `brandId` | string |
+| `campaignId` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createDate` | string |
+| `cspId` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isTMobileNumberPoolingEnabled` | boolean |
+| `isTMobileRegistered` | boolean |
+| `isTMobileSuspended` | boolean |
+| `messageFlow` | string |
+| `mock` | boolean |
+| `nextRenewalOrExpirationDate` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `referenceId` | string |
+| `resellerId` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `status` | string |
+| `subUsecases` | array[string] |
+| `submissionStatus` | enum: CREATED, FAILED, PENDING |
+| `subscriberHelp` | boolean |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `usecase` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Deactivate campaign
+
+| Field | Type |
+|-------|------|
+| `message` | string |
+| `record_type` | string |
+| `time` | number |
+
+**Returned by:** Submit campaign appeal for manual review
+
+| Field | Type |
+|-------|------|
+| `appealed_at` | date-time |
+
+**Returned by:** Get Campaign Mno Metadata
+
+| Field | Type |
+|-------|------|
+| `10999` | object |
+
+**Returned by:** Get Sharing Status
+
+| Field | Type |
+|-------|------|
+| `sharedByMe` | object |
+| `sharedWithMe` | object |
+
+**Returned by:** Qualify By Usecase
+
+| Field | Type |
+|-------|------|
+| `annualFee` | number |
+| `maxSubUsecases` | integer |
+| `minSubUsecases` | integer |
+| `mnoMetadata` | object |
+| `monthlyFee` | number |
+| `quarterlyFee` | number |
+| `usecase` | string |
+
+**Returned by:** Get Single Shared Campaign, Update Single Shared Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `assignedPhoneNumbersCount` | number |
+| `brandDisplayName` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createdAt` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isNumberPoolingEnabled` | boolean |
+| `messageFlow` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `subUsecases` | array[string] |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `updatedAt` | string |
+| `usecase` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Assign Messaging Profile To Campaign
+
+| Field | Type |
+|-------|------|
+| `campaignId` | string |
+| `messagingProfileId` | string |
+| `taskId` | string |
+| `tcrCampaignId` | string |
+
+**Returned by:** Get Assignment Task Status
+
+| Field | Type |
+|-------|------|
+| `createdAt` | date-time |
+| `status` | string |
+| `taskId` | string |
+| `updatedAt` | date-time |
+
+**Returned by:** Get Phone Number Status
+
+| Field | Type |
+|-------|------|
+| `records` | array[object] |
+
+**Returned by:** Create New Phone Number Campaign, Get Single Phone Number Campaign, Create New Phone Number Campaign, Delete Phone Number Campaign
+
+| Field | Type |
+|-------|------|
+| `assignmentStatus` | enum: FAILED_ASSIGNMENT, PENDING_ASSIGNMENT, ASSIGNED, PENDING_UNASSIGNMENT, FAILED_UNASSIGNMENT |
+| `brandId` | string |
+| `campaignId` | string |
+| `createdAt` | string |
+| `failureReasons` | string |
+| `phoneNumber` | string |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `telnyxCampaignId` | string |
+| `updatedAt` | string |
+
+## Optional Parameters
+
+### Create Brand — `client.messaging_10dlc.brand.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `company_name` | string | (Required for Non-profit/private/public) Legal company name. |
+| `first_name` | string | First name of business contact. |
+| `last_name` | string | Last name of business contact. |
+| `ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `phone` | string | Valid phone number in e.164 international format. |
+| `street` | string | Street number and name. |
+| `city` | string | City name |
+| `state` | string | State. |
+| `postal_code` | string | Postal codes. |
+| `stock_symbol` | string | (Required for public company) stock symbol. |
+| `stock_exchange` | object | (Required for public company) stock exchange. |
+| `ip_address` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `website` | string | Brand website URL. |
+| `is_reseller` | boolean |  |
+| `mock` | boolean | Mock brand for testing purposes. |
+| `mobile_phone` | string | Valid mobile phone number in e.164 international format. |
+| `business_contact_email` | string | Business contact email. |
+| `webhook_url` | string | Webhook URL for brand status updates. |
+| `webhook_failover_url` | string | Webhook failover URL for brand status updates. |
+
+### Update Brand — `client.messaging_10dlc.brand.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `company_name` | string | (Required for Non-profit/private/public) Legal company name. |
+| `first_name` | string | First name of business contact. |
+| `last_name` | string | Last name of business contact. |
+| `ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `phone` | string | Valid phone number in e.164 international format. |
+| `street` | string | Street number and name. |
+| `city` | string | City name |
+| `state` | string | State. |
+| `postal_code` | string | Postal codes. |
+| `stock_symbol` | string | (Required for public company) stock symbol. |
+| `stock_exchange` | object | (Required for public company) stock exchange. |
+| `ip_address` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `website` | string | Brand website URL. |
+| `alt_business_id_type` | enum (NONE, DUNS, GIIN, LEI) | An enumeration. |
+| `is_reseller` | boolean |  |
+| `identity_status` | enum (VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED) | The verification status of an active brand |
+| `business_contact_email` | string | Business contact email. |
+| `webhook_url` | string | Webhook URL for brand status updates. |
+| `webhook_failover_url` | string | Webhook failover URL for brand status updates. |
+| `alt_business_id` | string (UUID) | Alternate business identifier such as DUNS, LEI, or GIIN |
+
+### Import External Vetting Record — `client.messaging_10dlc.brand.external_vetting.imports()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `vetting_token` | string | Required by some providers for vetting record confirmation. |
+
+### Update campaign — `client.messaging_10dlc.campaign.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `reseller_id` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `sample1` | string | Message sample. |
+| `sample2` | string | Message sample. |
+| `sample3` | string | Message sample. |
+| `sample4` | string | Message sample. |
+| `sample5` | string | Message sample. |
+| `message_flow` | string | Message flow description. |
+| `help_message` | string | Help message of the campaign. |
+| `auto_renewal` | boolean | Help message of the campaign. |
+| `webhook_url` | string | Webhook to which campaign status updates are sent. |
+| `webhook_failover_url` | string | Webhook failover to which campaign status updates are sent. |
+
+### Submit Campaign — `client.messaging_10dlc.campaign_builder.submit()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `age_gated` | boolean | Age gated message content in campaign. |
+| `auto_renewal` | boolean | Campaign subscription auto-renewal option. |
+| `direct_lending` | boolean | Direct lending or loan arrangement |
+| `embedded_link` | boolean | Does message generated by the campaign include URL link in SMS? |
+| `embedded_phone` | boolean | Does message generated by the campaign include phone number in SMS? |
+| `help_keywords` | string | Subscriber help keywords. |
+| `help_message` | string | Help message of the campaign. |
+| `message_flow` | string | Message flow description. |
+| `mno_ids` | array[integer] | Submit campaign to given list of MNOs by MNO's network ID. |
+| `number_pool` | boolean | Does campaign utilize pool of phone numbers? |
+| `optin_keywords` | string | Subscriber opt-in keywords. |
+| `optin_message` | string | Subscriber opt-in message. |
+| `optout_keywords` | string | Subscriber opt-out keywords. |
+| `optout_message` | string | Subscriber opt-out message. |
+| `reference_id` | string (UUID) | Caller supplied campaign reference ID. |
+| `reseller_id` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `sample1` | string | Message sample. |
+| `sample2` | string | Message sample. |
+| `sample3` | string | Message sample. |
+| `sample4` | string | Message sample. |
+| `sample5` | string | Message sample. |
+| `sub_usecases` | array[string] | Campaign sub-usecases. |
+| `subscriber_help` | boolean | Does campaign responds to help keyword(s)? |
+| `subscriber_optin` | boolean | Does campaign require subscriber to opt-in before SMS is sent to subscriber? |
+| `subscriber_optout` | boolean | Does campaign support subscriber opt-out keyword(s)? |
+| `tag` | array[string] | Tags to be set on the Campaign. |
+| `terms_and_conditions` | boolean | Is terms and conditions accepted? |
+| `privacy_policy_link` | string | Link to the campaign's privacy policy. |
+| `terms_and_conditions_link` | string | Link to the campaign's terms and conditions. |
+| `embedded_link_sample` | string | Sample of an embedded link that will be sent to subscribers. |
+| `webhook_url` | string | Webhook to which campaign status updates are sent. |
+| `webhook_failover_url` | string | Failover webhook to which campaign status updates are sent. |
+
+### Update Single Shared Campaign — `client.messaging_10dlc.partner_campaigns.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `webhook_url` | string | Webhook to which campaign status updates are sent. |
+| `webhook_failover_url` | string | Webhook failover to which campaign status updates are sent. |
+
+### Assign Messaging Profile To Campaign — `client.messaging_10dlc.phone_number_assignment_by_profile.assign()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `tcr_campaign_id` | string (UUID) | The TCR ID of the shared campaign you want to link to the specified messaging... |
+| `campaign_id` | string (UUID) | The ID of the campaign you want to link to the specified messaging profile. |
+
+## Webhook Payload Fields
+
+### `campaignStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `brandId` | string | Brand ID associated with the campaign. |
+| `campaignId` | string | The ID of the campaign. |
+| `createDate` | string | Unix timestamp when campaign was created. |
+| `cspId` | string | Alphanumeric identifier of the CSP associated with this campaign. |
+| `isTMobileRegistered` | boolean | Indicates whether the campaign is registered with T-Mobile. |
+| `type` | enum: TELNYX_EVENT, REGISTRATION, MNO_REVIEW, TELNYX_REVIEW, NUMBER_POOL_PROVISIONED, NUMBER_POOL_DEPROVISIONED, TCR_EVENT, VERIFIED |  |
+| `description` | string | Description of the event. |
+| `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/ruby/ai-assistants.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/ruby/ai-assistants.md
@@ -26,7 +26,7 @@ All API calls can fail with network errors, rate limits (429), validation errors
 or authentication errors (401). Always handle errors in production code:
 
 ```ruby
-assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", model: "openai/gpt-4o", name: "my-resource")
+assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", name: "my-resource", model: "openai/gpt-4o")
 puts(assistant)
 ```
 
@@ -44,7 +44,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -57,16 +57,14 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `description` | string | No |  |
-| `greeting` | string | No | Text that the assistant will use to start the conversation. |
-| ... | | | +11 optional params in the API Details section below |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in the API Details section below |
 
 ```ruby
-assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", model: "openai/gpt-4o", name: "my-resource")
-
+assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", name: "my-resource", model: "openai/gpt-4o")
 puts(assistant)
 ```
 
@@ -175,7 +173,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### Update an assistant
 
@@ -186,10 +184,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistant_id` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +15 optional params in the API Details section below |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in the API Details section below |
 
 ```ruby
 assistant = client.ai.assistants.update("550e8400-e29b-41d4-a716-446655440000")
@@ -203,7 +201,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### List assistants
 
@@ -226,7 +224,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Import assistants from external provider
 
@@ -255,7 +253,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Get All Tags
 
@@ -357,7 +355,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -370,8 +368,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
 | Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Get Canary Deploy | `client.ai.assistants.canary_deploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
-| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistant_id` |
-| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistant_id` |
+| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
 | Delete Canary Deploy | `client.ai.assistants.canary_deploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Assistant Sms Chat | `client.ai.assistants.send_sms()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistant_id` |
 | Clone Assistant | `client.ai.assistants.clone_()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |
@@ -382,6 +380,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Add Assistant Tag | `client.ai.assistants.tags.add()` | `POST /ai/assistants/{assistant_id}/tags` | Create or provision an additional resource when the core tasks do not cover this flow. | `tag`, `assistant_id` |
 | Remove Assistant Tag | `client.ai.assistants.tags.remove()` | `DELETE /ai/assistants/{assistant_id}/tags/{tag}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `tag` |
 | Get assistant texml | `client.ai.assistants.get_texml()` | `GET /ai/assistants/{assistant_id}/texml` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Add Assistant Tool | `client.ai.assistants.tools.add()` | `PUT /ai/assistants/{assistant_id}/tools/{tool_id}` | Modify an existing resource without recreating it. | `assistant_id`, `tool_id` |
+| Remove Assistant Tool | `client.ai.assistants.tools.remove()` | `DELETE /ai/assistants/{assistant_id}/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `tool_id` |
 | Test Assistant Tool | `client.ai.assistants.tools.test_()` | `POST /ai/assistants/{assistant_id}/tools/{tool_id}/test` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id`, `tool_id` |
 | Get all versions of an assistant | `client.ai.assistants.versions.list()` | `GET /ai/assistants/{assistant_id}/versions` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
 | Get a specific assistant version | `client.ai.assistants.versions.retrieve()` | `GET /ai/assistants/{assistant_id}/versions/{version_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id`, `version_id` |
@@ -393,7 +393,398 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get MCP Server | `client.ai.mcp_servers.retrieve()` | `GET /ai/mcp_servers/{mcp_server_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `mcp_server_id` |
 | Update MCP Server | `client.ai.mcp_servers.update()` | `PUT /ai/mcp_servers/{mcp_server_id}` | Modify an existing resource without recreating it. | `mcp_server_id` |
 | Delete MCP Server | `client.ai.mcp_servers.delete()` | `DELETE /ai/mcp_servers/{mcp_server_id}` | Remove, detach, or clean up an existing resource. | `mcp_server_id` |
+| List Tools | `client.ai.tools.list()` | `GET /ai/tools` | Inspect available resources or choose an existing resource before mutating it. | None |
+| Create Tool | `client.ai.tools.create()` | `POST /ai/tools` | Create or provision an additional resource when the core tasks do not cover this flow. | `type`, `display_name` |
+| Get Tool | `client.ai.tools.retrieve()` | `GET /ai/tools/{tool_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `tool_id` |
+| Update Tool | `client.ai.tools.update()` | `PATCH /ai/tools/{tool_id}` | Modify an existing resource without recreating it. | `tool_id` |
+| Delete Tool | `client.ai.tools.delete()` | `DELETE /ai/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `tool_id` |
 
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# AI Assistants (Ruby) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+
+## Response Schemas
+
+**Returned by:** List assistants, Create an assistant, Import assistants from external provider, Get an assistant, Update an assistant, Clone Assistant, Get all versions of an assistant, Get a specific assistant version, Update a specific assistant version, Promote an assistant version to main
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
+| `dynamic_variables_webhook_url` | string |
+| `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
+| `greeting` | string |
+| `id` | string |
+| `import_metadata` | object |
+| `insight_settings` | object |
+| `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
+| `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
+| `messaging_settings` | object |
+| `model` | string |
+| `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
+| `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
+| `telephony_settings` | object |
+| `tools` | array[object] |
+| `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
+| `voice_settings` | object |
+| `widget_settings` | object |
+
+**Returned by:** Get All Tags, Add Assistant Tag, Remove Assistant Tag
+
+| Field | Type |
+|-------|------|
+| `tags` | array[string] |
+
+**Returned by:** List assistant tests with pagination, Create a new assistant test, Get assistant test by ID, Update an assistant test
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `destination` | string |
+| `instructions` | string |
+| `max_duration_seconds` | integer |
+| `name` | string |
+| `rubric` | array[object] |
+| `telnyx_conversation_channel` | object |
+| `test_id` | uuid |
+| `test_suite` | string |
+
+**Returned by:** Get all test suite names
+
+| Field | Type |
+|-------|------|
+| `data` | array[string] |
+
+**Returned by:** Get test suite run history, Get test run history for a specific test, Trigger a manual test run, Get specific test run details
+
+| Field | Type |
+|-------|------|
+| `completed_at` | date-time |
+| `conversation_id` | string |
+| `conversation_insights_id` | string |
+| `created_at` | date-time |
+| `detail_status` | array[object] |
+| `logs` | string |
+| `run_id` | uuid |
+| `status` | enum: pending, starting, running, passed, failed, error |
+| `test_id` | uuid |
+| `test_suite_run_id` | uuid |
+| `triggered_by` | string |
+| `updated_at` | date-time |
+
+**Returned by:** Delete an assistant
+
+| Field | Type |
+|-------|------|
+| `deleted` | boolean |
+| `id` | string |
+| `object` | string |
+
+**Returned by:** Get Canary Deploy, Create Canary Deploy, Update Canary Deploy
+
+| Field | Type |
+|-------|------|
+| `assistant_id` | string |
+| `created_at` | date-time |
+| `rules` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Assistant Chat (BETA)
+
+| Field | Type |
+|-------|------|
+| `content` | string |
+
+**Returned by:** Assistant Sms Chat
+
+| Field | Type |
+|-------|------|
+| `conversation_id` | string |
+
+**Returned by:** List scheduled events
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Test Assistant Tool
+
+| Field | Type |
+|-------|------|
+| `content_type` | string |
+| `request` | object |
+| `response` | string |
+| `status_code` | integer |
+| `success` | boolean |
+
+**Returned by:** Create MCP Server, Get MCP Server, Update MCP Server
+
+| Field | Type |
+|-------|------|
+| `allowed_tools` | array \| null |
+| `api_key_ref` | string \| null |
+| `created_at` | date-time |
+| `id` | string |
+| `name` | string |
+| `type` | string |
+| `url` | string |
+
+**Returned by:** List Tools, Create Tool, Get Tool, Update Tool
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `display_name` | string |
+| `id` | string |
+| `timeout_ms` | integer |
+| `tool_definition` | object |
+| `type` | string |
+
+## Optional Parameters
+
+### Create an assistant — `client.ai.assistants.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
+| `transcription` | object |  |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+
+### Import assistants from external provider — `client.ai.assistants.imports()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `import_ids` | array[string] | Optional list of assistant IDs to import from the external provider. |
+
+### Create a new assistant test — `client.ai.assistants.tests.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `description` | string | Optional detailed description of what this test evaluates and its purpose. |
+| `telnyx_conversation_channel` | object | The communication channel through which the test will be conducted. |
+| `max_duration_seconds` | integer | Maximum duration in seconds that the test conversation should run before timi... |
+| `test_suite` | string | Optional test suite name to group related tests together. |
+
+### Trigger test suite execution — `client.ai.assistants.tests.test_suites.runs.trigger()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `destination_version_id` | string (UUID) | Optional assistant version ID to use for all test runs in this suite. |
+
+### Update an assistant test — `client.ai.assistants.tests.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | Updated name for the assistant test. |
+| `description` | string | Updated description of the test's purpose and evaluation criteria. |
+| `telnyx_conversation_channel` | enum (phone_call, web_call, sms_chat, web_chat) |  |
+| `destination` | string | Updated target destination for test conversations. |
+| `max_duration_seconds` | integer | Updated maximum test duration in seconds. |
+| `test_suite` | string | Updated test suite assignment for better organization. |
+| `instructions` | string | Updated test scenario instructions and objectives. |
+| `rubric` | array[object] | Updated evaluation criteria for assessing assistant performance. |
+
+### Trigger a manual test run — `client.ai.assistants.tests.runs.trigger()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `destination_version_id` | string (UUID) | Optional assistant version ID to use for this test run. |
+
+### Update an assistant — `client.ai.assistants.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `instructions` | string | System instructions for the assistant. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
+| `transcription` | object |  |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+| `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai.assistants.canary_deploys.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai.assistants.canary_deploys.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Assistant Chat (BETA) — `client.ai.assistants.chat()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | The optional display name of the user sending the message |
+
+### Assistant Sms Chat — `client.ai.assistants.send_sms()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string |  |
+| `conversation_metadata` | object |  |
+| `should_create_conversation` | boolean |  |
+
+### Create a scheduled event — `client.ai.assistants.scheduled_events.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Required for sms scheduled events. |
+| `conversation_metadata` | object | Metadata associated with the conversation. |
+| `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
+
+### Test Assistant Tool — `client.ai.assistants.tools.test_()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `arguments` | object | Key-value arguments to use for the webhook test |
+| `dynamic_variables` | object | Key-value dynamic variables to use for the webhook test |
+
+### Update a specific assistant version — `client.ai.assistants.versions.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `instructions` | string | System instructions for the assistant. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
+| `transcription` | object |  |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+
+### Create MCP Server — `client.ai.mcp_servers.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `api_key_ref` | string |  |
+| `allowed_tools` | array[string] |  |
+
+### Update MCP Server — `client.ai.mcp_servers.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `name` | string |  |
+| `type` | string |  |
+| `url` | string (URL) |  |
+| `api_key_ref` | string |  |
+| `allowed_tools` | array[string] |  |
+| `created_at` | string (date-time) |  |
+
+### Create Tool — `client.ai.tools.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `function` | object |  |
+| `retrieval` | object |  |
+| `handoff` | object |  |
+| `invite` | object |  |
+| `webhook` | object |  |
+| `timeout_ms` | integer |  |
+
+### Update Tool — `client.ai.tools.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type` | string |  |
+| `display_name` | string |  |
+| `function` | object |  |
+| `retrieval` | object |  |
+| `handoff` | object |  |
+| `invite` | object |  |
+| `webhook` | object |  |
+| `timeout_ms` | integer |  |

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/ruby/messaging.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/ruby/messaging.md
@@ -50,8 +50,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -175,7 +175,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.media` | array[object] |  |
 | `data.record_type` | enum: event | Identifies the type of the resource. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -340,6 +340,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsapp_message` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```ruby
 response = client.messages.send_whatsapp(from: "+13125551234", to: "+13125551234", whatsapp_message: {})
@@ -360,7 +361,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -394,3 +395,425 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Messaging (Ruby) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List alphanumeric sender IDs, Create an alphanumeric sender ID, Retrieve an alphanumeric sender ID, Delete an alphanumeric sender ID, List alphanumeric sender IDs for a messaging profile
+
+| Field | Type |
+|-------|------|
+| `alphanumeric_sender_id` | string |
+| `id` | uuid |
+| `messaging_profile_id` | uuid |
+| `organization_id` | string |
+| `record_type` | enum: alphanumeric_sender_id |
+| `us_long_code_fallback` | string |
+
+**Returned by:** Send a message, Send a message using an alphanumeric sender ID, Retrieve group MMS messages, Send a group MMS message, Send a long code message, Send a message using number pool, Schedule a message, Send a short code message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `wait_seconds` | float |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** Send a WhatsApp message
+
+| Field | Type |
+|-------|------|
+| `body` | object |
+| `direction` | string |
+| `encoding` | string |
+| `from` | object |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `organization_id` | string |
+| `received_at` | date-time |
+| `record_type` | string |
+| `to` | array[object] |
+| `type` | string |
+| `wait_seconds` | float |
+
+**Returned by:** Retrieve a message, Get detailed messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Cancel a scheduled message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** List messaging hosted numbers, Retrieve a messaging hosted number, Update a messaging hosted number
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `eligible_messaging_products` | array[string] |
+| `features` | object |
+| `health` | object |
+| `id` | string |
+| `messaging_product` | string |
+| `messaging_profile_id` | string \| null |
+| `organization_id` | string |
+| `phone_number` | string |
+| `record_type` | enum: messaging_phone_number, messaging_settings |
+| `tags` | array[string] |
+| `traffic_type` | string |
+| `type` | enum: long-code, toll-free, short-code, longcode, tollfree, shortcode |
+| `updated_at` | date-time |
+
+**Returned by:** List opt-outs
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `from` | string |
+| `keyword` | string \| null |
+| `messaging_profile_id` | string \| null |
+| `to` | string |
+
+**Returned by:** List high-level messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Regenerate messaging profile secret
+
+| Field | Type |
+|-------|------|
+| `ai_assistant_id` | string \| null |
+| `alpha_sender` | string \| null |
+| `created_at` | date-time |
+| `daily_spend_limit` | string |
+| `daily_spend_limit_enabled` | boolean |
+| `enabled` | boolean |
+| `health_webhook_url` | url |
+| `id` | uuid |
+| `mms_fall_back_to_sms` | boolean |
+| `mms_transcoding` | boolean |
+| `mobile_only` | boolean |
+| `name` | string |
+| `number_pool_settings` | object \| null |
+| `organization_id` | string |
+| `record_type` | enum: messaging_profile |
+| `redaction_enabled` | boolean |
+| `redaction_level` | integer |
+| `resource_group_id` | string \| null |
+| `smart_encoding` | boolean |
+| `updated_at` | date-time |
+| `url_shortener_settings` | object \| null |
+| `v1_secret` | string |
+| `webhook_api_version` | enum: 1, 2, 2010-04-01 |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+| `whitelisted_destinations` | array[string] |
+
+**Returned by:** List Auto-Response Settings, Create auto-response setting, Get Auto-Response Setting, Update Auto-Response Setting
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `id` | string |
+| `keywords` | array[string] |
+| `op` | enum: start, stop, info |
+| `resp_text` | string |
+| `updated_at` | date-time |
+
+## Optional Parameters
+
+### Create an alphanumeric sender ID — `client.alphanumeric_sender_ids.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `us_long_code_fallback` | string | A US long code number to use as fallback when sending to US destinations. |
+
+### Send a message — `client.messages.send_()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using an alphanumeric sender ID — `client.messages.send_with_alphanumeric_sender()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `webhook_url` | string (URL) | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | If true, use the messaging profile's webhook settings. |
+
+### Send a group MMS message — `client.messages.send_group_mms()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+
+### Send a long code message — `client.messages.send_long_code()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using number pool — `client.messages.send_number_pool()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Schedule a message — `client.messages.schedule()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+
+### Send a short code message — `client.messages.send_short_code()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a WhatsApp message — `client.messages.send_whatsapp()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
+
+### Update a messaging hosted number — `client.messaging_hosted_numbers.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `messaging_profile_id` | string (UUID) | Configure the messaging profile this phone number is assigned to:
+
+* Omit thi... |
+| `messaging_product` | string | Configure the messaging product for this number:
+
+* Omit this field or set it... |
+| `tags` | array[string] | Tags to set on this phone number. |
+
+### Create auto-response setting — `client.messaging_profiles.autoresp_configs.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `resp_text` | string |  |
+
+### Update Auto-Response Setting — `client.messaging_profiles.autoresp_configs.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `resp_text` | string |  |
+
+## Webhook Payload Fields
+
+### `deliveryUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.sent, message.finalized | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: outbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | uuid | The id of the organization the messaging profile belongs to. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Subject of multimedia message |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | ISO 8601 formatted date indicating when the message was sent. |
+| `data.payload.completed_at` | date-time | ISO 8601 formatted date indicating when the message was finalized. |
+| `data.payload.valid_until` | date-time | Message must be out of the queue by this time or else it will be discarded and marked as 'sending_failed'. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+| `data.payload.smart_encoding_applied` | boolean | Indicates whether smart encoding was applied to this message. |
+| `data.payload.wait_seconds` | float | Seconds the message is queued due to rate limiting before being sent to the carrier. |
+| `meta.attempt` | integer | Number of attempts to deliver the webhook event. |
+| `meta.delivered_to` | url | The webhook URL the event was delivered to. |
+
+### `inboundMessage`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.received | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: inbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Message subject. |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | Not used for inbound messages. |
+| `data.payload.completed_at` | date-time | Not used for inbound messages. |
+| `data.payload.valid_until` | date-time | Not used for inbound messages. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+
+### `replacedLinkClick`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | string | Identifies the type of the resource. |
+| `data.url` | string | The original link that was sent in the message. |
+| `data.to` | string | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or short code). |
+| `data.message_id` | uuid | The message ID associated with the clicked link. |
+| `data.time_clicked` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+
+### Field Type Notes
+
+- `from` in responses/webhooks: object with sub-fields `phone_number` (string), `carrier` (string), `line_type` (string)
+- `to` in responses/webhooks: array of objects, each with `phone_number` (string), `carrier` (string), `line_type` (string), `status` (string)
+- `cost`: object with `amount` (string, decimal), `currency` (string, e.g., 'USD')

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/ruby/numbers.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/ruby/numbers.md
@@ -44,7 +44,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -347,7 +347,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -397,3 +397,433 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Numbers (Ruby) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Advanced Orders, Create Advanced Order, Update Advanced Order, Get Advanced Order
+
+| Field | Type |
+|-------|------|
+| `area_code` | string |
+| `comments` | string |
+| `country_code` | string |
+| `customer_reference` | string |
+| `features` | array[object] |
+| `id` | uuid |
+| `orders` | array[string] |
+| `phone_number_type` | object |
+| `quantity` | integer |
+| `requirement_group_id` | uuid |
+| `status` | object |
+
+**Returned by:** List available phone number blocks
+
+| Field | Type |
+|-------|------|
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `range` | integer |
+| `record_type` | enum: available_phone_number_block |
+| `region_information` | array[object] |
+
+**Returned by:** List available phone numbers
+
+| Field | Type |
+|-------|------|
+| `best_effort` | boolean |
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `quickship` | boolean |
+| `record_type` | enum: available_phone_number |
+| `region_information` | array[object] |
+| `reservable` | boolean |
+| `vanity_format` | string |
+
+**Returned by:** Retrieve all comments
+
+| Field | Type |
+|-------|------|
+| `body` | string |
+| `comment_record_id` | uuid |
+| `comment_record_type` | enum: sub_number_order, requirement_group |
+| `commenter` | string |
+| `commenter_type` | enum: admin, user |
+| `created_at` | date-time |
+| `id` | uuid |
+| `read_at` | date-time |
+| `updated_at` | date-time |
+
+**Returned by:** Create a comment, Retrieve a comment, Mark a comment as read, Get country coverage
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Get coverage for a specific country
+
+| Field | Type |
+|-------|------|
+| `code` | string |
+| `features` | array[string] |
+| `international_sms` | boolean |
+| `inventory_coverage` | boolean |
+| `local` | object |
+| `mobile` | object |
+| `national` | object |
+| `numbers` | boolean |
+| `p2p` | boolean |
+| `phone_number_type` | array[string] |
+| `quickship` | boolean |
+| `region` | string \| null |
+| `reservable` | boolean |
+| `shared_cost` | object |
+| `toll_free` | object |
+
+**Returned by:** List customer service records, Create a customer service record, Get a customer service record
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `error_message` | string \| null |
+| `id` | uuid |
+| `phone_number` | string |
+| `record_type` | string |
+| `result` | object \| null |
+| `status` | enum: pending, completed, failed |
+| `updated_at` | date-time |
+| `webhook_url` | string |
+
+**Returned by:** Verify CSR phone number coverage
+
+| Field | Type |
+|-------|------|
+| `additional_data_required` | array[string] |
+| `has_csr_coverage` | boolean |
+| `phone_number` | string |
+| `reason` | string |
+| `record_type` | string |
+
+**Returned by:** List inexplicit number orders, Create an inexplicit number order, Retrieve an inexplicit number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `ordering_groups` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Create an inventory coverage request
+
+| Field | Type |
+|-------|------|
+| `administrative_area` | string |
+| `advance_requirements` | boolean |
+| `count` | integer |
+| `coverage_type` | enum: number, block |
+| `group` | string |
+| `group_type` | string |
+| `number_range` | integer |
+| `number_type` | enum: did, toll-free |
+| `phone_number_type` | enum: local, toll_free, national, landline, shared_cost, mobile |
+| `record_type` | string |
+
+**Returned by:** List mobile network operators
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `id` | uuid |
+| `mcc` | string |
+| `mnc` | string |
+| `name` | string |
+| `network_preferences_enabled` | boolean |
+| `record_type` | string |
+| `tadig` | string |
+
+**Returned by:** List network coverage locations
+
+| Field | Type |
+|-------|------|
+| `available_services` | array[object] |
+| `location` | object |
+| `record_type` | string |
+
+**Returned by:** List number block orders, Create a number block order, Retrieve a number block order
+
+| Field | Type |
+|-------|------|
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers_count` | integer |
+| `range` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `starting_number` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve a list of phone numbers associated to orders, Retrieve a single phone number within a number order., Update requirements for a single phone number within a number order.
+
+| Field | Type |
+|-------|------|
+| `bundle_id` | uuid |
+| `country_code` | string |
+| `deadline` | date-time |
+| `id` | uuid |
+| `is_block_number` | boolean |
+| `locality` | string |
+| `order_request_id` | uuid |
+| `phone_number` | string |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `requirements_status` | enum: pending, approved, cancelled, deleted, requirement-info-exception, requirement-info-pending, requirement-info-under-review |
+| `status` | enum: pending, success, failure |
+| `sub_number_order_id` | uuid |
+
+**Returned by:** List number orders, Create a number order, Retrieve a number order, Update a number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers` | array[object] |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `sub_number_orders_ids` | array[string] |
+| `updated_at` | date-time |
+
+**Returned by:** List number reservations, Create a number reservation, Retrieve a number reservation, Extend a number reservation
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `errors` | string |
+| `id` | uuid |
+| `phone_numbers` | array[object] |
+| `record_type` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve the features for a list of numbers
+
+| Field | Type |
+|-------|------|
+| `features` | array[string] |
+| `phone_number` | string |
+
+**Returned by:** Lists the phone number blocks jobs, Deletes all numbers associated with a phone number block, Retrieves a phone number blocks job
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `etc` | date-time |
+| `failed_operations` | array[object] |
+| `id` | uuid |
+| `record_type` | string |
+| `status` | enum: pending, in_progress, completed, failed |
+| `successful_operations` | array[object] |
+| `type` | enum: delete_phone_number_block |
+| `updated_at` | string |
+
+**Returned by:** List sub number orders, Retrieve a sub number order, Update a sub number order's requirements, Cancel a sub number order
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `is_block_sub_number_order` | boolean |
+| `order_request_id` | uuid |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+**Returned by:** Create a sub number orders report, Retrieve a sub number orders report
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `filters` | object |
+| `id` | uuid |
+| `order_type` | string |
+| `status` | enum: pending, success, failed, expired |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+## Optional Parameters
+
+### Create Advanced Order — `client.advanced_orders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `country_code` | string (ISO 3166-1 alpha-2) |  |
+| `comments` | string |  |
+| `quantity` | integer |  |
+| `area_code` | string |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `features` | array[object] |  |
+| `customer_reference` | string |  |
+| `requirement_group_id` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Update Advanced Order — `client.advanced_orders.update_requirement_group()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `country_code` | string (ISO 3166-1 alpha-2) |  |
+| `comments` | string |  |
+| `quantity` | integer |  |
+| `area_code` | string |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `features` | array[object] |  |
+| `customer_reference` | string |  |
+| `requirement_group_id` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Create a comment — `client.comments.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `body` | string |  |
+| `commenter` | string |  |
+| `commenter_type` | enum (admin, user) |  |
+| `comment_record_type` | enum (sub_number_order, requirement_group) |  |
+| `comment_record_id` | string (UUID) |  |
+| `read_at` | string (date-time) | An ISO 8901 datetime string for when the comment was read. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the comment was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the comment was updated. |
+
+### Create an inexplicit number order — `client.inexplicit_number_orders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `connection_id` | string (UUID) | Connection id to apply to phone numbers that are purchased |
+| `messaging_profile_id` | string (UUID) | Messaging profile id to apply to phone numbers that are purchased |
+| `customer_reference` | string | Reference label for the customer |
+| `billing_group_id` | string (UUID) | Billing group id to apply to phone numbers that are purchased |
+
+### Create a number block order — `client.number_block_orders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `record_type` | string |  |
+| `phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `connection_id` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `status` | enum (pending, success, failure) | The status of the order. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the number order was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the number order was updated. |
+| `requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `errors` | string | Errors the reservation could happen upon |
+
+### Update requirements for a single phone number within a number order. — `client.number_order_phone_numbers.update_requirements()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatory_requirements` | array[object] |  |
+
+### Create a number order — `client.number_orders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `phone_numbers` | array[object] |  |
+| `connection_id` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `billing_group_id` | string (UUID) | Identifies the billing group associated with the phone number. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+
+### Update a number order — `client.number_orders.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatory_requirements` | array[object] |  |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+
+### Create a number reservation — `client.number_reservations.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `record_type` | string |  |
+| `phone_numbers` | array[object] |  |
+| `status` | enum (pending, success, failure) | The status of the entire reservation. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the numbers reservation was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the number reservation was updated. |
+
+### Update a sub number order's requirements — `client.sub_number_orders.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatory_requirements` | array[object] |  |
+
+### Create a sub number orders report — `client.sub_number_orders_report.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `status` | enum (pending, success, failure) | Filter by order status |
+| `country_code` | string (ISO 3166-1 alpha-2) | Filter by country code |
+| `created_at_gt` | string (date-time) | Filter for orders created after this date |
+| `created_at_lt` | string (date-time) | Filter for orders created before this date |
+| `order_request_id` | string (UUID) | Filter by specific order request ID |
+| `customer_reference` | string | Filter by customer reference |
+
+## Webhook Payload Fields
+
+### `numberOrderStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.event_type` | string | The type of event being sent |
+| `data.id` | uuid | Unique identifier for the event |
+| `data.occurred_at` | date-time | ISO 8601 timestamp of when the event occurred |
+| `data.payload.id` | uuid |  |
+| `data.payload.record_type` | string |  |
+| `data.payload.phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `data.payload.connection_id` | string | Identifies the connection associated with this phone number. |
+| `data.payload.messaging_profile_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.billing_group_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.phone_numbers` | array[object] |  |
+| `data.payload.sub_number_orders_ids` | array[string] |  |
+| `data.payload.status` | enum: pending, success, failure | The status of the order. |
+| `data.payload.customer_reference` | string | A customer reference string for customer look ups. |
+| `data.payload.created_at` | date-time | An ISO 8901 datetime string denoting when the number order was created. |
+| `data.payload.updated_at` | date-time | An ISO 8901 datetime string for when the number order was updated. |
+| `data.payload.requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `data.record_type` | string | Type of record |
+| `meta.attempt` | integer | Webhook delivery attempt number |
+| `meta.delivered_to` | uri | URL where the webhook was delivered |

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/ruby/voice.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/ruby/voice.md
@@ -29,7 +29,7 @@ or authentication errors (401). Always handle errors in production code:
 response = client.calls.dial(
   connection_id: "7267xxxxxxxxxxxxxx",
   from: "+18005550101",
-  to: "+18005550100"
+  to: "+18005550100;secure=srtp"
 )
 puts(response)
 ```
@@ -54,8 +54,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -73,13 +73,13 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in the API Details section below |
+| ... | | | +56 optional params in the API Details section below |
 
 ```ruby
 response = client.calls.dial(
   connection_id: "7267xxxxxxxxxxxxxx",
   from: "+18005550101",
-  to: "+18005550100"
+  to: "+18005550100;secure=srtp"
 )
 
 puts(response)
@@ -105,7 +105,7 @@ Primary inbound call-control command.
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in the API Details section below |
+| ... | | | +29 optional params in the API Details section below |
 
 ```ruby
 response = client.calls.actions.answer("v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ")
@@ -130,10 +130,13 @@ Common post-answer control path with downstream webhook implications.
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in the API Details section below |
+| ... | | | +35 optional params in the API Details section below |
 
 ```ruby
-response = client.calls.actions.transfer("call_control_id", to: "+18005550100")
+response = client.calls.actions.transfer(
+  "call_control_id",
+  to: "+18005550100;secure=srtp"
+)
 
 puts(response)
 ```
@@ -210,7 +213,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
 | `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -377,7 +380,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -397,3 +400,427 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Voice (Ruby) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List call control applications, Create a call control application, Retrieve a call control application, Update a call control application, Delete a call control application
+
+| Field | Type |
+|-------|------|
+| `active` | boolean |
+| `anchorsite_override` | enum: Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, Chennai, IN, Amsterdam, Netherlands, Toronto, Canada, Sydney, Australia |
+| `application_name` | string |
+| `call_cost_in_webhooks` | boolean |
+| `created_at` | string |
+| `dtmf_type` | enum: RFC 2833, Inband, SIP INFO |
+| `first_command_timeout` | boolean |
+| `first_command_timeout_secs` | integer |
+| `id` | string |
+| `inbound` | object |
+| `outbound` | object |
+| `record_type` | enum: call_control_application |
+| `redact_dtmf_debug_logging` | boolean |
+| `tags` | array[string] |
+| `updated_at` | string |
+| `webhook_api_version` | enum: 1, 2 |
+| `webhook_event_failover_url` | url |
+| `webhook_event_url` | url |
+| `webhook_timeout_secs` | integer \| null |
+
+**Returned by:** Dial
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `recording_id` | uuid |
+| `start_time` | string |
+
+**Returned by:** Retrieve a call status
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `start_time` | string |
+
+**Returned by:** Answer call
+
+| Field | Type |
+|-------|------|
+| `recording_id` | uuid |
+| `result` | string |
+
+**Returned by:** Bridge calls, Hangup call, SIP Refer a call, Reject a call, Send SIP info, Transfer call
+
+| Field | Type |
+|-------|------|
+| `result` | string |
+
+**Returned by:** List all active calls for given connection
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `record_type` | enum: call |
+
+## Optional Parameters
+
+### Create a call control application — `client.call_control_applications.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `active` | boolean | Specifies whether the connection can be used. |
+| `anchorsite_override` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmf_type` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `first_command_timeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `first_command_timeout_secs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `inbound` | object |  |
+| `outbound` | object |  |
+| `webhook_api_version` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhook_event_failover_url` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhook_timeout_secs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `call_cost_in_webhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `redact_dtmf_debug_logging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Update a call control application — `client.call_control_applications.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `call_cost_in_webhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `active` | boolean | Specifies whether the connection can be used. |
+| `anchorsite_override` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmf_type` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `first_command_timeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `first_command_timeout_secs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `tags` | array[string] | Tags assigned to the Call Control Application. |
+| `inbound` | object |  |
+| `outbound` | object |  |
+| `webhook_api_version` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhook_event_failover_url` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhook_timeout_secs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `redact_dtmf_debug_logging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Dial — `client.calls.dial()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
+| `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
+| `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
+| `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `link_to` | string | Use another call's control id for sharing the same call session id |
+| `bridge_intent` | boolean | Indicates the intent to bridge this call with the call specified in link_to. |
+| `bridge_on_answer` | boolean | Whether to automatically bridge answered call to the call specified in link_to. |
+| `prevent_double_bridge` | boolean | Prevents bridging and hangs up the call if the target is already bridged. |
+| `park_after_unbridge` | string | If supplied with the value `self`, the current leg will be parked after unbri... |
+| `media_encryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the call. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE request. |
+| `sip_transport_protocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `stream_url` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `stream_track` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `stream_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `stream_bidirectional_mode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `stream_bidirectional_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `stream_bidirectional_target_legs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `stream_bidirectional_sampling_rate` | enum (8000, 16000, 22050, 24000, 48000) | Audio sampling rate. |
+| `stream_establish_before_call_originate` | boolean | Establish websocket connection before dialing the destination. |
+| `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `supervise_call_control_id` | string (UUID) | The call leg which will be supervised by the new call. |
+| `supervisor_role` | enum (barge, whisper, monitor) | The role of the supervisor call. |
+| `enable_dialogflow` | boolean | Enables Dialogflow for the current call. |
+| `dialogflow_config` | object |  |
+| `transcription` | boolean | Enable transcription upon call answer. |
+| `transcription_config` | object |  |
+| `sip_region` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `stream_auth_token` | string | An authentication token to be sent as part of the WebSocket connection when u... |
+
+### Answer call — `client.calls.actions.answer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE response. |
+| `preferred_codecs` | enum (G722,PCMU,PCMA,G729,OPUS,VP8,H264) | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE response. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `stream_url` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `stream_track` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `stream_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `stream_bidirectional_mode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `stream_bidirectional_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `stream_bidirectional_target_legs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `transcription` | boolean | Enable transcription upon call answer. |
+| `transcription_config` | object |  |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
+
+### Bridge calls — `client.calls.actions.bridge()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `queue` | string | The name of the queue you want to bridge with, can't be used together with ca... |
+| `video_room_id` | string (UUID) | The ID of the video room you want to bridge with, can't be used together with... |
+| `video_room_context` | string | The additional parameter that will be passed to the video conference. |
+| `prevent_double_bridge` | boolean | When set to `true`, it prevents bridging if the target call is already bridge... |
+| `park_after_unbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `play_ringtone` | boolean | Specifies whether to play a ringtone if the call you want to bridge with has ... |
+| `ringtone` | enum (at, au, be, bg, br, ...) | Specifies which country ringtone to play when `play_ringtone` is set to `true`. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `mute_dtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `hold_after_unbridge` | boolean | Specifies behavior after the bridge ends. |
+
+### Hangup call — `client.calls.actions.hangup()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP BYE message. |
+
+### SIP Refer a call — `client.calls.actions.refer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid execution of duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the request. |
+
+### Reject a call — `client.calls.actions.reject()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Send SIP info — `client.calls.actions.send_sip_info()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Transfer call — `client.calls.actions.transfer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
+| `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
+| `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
+| `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
+| `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `park_after_unbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `target_leg_client_state` | string | Use this field to add state to every subsequent webhook for the new leg. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `media_encryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the new call leg. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE. |
+| `sip_transport_protocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `mute_dtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `sip_region` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `preferred_codecs` | string | The list of comma-separated codecs in order of preference to be used during t... |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+
+## Webhook Payload Fields
+
+### `callAnswered`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.answered | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: answered | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### `callBridged`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.bridged | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+
+### `callHangup`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.hangup | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: hangup | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+| `data.payload.hangup_cause` | enum: call_rejected, normal_clearing, originator_cancel, timeout, time_limit, user_busy, not_found, no_answer, unspecified | The reason the call was ended (`call_rejected`, `normal_clearing`, `originator_cancel`, `timeout`, `time_limit`, `use... |
+| `data.payload.hangup_source` | enum: caller, callee, unknown | The party who ended the call (`callee`, `caller`, `unknown`). |
+| `data.payload.sip_hangup_cause` | string | The reason the call was ended (SIP response code). |
+| `data.payload.call_quality_stats` | object \| null | Call quality statistics aggregated from the CHANNEL_HANGUP_COMPLETE event. |
+
+### `callInitiated`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.initiated | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
+| `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.custom_headers` | array[object] | Custom headers from sip invite |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.shaken_stir_attestation` | string | SHAKEN/STIR attestation level. |
+| `data.payload.shaken_stir_validated` | boolean | Whether attestation was successfully validated or not. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.caller_id_name` | string | Caller id. |
+| `data.payload.call_screening_result` | string | Call screening result. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.direction` | enum: incoming, outgoing | Whether the call is `incoming` or `outgoing`. |
+| `data.payload.state` | enum: parked, bridging | State received from a command. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### Field Type Notes
+
+- `from` in webhook payloads: string (E.164 phone number)
+- `to` in webhook payloads: string (E.164 phone number)
+- The return value of `client.webhooks.unwrap()` is a parsed event object — access fields via `event.data.event_type`, `event.data.payload.call_control_id`, etc.

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/webrtc-client/android.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/webrtc-client/android.md
@@ -385,7 +385,7 @@ If using code obfuscation, add to `proguard-rules.pro`:
 
 <!-- BEGIN AUTO-GENERATED API REFERENCE -- do not edit below this line -->
 
-**[references/webrtc-server-api.md](references/webrtc-server-api.md) has the server-side WebRTC API — credential creation, token generation, and push notification setup. You MUST read it when setting up authentication or push notifications.**
+**[../curl/webrtc.md](../curl/webrtc.md) has the server-side WebRTC API — credential creation, token generation, and push notification setup. You MUST read it when setting up authentication or push notifications.**
 
 ## API Reference
 

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/webrtc-client/flutter.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/webrtc-client/flutter.md
@@ -493,7 +493,7 @@ final config = CredentialConfig(
 
 <!-- BEGIN AUTO-GENERATED API REFERENCE -- do not edit below this line -->
 
-**[references/webrtc-server-api.md](references/webrtc-server-api.md) has the server-side WebRTC API — credential creation, token generation, and push notification setup. You MUST read it when setting up authentication or push notifications.**
+**[../curl/webrtc.md](../curl/webrtc.md) has the server-side WebRTC API — credential creation, token generation, and push notification setup. You MUST read it when setting up authentication or push notifications.**
 
 ## API Reference
 

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/webrtc-client/ios.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/webrtc-client/ios.md
@@ -439,7 +439,7 @@ let txConfig = TxConfig(
 
 <!-- BEGIN AUTO-GENERATED API REFERENCE -- do not edit below this line -->
 
-**[references/webrtc-server-api.md](references/webrtc-server-api.md) has the server-side WebRTC API — credential creation, token generation, and push notification setup. You MUST read it when setting up authentication or push notifications.**
+**[../curl/webrtc.md](../curl/webrtc.md) has the server-side WebRTC API — credential creation, token generation, and push notification setup. You MUST read it when setting up authentication or push notifications.**
 
 ## API Reference
 

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/webrtc-client/javascript.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/webrtc-client/javascript.md
@@ -320,7 +320,7 @@ console.log('WebRTC supported:', webRTCInfo.supportWebRTC);
 
 <!-- BEGIN AUTO-GENERATED API REFERENCE -- do not edit below this line -->
 
-**[references/webrtc-server-api.md](references/webrtc-server-api.md) has the server-side WebRTC API — credential creation, token generation, and push notification setup. You MUST read it when setting up authentication or push notifications.**
+**[../curl/webrtc.md](../curl/webrtc.md) has the server-side WebRTC API — credential creation, token generation, and push notification setup. You MUST read it when setting up authentication or push notifications.**
 
 ## API Reference
 

--- a/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/webrtc-client/react-native.md
+++ b/providers/claude/plugin/skills/telnyx-twilio-migration/sdk-reference/webrtc-client/react-native.md
@@ -307,7 +307,7 @@ await AsyncStorage.multiRemove([
 
 <!-- BEGIN AUTO-GENERATED API REFERENCE -- do not edit below this line -->
 
-**[references/webrtc-server-api.md](references/webrtc-server-api.md) has the server-side WebRTC API — credential creation, token generation, and push notification setup. You MUST read it when setting up authentication or push notifications.**
+**[../curl/webrtc.md](../curl/webrtc.md) has the server-side WebRTC API — credential creation, token generation, and push notification setup. You MUST read it when setting up authentication or push notifications.**
 
 ## API Reference
 

--- a/providers/claude/plugin/skills/telnyx-voice-curl/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-voice-curl/SKILL.md
@@ -86,7 +86,7 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +56 optional params in [references/api-details.md](references/api-details.md) |
 
 ```bash
 curl \
@@ -121,7 +121,7 @@ Primary inbound call-control command.
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +29 optional params in [references/api-details.md](references/api-details.md) |
 
 ```bash
 curl \
@@ -148,7 +148,7 @@ Common post-answer control path with downstream webhook implications.
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```bash
 curl \
@@ -156,7 +156,7 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-  "to": "+18005550100"
+  "to": "+18005550100;secure=srtp"
 }' \
   "https://api.telnyx.com/v2/calls/v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ/actions/transfer"
 ```

--- a/providers/claude/plugin/skills/telnyx-voice-curl/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-voice-curl/references/api-details.md
@@ -128,14 +128,19 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
 | `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 | `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
 | `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +168,9 @@
 | `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
 | `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +192,8 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | Use this field to add state to every subsequent webhook. |
 | `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +223,7 @@
 | `webhook_urls` | object | A map of event types to webhook URLs. |
 | `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls
 
@@ -277,7 +288,9 @@
 |-----------|------|-------------|
 | `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/providers/claude/plugin/skills/telnyx-voice-go/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-voice-go/SKILL.md
@@ -52,7 +52,7 @@ response, err := client.Calls.Dial(context.Background(), telnyx.CallDialParams{
 		ConnectionID: "7267xxxxxxxxxxxxxx",
 		From:         "+18005550101",
 		To: telnyx.CallDialParamsToUnion{
-			OfString: telnyx.String("+18005550100"),
+			OfString: telnyx.String("+18005550100;secure=srtp"),
 		},
 	})
 if err != nil {
@@ -111,14 +111,14 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `TimeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `BillingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `ClientState` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +56 optional params in [references/api-details.md](references/api-details.md) |
 
 ```go
 	response, err := client.Calls.Dial(context.Background(), telnyx.CallDialParams{
 		ConnectionID: "7267xxxxxxxxxxxxxx",
 		From:         "+18005550101",
 		To: telnyx.CallDialParamsToUnion{
-			OfString: telnyx.String("+18005550100"),
+			OfString: telnyx.String("+18005550100;secure=srtp"),
 		},
 	})
 	if err != nil {
@@ -147,7 +147,7 @@ Primary inbound call-control command.
 | `BillingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `ClientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `WebhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +29 optional params in [references/api-details.md](references/api-details.md) |
 
 ```go
 	response, err := client.Calls.Actions.Answer(
@@ -178,14 +178,14 @@ Common post-answer control path with downstream webhook implications.
 | `TimeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `ClientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `WebhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```go
 	response, err := client.Calls.Actions.Transfer(
 		context.Background(),
 		"call_control_id",
 		telnyx.CallActionTransferParams{
-			To: "+18005550100",
+			To: "+18005550100;secure=srtp",
 		},
 	)
 	if err != nil {

--- a/providers/claude/plugin/skills/telnyx-voice-go/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-voice-go/references/api-details.md
@@ -128,14 +128,19 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `Assistant` | object | AI Assistant configuration. |
+| `ConversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `FromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `Privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `AudioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `SendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
 | `MediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `PreferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `TimeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `TimeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `AnsweringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `AnsweringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `DeepfakeDetection` | object | Enables deepfake detection on the call. |
 | `ConferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
 | `CustomHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `BillingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +168,9 @@
 | `SendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
 | `WebhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `WebhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `WebhookUrls` | object | A map of event types to webhook URLs. |
+| `WebhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `WebhookRetriesPolicies` | object | A map of event types to retry policies. |
 | `Record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `RecordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `RecordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +192,8 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `Assistant` | object | AI Assistant configuration. |
+| `ConversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `BillingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `ClientState` | string | Use this field to add state to every subsequent webhook. |
 | `CommandId` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +223,7 @@
 | `WebhookUrls` | object | A map of event types to webhook URLs. |
 | `WebhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `WebhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `DeepfakeDetection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.Calls.Actions.Bridge()`
 
@@ -277,7 +288,9 @@
 |-----------|------|-------------|
 | `From` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `FromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `Privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `AudioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `SendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `EarlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `MediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `TimeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/providers/claude/plugin/skills/telnyx-voice-java/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-voice-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -51,7 +51,7 @@ import com.telnyx.sdk.models.calls.CallDialResponse;
 CallDialParams params = CallDialParams.builder()
     .connectionId("7267xxxxxxxxxxxxxx")
     .from("+18005550101")
-    .to("+18005550100")
+    .to("+18005550100;secure=srtp")
     .build();
 CallDialResponse response = client.calls().dial(params);
 ```
@@ -95,7 +95,7 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +56 optional params in [references/api-details.md](references/api-details.md) |
 
 ```java
 import com.telnyx.sdk.models.calls.CallDialParams;
@@ -104,7 +104,7 @@ import com.telnyx.sdk.models.calls.CallDialResponse;
 CallDialParams params = CallDialParams.builder()
     .connectionId("7267xxxxxxxxxxxxxx")
     .from("+18005550101")
-    .to("+18005550100")
+    .to("+18005550100;secure=srtp")
     .build();
 CallDialResponse response = client.calls().dial(params);
 ```
@@ -129,7 +129,7 @@ Primary inbound call-control command.
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +29 optional params in [references/api-details.md](references/api-details.md) |
 
 ```java
 import com.telnyx.sdk.models.calls.actions.ActionAnswerParams;
@@ -155,7 +155,7 @@ Common post-answer control path with downstream webhook implications.
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```java
 import com.telnyx.sdk.models.calls.actions.ActionTransferParams;
@@ -163,7 +163,7 @@ import com.telnyx.sdk.models.calls.actions.ActionTransferResponse;
 
 ActionTransferParams params = ActionTransferParams.builder()
     .callControlId("v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ")
-    .to("+18005550100")
+    .to("+18005550100;secure=srtp")
     .build();
 ActionTransferResponse response = client.calls().actions().transfer(params);
 ```

--- a/providers/claude/plugin/skills/telnyx-voice-java/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-voice-java/references/api-details.md
@@ -128,14 +128,19 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
 | `mediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `preferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
 | `conferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
 | `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +168,9 @@
 | `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
 | `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhookUrls` | object | A map of event types to webhook URLs. |
+| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +192,8 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | Use this field to add state to every subsequent webhook. |
 | `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +223,7 @@
 | `webhookUrls` | object | A map of event types to webhook URLs. |
 | `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.calls().actions().bridge()`
 
@@ -277,7 +288,9 @@
 |-----------|------|-------------|
 | `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `earlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `mediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/providers/claude/plugin/skills/telnyx-voice-javascript/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-voice-javascript/SKILL.md
@@ -43,7 +43,7 @@ try {
   const response = await client.calls.dial({
     connection_id: '7267xxxxxxxxxxxxxx',
     from: '+18005550101',
-    to: '+18005550100',
+    to: '+18005550100;secure=srtp',
   });
 } catch (err) {
   if (err instanceof Telnyx.APIConnectionError) {
@@ -99,13 +99,13 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +56 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const response = await client.calls.dial({
   connection_id: '7267xxxxxxxxxxxxxx',
   from: '+18005550101',
-  to: '+18005550100',
+  to: '+18005550100;secure=srtp',
 });
 
 console.log(response.data);
@@ -131,7 +131,7 @@ Primary inbound call-control command.
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +29 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const response = await client.calls.actions.answer('v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ');
@@ -156,11 +156,11 @@ Common post-answer control path with downstream webhook implications.
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const response = await client.calls.actions.transfer('call_control_id', {
-  to: '+18005550100',
+  to: '+18005550100;secure=srtp',
 });
 
 console.log(response.data);

--- a/providers/claude/plugin/skills/telnyx-voice-javascript/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-voice-javascript/references/api-details.md
@@ -128,14 +128,19 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
 | `mediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `preferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
 | `conferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
 | `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +168,9 @@
 | `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
 | `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhookUrls` | object | A map of event types to webhook URLs. |
+| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +192,8 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | Use this field to add state to every subsequent webhook. |
 | `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +223,7 @@
 | `webhookUrls` | object | A map of event types to webhook URLs. |
 | `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.calls.actions.bridge()`
 
@@ -277,7 +288,9 @@
 |-----------|------|-------------|
 | `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `earlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `mediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/providers/claude/plugin/skills/telnyx-voice-python/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-voice-python/SKILL.md
@@ -46,7 +46,7 @@ try:
     response = client.calls.dial(
         connection_id="7267xxxxxxxxxxxxxx",
         from_="+18005550101",
-        to="+18005550100",
+        to="+18005550100;secure=srtp",
     )
 except telnyx.APIConnectionError:
     print("Network error — check connectivity and retry")
@@ -98,13 +98,13 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +56 optional params in [references/api-details.md](references/api-details.md) |
 
 ```python
 response = client.calls.dial(
     connection_id="7267xxxxxxxxxxxxxx",
     from_="+18005550101",
-    to="+18005550100",
+    to="+18005550100;secure=srtp",
 )
 print(response.data)
 ```
@@ -129,7 +129,7 @@ Primary inbound call-control command.
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +29 optional params in [references/api-details.md](references/api-details.md) |
 
 ```python
 response = client.calls.actions.answer(
@@ -155,12 +155,12 @@ Common post-answer control path with downstream webhook implications.
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```python
 response = client.calls.actions.transfer(
     call_control_id="550e8400-e29b-41d4-a716-446655440000",
-    to="+18005550100",
+    to="+18005550100;secure=srtp",
 )
 print(response.data)
 ```

--- a/providers/claude/plugin/skills/telnyx-voice-python/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-voice-python/references/api-details.md
@@ -128,14 +128,19 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
 | `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 | `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
 | `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +168,9 @@
 | `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
 | `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +192,8 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | Use this field to add state to every subsequent webhook. |
 | `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +223,7 @@
 | `webhook_urls` | object | A map of event types to webhook URLs. |
 | `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.calls.actions.bridge()`
 
@@ -277,7 +288,9 @@
 |-----------|------|-------------|
 | `from_` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/providers/claude/plugin/skills/telnyx-voice-ruby/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-voice-ruby/SKILL.md
@@ -42,7 +42,7 @@ or authentication errors (401). Always handle errors in production code:
 response = client.calls.dial(
   connection_id: "7267xxxxxxxxxxxxxx",
   from: "+18005550101",
-  to: "+18005550100"
+  to: "+18005550100;secure=srtp"
 )
 puts(response)
 ```
@@ -86,13 +86,13 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +56 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
 response = client.calls.dial(
   connection_id: "7267xxxxxxxxxxxxxx",
   from: "+18005550101",
-  to: "+18005550100"
+  to: "+18005550100;secure=srtp"
 )
 
 puts(response)
@@ -118,7 +118,7 @@ Primary inbound call-control command.
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +29 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
 response = client.calls.actions.answer("v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ")
@@ -143,10 +143,13 @@ Common post-answer control path with downstream webhook implications.
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
-response = client.calls.actions.transfer("call_control_id", to: "+18005550100")
+response = client.calls.actions.transfer(
+  "call_control_id",
+  to: "+18005550100;secure=srtp"
+)
 
 puts(response)
 ```

--- a/providers/claude/plugin/skills/telnyx-voice-ruby/references/api-details.md
+++ b/providers/claude/plugin/skills/telnyx-voice-ruby/references/api-details.md
@@ -128,14 +128,19 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
 | `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 | `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
 | `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +168,9 @@
 | `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
 | `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +192,8 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | Use this field to add state to every subsequent webhook. |
 | `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +223,7 @@
 | `webhook_urls` | object | A map of event types to webhook URLs. |
 | `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.calls.actions.bridge()`
 
@@ -277,7 +288,9 @@
 |-----------|------|-------------|
 | `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/providers/cursor/plugin/skills/telnyx-10dlc-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-10dlc-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -322,7 +322,6 @@ Create or provision an additional resource when the core tasks do not cover this
 ```java
 import com.telnyx.sdk.models.messaging10dlc.phonenumbercampaigns.PhoneNumberCampaign;
 import com.telnyx.sdk.models.messaging10dlc.phonenumbercampaigns.PhoneNumberCampaignCreate;
-import com.telnyx.sdk.models.messaging10dlc.phonenumbercampaigns.PhoneNumberCampaignCreateParams;
 
 PhoneNumberCampaignCreate params = PhoneNumberCampaignCreate.builder()
     .campaignId("4b300178-131c-d902-d54e-72d90ba1620j")

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-curl/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-curl/SKILL.md
@@ -40,10 +40,10 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-  "name": "my-resource",
-  "model": "openai/gpt-4o",
-  "instructions": "You are a helpful assistant."
-}' \
+      "name": "my-resource",
+      "instructions": "You are a helpful assistant.",
+      "model": "openai/gpt-4o"
+  }' \
   "https://api.telnyx.com/v2/ai/assistants"
 ```
 
@@ -74,12 +74,11 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `tool_ids` | array[string] | No |  |
-| `description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```bash
 curl \
@@ -87,10 +86,10 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-  "name": "my-resource",
-  "model": "openai/gpt-4o",
-  "instructions": "You are a helpful assistant."
-}' \
+      "name": "my-resource",
+      "instructions": "You are a helpful assistant.",
+      "model": "openai/gpt-4o"
+  }' \
   "https://api.telnyx.com/v2/ai/assistants"
 ```
 
@@ -208,7 +207,7 @@ Primary response fields:
 - `.data.created_at`
 - `.data.description`
 - `.data.dynamic_variables`
-- `.data.dynamic_variables_webhook_url`
+- `.data.dynamic_variables_webhook_timeout_ms`
 
 ### Update an assistant
 
@@ -219,10 +218,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistant_id` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```bash
 curl \
@@ -238,7 +237,7 @@ Primary response fields:
 - `.data.created_at`
 - `.data.description`
 - `.data.dynamic_variables`
-- `.data.dynamic_variables_webhook_url`
+- `.data.dynamic_variables_webhook_timeout_ms`
 
 ### List assistants
 
@@ -259,7 +258,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Import assistants from external provider
 
@@ -294,7 +293,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Get All Tags
 
@@ -401,8 +400,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | HTTP only | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
 | Delete an assistant | HTTP only | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Get Canary Deploy | HTTP only | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
-| Create Canary Deploy | HTTP only | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistant_id` |
-| Update Canary Deploy | HTTP only | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistant_id` |
+| Create Canary Deploy | HTTP only | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | HTTP only | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
 | Delete Canary Deploy | HTTP only | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Assistant Sms Chat | HTTP only | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistant_id` |
 | Clone Assistant | HTTP only | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-curl/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-curl/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -165,9 +182,15 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -228,10 +254,29 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 | `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
 
 ### Assistant Chat (BETA)
 
@@ -254,6 +299,8 @@
 | `text` | string | Required for sms scheduled events. |
 | `conversation_metadata` | object | Metadata associated with the conversation. |
 | `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
 
 ### Test Assistant Tool
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -281,9 +331,16 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server
 

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-go/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-go/SKILL.md
@@ -50,8 +50,8 @@ import "errors"
 
 assistant, err := client.AI.Assistants.New(context.Background(), telnyx.AIAssistantNewParams{
 		Instructions: "You are a helpful assistant.",
-		Model: "openai/gpt-4o",
 		Name: "my-resource",
+		Model: "openai/gpt-4o",
 	})
 if err != nil {
   var apiErr *telnyx.Error
@@ -97,18 +97,17 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `Name` | string | Yes |  |
-| `Model` | string | Yes | ID of the model to use. |
 | `Instructions` | string | Yes | System instructions for the assistant. |
-| `Tools` | array[object] | No | The tools that the assistant can use. |
-| `ToolIds` | array[string] | No |  |
-| `Description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `Tags` | array[string] | No | Tags associated with the assistant. |
+| `Model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `Tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```go
 	assistant, err := client.AI.Assistants.New(context.Background(), telnyx.AIAssistantNewParams{
 		Instructions: "You are a helpful assistant.",
-		Model: "openai/gpt-4o",
 		Name: "my-resource",
+		Model: "openai/gpt-4o",
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -237,7 +236,7 @@ Primary response fields:
 - `assistant.CreatedAt`
 - `assistant.Description`
 - `assistant.DynamicVariables`
-- `assistant.DynamicVariablesWebhookURL`
+- `assistant.DynamicVariablesWebhookTimeoutMs`
 
 ### Update an assistant
 
@@ -248,10 +247,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `AssistantId` | string (UUID) | Yes |  |
+| `Tags` | array[string] | No | Tags associated with the assistant. |
 | `Name` | string | No |  |
-| `Model` | string | No | ID of the model to use. |
-| `Instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `Model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```go
 	assistant, err := client.AI.Assistants.Update(
@@ -271,7 +270,7 @@ Primary response fields:
 - `assistant.CreatedAt`
 - `assistant.Description`
 - `assistant.DynamicVariables`
-- `assistant.DynamicVariablesWebhookURL`
+- `assistant.DynamicVariablesWebhookTimeoutMs`
 
 ### List assistants
 
@@ -296,7 +295,7 @@ Primary item fields:
 - `CreatedAt`
 - `Description`
 - `DynamicVariables`
-- `DynamicVariablesWebhookURL`
+- `DynamicVariablesWebhookTimeoutMs`
 
 ### Import assistants from external provider
 
@@ -330,7 +329,7 @@ Primary item fields:
 - `CreatedAt`
 - `Description`
 - `DynamicVariables`
-- `DynamicVariablesWebhookURL`
+- `DynamicVariablesWebhookTimeoutMs`
 
 ### Get All Tags
 
@@ -457,8 +456,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.AI.Assistants.Tests.Runs.Get()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `TestId`, `RunId` |
 | Delete an assistant | `client.AI.Assistants.Delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `AssistantId` |
 | Get Canary Deploy | `client.AI.Assistants.CanaryDeploys.Get()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `AssistantId` |
-| Create Canary Deploy | `client.AI.Assistants.CanaryDeploys.New()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `Versions`, `AssistantId` |
-| Update Canary Deploy | `client.AI.Assistants.CanaryDeploys.Update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `Versions`, `AssistantId` |
+| Create Canary Deploy | `client.AI.Assistants.CanaryDeploys.New()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `AssistantId` |
+| Update Canary Deploy | `client.AI.Assistants.CanaryDeploys.Update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `AssistantId` |
 | Delete Canary Deploy | `client.AI.Assistants.CanaryDeploys.Delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `AssistantId` |
 | Assistant Sms Chat | `client.AI.Assistants.SendSMS()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `From`, `To`, `AssistantId` |
 | Clone Assistant | `client.AI.Assistants.Clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `AssistantId` |

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-go/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-go/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `Tools` | array[object] | The tools that the assistant can use. |
-| `ToolIds` | array[string] |  |
+| `Model` | string | ID of the model to use when `external_llm` is not set. |
+| `Tools` | array[object] | Deprecated for new integrations. |
+| `McpServers` | array[object] | MCP servers attached to the assistant. |
+| `ToolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `Description` | string |  |
 | `Greeting` | string | Text that the assistant will use to start the conversation. |
-| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `ExternalLlm` | object |  |
+| `FallbackConfig` | object |  |
 | `VoiceSettings` | object |  |
 | `Transcription` | object |  |
 | `TelephonySettings` | object |  |
@@ -165,9 +182,15 @@
 | `EnabledFeatures` | array[object] |  |
 | `InsightSettings` | object |  |
 | `PrivacySettings` | object |  |
-| `DynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `DynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `DynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `DynamicVariables` | object | Map of dynamic variables and their default values |
 | `WidgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `InterruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `Integrations` | array[object] | Connected integrations attached to the assistant. |
+| `ObservabilitySettings` | object |  |
+| `Tags` | array[string] | Tags associated with the assistant. |
+| `PostConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider — `client.AI.Assistants.Imports()`
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `Name` | string |  |
-| `Model` | string | ID of the model to use. |
+| `Model` | string | ID of the model to use when `external_llm` is not set. |
 | `Instructions` | string | System instructions for the assistant. |
-| `Tools` | array[object] | The tools that the assistant can use. |
-| `ToolIds` | array[string] |  |
+| `Tools` | array[object] | Deprecated for new integrations. |
+| `McpServers` | array[object] | MCP servers attached to the assistant. |
+| `ToolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `Description` | string |  |
 | `Greeting` | string | Text that the assistant will use to start the conversation. |
-| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `ExternalLlm` | object |  |
+| `FallbackConfig` | object |  |
 | `VoiceSettings` | object |  |
 | `Transcription` | object |  |
 | `TelephonySettings` | object |  |
@@ -228,10 +254,29 @@
 | `EnabledFeatures` | array[object] |  |
 | `InsightSettings` | object |  |
 | `PrivacySettings` | object |  |
-| `DynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `DynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `DynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `DynamicVariables` | object | Map of dynamic variables and their default values |
 | `WidgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `InterruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `Integrations` | array[object] | Connected integrations attached to the assistant. |
+| `ObservabilitySettings` | object |  |
+| `Tags` | array[string] | Tags associated with the assistant. |
+| `VersionName` | string | Human-readable name for the assistant version. |
+| `PostConversationSettings` | object | Configuration for post-conversation processing. |
 | `PromoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.AI.Assistants.CanaryDeploys.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Rules` | array[object] |  |
+
+### Update Canary Deploy — `client.AI.Assistants.CanaryDeploys.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Rules` | array[object] |  |
 
 ### Assistant Chat (BETA) — `client.AI.Assistants.Chat()`
 
@@ -254,6 +299,8 @@
 | `Text` | string | Required for sms scheduled events. |
 | `ConversationMetadata` | object | Metadata associated with the conversation. |
 | `DynamicVariables` | object | A map of dynamic variable names to values. |
+| `MaxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `RetryIntervalSecs` | integer |  |
 
 ### Test Assistant Tool — `client.AI.Assistants.Tools.Test()`
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `Name` | string |  |
-| `Model` | string | ID of the model to use. |
+| `Model` | string | ID of the model to use when `external_llm` is not set. |
 | `Instructions` | string | System instructions for the assistant. |
-| `Tools` | array[object] | The tools that the assistant can use. |
-| `ToolIds` | array[string] |  |
+| `Tools` | array[object] | Deprecated for new integrations. |
+| `McpServers` | array[object] | MCP servers attached to the assistant. |
+| `ToolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `Description` | string |  |
 | `Greeting` | string | Text that the assistant will use to start the conversation. |
-| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `ExternalLlm` | object |  |
+| `FallbackConfig` | object |  |
 | `VoiceSettings` | object |  |
 | `Transcription` | object |  |
 | `TelephonySettings` | object |  |
@@ -281,9 +331,16 @@
 | `EnabledFeatures` | array[object] |  |
 | `InsightSettings` | object |  |
 | `PrivacySettings` | object |  |
-| `DynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `DynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `DynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `DynamicVariables` | object | Map of dynamic variables and their default values |
 | `WidgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `InterruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `Integrations` | array[object] | Connected integrations attached to the assistant. |
+| `ObservabilitySettings` | object |  |
+| `Tags` | array[string] | Tags associated with the assistant. |
+| `VersionName` | string | Human-readable name for the assistant version. |
+| `PostConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server — `client.AI.McpServers.New()`
 

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -50,8 +50,8 @@ import com.telnyx.sdk.models.ai.assistants.AssistantCreateParams;
 import com.telnyx.sdk.models.ai.assistants.InferenceEmbedding;
 AssistantCreateParams params = AssistantCreateParams.builder()
     .instructions("You are a helpful assistant.")
-    .model("openai/gpt-4o")
     .name("my-resource")
+    .model("openai/gpt-4o")
     .build();
 InferenceEmbedding assistant = client.ai().assistants().create(params);
 ```
@@ -83,12 +83,11 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `toolIds` | array[string] | No |  |
-| `description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```java
 import com.telnyx.sdk.models.ai.assistants.AssistantCreateParams;
@@ -96,8 +95,8 @@ import com.telnyx.sdk.models.ai.assistants.InferenceEmbedding;
 
 AssistantCreateParams params = AssistantCreateParams.builder()
     .instructions("You are a helpful assistant.")
-    .model("openai/gpt-4o")
     .name("my-resource")
+    .model("openai/gpt-4o")
     .build();
 InferenceEmbedding assistant = client.ai().assistants().create(params);
 ```
@@ -216,7 +215,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### Update an assistant
 
@@ -227,10 +226,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistantId` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```java
 import com.telnyx.sdk.models.ai.assistants.AssistantUpdateParams;
@@ -245,7 +244,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### List assistants
 
@@ -269,7 +268,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Import assistants from external provider
 
@@ -303,7 +302,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Get All Tags
 
@@ -422,8 +421,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai().assistants().tests().runs().retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId`, `runId` |
 | Delete an assistant | `client.ai().assistants().delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Get Canary Deploy | `client.ai().assistants().canaryDeploys().retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Create Canary Deploy | `client.ai().assistants().canaryDeploys().create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistantId` |
-| Update Canary Deploy | `client.ai().assistants().canaryDeploys().update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistantId` |
+| Create Canary Deploy | `client.ai().assistants().canaryDeploys().create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId` |
+| Update Canary Deploy | `client.ai().assistants().canaryDeploys().update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistantId` |
 | Delete Canary Deploy | `client.ai().assistants().canaryDeploys().delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Assistant Sms Chat | `client.ai().assistants().sendSms()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistantId` |
 | Clone Assistant | `client.ai().assistants().clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId` |

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-java/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-java/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -165,9 +182,15 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider — `client.ai().assistants().imports()`
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -228,10 +254,29 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 | `promoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai().assistants().canaryDeploys().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai().assistants().canaryDeploys().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
 
 ### Assistant Chat (BETA) — `client.ai().assistants().chat()`
 
@@ -254,6 +299,8 @@
 | `text` | string | Required for sms scheduled events. |
 | `conversationMetadata` | object | Metadata associated with the conversation. |
 | `dynamicVariables` | object | A map of dynamic variable names to values. |
+| `maxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retryIntervalSecs` | integer |  |
 
 ### Test Assistant Tool — `client.ai().assistants().tools().test()`
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -281,9 +331,16 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server — `client.ai().mcpServers().create()`
 

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-javascript/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-javascript/SKILL.md
@@ -42,8 +42,8 @@ or authentication errors (401). Always handle errors in production code:
 try {
   const assistant = await client.ai.assistants.create({
     instructions: 'You are a helpful assistant.',
-    model: 'openai/gpt-4o',
     name: 'my-resource',
+      model: 'openai/gpt-4o',
   });
 } catch (err) {
   if (err instanceof Telnyx.APIConnectionError) {
@@ -87,18 +87,17 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `toolIds` | array[string] | No |  |
-| `description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const assistant = await client.ai.assistants.create({
   instructions: 'You are a helpful assistant.',
-  model: 'openai/gpt-4o',
   name: 'my-resource',
+    model: 'openai/gpt-4o',
 });
 
 console.log(assistant.id);
@@ -209,7 +208,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### Update an assistant
 
@@ -220,10 +219,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistantId` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const assistant = await client.ai.assistants.update('550e8400-e29b-41d4-a716-446655440000');
@@ -237,7 +236,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### List assistants
 
@@ -260,7 +259,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Import assistants from external provider
 
@@ -292,7 +291,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Get All Tags
 
@@ -409,8 +408,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId`, `runId` |
 | Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Get Canary Deploy | `client.ai.assistants.canaryDeploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Create Canary Deploy | `client.ai.assistants.canaryDeploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistantId` |
-| Update Canary Deploy | `client.ai.assistants.canaryDeploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistantId` |
+| Create Canary Deploy | `client.ai.assistants.canaryDeploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId` |
+| Update Canary Deploy | `client.ai.assistants.canaryDeploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistantId` |
 | Delete Canary Deploy | `client.ai.assistants.canaryDeploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Assistant Sms Chat | `client.ai.assistants.sendSMS()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistantId` |
 | Clone Assistant | `client.ai.assistants.clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId` |

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-javascript/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-javascript/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -165,9 +182,15 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider — `client.ai.assistants.imports()`
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -228,10 +254,29 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 | `promoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai.assistants.canaryDeploys.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai.assistants.canaryDeploys.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
 
 ### Assistant Chat (BETA) — `client.ai.assistants.chat()`
 
@@ -254,6 +299,8 @@
 | `text` | string | Required for sms scheduled events. |
 | `conversationMetadata` | object | Metadata associated with the conversation. |
 | `dynamicVariables` | object | A map of dynamic variable names to values. |
+| `maxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retryIntervalSecs` | integer |  |
 
 ### Test Assistant Tool — `client.ai.assistants.tools.test()`
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -281,9 +331,16 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server — `client.ai.mcpServers.create()`
 

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-python/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-python/SKILL.md
@@ -45,8 +45,8 @@ import telnyx
 try:
     assistant = client.ai.assistants.create(
         instructions="You are a helpful assistant.",
-        model="openai/gpt-4o",
         name="my-resource",
+        model="openai/gpt-4o",
     )
 except telnyx.APIConnectionError:
     print("Network error — check connectivity and retry")
@@ -87,18 +87,17 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `tool_ids` | array[string] | No |  |
-| `description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```python
 assistant = client.ai.assistants.create(
     instructions="You are a helpful assistant.",
-    model="openai/gpt-4o",
     name="my-resource",
+    model="openai/gpt-4o",
 )
 print(assistant.id)
 ```
@@ -210,7 +209,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### Update an assistant
 
@@ -221,10 +220,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistant_id` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```python
 assistant = client.ai.assistants.update(
@@ -239,7 +238,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### List assistants
 
@@ -261,7 +260,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Import assistants from external provider
 
@@ -292,7 +291,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Get All Tags
 
@@ -407,8 +406,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
 | Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Get Canary Deploy | `client.ai.assistants.canary_deploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
-| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistant_id` |
-| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistant_id` |
+| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
 | Delete Canary Deploy | `client.ai.assistants.canary_deploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Assistant Sms Chat | `client.ai.assistants.send_sms()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from_`, `to`, `assistant_id` |
 | Clone Assistant | `client.ai.assistants.clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-python/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-python/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -165,9 +182,15 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider — `client.ai.assistants.imports()`
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -228,10 +254,29 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 | `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai.assistants.canary_deploys.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai.assistants.canary_deploys.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
 
 ### Assistant Chat (BETA) — `client.ai.assistants.chat()`
 
@@ -254,6 +299,8 @@
 | `text` | string | Required for sms scheduled events. |
 | `conversation_metadata` | object | Metadata associated with the conversation. |
 | `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
 
 ### Test Assistant Tool — `client.ai.assistants.tools.test()`
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -281,9 +331,16 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server — `client.ai.mcp_servers.create()`
 

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-ruby/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-ruby/SKILL.md
@@ -39,7 +39,7 @@ All API calls can fail with network errors, rate limits (429), validation errors
 or authentication errors (401). Always handle errors in production code:
 
 ```ruby
-assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", model: "openai/gpt-4o", name: "my-resource")
+assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", name: "my-resource", model: "openai/gpt-4o")
 puts(assistant)
 ```
 
@@ -70,16 +70,14 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `tool_ids` | array[string] | No |  |
-| `description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
-assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", model: "openai/gpt-4o", name: "my-resource")
-
+assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", name: "my-resource", model: "openai/gpt-4o")
 puts(assistant)
 ```
 
@@ -188,7 +186,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### Update an assistant
 
@@ -199,10 +197,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistant_id` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
 assistant = client.ai.assistants.update("550e8400-e29b-41d4-a716-446655440000")
@@ -216,7 +214,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### List assistants
 
@@ -239,7 +237,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Import assistants from external provider
 
@@ -268,7 +266,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Get All Tags
 
@@ -383,8 +381,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
 | Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Get Canary Deploy | `client.ai.assistants.canary_deploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
-| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistant_id` |
-| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistant_id` |
+| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
 | Delete Canary Deploy | `client.ai.assistants.canary_deploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Assistant Sms Chat | `client.ai.assistants.send_sms()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistant_id` |
 | Clone Assistant | `client.ai.assistants.clone_()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-ruby/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-ruby/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -165,9 +182,15 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider — `client.ai.assistants.imports()`
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -228,10 +254,29 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 | `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai.assistants.canary_deploys.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai.assistants.canary_deploys.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
 
 ### Assistant Chat (BETA) — `client.ai.assistants.chat()`
 
@@ -254,6 +299,8 @@
 | `text` | string | Required for sms scheduled events. |
 | `conversation_metadata` | object | Metadata associated with the conversation. |
 | `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
 
 ### Test Assistant Tool — `client.ai.assistants.tools.test_()`
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -281,9 +331,16 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server — `client.ai.mcp_servers.create()`
 

--- a/providers/cursor/plugin/skills/telnyx-messaging-curl/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-curl/SKILL.md
@@ -399,6 +399,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsapp_message` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```bash
 curl \

--- a/providers/cursor/plugin/skills/telnyx-messaging-curl/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-curl/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/providers/cursor/plugin/skills/telnyx-messaging-go/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-go/SKILL.md
@@ -416,6 +416,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `WhatsappMessage` | object | Yes |  |
 | `Type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `WebhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `MessagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```go
 	response, err := client.Messages.SendWhatsapp(context.Background(), telnyx.MessageSendWhatsappParams{

--- a/providers/cursor/plugin/skills/telnyx-messaging-go/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-go/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `Type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `WebhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `MessagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.MessagingHostedNumbers.Update()`
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/providers/cursor/plugin/skills/telnyx-messaging-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -420,6 +420,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsappMessage` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```java
 import com.telnyx.sdk.models.messages.MessageSendWhatsappParams;

--- a/providers/cursor/plugin/skills/telnyx-messaging-java/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-java/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messagingHostedNumbers().update()`
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/providers/cursor/plugin/skills/telnyx-messaging-javascript/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-javascript/SKILL.md
@@ -392,6 +392,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsappMessage` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```javascript
 const response = await client.messages.sendWhatsapp({

--- a/providers/cursor/plugin/skills/telnyx-messaging-javascript/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-javascript/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messagingHostedNumbers.update()`
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/providers/cursor/plugin/skills/telnyx-messaging-python/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-python/SKILL.md
@@ -385,6 +385,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsapp_message` | object | Yes |  |
 | `type_` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```python
 response = client.messages.send_whatsapp(

--- a/providers/cursor/plugin/skills/telnyx-messaging-python/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-python/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `type_` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messaging_hosted_numbers.update()`
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/providers/cursor/plugin/skills/telnyx-messaging-ruby/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-ruby/SKILL.md
@@ -353,6 +353,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsapp_message` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```ruby
 response = client.messages.send_whatsapp(from: "+13125551234", to: "+13125551234", whatsapp_message: {})

--- a/providers/cursor/plugin/skills/telnyx-messaging-ruby/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-ruby/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messaging_hosted_numbers.update()`
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/providers/cursor/plugin/skills/telnyx-numbers-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-numbers-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -278,7 +278,6 @@ Create or provision an additional resource when the core tasks do not cover this
 
 ```java
 import com.telnyx.sdk.models.advancedorders.AdvancedOrder;
-import com.telnyx.sdk.models.advancedorders.AdvancedOrderCreateParams;
 import com.telnyx.sdk.models.advancedorders.AdvancedOrderCreateResponse;
 
 AdvancedOrder params = AdvancedOrder.builder().build();

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/curl/10dlc.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/curl/10dlc.md
@@ -55,8 +55,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -207,7 +207,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `description` | string | Description of the event. |
 | `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -358,7 +358,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -398,3 +398,471 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# 10DLC (curl) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Brands, List Campaigns, List shared partner campaigns, List Shared Campaigns, List phone number campaigns
+
+| Field | Type |
+|-------|------|
+| `page` | integer |
+| `records` | array[object] |
+| `totalRecords` | integer |
+
+**Returned by:** Create Brand, Update Brand, Revet Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Get Brand Feedback By Id
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `category` | array[object] |
+
+**Returned by:** Get Brand SMS OTP Status, Get Brand SMS OTP Status by Brand ID
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `deliveryStatus` | string |
+| `deliveryStatusDate` | date-time |
+| `deliveryStatusDetails` | string |
+| `mobilePhone` | string |
+| `referenceId` | string |
+| `requestDate` | date-time |
+| `verifyDate` | date-time |
+
+**Returned by:** Get Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `assignedCampaignsCount` | number |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Order Brand External Vetting, Import External Vetting Record
+
+| Field | Type |
+|-------|------|
+| `createDate` | string |
+| `evpId` | string |
+| `vettedDate` | string |
+| `vettingClass` | string |
+| `vettingId` | string |
+| `vettingScore` | integer |
+| `vettingToken` | string |
+
+**Returned by:** Trigger Brand SMS OTP
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `referenceId` | string |
+
+**Returned by:** Get Campaign Cost
+
+| Field | Type |
+|-------|------|
+| `campaignUsecase` | string |
+| `description` | string |
+| `monthlyCost` | string |
+| `upFrontCost` | string |
+
+**Returned by:** Get campaign, Update campaign, Submit Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `autoRenewal` | boolean |
+| `billedDate` | string |
+| `brandDisplayName` | string |
+| `brandId` | string |
+| `campaignId` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createDate` | string |
+| `cspId` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isTMobileNumberPoolingEnabled` | boolean |
+| `isTMobileRegistered` | boolean |
+| `isTMobileSuspended` | boolean |
+| `messageFlow` | string |
+| `mock` | boolean |
+| `nextRenewalOrExpirationDate` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `referenceId` | string |
+| `resellerId` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `status` | string |
+| `subUsecases` | array[string] |
+| `submissionStatus` | enum: CREATED, FAILED, PENDING |
+| `subscriberHelp` | boolean |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `usecase` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Deactivate campaign
+
+| Field | Type |
+|-------|------|
+| `message` | string |
+| `record_type` | string |
+| `time` | number |
+
+**Returned by:** Submit campaign appeal for manual review
+
+| Field | Type |
+|-------|------|
+| `appealed_at` | date-time |
+
+**Returned by:** Get Campaign Mno Metadata
+
+| Field | Type |
+|-------|------|
+| `10999` | object |
+
+**Returned by:** Get Sharing Status
+
+| Field | Type |
+|-------|------|
+| `sharedByMe` | object |
+| `sharedWithMe` | object |
+
+**Returned by:** Qualify By Usecase
+
+| Field | Type |
+|-------|------|
+| `annualFee` | number |
+| `maxSubUsecases` | integer |
+| `minSubUsecases` | integer |
+| `mnoMetadata` | object |
+| `monthlyFee` | number |
+| `quarterlyFee` | number |
+| `usecase` | string |
+
+**Returned by:** Get Single Shared Campaign, Update Single Shared Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `assignedPhoneNumbersCount` | number |
+| `brandDisplayName` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createdAt` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isNumberPoolingEnabled` | boolean |
+| `messageFlow` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `subUsecases` | array[string] |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `updatedAt` | string |
+| `usecase` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Assign Messaging Profile To Campaign
+
+| Field | Type |
+|-------|------|
+| `campaignId` | string |
+| `messagingProfileId` | string |
+| `taskId` | string |
+| `tcrCampaignId` | string |
+
+**Returned by:** Get Assignment Task Status
+
+| Field | Type |
+|-------|------|
+| `createdAt` | date-time |
+| `status` | string |
+| `taskId` | string |
+| `updatedAt` | date-time |
+
+**Returned by:** Get Phone Number Status
+
+| Field | Type |
+|-------|------|
+| `records` | array[object] |
+
+**Returned by:** Create New Phone Number Campaign, Get Single Phone Number Campaign, Create New Phone Number Campaign, Delete Phone Number Campaign
+
+| Field | Type |
+|-------|------|
+| `assignmentStatus` | enum: FAILED_ASSIGNMENT, PENDING_ASSIGNMENT, ASSIGNED, PENDING_UNASSIGNMENT, FAILED_UNASSIGNMENT |
+| `brandId` | string |
+| `campaignId` | string |
+| `createdAt` | string |
+| `failureReasons` | string |
+| `phoneNumber` | string |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `telnyxCampaignId` | string |
+| `updatedAt` | string |
+
+## Optional Parameters
+
+### Create Brand
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `companyName` | string | (Required for Non-profit/private/public) Legal company name. |
+| `firstName` | string | First name of business contact. |
+| `lastName` | string | Last name of business contact. |
+| `ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `phone` | string | Valid phone number in e.164 international format. |
+| `street` | string | Street number and name. |
+| `city` | string | City name |
+| `state` | string | State. |
+| `postalCode` | string | Postal codes. |
+| `stockSymbol` | string | (Required for public company) stock symbol. |
+| `stockExchange` | object | (Required for public company) stock exchange. |
+| `ipAddress` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `website` | string | Brand website URL. |
+| `isReseller` | boolean |  |
+| `mock` | boolean | Mock brand for testing purposes. |
+| `mobilePhone` | string | Valid mobile phone number in e.164 international format. |
+| `businessContactEmail` | string | Business contact email. |
+| `webhookURL` | string | Webhook URL for brand status updates. |
+| `webhookFailoverURL` | string | Webhook failover URL for brand status updates. |
+
+### Update Brand
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `companyName` | string | (Required for Non-profit/private/public) Legal company name. |
+| `firstName` | string | First name of business contact. |
+| `lastName` | string | Last name of business contact. |
+| `ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `phone` | string | Valid phone number in e.164 international format. |
+| `street` | string | Street number and name. |
+| `city` | string | City name |
+| `state` | string | State. |
+| `postalCode` | string | Postal codes. |
+| `stockSymbol` | string | (Required for public company) stock symbol. |
+| `stockExchange` | object | (Required for public company) stock exchange. |
+| `ipAddress` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `website` | string | Brand website URL. |
+| `altBusinessIdType` | enum (NONE, DUNS, GIIN, LEI) | An enumeration. |
+| `isReseller` | boolean |  |
+| `identityStatus` | enum (VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED) | The verification status of an active brand |
+| `businessContactEmail` | string | Business contact email. |
+| `webhookURL` | string | Webhook URL for brand status updates. |
+| `webhookFailoverURL` | string | Webhook failover URL for brand status updates. |
+| `altBusinessId` | string (UUID) | Alternate business identifier such as DUNS, LEI, or GIIN |
+
+### Import External Vetting Record
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `vettingToken` | string | Required by some providers for vetting record confirmation. |
+
+### Update campaign
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `resellerId` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `sample1` | string | Message sample. |
+| `sample2` | string | Message sample. |
+| `sample3` | string | Message sample. |
+| `sample4` | string | Message sample. |
+| `sample5` | string | Message sample. |
+| `messageFlow` | string | Message flow description. |
+| `helpMessage` | string | Help message of the campaign. |
+| `autoRenewal` | boolean | Help message of the campaign. |
+| `webhookURL` | string | Webhook to which campaign status updates are sent. |
+| `webhookFailoverURL` | string | Webhook failover to which campaign status updates are sent. |
+
+### Submit Campaign
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ageGated` | boolean | Age gated message content in campaign. |
+| `autoRenewal` | boolean | Campaign subscription auto-renewal option. |
+| `directLending` | boolean | Direct lending or loan arrangement |
+| `embeddedLink` | boolean | Does message generated by the campaign include URL link in SMS? |
+| `embeddedPhone` | boolean | Does message generated by the campaign include phone number in SMS? |
+| `helpKeywords` | string | Subscriber help keywords. |
+| `helpMessage` | string | Help message of the campaign. |
+| `messageFlow` | string | Message flow description. |
+| `mnoIds` | array[integer] | Submit campaign to given list of MNOs by MNO's network ID. |
+| `numberPool` | boolean | Does campaign utilize pool of phone numbers? |
+| `optinKeywords` | string | Subscriber opt-in keywords. |
+| `optinMessage` | string | Subscriber opt-in message. |
+| `optoutKeywords` | string | Subscriber opt-out keywords. |
+| `optoutMessage` | string | Subscriber opt-out message. |
+| `referenceId` | string (UUID) | Caller supplied campaign reference ID. |
+| `resellerId` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `sample1` | string | Message sample. |
+| `sample2` | string | Message sample. |
+| `sample3` | string | Message sample. |
+| `sample4` | string | Message sample. |
+| `sample5` | string | Message sample. |
+| `subUsecases` | array[string] | Campaign sub-usecases. |
+| `subscriberHelp` | boolean | Does campaign responds to help keyword(s)? |
+| `subscriberOptin` | boolean | Does campaign require subscriber to opt-in before SMS is sent to subscriber? |
+| `subscriberOptout` | boolean | Does campaign support subscriber opt-out keyword(s)? |
+| `tag` | array[string] | Tags to be set on the Campaign. |
+| `termsAndConditions` | boolean | Is terms and conditions accepted? |
+| `privacyPolicyLink` | string | Link to the campaign's privacy policy. |
+| `termsAndConditionsLink` | string | Link to the campaign's terms and conditions. |
+| `embeddedLinkSample` | string | Sample of an embedded link that will be sent to subscribers. |
+| `webhookURL` | string | Webhook to which campaign status updates are sent. |
+| `webhookFailoverURL` | string | Failover webhook to which campaign status updates are sent. |
+
+### Update Single Shared Campaign
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `webhookURL` | string | Webhook to which campaign status updates are sent. |
+| `webhookFailoverURL` | string | Webhook failover to which campaign status updates are sent. |
+
+### Assign Messaging Profile To Campaign
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `tcrCampaignId` | string (UUID) | The TCR ID of the shared campaign you want to link to the specified messaging... |
+| `campaignId` | string (UUID) | The ID of the campaign you want to link to the specified messaging profile. |
+
+## Webhook Payload Fields
+
+### `campaignStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `brandId` | string | Brand ID associated with the campaign. |
+| `campaignId` | string | The ID of the campaign. |
+| `createDate` | string | Unix timestamp when campaign was created. |
+| `cspId` | string | Alphanumeric identifier of the CSP associated with this campaign. |
+| `isTMobileRegistered` | boolean | Indicates whether the campaign is registered with T-Mobile. |
+| `type` | enum: TELNYX_EVENT, REGISTRATION, MNO_REVIEW, TELNYX_REVIEW, NUMBER_POOL_PROVISIONED, NUMBER_POOL_DEPROVISIONED, TCR_EVENT, VERIFIED |  |
+| `description` | string | Description of the event. |
+| `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/curl/ai-assistants.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/curl/ai-assistants.md
@@ -27,10 +27,10 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-  "name": "my-resource",
-  "model": "openai/gpt-4o",
-  "instructions": "You are a helpful assistant."
-}' \
+      "name": "my-resource",
+      "instructions": "You are a helpful assistant.",
+      "model": "openai/gpt-4o"
+  }' \
   "https://api.telnyx.com/v2/ai/assistants"
 ```
 
@@ -48,7 +48,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -61,12 +61,11 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `description` | string | No |  |
-| `greeting` | string | No | Text that the assistant will use to start the conversation. |
-| ... | | | +11 optional params in the API Details section below |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in the API Details section below |
 
 ```bash
 curl \
@@ -74,10 +73,10 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-  "name": "my-resource",
-  "model": "openai/gpt-4o",
-  "instructions": "You are a helpful assistant."
-}' \
+      "name": "my-resource",
+      "instructions": "You are a helpful assistant.",
+      "model": "openai/gpt-4o"
+  }' \
   "https://api.telnyx.com/v2/ai/assistants"
 ```
 
@@ -195,7 +194,7 @@ Primary response fields:
 - `.data.created_at`
 - `.data.description`
 - `.data.dynamic_variables`
-- `.data.dynamic_variables_webhook_url`
+- `.data.dynamic_variables_webhook_timeout_ms`
 
 ### Update an assistant
 
@@ -206,10 +205,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistant_id` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +15 optional params in the API Details section below |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in the API Details section below |
 
 ```bash
 curl \
@@ -225,7 +224,7 @@ Primary response fields:
 - `.data.created_at`
 - `.data.description`
 - `.data.dynamic_variables`
-- `.data.dynamic_variables_webhook_url`
+- `.data.dynamic_variables_webhook_timeout_ms`
 
 ### List assistants
 
@@ -246,7 +245,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Import assistants from external provider
 
@@ -281,7 +280,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Get All Tags
 
@@ -375,7 +374,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -388,8 +387,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | HTTP only | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
 | Delete an assistant | HTTP only | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Get Canary Deploy | HTTP only | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
-| Create Canary Deploy | HTTP only | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistant_id` |
-| Update Canary Deploy | HTTP only | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistant_id` |
+| Create Canary Deploy | HTTP only | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | HTTP only | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
 | Delete Canary Deploy | HTTP only | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Assistant Sms Chat | HTTP only | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistant_id` |
 | Clone Assistant | HTTP only | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |
@@ -400,6 +399,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Add Assistant Tag | HTTP only | `POST /ai/assistants/{assistant_id}/tags` | Create or provision an additional resource when the core tasks do not cover this flow. | `tag`, `assistant_id` |
 | Remove Assistant Tag | HTTP only | `DELETE /ai/assistants/{assistant_id}/tags/{tag}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `tag` |
 | Get assistant texml | HTTP only | `GET /ai/assistants/{assistant_id}/texml` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Add Assistant Tool | HTTP only | `PUT /ai/assistants/{assistant_id}/tools/{tool_id}` | Modify an existing resource without recreating it. | `assistant_id`, `tool_id` |
+| Remove Assistant Tool | HTTP only | `DELETE /ai/assistants/{assistant_id}/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `tool_id` |
 | Test Assistant Tool | HTTP only | `POST /ai/assistants/{assistant_id}/tools/{tool_id}/test` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id`, `tool_id` |
 | Get all versions of an assistant | HTTP only | `GET /ai/assistants/{assistant_id}/versions` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
 | Get a specific assistant version | HTTP only | `GET /ai/assistants/{assistant_id}/versions/{version_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id`, `version_id` |
@@ -411,7 +412,398 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get MCP Server | HTTP only | `GET /ai/mcp_servers/{mcp_server_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `mcp_server_id` |
 | Update MCP Server | HTTP only | `PUT /ai/mcp_servers/{mcp_server_id}` | Modify an existing resource without recreating it. | `mcp_server_id` |
 | Delete MCP Server | HTTP only | `DELETE /ai/mcp_servers/{mcp_server_id}` | Remove, detach, or clean up an existing resource. | `mcp_server_id` |
+| List Tools | HTTP only | `GET /ai/tools` | Inspect available resources or choose an existing resource before mutating it. | None |
+| Create Tool | HTTP only | `POST /ai/tools` | Create or provision an additional resource when the core tasks do not cover this flow. | `type`, `display_name` |
+| Get Tool | HTTP only | `GET /ai/tools/{tool_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `tool_id` |
+| Update Tool | HTTP only | `PATCH /ai/tools/{tool_id}` | Modify an existing resource without recreating it. | `tool_id` |
+| Delete Tool | HTTP only | `DELETE /ai/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `tool_id` |
 
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# AI Assistants (curl) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+
+## Response Schemas
+
+**Returned by:** List assistants, Create an assistant, Import assistants from external provider, Get an assistant, Update an assistant, Clone Assistant, Get all versions of an assistant, Get a specific assistant version, Update a specific assistant version, Promote an assistant version to main
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
+| `dynamic_variables_webhook_url` | string |
+| `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
+| `greeting` | string |
+| `id` | string |
+| `import_metadata` | object |
+| `insight_settings` | object |
+| `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
+| `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
+| `messaging_settings` | object |
+| `model` | string |
+| `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
+| `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
+| `telephony_settings` | object |
+| `tools` | array[object] |
+| `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
+| `voice_settings` | object |
+| `widget_settings` | object |
+
+**Returned by:** Get All Tags, Add Assistant Tag, Remove Assistant Tag
+
+| Field | Type |
+|-------|------|
+| `tags` | array[string] |
+
+**Returned by:** List assistant tests with pagination, Create a new assistant test, Get assistant test by ID, Update an assistant test
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `destination` | string |
+| `instructions` | string |
+| `max_duration_seconds` | integer |
+| `name` | string |
+| `rubric` | array[object] |
+| `telnyx_conversation_channel` | object |
+| `test_id` | uuid |
+| `test_suite` | string |
+
+**Returned by:** Get all test suite names
+
+| Field | Type |
+|-------|------|
+| `data` | array[string] |
+
+**Returned by:** Get test suite run history, Get test run history for a specific test, Trigger a manual test run, Get specific test run details
+
+| Field | Type |
+|-------|------|
+| `completed_at` | date-time |
+| `conversation_id` | string |
+| `conversation_insights_id` | string |
+| `created_at` | date-time |
+| `detail_status` | array[object] |
+| `logs` | string |
+| `run_id` | uuid |
+| `status` | enum: pending, starting, running, passed, failed, error |
+| `test_id` | uuid |
+| `test_suite_run_id` | uuid |
+| `triggered_by` | string |
+| `updated_at` | date-time |
+
+**Returned by:** Delete an assistant
+
+| Field | Type |
+|-------|------|
+| `deleted` | boolean |
+| `id` | string |
+| `object` | string |
+
+**Returned by:** Get Canary Deploy, Create Canary Deploy, Update Canary Deploy
+
+| Field | Type |
+|-------|------|
+| `assistant_id` | string |
+| `created_at` | date-time |
+| `rules` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Assistant Chat (BETA)
+
+| Field | Type |
+|-------|------|
+| `content` | string |
+
+**Returned by:** Assistant Sms Chat
+
+| Field | Type |
+|-------|------|
+| `conversation_id` | string |
+
+**Returned by:** List scheduled events
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Test Assistant Tool
+
+| Field | Type |
+|-------|------|
+| `content_type` | string |
+| `request` | object |
+| `response` | string |
+| `status_code` | integer |
+| `success` | boolean |
+
+**Returned by:** Create MCP Server, Get MCP Server, Update MCP Server
+
+| Field | Type |
+|-------|------|
+| `allowed_tools` | array \| null |
+| `api_key_ref` | string \| null |
+| `created_at` | date-time |
+| `id` | string |
+| `name` | string |
+| `type` | string |
+| `url` | string |
+
+**Returned by:** List Tools, Create Tool, Get Tool, Update Tool
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `display_name` | string |
+| `id` | string |
+| `timeout_ms` | integer |
+| `tool_definition` | object |
+| `type` | string |
+
+## Optional Parameters
+
+### Create an assistant
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
+| `transcription` | object |  |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+
+### Import assistants from external provider
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `import_ids` | array[string] | Optional list of assistant IDs to import from the external provider. |
+
+### Create a new assistant test
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `description` | string | Optional detailed description of what this test evaluates and its purpose. |
+| `telnyx_conversation_channel` | object | The communication channel through which the test will be conducted. |
+| `max_duration_seconds` | integer | Maximum duration in seconds that the test conversation should run before timi... |
+| `test_suite` | string | Optional test suite name to group related tests together. |
+
+### Trigger test suite execution
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `destination_version_id` | string (UUID) | Optional assistant version ID to use for all test runs in this suite. |
+
+### Update an assistant test
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | Updated name for the assistant test. |
+| `description` | string | Updated description of the test's purpose and evaluation criteria. |
+| `telnyx_conversation_channel` | enum (phone_call, web_call, sms_chat, web_chat) |  |
+| `destination` | string | Updated target destination for test conversations. |
+| `max_duration_seconds` | integer | Updated maximum test duration in seconds. |
+| `test_suite` | string | Updated test suite assignment for better organization. |
+| `instructions` | string | Updated test scenario instructions and objectives. |
+| `rubric` | array[object] | Updated evaluation criteria for assessing assistant performance. |
+
+### Trigger a manual test run
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `destination_version_id` | string (UUID) | Optional assistant version ID to use for this test run. |
+
+### Update an assistant
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `instructions` | string | System instructions for the assistant. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
+| `transcription` | object |  |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+| `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Assistant Chat (BETA)
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | The optional display name of the user sending the message |
+
+### Assistant Sms Chat
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string |  |
+| `conversation_metadata` | object |  |
+| `should_create_conversation` | boolean |  |
+
+### Create a scheduled event
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Required for sms scheduled events. |
+| `conversation_metadata` | object | Metadata associated with the conversation. |
+| `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
+
+### Test Assistant Tool
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `arguments` | object | Key-value arguments to use for the webhook test |
+| `dynamic_variables` | object | Key-value dynamic variables to use for the webhook test |
+
+### Update a specific assistant version
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `instructions` | string | System instructions for the assistant. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
+| `transcription` | object |  |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+
+### Create MCP Server
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `api_key_ref` | string |  |
+| `allowed_tools` | array[string] |  |
+
+### Update MCP Server
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `name` | string |  |
+| `type` | string |  |
+| `url` | string (URL) |  |
+| `api_key_ref` | string |  |
+| `allowed_tools` | array[string] |  |
+| `created_at` | string (date-time) |  |
+
+### Create Tool
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `function` | object |  |
+| `retrieval` | object |  |
+| `handoff` | object |  |
+| `invite` | object |  |
+| `webhook` | object |  |
+| `timeout_ms` | integer |  |
+
+### Update Tool
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type` | string |  |
+| `display_name` | string |  |
+| `function` | object |  |
+| `retrieval` | object |  |
+| `handoff` | object |  |
+| `invite` | object |  |
+| `webhook` | object |  |
+| `timeout_ms` | integer |  |

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/curl/messaging.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/curl/messaging.md
@@ -54,8 +54,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -183,7 +183,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.media` | array[object] |  |
 | `data.record_type` | enum: event | Identifies the type of the resource. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -386,6 +386,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsapp_message` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```bash
 curl \
@@ -413,7 +414,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -447,3 +448,425 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Messaging (curl) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List alphanumeric sender IDs, Create an alphanumeric sender ID, Retrieve an alphanumeric sender ID, Delete an alphanumeric sender ID, List alphanumeric sender IDs for a messaging profile
+
+| Field | Type |
+|-------|------|
+| `alphanumeric_sender_id` | string |
+| `id` | uuid |
+| `messaging_profile_id` | uuid |
+| `organization_id` | string |
+| `record_type` | enum: alphanumeric_sender_id |
+| `us_long_code_fallback` | string |
+
+**Returned by:** Send a message, Send a message using an alphanumeric sender ID, Retrieve group MMS messages, Send a group MMS message, Send a long code message, Send a message using number pool, Schedule a message, Send a short code message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `wait_seconds` | float |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** Send a WhatsApp message
+
+| Field | Type |
+|-------|------|
+| `body` | object |
+| `direction` | string |
+| `encoding` | string |
+| `from` | object |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `organization_id` | string |
+| `received_at` | date-time |
+| `record_type` | string |
+| `to` | array[object] |
+| `type` | string |
+| `wait_seconds` | float |
+
+**Returned by:** Retrieve a message, Get detailed messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Cancel a scheduled message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** List messaging hosted numbers, Retrieve a messaging hosted number, Update a messaging hosted number
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `eligible_messaging_products` | array[string] |
+| `features` | object |
+| `health` | object |
+| `id` | string |
+| `messaging_product` | string |
+| `messaging_profile_id` | string \| null |
+| `organization_id` | string |
+| `phone_number` | string |
+| `record_type` | enum: messaging_phone_number, messaging_settings |
+| `tags` | array[string] |
+| `traffic_type` | string |
+| `type` | enum: long-code, toll-free, short-code, longcode, tollfree, shortcode |
+| `updated_at` | date-time |
+
+**Returned by:** List opt-outs
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `from` | string |
+| `keyword` | string \| null |
+| `messaging_profile_id` | string \| null |
+| `to` | string |
+
+**Returned by:** List high-level messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Regenerate messaging profile secret
+
+| Field | Type |
+|-------|------|
+| `ai_assistant_id` | string \| null |
+| `alpha_sender` | string \| null |
+| `created_at` | date-time |
+| `daily_spend_limit` | string |
+| `daily_spend_limit_enabled` | boolean |
+| `enabled` | boolean |
+| `health_webhook_url` | url |
+| `id` | uuid |
+| `mms_fall_back_to_sms` | boolean |
+| `mms_transcoding` | boolean |
+| `mobile_only` | boolean |
+| `name` | string |
+| `number_pool_settings` | object \| null |
+| `organization_id` | string |
+| `record_type` | enum: messaging_profile |
+| `redaction_enabled` | boolean |
+| `redaction_level` | integer |
+| `resource_group_id` | string \| null |
+| `smart_encoding` | boolean |
+| `updated_at` | date-time |
+| `url_shortener_settings` | object \| null |
+| `v1_secret` | string |
+| `webhook_api_version` | enum: 1, 2, 2010-04-01 |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+| `whitelisted_destinations` | array[string] |
+
+**Returned by:** List Auto-Response Settings, Create auto-response setting, Get Auto-Response Setting, Update Auto-Response Setting
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `id` | string |
+| `keywords` | array[string] |
+| `op` | enum: start, stop, info |
+| `resp_text` | string |
+| `updated_at` | date-time |
+
+## Optional Parameters
+
+### Create an alphanumeric sender ID
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `us_long_code_fallback` | string | A US long code number to use as fallback when sending to US destinations. |
+
+### Send a message
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using an alphanumeric sender ID
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `webhook_url` | string (URL) | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | If true, use the messaging profile's webhook settings. |
+
+### Send a group MMS message
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+
+### Send a long code message
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using number pool
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Schedule a message
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+
+### Send a short code message
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a WhatsApp message
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
+
+### Update a messaging hosted number
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `messaging_profile_id` | string (UUID) | Configure the messaging profile this phone number is assigned to:
+
+* Omit thi... |
+| `messaging_product` | string | Configure the messaging product for this number:
+
+* Omit this field or set it... |
+| `tags` | array[string] | Tags to set on this phone number. |
+
+### Create auto-response setting
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `resp_text` | string |  |
+
+### Update Auto-Response Setting
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `resp_text` | string |  |
+
+## Webhook Payload Fields
+
+### `deliveryUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.sent, message.finalized | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: outbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | uuid | The id of the organization the messaging profile belongs to. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Subject of multimedia message |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | ISO 8601 formatted date indicating when the message was sent. |
+| `data.payload.completed_at` | date-time | ISO 8601 formatted date indicating when the message was finalized. |
+| `data.payload.valid_until` | date-time | Message must be out of the queue by this time or else it will be discarded and marked as 'sending_failed'. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+| `data.payload.smart_encoding_applied` | boolean | Indicates whether smart encoding was applied to this message. |
+| `data.payload.wait_seconds` | float | Seconds the message is queued due to rate limiting before being sent to the carrier. |
+| `meta.attempt` | integer | Number of attempts to deliver the webhook event. |
+| `meta.delivered_to` | url | The webhook URL the event was delivered to. |
+
+### `inboundMessage`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.received | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: inbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Message subject. |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | Not used for inbound messages. |
+| `data.payload.completed_at` | date-time | Not used for inbound messages. |
+| `data.payload.valid_until` | date-time | Not used for inbound messages. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+
+### `replacedLinkClick`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | string | Identifies the type of the resource. |
+| `data.url` | string | The original link that was sent in the message. |
+| `data.to` | string | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or short code). |
+| `data.message_id` | uuid | The message ID associated with the clicked link. |
+| `data.time_clicked` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+
+### Field Type Notes
+
+- `from` in responses/webhooks: object with sub-fields `phone_number` (string), `carrier` (string), `line_type` (string)
+- `to` in responses/webhooks: array of objects, each with `phone_number` (string), `carrier` (string), `line_type` (string), `status` (string)
+- `cost`: object with `amount` (string, decimal), `currency` (string, e.g., 'USD')

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/curl/numbers.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/curl/numbers.md
@@ -39,7 +39,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -352,7 +352,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -402,3 +402,433 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Numbers (curl) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Advanced Orders, Create Advanced Order, Update Advanced Order, Get Advanced Order
+
+| Field | Type |
+|-------|------|
+| `area_code` | string |
+| `comments` | string |
+| `country_code` | string |
+| `customer_reference` | string |
+| `features` | array[object] |
+| `id` | uuid |
+| `orders` | array[string] |
+| `phone_number_type` | object |
+| `quantity` | integer |
+| `requirement_group_id` | uuid |
+| `status` | object |
+
+**Returned by:** List available phone number blocks
+
+| Field | Type |
+|-------|------|
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `range` | integer |
+| `record_type` | enum: available_phone_number_block |
+| `region_information` | array[object] |
+
+**Returned by:** List available phone numbers
+
+| Field | Type |
+|-------|------|
+| `best_effort` | boolean |
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `quickship` | boolean |
+| `record_type` | enum: available_phone_number |
+| `region_information` | array[object] |
+| `reservable` | boolean |
+| `vanity_format` | string |
+
+**Returned by:** Retrieve all comments
+
+| Field | Type |
+|-------|------|
+| `body` | string |
+| `comment_record_id` | uuid |
+| `comment_record_type` | enum: sub_number_order, requirement_group |
+| `commenter` | string |
+| `commenter_type` | enum: admin, user |
+| `created_at` | date-time |
+| `id` | uuid |
+| `read_at` | date-time |
+| `updated_at` | date-time |
+
+**Returned by:** Create a comment, Retrieve a comment, Mark a comment as read, Get country coverage
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Get coverage for a specific country
+
+| Field | Type |
+|-------|------|
+| `code` | string |
+| `features` | array[string] |
+| `international_sms` | boolean |
+| `inventory_coverage` | boolean |
+| `local` | object |
+| `mobile` | object |
+| `national` | object |
+| `numbers` | boolean |
+| `p2p` | boolean |
+| `phone_number_type` | array[string] |
+| `quickship` | boolean |
+| `region` | string \| null |
+| `reservable` | boolean |
+| `shared_cost` | object |
+| `toll_free` | object |
+
+**Returned by:** List customer service records, Create a customer service record, Get a customer service record
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `error_message` | string \| null |
+| `id` | uuid |
+| `phone_number` | string |
+| `record_type` | string |
+| `result` | object \| null |
+| `status` | enum: pending, completed, failed |
+| `updated_at` | date-time |
+| `webhook_url` | string |
+
+**Returned by:** Verify CSR phone number coverage
+
+| Field | Type |
+|-------|------|
+| `additional_data_required` | array[string] |
+| `has_csr_coverage` | boolean |
+| `phone_number` | string |
+| `reason` | string |
+| `record_type` | string |
+
+**Returned by:** List inexplicit number orders, Create an inexplicit number order, Retrieve an inexplicit number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `ordering_groups` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Create an inventory coverage request
+
+| Field | Type |
+|-------|------|
+| `administrative_area` | string |
+| `advance_requirements` | boolean |
+| `count` | integer |
+| `coverage_type` | enum: number, block |
+| `group` | string |
+| `group_type` | string |
+| `number_range` | integer |
+| `number_type` | enum: did, toll-free |
+| `phone_number_type` | enum: local, toll_free, national, landline, shared_cost, mobile |
+| `record_type` | string |
+
+**Returned by:** List mobile network operators
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `id` | uuid |
+| `mcc` | string |
+| `mnc` | string |
+| `name` | string |
+| `network_preferences_enabled` | boolean |
+| `record_type` | string |
+| `tadig` | string |
+
+**Returned by:** List network coverage locations
+
+| Field | Type |
+|-------|------|
+| `available_services` | array[object] |
+| `location` | object |
+| `record_type` | string |
+
+**Returned by:** List number block orders, Create a number block order, Retrieve a number block order
+
+| Field | Type |
+|-------|------|
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers_count` | integer |
+| `range` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `starting_number` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve a list of phone numbers associated to orders, Retrieve a single phone number within a number order., Update requirements for a single phone number within a number order.
+
+| Field | Type |
+|-------|------|
+| `bundle_id` | uuid |
+| `country_code` | string |
+| `deadline` | date-time |
+| `id` | uuid |
+| `is_block_number` | boolean |
+| `locality` | string |
+| `order_request_id` | uuid |
+| `phone_number` | string |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `requirements_status` | enum: pending, approved, cancelled, deleted, requirement-info-exception, requirement-info-pending, requirement-info-under-review |
+| `status` | enum: pending, success, failure |
+| `sub_number_order_id` | uuid |
+
+**Returned by:** List number orders, Create a number order, Retrieve a number order, Update a number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers` | array[object] |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `sub_number_orders_ids` | array[string] |
+| `updated_at` | date-time |
+
+**Returned by:** List number reservations, Create a number reservation, Retrieve a number reservation, Extend a number reservation
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `errors` | string |
+| `id` | uuid |
+| `phone_numbers` | array[object] |
+| `record_type` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve the features for a list of numbers
+
+| Field | Type |
+|-------|------|
+| `features` | array[string] |
+| `phone_number` | string |
+
+**Returned by:** Lists the phone number blocks jobs, Deletes all numbers associated with a phone number block, Retrieves a phone number blocks job
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `etc` | date-time |
+| `failed_operations` | array[object] |
+| `id` | uuid |
+| `record_type` | string |
+| `status` | enum: pending, in_progress, completed, failed |
+| `successful_operations` | array[object] |
+| `type` | enum: delete_phone_number_block |
+| `updated_at` | string |
+
+**Returned by:** List sub number orders, Retrieve a sub number order, Update a sub number order's requirements, Cancel a sub number order
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `is_block_sub_number_order` | boolean |
+| `order_request_id` | uuid |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+**Returned by:** Create a sub number orders report, Retrieve a sub number orders report
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `filters` | object |
+| `id` | uuid |
+| `order_type` | string |
+| `status` | enum: pending, success, failed, expired |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+## Optional Parameters
+
+### Create Advanced Order
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `country_code` | string (ISO 3166-1 alpha-2) |  |
+| `comments` | string |  |
+| `quantity` | integer |  |
+| `area_code` | string |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `features` | array[object] |  |
+| `customer_reference` | string |  |
+| `requirement_group_id` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Update Advanced Order
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `country_code` | string (ISO 3166-1 alpha-2) |  |
+| `comments` | string |  |
+| `quantity` | integer |  |
+| `area_code` | string |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `features` | array[object] |  |
+| `customer_reference` | string |  |
+| `requirement_group_id` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Create a comment
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `body` | string |  |
+| `commenter` | string |  |
+| `commenter_type` | enum (admin, user) |  |
+| `comment_record_type` | enum (sub_number_order, requirement_group) |  |
+| `comment_record_id` | string (UUID) |  |
+| `read_at` | string (date-time) | An ISO 8901 datetime string for when the comment was read. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the comment was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the comment was updated. |
+
+### Create an inexplicit number order
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `connection_id` | string (UUID) | Connection id to apply to phone numbers that are purchased |
+| `messaging_profile_id` | string (UUID) | Messaging profile id to apply to phone numbers that are purchased |
+| `customer_reference` | string | Reference label for the customer |
+| `billing_group_id` | string (UUID) | Billing group id to apply to phone numbers that are purchased |
+
+### Create a number block order
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `record_type` | string |  |
+| `phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `connection_id` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `status` | enum (pending, success, failure) | The status of the order. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the number order was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the number order was updated. |
+| `requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `errors` | string | Errors the reservation could happen upon |
+
+### Update requirements for a single phone number within a number order.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatory_requirements` | array[object] |  |
+
+### Create a number order
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `phone_numbers` | array[object] |  |
+| `connection_id` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `billing_group_id` | string (UUID) | Identifies the billing group associated with the phone number. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+
+### Update a number order
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatory_requirements` | array[object] |  |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+
+### Create a number reservation
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `record_type` | string |  |
+| `phone_numbers` | array[object] |  |
+| `status` | enum (pending, success, failure) | The status of the entire reservation. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the numbers reservation was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the number reservation was updated. |
+
+### Update a sub number order's requirements
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatory_requirements` | array[object] |  |
+
+### Create a sub number orders report
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `status` | enum (pending, success, failure) | Filter by order status |
+| `country_code` | string (ISO 3166-1 alpha-2) | Filter by country code |
+| `created_at_gt` | string (date-time) | Filter for orders created after this date |
+| `created_at_lt` | string (date-time) | Filter for orders created before this date |
+| `order_request_id` | string (UUID) | Filter by specific order request ID |
+| `customer_reference` | string | Filter by customer reference |
+
+## Webhook Payload Fields
+
+### `numberOrderStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.event_type` | string | The type of event being sent |
+| `data.id` | uuid | Unique identifier for the event |
+| `data.occurred_at` | date-time | ISO 8601 timestamp of when the event occurred |
+| `data.payload.id` | uuid |  |
+| `data.payload.record_type` | string |  |
+| `data.payload.phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `data.payload.connection_id` | string | Identifies the connection associated with this phone number. |
+| `data.payload.messaging_profile_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.billing_group_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.phone_numbers` | array[object] |  |
+| `data.payload.sub_number_orders_ids` | array[string] |  |
+| `data.payload.status` | enum: pending, success, failure | The status of the order. |
+| `data.payload.customer_reference` | string | A customer reference string for customer look ups. |
+| `data.payload.created_at` | date-time | An ISO 8901 datetime string denoting when the number order was created. |
+| `data.payload.updated_at` | date-time | An ISO 8901 datetime string for when the number order was updated. |
+| `data.payload.requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `data.record_type` | string | Type of record |
+| `meta.attempt` | integer | Webhook delivery attempt number |
+| `meta.delivered_to` | uri | URL where the webhook was delivered |

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/curl/voice.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/curl/voice.md
@@ -54,8 +54,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -73,7 +73,7 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in the API Details section below |
+| ... | | | +56 optional params in the API Details section below |
 
 ```bash
 curl \
@@ -108,7 +108,7 @@ Primary inbound call-control command.
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in the API Details section below |
+| ... | | | +29 optional params in the API Details section below |
 
 ```bash
 curl \
@@ -135,7 +135,7 @@ Common post-answer control path with downstream webhook implications.
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in the API Details section below |
+| ... | | | +35 optional params in the API Details section below |
 
 ```bash
 curl \
@@ -143,7 +143,7 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-  "to": "+18005550100"
+  "to": "+18005550100;secure=srtp"
 }' \
   "https://api.telnyx.com/v2/calls/v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ/actions/transfer"
 ```
@@ -213,7 +213,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
 | `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -383,7 +383,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -403,3 +403,427 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Voice (curl) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List call control applications, Create a call control application, Retrieve a call control application, Update a call control application, Delete a call control application
+
+| Field | Type |
+|-------|------|
+| `active` | boolean |
+| `anchorsite_override` | enum: Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, Chennai, IN, Amsterdam, Netherlands, Toronto, Canada, Sydney, Australia |
+| `application_name` | string |
+| `call_cost_in_webhooks` | boolean |
+| `created_at` | string |
+| `dtmf_type` | enum: RFC 2833, Inband, SIP INFO |
+| `first_command_timeout` | boolean |
+| `first_command_timeout_secs` | integer |
+| `id` | string |
+| `inbound` | object |
+| `outbound` | object |
+| `record_type` | enum: call_control_application |
+| `redact_dtmf_debug_logging` | boolean |
+| `tags` | array[string] |
+| `updated_at` | string |
+| `webhook_api_version` | enum: 1, 2 |
+| `webhook_event_failover_url` | url |
+| `webhook_event_url` | url |
+| `webhook_timeout_secs` | integer \| null |
+
+**Returned by:** Dial
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `recording_id` | uuid |
+| `start_time` | string |
+
+**Returned by:** Retrieve a call status
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `start_time` | string |
+
+**Returned by:** Answer call
+
+| Field | Type |
+|-------|------|
+| `recording_id` | uuid |
+| `result` | string |
+
+**Returned by:** Bridge calls, Hangup call, SIP Refer a call, Reject a call, Send SIP info, Transfer call
+
+| Field | Type |
+|-------|------|
+| `result` | string |
+
+**Returned by:** List all active calls for given connection
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `record_type` | enum: call |
+
+## Optional Parameters
+
+### Create a call control application
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `active` | boolean | Specifies whether the connection can be used. |
+| `anchorsite_override` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmf_type` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `first_command_timeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `first_command_timeout_secs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `inbound` | object |  |
+| `outbound` | object |  |
+| `webhook_api_version` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhook_event_failover_url` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhook_timeout_secs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `call_cost_in_webhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `redact_dtmf_debug_logging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Update a call control application
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `call_cost_in_webhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `active` | boolean | Specifies whether the connection can be used. |
+| `anchorsite_override` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmf_type` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `first_command_timeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `first_command_timeout_secs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `tags` | array[string] | Tags assigned to the Call Control Application. |
+| `inbound` | object |  |
+| `outbound` | object |  |
+| `webhook_api_version` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhook_event_failover_url` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhook_timeout_secs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `redact_dtmf_debug_logging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Dial
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
+| `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
+| `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
+| `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `link_to` | string | Use another call's control id for sharing the same call session id |
+| `bridge_intent` | boolean | Indicates the intent to bridge this call with the call specified in link_to. |
+| `bridge_on_answer` | boolean | Whether to automatically bridge answered call to the call specified in link_to. |
+| `prevent_double_bridge` | boolean | Prevents bridging and hangs up the call if the target is already bridged. |
+| `park_after_unbridge` | string | If supplied with the value `self`, the current leg will be parked after unbri... |
+| `media_encryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the call. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE request. |
+| `sip_transport_protocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `stream_url` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `stream_track` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `stream_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `stream_bidirectional_mode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `stream_bidirectional_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `stream_bidirectional_target_legs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `stream_bidirectional_sampling_rate` | enum (8000, 16000, 22050, 24000, 48000) | Audio sampling rate. |
+| `stream_establish_before_call_originate` | boolean | Establish websocket connection before dialing the destination. |
+| `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `supervise_call_control_id` | string (UUID) | The call leg which will be supervised by the new call. |
+| `supervisor_role` | enum (barge, whisper, monitor) | The role of the supervisor call. |
+| `enable_dialogflow` | boolean | Enables Dialogflow for the current call. |
+| `dialogflow_config` | object |  |
+| `transcription` | boolean | Enable transcription upon call answer. |
+| `transcription_config` | object |  |
+| `sip_region` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `stream_auth_token` | string | An authentication token to be sent as part of the WebSocket connection when u... |
+
+### Answer call
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE response. |
+| `preferred_codecs` | enum (G722,PCMU,PCMA,G729,OPUS,VP8,H264) | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE response. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `stream_url` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `stream_track` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `stream_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `stream_bidirectional_mode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `stream_bidirectional_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `stream_bidirectional_target_legs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `transcription` | boolean | Enable transcription upon call answer. |
+| `transcription_config` | object |  |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
+
+### Bridge calls
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `queue` | string | The name of the queue you want to bridge with, can't be used together with ca... |
+| `video_room_id` | string (UUID) | The ID of the video room you want to bridge with, can't be used together with... |
+| `video_room_context` | string | The additional parameter that will be passed to the video conference. |
+| `prevent_double_bridge` | boolean | When set to `true`, it prevents bridging if the target call is already bridge... |
+| `park_after_unbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `play_ringtone` | boolean | Specifies whether to play a ringtone if the call you want to bridge with has ... |
+| `ringtone` | enum (at, au, be, bg, br, ...) | Specifies which country ringtone to play when `play_ringtone` is set to `true`. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `mute_dtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `hold_after_unbridge` | boolean | Specifies behavior after the bridge ends. |
+
+### Hangup call
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP BYE message. |
+
+### SIP Refer a call
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid execution of duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the request. |
+
+### Reject a call
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Send SIP info
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Transfer call
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
+| `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
+| `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
+| `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
+| `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `park_after_unbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `target_leg_client_state` | string | Use this field to add state to every subsequent webhook for the new leg. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `media_encryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the new call leg. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE. |
+| `sip_transport_protocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `mute_dtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `sip_region` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `preferred_codecs` | string | The list of comma-separated codecs in order of preference to be used during t... |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+
+## Webhook Payload Fields
+
+### `callAnswered`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.answered | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: answered | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### `callBridged`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.bridged | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+
+### `callHangup`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.hangup | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: hangup | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+| `data.payload.hangup_cause` | enum: call_rejected, normal_clearing, originator_cancel, timeout, time_limit, user_busy, not_found, no_answer, unspecified | The reason the call was ended (`call_rejected`, `normal_clearing`, `originator_cancel`, `timeout`, `time_limit`, `use... |
+| `data.payload.hangup_source` | enum: caller, callee, unknown | The party who ended the call (`callee`, `caller`, `unknown`). |
+| `data.payload.sip_hangup_cause` | string | The reason the call was ended (SIP response code). |
+| `data.payload.call_quality_stats` | object \| null | Call quality statistics aggregated from the CHANNEL_HANGUP_COMPLETE event. |
+
+### `callInitiated`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.initiated | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
+| `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.custom_headers` | array[object] | Custom headers from sip invite |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.shaken_stir_attestation` | string | SHAKEN/STIR attestation level. |
+| `data.payload.shaken_stir_validated` | boolean | Whether attestation was successfully validated or not. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.caller_id_name` | string | Caller id. |
+| `data.payload.call_screening_result` | string | Call screening result. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.direction` | enum: incoming, outgoing | Whether the call is `incoming` or `outgoing`. |
+| `data.payload.state` | enum: parked, bridging | State received from a command. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### Field Type Notes
+
+- `from` in webhook payloads: string (E.164 phone number)
+- `to` in webhook payloads: string (E.164 phone number)
+- The return value of `client.webhooks.unwrap()` is a parsed event object — access fields via `event.data.event_type`, `event.data.payload.call_control_id`, etc.

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/go/10dlc.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/go/10dlc.md
@@ -78,8 +78,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -228,7 +228,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `description` | string | Description of the event. |
 | `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -406,7 +406,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -446,3 +446,471 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# 10DLC (Go) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Brands, List Campaigns, List shared partner campaigns, List Shared Campaigns, List phone number campaigns
+
+| Field | Type |
+|-------|------|
+| `page` | integer |
+| `records` | array[object] |
+| `totalRecords` | integer |
+
+**Returned by:** Create Brand, Update Brand, Revet Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Get Brand Feedback By Id
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `category` | array[object] |
+
+**Returned by:** Get Brand SMS OTP Status, Get Brand SMS OTP Status by Brand ID
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `deliveryStatus` | string |
+| `deliveryStatusDate` | date-time |
+| `deliveryStatusDetails` | string |
+| `mobilePhone` | string |
+| `referenceId` | string |
+| `requestDate` | date-time |
+| `verifyDate` | date-time |
+
+**Returned by:** Get Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `assignedCampaignsCount` | number |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Order Brand External Vetting, Import External Vetting Record
+
+| Field | Type |
+|-------|------|
+| `createDate` | string |
+| `evpId` | string |
+| `vettedDate` | string |
+| `vettingClass` | string |
+| `vettingId` | string |
+| `vettingScore` | integer |
+| `vettingToken` | string |
+
+**Returned by:** Trigger Brand SMS OTP
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `referenceId` | string |
+
+**Returned by:** Get Campaign Cost
+
+| Field | Type |
+|-------|------|
+| `campaignUsecase` | string |
+| `description` | string |
+| `monthlyCost` | string |
+| `upFrontCost` | string |
+
+**Returned by:** Get campaign, Update campaign, Submit Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `autoRenewal` | boolean |
+| `billedDate` | string |
+| `brandDisplayName` | string |
+| `brandId` | string |
+| `campaignId` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createDate` | string |
+| `cspId` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isTMobileNumberPoolingEnabled` | boolean |
+| `isTMobileRegistered` | boolean |
+| `isTMobileSuspended` | boolean |
+| `messageFlow` | string |
+| `mock` | boolean |
+| `nextRenewalOrExpirationDate` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `referenceId` | string |
+| `resellerId` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `status` | string |
+| `subUsecases` | array[string] |
+| `submissionStatus` | enum: CREATED, FAILED, PENDING |
+| `subscriberHelp` | boolean |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `usecase` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Deactivate campaign
+
+| Field | Type |
+|-------|------|
+| `message` | string |
+| `record_type` | string |
+| `time` | number |
+
+**Returned by:** Submit campaign appeal for manual review
+
+| Field | Type |
+|-------|------|
+| `appealed_at` | date-time |
+
+**Returned by:** Get Campaign Mno Metadata
+
+| Field | Type |
+|-------|------|
+| `10999` | object |
+
+**Returned by:** Get Sharing Status
+
+| Field | Type |
+|-------|------|
+| `sharedByMe` | object |
+| `sharedWithMe` | object |
+
+**Returned by:** Qualify By Usecase
+
+| Field | Type |
+|-------|------|
+| `annualFee` | number |
+| `maxSubUsecases` | integer |
+| `minSubUsecases` | integer |
+| `mnoMetadata` | object |
+| `monthlyFee` | number |
+| `quarterlyFee` | number |
+| `usecase` | string |
+
+**Returned by:** Get Single Shared Campaign, Update Single Shared Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `assignedPhoneNumbersCount` | number |
+| `brandDisplayName` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createdAt` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isNumberPoolingEnabled` | boolean |
+| `messageFlow` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `subUsecases` | array[string] |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `updatedAt` | string |
+| `usecase` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Assign Messaging Profile To Campaign
+
+| Field | Type |
+|-------|------|
+| `campaignId` | string |
+| `messagingProfileId` | string |
+| `taskId` | string |
+| `tcrCampaignId` | string |
+
+**Returned by:** Get Assignment Task Status
+
+| Field | Type |
+|-------|------|
+| `createdAt` | date-time |
+| `status` | string |
+| `taskId` | string |
+| `updatedAt` | date-time |
+
+**Returned by:** Get Phone Number Status
+
+| Field | Type |
+|-------|------|
+| `records` | array[object] |
+
+**Returned by:** Create New Phone Number Campaign, Get Single Phone Number Campaign, Create New Phone Number Campaign, Delete Phone Number Campaign
+
+| Field | Type |
+|-------|------|
+| `assignmentStatus` | enum: FAILED_ASSIGNMENT, PENDING_ASSIGNMENT, ASSIGNED, PENDING_UNASSIGNMENT, FAILED_UNASSIGNMENT |
+| `brandId` | string |
+| `campaignId` | string |
+| `createdAt` | string |
+| `failureReasons` | string |
+| `phoneNumber` | string |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `telnyxCampaignId` | string |
+| `updatedAt` | string |
+
+## Optional Parameters
+
+### Create Brand — `client.Messaging10dlc.Brand.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `CompanyName` | string | (Required for Non-profit/private/public) Legal company name. |
+| `FirstName` | string | First name of business contact. |
+| `LastName` | string | Last name of business contact. |
+| `Ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `Phone` | string | Valid phone number in e.164 international format. |
+| `Street` | string | Street number and name. |
+| `City` | string | City name |
+| `State` | string | State. |
+| `PostalCode` | string | Postal codes. |
+| `StockSymbol` | string | (Required for public company) stock symbol. |
+| `StockExchange` | object | (Required for public company) stock exchange. |
+| `IpAddress` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `Website` | string | Brand website URL. |
+| `IsReseller` | boolean |  |
+| `Mock` | boolean | Mock brand for testing purposes. |
+| `MobilePhone` | string | Valid mobile phone number in e.164 international format. |
+| `BusinessContactEmail` | string | Business contact email. |
+| `WebhookURL` | string | Webhook URL for brand status updates. |
+| `WebhookFailoverURL` | string | Webhook failover URL for brand status updates. |
+
+### Update Brand — `client.Messaging10dlc.Brand.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `CompanyName` | string | (Required for Non-profit/private/public) Legal company name. |
+| `FirstName` | string | First name of business contact. |
+| `LastName` | string | Last name of business contact. |
+| `Ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `Phone` | string | Valid phone number in e.164 international format. |
+| `Street` | string | Street number and name. |
+| `City` | string | City name |
+| `State` | string | State. |
+| `PostalCode` | string | Postal codes. |
+| `StockSymbol` | string | (Required for public company) stock symbol. |
+| `StockExchange` | object | (Required for public company) stock exchange. |
+| `IpAddress` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `Website` | string | Brand website URL. |
+| `AltBusinessIdType` | enum (NONE, DUNS, GIIN, LEI) | An enumeration. |
+| `IsReseller` | boolean |  |
+| `IdentityStatus` | enum (VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED) | The verification status of an active brand |
+| `BusinessContactEmail` | string | Business contact email. |
+| `WebhookURL` | string | Webhook URL for brand status updates. |
+| `WebhookFailoverURL` | string | Webhook failover URL for brand status updates. |
+| `AltBusinessId` | string (UUID) | Alternate business identifier such as DUNS, LEI, or GIIN |
+
+### Import External Vetting Record — `client.Messaging10dlc.Brand.ExternalVetting.Imports()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `VettingToken` | string | Required by some providers for vetting record confirmation. |
+
+### Update campaign — `client.Messaging10dlc.Campaign.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ResellerId` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `Sample1` | string | Message sample. |
+| `Sample2` | string | Message sample. |
+| `Sample3` | string | Message sample. |
+| `Sample4` | string | Message sample. |
+| `Sample5` | string | Message sample. |
+| `MessageFlow` | string | Message flow description. |
+| `HelpMessage` | string | Help message of the campaign. |
+| `AutoRenewal` | boolean | Help message of the campaign. |
+| `WebhookURL` | string | Webhook to which campaign status updates are sent. |
+| `WebhookFailoverURL` | string | Webhook failover to which campaign status updates are sent. |
+
+### Submit Campaign — `client.Messaging10dlc.CampaignBuilder.Submit()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `AgeGated` | boolean | Age gated message content in campaign. |
+| `AutoRenewal` | boolean | Campaign subscription auto-renewal option. |
+| `DirectLending` | boolean | Direct lending or loan arrangement |
+| `EmbeddedLink` | boolean | Does message generated by the campaign include URL link in SMS? |
+| `EmbeddedPhone` | boolean | Does message generated by the campaign include phone number in SMS? |
+| `HelpKeywords` | string | Subscriber help keywords. |
+| `HelpMessage` | string | Help message of the campaign. |
+| `MessageFlow` | string | Message flow description. |
+| `MnoIds` | array[integer] | Submit campaign to given list of MNOs by MNO's network ID. |
+| `NumberPool` | boolean | Does campaign utilize pool of phone numbers? |
+| `OptinKeywords` | string | Subscriber opt-in keywords. |
+| `OptinMessage` | string | Subscriber opt-in message. |
+| `OptoutKeywords` | string | Subscriber opt-out keywords. |
+| `OptoutMessage` | string | Subscriber opt-out message. |
+| `ReferenceId` | string (UUID) | Caller supplied campaign reference ID. |
+| `ResellerId` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `Sample1` | string | Message sample. |
+| `Sample2` | string | Message sample. |
+| `Sample3` | string | Message sample. |
+| `Sample4` | string | Message sample. |
+| `Sample5` | string | Message sample. |
+| `SubUsecases` | array[string] | Campaign sub-usecases. |
+| `SubscriberHelp` | boolean | Does campaign responds to help keyword(s)? |
+| `SubscriberOptin` | boolean | Does campaign require subscriber to opt-in before SMS is sent to subscriber? |
+| `SubscriberOptout` | boolean | Does campaign support subscriber opt-out keyword(s)? |
+| `Tag` | array[string] | Tags to be set on the Campaign. |
+| `TermsAndConditions` | boolean | Is terms and conditions accepted? |
+| `PrivacyPolicyLink` | string | Link to the campaign's privacy policy. |
+| `TermsAndConditionsLink` | string | Link to the campaign's terms and conditions. |
+| `EmbeddedLinkSample` | string | Sample of an embedded link that will be sent to subscribers. |
+| `WebhookURL` | string | Webhook to which campaign status updates are sent. |
+| `WebhookFailoverURL` | string | Failover webhook to which campaign status updates are sent. |
+
+### Update Single Shared Campaign — `client.Messaging10dlc.PartnerCampaigns.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `WebhookURL` | string | Webhook to which campaign status updates are sent. |
+| `WebhookFailoverURL` | string | Webhook failover to which campaign status updates are sent. |
+
+### Assign Messaging Profile To Campaign — `client.Messaging10dlc.PhoneNumberAssignmentByProfile.Assign()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `TcrCampaignId` | string (UUID) | The TCR ID of the shared campaign you want to link to the specified messaging... |
+| `CampaignId` | string (UUID) | The ID of the campaign you want to link to the specified messaging profile. |
+
+## Webhook Payload Fields
+
+### `campaignStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `brandId` | string | Brand ID associated with the campaign. |
+| `campaignId` | string | The ID of the campaign. |
+| `createDate` | string | Unix timestamp when campaign was created. |
+| `cspId` | string | Alphanumeric identifier of the CSP associated with this campaign. |
+| `isTMobileRegistered` | boolean | Indicates whether the campaign is registered with T-Mobile. |
+| `type` | enum: TELNYX_EVENT, REGISTRATION, MNO_REVIEW, TELNYX_REVIEW, NUMBER_POOL_PROVISIONED, NUMBER_POOL_DEPROVISIONED, TCR_EVENT, VERIFIED |  |
+| `description` | string | Description of the event. |
+| `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/go/ai-assistants.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/go/ai-assistants.md
@@ -37,8 +37,8 @@ import "errors"
 
 assistant, err := client.AI.Assistants.New(context.Background(), telnyx.AIAssistantNewParams{
 		Instructions: "You are a helpful assistant.",
-		Model: "openai/gpt-4o",
 		Name: "my-resource",
+		Model: "openai/gpt-4o",
 	})
 if err != nil {
   var apiErr *telnyx.Error
@@ -71,7 +71,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -84,18 +84,17 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `Name` | string | Yes |  |
-| `Model` | string | Yes | ID of the model to use. |
 | `Instructions` | string | Yes | System instructions for the assistant. |
-| `Tools` | array[object] | No | The tools that the assistant can use. |
-| `Description` | string | No |  |
-| `Greeting` | string | No | Text that the assistant will use to start the conversation. |
-| ... | | | +11 optional params in the API Details section below |
+| `Tags` | array[string] | No | Tags associated with the assistant. |
+| `Model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `Tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in the API Details section below |
 
 ```go
 	assistant, err := client.AI.Assistants.New(context.Background(), telnyx.AIAssistantNewParams{
 		Instructions: "You are a helpful assistant.",
-		Model: "openai/gpt-4o",
 		Name: "my-resource",
+		Model: "openai/gpt-4o",
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -224,7 +223,7 @@ Primary response fields:
 - `assistant.CreatedAt`
 - `assistant.Description`
 - `assistant.DynamicVariables`
-- `assistant.DynamicVariablesWebhookURL`
+- `assistant.DynamicVariablesWebhookTimeoutMs`
 
 ### Update an assistant
 
@@ -235,10 +234,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `AssistantId` | string (UUID) | Yes |  |
+| `Tags` | array[string] | No | Tags associated with the assistant. |
 | `Name` | string | No |  |
-| `Model` | string | No | ID of the model to use. |
-| `Instructions` | string | No | System instructions for the assistant. |
-| ... | | | +15 optional params in the API Details section below |
+| `Model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in the API Details section below |
 
 ```go
 	assistant, err := client.AI.Assistants.Update(
@@ -258,7 +257,7 @@ Primary response fields:
 - `assistant.CreatedAt`
 - `assistant.Description`
 - `assistant.DynamicVariables`
-- `assistant.DynamicVariablesWebhookURL`
+- `assistant.DynamicVariablesWebhookTimeoutMs`
 
 ### List assistants
 
@@ -283,7 +282,7 @@ Primary item fields:
 - `CreatedAt`
 - `Description`
 - `DynamicVariables`
-- `DynamicVariablesWebhookURL`
+- `DynamicVariablesWebhookTimeoutMs`
 
 ### Import assistants from external provider
 
@@ -317,7 +316,7 @@ Primary item fields:
 - `CreatedAt`
 - `Description`
 - `DynamicVariables`
-- `DynamicVariablesWebhookURL`
+- `DynamicVariablesWebhookTimeoutMs`
 
 ### Get All Tags
 
@@ -431,7 +430,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -444,8 +443,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.AI.Assistants.Tests.Runs.Get()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `TestId`, `RunId` |
 | Delete an assistant | `client.AI.Assistants.Delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `AssistantId` |
 | Get Canary Deploy | `client.AI.Assistants.CanaryDeploys.Get()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `AssistantId` |
-| Create Canary Deploy | `client.AI.Assistants.CanaryDeploys.New()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `Versions`, `AssistantId` |
-| Update Canary Deploy | `client.AI.Assistants.CanaryDeploys.Update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `Versions`, `AssistantId` |
+| Create Canary Deploy | `client.AI.Assistants.CanaryDeploys.New()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `AssistantId` |
+| Update Canary Deploy | `client.AI.Assistants.CanaryDeploys.Update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `AssistantId` |
 | Delete Canary Deploy | `client.AI.Assistants.CanaryDeploys.Delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `AssistantId` |
 | Assistant Sms Chat | `client.AI.Assistants.SendSMS()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `From`, `To`, `AssistantId` |
 | Clone Assistant | `client.AI.Assistants.Clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `AssistantId` |
@@ -456,6 +455,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Add Assistant Tag | `client.AI.Assistants.Tags.Add()` | `POST /ai/assistants/{assistant_id}/tags` | Create or provision an additional resource when the core tasks do not cover this flow. | `Tag`, `AssistantId` |
 | Remove Assistant Tag | `client.AI.Assistants.Tags.Remove()` | `DELETE /ai/assistants/{assistant_id}/tags/{tag}` | Remove, detach, or clean up an existing resource. | `AssistantId`, `Tag` |
 | Get assistant texml | `client.AI.Assistants.GetTexml()` | `GET /ai/assistants/{assistant_id}/texml` | Fetch the current state before updating, deleting, or making control-flow decisions. | `AssistantId` |
+| Add Assistant Tool | `client.AI.Assistants.Tools.Add()` | `PUT /ai/assistants/{assistant_id}/tools/{tool_id}` | Modify an existing resource without recreating it. | `AssistantId`, `ToolId` |
+| Remove Assistant Tool | `client.AI.Assistants.Tools.Remove()` | `DELETE /ai/assistants/{assistant_id}/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `AssistantId`, `ToolId` |
 | Test Assistant Tool | `client.AI.Assistants.Tools.Test()` | `POST /ai/assistants/{assistant_id}/tools/{tool_id}/test` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `AssistantId`, `ToolId` |
 | Get all versions of an assistant | `client.AI.Assistants.Versions.List()` | `GET /ai/assistants/{assistant_id}/versions` | Fetch the current state before updating, deleting, or making control-flow decisions. | `AssistantId` |
 | Get a specific assistant version | `client.AI.Assistants.Versions.Get()` | `GET /ai/assistants/{assistant_id}/versions/{version_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `AssistantId`, `VersionId` |
@@ -467,7 +468,398 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get MCP Server | `client.AI.McpServers.Get()` | `GET /ai/mcp_servers/{mcp_server_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `McpServerId` |
 | Update MCP Server | `client.AI.McpServers.Update()` | `PUT /ai/mcp_servers/{mcp_server_id}` | Modify an existing resource without recreating it. | `McpServerId` |
 | Delete MCP Server | `client.AI.McpServers.Delete()` | `DELETE /ai/mcp_servers/{mcp_server_id}` | Remove, detach, or clean up an existing resource. | `McpServerId` |
+| List Tools | `client.AI.Tools.List()` | `GET /ai/tools` | Inspect available resources or choose an existing resource before mutating it. | None |
+| Create Tool | `client.AI.Tools.New()` | `POST /ai/tools` | Create or provision an additional resource when the core tasks do not cover this flow. | `Type`, `DisplayName` |
+| Get Tool | `client.AI.Tools.Get()` | `GET /ai/tools/{tool_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `ToolId` |
+| Update Tool | `client.AI.Tools.Update()` | `PATCH /ai/tools/{tool_id}` | Modify an existing resource without recreating it. | `ToolId` |
+| Delete Tool | `client.AI.Tools.Delete()` | `DELETE /ai/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `ToolId` |
 
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# AI Assistants (Go) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+
+## Response Schemas
+
+**Returned by:** List assistants, Create an assistant, Import assistants from external provider, Get an assistant, Update an assistant, Clone Assistant, Get all versions of an assistant, Get a specific assistant version, Update a specific assistant version, Promote an assistant version to main
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
+| `dynamic_variables_webhook_url` | string |
+| `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
+| `greeting` | string |
+| `id` | string |
+| `import_metadata` | object |
+| `insight_settings` | object |
+| `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
+| `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
+| `messaging_settings` | object |
+| `model` | string |
+| `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
+| `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
+| `telephony_settings` | object |
+| `tools` | array[object] |
+| `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
+| `voice_settings` | object |
+| `widget_settings` | object |
+
+**Returned by:** Get All Tags, Add Assistant Tag, Remove Assistant Tag
+
+| Field | Type |
+|-------|------|
+| `tags` | array[string] |
+
+**Returned by:** List assistant tests with pagination, Create a new assistant test, Get assistant test by ID, Update an assistant test
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `destination` | string |
+| `instructions` | string |
+| `max_duration_seconds` | integer |
+| `name` | string |
+| `rubric` | array[object] |
+| `telnyx_conversation_channel` | object |
+| `test_id` | uuid |
+| `test_suite` | string |
+
+**Returned by:** Get all test suite names
+
+| Field | Type |
+|-------|------|
+| `data` | array[string] |
+
+**Returned by:** Get test suite run history, Get test run history for a specific test, Trigger a manual test run, Get specific test run details
+
+| Field | Type |
+|-------|------|
+| `completed_at` | date-time |
+| `conversation_id` | string |
+| `conversation_insights_id` | string |
+| `created_at` | date-time |
+| `detail_status` | array[object] |
+| `logs` | string |
+| `run_id` | uuid |
+| `status` | enum: pending, starting, running, passed, failed, error |
+| `test_id` | uuid |
+| `test_suite_run_id` | uuid |
+| `triggered_by` | string |
+| `updated_at` | date-time |
+
+**Returned by:** Delete an assistant
+
+| Field | Type |
+|-------|------|
+| `deleted` | boolean |
+| `id` | string |
+| `object` | string |
+
+**Returned by:** Get Canary Deploy, Create Canary Deploy, Update Canary Deploy
+
+| Field | Type |
+|-------|------|
+| `assistant_id` | string |
+| `created_at` | date-time |
+| `rules` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Assistant Chat (BETA)
+
+| Field | Type |
+|-------|------|
+| `content` | string |
+
+**Returned by:** Assistant Sms Chat
+
+| Field | Type |
+|-------|------|
+| `conversation_id` | string |
+
+**Returned by:** List scheduled events
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Test Assistant Tool
+
+| Field | Type |
+|-------|------|
+| `content_type` | string |
+| `request` | object |
+| `response` | string |
+| `status_code` | integer |
+| `success` | boolean |
+
+**Returned by:** Create MCP Server, Get MCP Server, Update MCP Server
+
+| Field | Type |
+|-------|------|
+| `allowed_tools` | array \| null |
+| `api_key_ref` | string \| null |
+| `created_at` | date-time |
+| `id` | string |
+| `name` | string |
+| `type` | string |
+| `url` | string |
+
+**Returned by:** List Tools, Create Tool, Get Tool, Update Tool
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `display_name` | string |
+| `id` | string |
+| `timeout_ms` | integer |
+| `tool_definition` | object |
+| `type` | string |
+
+## Optional Parameters
+
+### Create an assistant — `client.AI.Assistants.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Model` | string | ID of the model to use when `external_llm` is not set. |
+| `Tools` | array[object] | Deprecated for new integrations. |
+| `McpServers` | array[object] | MCP servers attached to the assistant. |
+| `ToolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `Description` | string |  |
+| `Greeting` | string | Text that the assistant will use to start the conversation. |
+| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `ExternalLlm` | object |  |
+| `FallbackConfig` | object |  |
+| `VoiceSettings` | object |  |
+| `Transcription` | object |  |
+| `TelephonySettings` | object |  |
+| `MessagingSettings` | object |  |
+| `EnabledFeatures` | array[object] |  |
+| `InsightSettings` | object |  |
+| `PrivacySettings` | object |  |
+| `DynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `DynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `DynamicVariables` | object | Map of dynamic variables and their default values |
+| `WidgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `InterruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `Integrations` | array[object] | Connected integrations attached to the assistant. |
+| `ObservabilitySettings` | object |  |
+| `Tags` | array[string] | Tags associated with the assistant. |
+| `PostConversationSettings` | object | Configuration for post-conversation processing. |
+
+### Import assistants from external provider — `client.AI.Assistants.Imports()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ImportIds` | array[string] | Optional list of assistant IDs to import from the external provider. |
+
+### Create a new assistant test — `client.AI.Assistants.Tests.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Description` | string | Optional detailed description of what this test evaluates and its purpose. |
+| `TelnyxConversationChannel` | object | The communication channel through which the test will be conducted. |
+| `MaxDurationSeconds` | integer | Maximum duration in seconds that the test conversation should run before timi... |
+| `TestSuite` | string | Optional test suite name to group related tests together. |
+
+### Trigger test suite execution — `client.AI.Assistants.Tests.TestSuites.Runs.Trigger()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `DestinationVersionId` | string (UUID) | Optional assistant version ID to use for all test runs in this suite. |
+
+### Update an assistant test — `client.AI.Assistants.Tests.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Name` | string | Updated name for the assistant test. |
+| `Description` | string | Updated description of the test's purpose and evaluation criteria. |
+| `TelnyxConversationChannel` | enum (phone_call, web_call, sms_chat, web_chat) |  |
+| `Destination` | string | Updated target destination for test conversations. |
+| `MaxDurationSeconds` | integer | Updated maximum test duration in seconds. |
+| `TestSuite` | string | Updated test suite assignment for better organization. |
+| `Instructions` | string | Updated test scenario instructions and objectives. |
+| `Rubric` | array[object] | Updated evaluation criteria for assessing assistant performance. |
+
+### Trigger a manual test run — `client.AI.Assistants.Tests.Runs.Trigger()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `DestinationVersionId` | string (UUID) | Optional assistant version ID to use for this test run. |
+
+### Update an assistant — `client.AI.Assistants.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Name` | string |  |
+| `Model` | string | ID of the model to use when `external_llm` is not set. |
+| `Instructions` | string | System instructions for the assistant. |
+| `Tools` | array[object] | Deprecated for new integrations. |
+| `McpServers` | array[object] | MCP servers attached to the assistant. |
+| `ToolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `Description` | string |  |
+| `Greeting` | string | Text that the assistant will use to start the conversation. |
+| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `ExternalLlm` | object |  |
+| `FallbackConfig` | object |  |
+| `VoiceSettings` | object |  |
+| `Transcription` | object |  |
+| `TelephonySettings` | object |  |
+| `MessagingSettings` | object |  |
+| `EnabledFeatures` | array[object] |  |
+| `InsightSettings` | object |  |
+| `PrivacySettings` | object |  |
+| `DynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `DynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `DynamicVariables` | object | Map of dynamic variables and their default values |
+| `WidgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `InterruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `Integrations` | array[object] | Connected integrations attached to the assistant. |
+| `ObservabilitySettings` | object |  |
+| `Tags` | array[string] | Tags associated with the assistant. |
+| `VersionName` | string | Human-readable name for the assistant version. |
+| `PostConversationSettings` | object | Configuration for post-conversation processing. |
+| `PromoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.AI.Assistants.CanaryDeploys.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Rules` | array[object] |  |
+
+### Update Canary Deploy — `client.AI.Assistants.CanaryDeploys.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Rules` | array[object] |  |
+
+### Assistant Chat (BETA) — `client.AI.Assistants.Chat()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Name` | string | The optional display name of the user sending the message |
+
+### Assistant Sms Chat — `client.AI.Assistants.SendSMS()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Text` | string |  |
+| `ConversationMetadata` | object |  |
+| `ShouldCreateConversation` | boolean |  |
+
+### Create a scheduled event — `client.AI.Assistants.ScheduledEvents.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Text` | string | Required for sms scheduled events. |
+| `ConversationMetadata` | object | Metadata associated with the conversation. |
+| `DynamicVariables` | object | A map of dynamic variable names to values. |
+| `MaxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `RetryIntervalSecs` | integer |  |
+
+### Test Assistant Tool — `client.AI.Assistants.Tools.Test()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Arguments` | object | Key-value arguments to use for the webhook test |
+| `DynamicVariables` | object | Key-value dynamic variables to use for the webhook test |
+
+### Update a specific assistant version — `client.AI.Assistants.Versions.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Name` | string |  |
+| `Model` | string | ID of the model to use when `external_llm` is not set. |
+| `Instructions` | string | System instructions for the assistant. |
+| `Tools` | array[object] | Deprecated for new integrations. |
+| `McpServers` | array[object] | MCP servers attached to the assistant. |
+| `ToolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `Description` | string |  |
+| `Greeting` | string | Text that the assistant will use to start the conversation. |
+| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `ExternalLlm` | object |  |
+| `FallbackConfig` | object |  |
+| `VoiceSettings` | object |  |
+| `Transcription` | object |  |
+| `TelephonySettings` | object |  |
+| `MessagingSettings` | object |  |
+| `EnabledFeatures` | array[object] |  |
+| `InsightSettings` | object |  |
+| `PrivacySettings` | object |  |
+| `DynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `DynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `DynamicVariables` | object | Map of dynamic variables and their default values |
+| `WidgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `InterruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `Integrations` | array[object] | Connected integrations attached to the assistant. |
+| `ObservabilitySettings` | object |  |
+| `Tags` | array[string] | Tags associated with the assistant. |
+| `VersionName` | string | Human-readable name for the assistant version. |
+| `PostConversationSettings` | object | Configuration for post-conversation processing. |
+
+### Create MCP Server — `client.AI.McpServers.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ApiKeyRef` | string |  |
+| `AllowedTools` | array[string] |  |
+
+### Update MCP Server — `client.AI.McpServers.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Id` | string (UUID) |  |
+| `Name` | string |  |
+| `Type` | string |  |
+| `Url` | string (URL) |  |
+| `ApiKeyRef` | string |  |
+| `AllowedTools` | array[string] |  |
+| `CreatedAt` | string (date-time) |  |
+
+### Create Tool — `client.AI.Tools.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Function` | object |  |
+| `Retrieval` | object |  |
+| `Handoff` | object |  |
+| `Invite` | object |  |
+| `Webhook` | object |  |
+| `TimeoutMs` | integer |  |
+
+### Update Tool — `client.AI.Tools.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Type` | string |  |
+| `DisplayName` | string |  |
+| `Function` | object |  |
+| `Retrieval` | object |  |
+| `Handoff` | object |  |
+| `Invite` | object |  |
+| `Webhook` | object |  |
+| `TimeoutMs` | integer |  |

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/go/messaging.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/go/messaging.md
@@ -77,8 +77,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -207,7 +207,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.media` | array[object] |  |
 | `data.record_type` | enum: event | Identifies the type of the resource. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -403,6 +403,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `WhatsappMessage` | object | Yes |  |
 | `Type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `WebhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `MessagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```go
 	response, err := client.Messages.SendWhatsapp(context.Background(), telnyx.MessageSendWhatsappParams{
@@ -429,7 +430,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -463,3 +464,425 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Messaging (Go) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List alphanumeric sender IDs, Create an alphanumeric sender ID, Retrieve an alphanumeric sender ID, Delete an alphanumeric sender ID, List alphanumeric sender IDs for a messaging profile
+
+| Field | Type |
+|-------|------|
+| `alphanumeric_sender_id` | string |
+| `id` | uuid |
+| `messaging_profile_id` | uuid |
+| `organization_id` | string |
+| `record_type` | enum: alphanumeric_sender_id |
+| `us_long_code_fallback` | string |
+
+**Returned by:** Send a message, Send a message using an alphanumeric sender ID, Retrieve group MMS messages, Send a group MMS message, Send a long code message, Send a message using number pool, Schedule a message, Send a short code message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `wait_seconds` | float |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** Send a WhatsApp message
+
+| Field | Type |
+|-------|------|
+| `body` | object |
+| `direction` | string |
+| `encoding` | string |
+| `from` | object |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `organization_id` | string |
+| `received_at` | date-time |
+| `record_type` | string |
+| `to` | array[object] |
+| `type` | string |
+| `wait_seconds` | float |
+
+**Returned by:** Retrieve a message, Get detailed messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Cancel a scheduled message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** List messaging hosted numbers, Retrieve a messaging hosted number, Update a messaging hosted number
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `eligible_messaging_products` | array[string] |
+| `features` | object |
+| `health` | object |
+| `id` | string |
+| `messaging_product` | string |
+| `messaging_profile_id` | string \| null |
+| `organization_id` | string |
+| `phone_number` | string |
+| `record_type` | enum: messaging_phone_number, messaging_settings |
+| `tags` | array[string] |
+| `traffic_type` | string |
+| `type` | enum: long-code, toll-free, short-code, longcode, tollfree, shortcode |
+| `updated_at` | date-time |
+
+**Returned by:** List opt-outs
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `from` | string |
+| `keyword` | string \| null |
+| `messaging_profile_id` | string \| null |
+| `to` | string |
+
+**Returned by:** List high-level messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Regenerate messaging profile secret
+
+| Field | Type |
+|-------|------|
+| `ai_assistant_id` | string \| null |
+| `alpha_sender` | string \| null |
+| `created_at` | date-time |
+| `daily_spend_limit` | string |
+| `daily_spend_limit_enabled` | boolean |
+| `enabled` | boolean |
+| `health_webhook_url` | url |
+| `id` | uuid |
+| `mms_fall_back_to_sms` | boolean |
+| `mms_transcoding` | boolean |
+| `mobile_only` | boolean |
+| `name` | string |
+| `number_pool_settings` | object \| null |
+| `organization_id` | string |
+| `record_type` | enum: messaging_profile |
+| `redaction_enabled` | boolean |
+| `redaction_level` | integer |
+| `resource_group_id` | string \| null |
+| `smart_encoding` | boolean |
+| `updated_at` | date-time |
+| `url_shortener_settings` | object \| null |
+| `v1_secret` | string |
+| `webhook_api_version` | enum: 1, 2, 2010-04-01 |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+| `whitelisted_destinations` | array[string] |
+
+**Returned by:** List Auto-Response Settings, Create auto-response setting, Get Auto-Response Setting, Update Auto-Response Setting
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `id` | string |
+| `keywords` | array[string] |
+| `op` | enum: start, stop, info |
+| `resp_text` | string |
+| `updated_at` | date-time |
+
+## Optional Parameters
+
+### Create an alphanumeric sender ID — `client.AlphanumericSenderIDs.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `UsLongCodeFallback` | string | A US long code number to use as fallback when sending to US destinations. |
+
+### Send a message — `client.Messages.Send()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `From` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `MessagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `Text` | string | Message body (i.e., content) as a non-empty string. |
+| `Subject` | string | Subject of multimedia message |
+| `MediaUrls` | array[string] | A list of media URLs. |
+| `WebhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `WebhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `UseProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `Type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `AutoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `SendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `Encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using an alphanumeric sender ID — `client.Messages.SendWithAlphanumericSender()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `WebhookUrl` | string (URL) | Callback URL for delivery status updates. |
+| `WebhookFailoverUrl` | string (URL) | Failover callback URL for delivery status updates. |
+| `UseProfileWebhooks` | boolean | If true, use the messaging profile's webhook settings. |
+
+### Send a group MMS message — `client.Messages.SendGroupMms()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Text` | string | Message body (i.e., content) as a non-empty string. |
+| `Subject` | string | Subject of multimedia message |
+| `MediaUrls` | array[string] | A list of media URLs. |
+| `WebhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `WebhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `UseProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+
+### Send a long code message — `client.Messages.SendLongCode()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Text` | string | Message body (i.e., content) as a non-empty string. |
+| `Subject` | string | Subject of multimedia message |
+| `MediaUrls` | array[string] | A list of media URLs. |
+| `WebhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `WebhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `UseProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `Type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `AutoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `Encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using number pool — `client.Messages.SendNumberPool()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Text` | string | Message body (i.e., content) as a non-empty string. |
+| `Subject` | string | Subject of multimedia message |
+| `MediaUrls` | array[string] | A list of media URLs. |
+| `WebhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `WebhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `UseProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `Type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `AutoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `Encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Schedule a message — `client.Messages.Schedule()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `From` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `MessagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `Text` | string | Message body (i.e., content) as a non-empty string. |
+| `Subject` | string | Subject of multimedia message |
+| `MediaUrls` | array[string] | A list of media URLs. |
+| `WebhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `WebhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `UseProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `Type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `AutoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `SendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+
+### Send a short code message — `client.Messages.SendShortCode()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Text` | string | Message body (i.e., content) as a non-empty string. |
+| `Subject` | string | Subject of multimedia message |
+| `MediaUrls` | array[string] | A list of media URLs. |
+| `WebhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `WebhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `UseProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `Type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `AutoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `Encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a WhatsApp message — `client.Messages.SendWhatsapp()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
+| `WebhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `MessagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
+
+### Update a messaging hosted number — `client.MessagingHostedNumbers.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `MessagingProfileId` | string (UUID) | Configure the messaging profile this phone number is assigned to:
+
+* Omit thi... |
+| `MessagingProduct` | string | Configure the messaging product for this number:
+
+* Omit this field or set it... |
+| `Tags` | array[string] | Tags to set on this phone number. |
+
+### Create auto-response setting — `client.MessagingProfiles.AutorespConfigs.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `RespText` | string |  |
+
+### Update Auto-Response Setting — `client.MessagingProfiles.AutorespConfigs.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `RespText` | string |  |
+
+## Webhook Payload Fields
+
+### `deliveryUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.sent, message.finalized | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: outbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | uuid | The id of the organization the messaging profile belongs to. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Subject of multimedia message |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | ISO 8601 formatted date indicating when the message was sent. |
+| `data.payload.completed_at` | date-time | ISO 8601 formatted date indicating when the message was finalized. |
+| `data.payload.valid_until` | date-time | Message must be out of the queue by this time or else it will be discarded and marked as 'sending_failed'. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+| `data.payload.smart_encoding_applied` | boolean | Indicates whether smart encoding was applied to this message. |
+| `data.payload.wait_seconds` | float | Seconds the message is queued due to rate limiting before being sent to the carrier. |
+| `meta.attempt` | integer | Number of attempts to deliver the webhook event. |
+| `meta.delivered_to` | url | The webhook URL the event was delivered to. |
+
+### `inboundMessage`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.received | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: inbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Message subject. |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | Not used for inbound messages. |
+| `data.payload.completed_at` | date-time | Not used for inbound messages. |
+| `data.payload.valid_until` | date-time | Not used for inbound messages. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+
+### `replacedLinkClick`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | string | Identifies the type of the resource. |
+| `data.url` | string | The original link that was sent in the message. |
+| `data.to` | string | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or short code). |
+| `data.message_id` | uuid | The message ID associated with the clicked link. |
+| `data.time_clicked` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+
+### Field Type Notes
+
+- `from` in responses/webhooks: object with sub-fields `phone_number` (string), `carrier` (string), `line_type` (string)
+- `to` in responses/webhooks: array of objects, each with `phone_number` (string), `carrier` (string), `line_type` (string), `status` (string)
+- `cost`: object with `amount` (string, decimal), `currency` (string, e.g., 'USD')

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/go/numbers.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/go/numbers.md
@@ -67,7 +67,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -406,7 +406,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -456,3 +456,433 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Numbers (Go) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Advanced Orders, Create Advanced Order, Update Advanced Order, Get Advanced Order
+
+| Field | Type |
+|-------|------|
+| `area_code` | string |
+| `comments` | string |
+| `country_code` | string |
+| `customer_reference` | string |
+| `features` | array[object] |
+| `id` | uuid |
+| `orders` | array[string] |
+| `phone_number_type` | object |
+| `quantity` | integer |
+| `requirement_group_id` | uuid |
+| `status` | object |
+
+**Returned by:** List available phone number blocks
+
+| Field | Type |
+|-------|------|
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `range` | integer |
+| `record_type` | enum: available_phone_number_block |
+| `region_information` | array[object] |
+
+**Returned by:** List available phone numbers
+
+| Field | Type |
+|-------|------|
+| `best_effort` | boolean |
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `quickship` | boolean |
+| `record_type` | enum: available_phone_number |
+| `region_information` | array[object] |
+| `reservable` | boolean |
+| `vanity_format` | string |
+
+**Returned by:** Retrieve all comments
+
+| Field | Type |
+|-------|------|
+| `body` | string |
+| `comment_record_id` | uuid |
+| `comment_record_type` | enum: sub_number_order, requirement_group |
+| `commenter` | string |
+| `commenter_type` | enum: admin, user |
+| `created_at` | date-time |
+| `id` | uuid |
+| `read_at` | date-time |
+| `updated_at` | date-time |
+
+**Returned by:** Create a comment, Retrieve a comment, Mark a comment as read, Get country coverage
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Get coverage for a specific country
+
+| Field | Type |
+|-------|------|
+| `code` | string |
+| `features` | array[string] |
+| `international_sms` | boolean |
+| `inventory_coverage` | boolean |
+| `local` | object |
+| `mobile` | object |
+| `national` | object |
+| `numbers` | boolean |
+| `p2p` | boolean |
+| `phone_number_type` | array[string] |
+| `quickship` | boolean |
+| `region` | string \| null |
+| `reservable` | boolean |
+| `shared_cost` | object |
+| `toll_free` | object |
+
+**Returned by:** List customer service records, Create a customer service record, Get a customer service record
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `error_message` | string \| null |
+| `id` | uuid |
+| `phone_number` | string |
+| `record_type` | string |
+| `result` | object \| null |
+| `status` | enum: pending, completed, failed |
+| `updated_at` | date-time |
+| `webhook_url` | string |
+
+**Returned by:** Verify CSR phone number coverage
+
+| Field | Type |
+|-------|------|
+| `additional_data_required` | array[string] |
+| `has_csr_coverage` | boolean |
+| `phone_number` | string |
+| `reason` | string |
+| `record_type` | string |
+
+**Returned by:** List inexplicit number orders, Create an inexplicit number order, Retrieve an inexplicit number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `ordering_groups` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Create an inventory coverage request
+
+| Field | Type |
+|-------|------|
+| `administrative_area` | string |
+| `advance_requirements` | boolean |
+| `count` | integer |
+| `coverage_type` | enum: number, block |
+| `group` | string |
+| `group_type` | string |
+| `number_range` | integer |
+| `number_type` | enum: did, toll-free |
+| `phone_number_type` | enum: local, toll_free, national, landline, shared_cost, mobile |
+| `record_type` | string |
+
+**Returned by:** List mobile network operators
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `id` | uuid |
+| `mcc` | string |
+| `mnc` | string |
+| `name` | string |
+| `network_preferences_enabled` | boolean |
+| `record_type` | string |
+| `tadig` | string |
+
+**Returned by:** List network coverage locations
+
+| Field | Type |
+|-------|------|
+| `available_services` | array[object] |
+| `location` | object |
+| `record_type` | string |
+
+**Returned by:** List number block orders, Create a number block order, Retrieve a number block order
+
+| Field | Type |
+|-------|------|
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers_count` | integer |
+| `range` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `starting_number` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve a list of phone numbers associated to orders, Retrieve a single phone number within a number order., Update requirements for a single phone number within a number order.
+
+| Field | Type |
+|-------|------|
+| `bundle_id` | uuid |
+| `country_code` | string |
+| `deadline` | date-time |
+| `id` | uuid |
+| `is_block_number` | boolean |
+| `locality` | string |
+| `order_request_id` | uuid |
+| `phone_number` | string |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `requirements_status` | enum: pending, approved, cancelled, deleted, requirement-info-exception, requirement-info-pending, requirement-info-under-review |
+| `status` | enum: pending, success, failure |
+| `sub_number_order_id` | uuid |
+
+**Returned by:** List number orders, Create a number order, Retrieve a number order, Update a number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers` | array[object] |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `sub_number_orders_ids` | array[string] |
+| `updated_at` | date-time |
+
+**Returned by:** List number reservations, Create a number reservation, Retrieve a number reservation, Extend a number reservation
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `errors` | string |
+| `id` | uuid |
+| `phone_numbers` | array[object] |
+| `record_type` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve the features for a list of numbers
+
+| Field | Type |
+|-------|------|
+| `features` | array[string] |
+| `phone_number` | string |
+
+**Returned by:** Lists the phone number blocks jobs, Deletes all numbers associated with a phone number block, Retrieves a phone number blocks job
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `etc` | date-time |
+| `failed_operations` | array[object] |
+| `id` | uuid |
+| `record_type` | string |
+| `status` | enum: pending, in_progress, completed, failed |
+| `successful_operations` | array[object] |
+| `type` | enum: delete_phone_number_block |
+| `updated_at` | string |
+
+**Returned by:** List sub number orders, Retrieve a sub number order, Update a sub number order's requirements, Cancel a sub number order
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `is_block_sub_number_order` | boolean |
+| `order_request_id` | uuid |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+**Returned by:** Create a sub number orders report, Retrieve a sub number orders report
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `filters` | object |
+| `id` | uuid |
+| `order_type` | string |
+| `status` | enum: pending, success, failed, expired |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+## Optional Parameters
+
+### Create Advanced Order — `client.AdvancedOrders.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `CountryCode` | string (ISO 3166-1 alpha-2) |  |
+| `Comments` | string |  |
+| `Quantity` | integer |  |
+| `AreaCode` | string |  |
+| `PhoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `Features` | array[object] |  |
+| `CustomerReference` | string |  |
+| `RequirementGroupId` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Update Advanced Order — `client.AdvancedOrders.UpdateRequirementGroup()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `CountryCode` | string (ISO 3166-1 alpha-2) |  |
+| `Comments` | string |  |
+| `Quantity` | integer |  |
+| `AreaCode` | string |  |
+| `PhoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `Features` | array[object] |  |
+| `CustomerReference` | string |  |
+| `RequirementGroupId` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Create a comment — `client.Comments.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Id` | string (UUID) |  |
+| `Body` | string |  |
+| `Commenter` | string |  |
+| `CommenterType` | enum (admin, user) |  |
+| `CommentRecordType` | enum (sub_number_order, requirement_group) |  |
+| `CommentRecordId` | string (UUID) |  |
+| `ReadAt` | string (date-time) | An ISO 8901 datetime string for when the comment was read. |
+| `CreatedAt` | string (date-time) | An ISO 8901 datetime string denoting when the comment was created. |
+| `UpdatedAt` | string (date-time) | An ISO 8901 datetime string for when the comment was updated. |
+
+### Create an inexplicit number order — `client.InexplicitNumberOrders.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ConnectionId` | string (UUID) | Connection id to apply to phone numbers that are purchased |
+| `MessagingProfileId` | string (UUID) | Messaging profile id to apply to phone numbers that are purchased |
+| `CustomerReference` | string | Reference label for the customer |
+| `BillingGroupId` | string (UUID) | Billing group id to apply to phone numbers that are purchased |
+
+### Create a number block order — `client.NumberBlockOrders.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Id` | string (UUID) |  |
+| `RecordType` | string |  |
+| `PhoneNumbersCount` | integer | The count of phone numbers in the number order. |
+| `ConnectionId` | string (UUID) | Identifies the connection associated with this phone number. |
+| `MessagingProfileId` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `Status` | enum (pending, success, failure) | The status of the order. |
+| `CustomerReference` | string | A customer reference string for customer look ups. |
+| `CreatedAt` | string (date-time) | An ISO 8901 datetime string denoting when the number order was created. |
+| `UpdatedAt` | string (date-time) | An ISO 8901 datetime string for when the number order was updated. |
+| `RequirementsMet` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `Errors` | string | Errors the reservation could happen upon |
+
+### Update requirements for a single phone number within a number order. — `client.NumberOrderPhoneNumbers.UpdateRequirements()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `RegulatoryRequirements` | array[object] |  |
+
+### Create a number order — `client.NumberOrders.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `PhoneNumbers` | array[object] |  |
+| `ConnectionId` | string (UUID) | Identifies the connection associated with this phone number. |
+| `MessagingProfileId` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `BillingGroupId` | string (UUID) | Identifies the billing group associated with the phone number. |
+| `CustomerReference` | string | A customer reference string for customer look ups. |
+
+### Update a number order — `client.NumberOrders.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `RegulatoryRequirements` | array[object] |  |
+| `CustomerReference` | string | A customer reference string for customer look ups. |
+
+### Create a number reservation — `client.NumberReservations.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Id` | string (UUID) |  |
+| `RecordType` | string |  |
+| `PhoneNumbers` | array[object] |  |
+| `Status` | enum (pending, success, failure) | The status of the entire reservation. |
+| `CustomerReference` | string | A customer reference string for customer look ups. |
+| `CreatedAt` | string (date-time) | An ISO 8901 datetime string denoting when the numbers reservation was created. |
+| `UpdatedAt` | string (date-time) | An ISO 8901 datetime string for when the number reservation was updated. |
+
+### Update a sub number order's requirements — `client.SubNumberOrders.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `RegulatoryRequirements` | array[object] |  |
+
+### Create a sub number orders report — `client.SubNumberOrdersReport.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Status` | enum (pending, success, failure) | Filter by order status |
+| `CountryCode` | string (ISO 3166-1 alpha-2) | Filter by country code |
+| `CreatedAtGt` | string (date-time) | Filter for orders created after this date |
+| `CreatedAtLt` | string (date-time) | Filter for orders created before this date |
+| `OrderRequestId` | string (UUID) | Filter by specific order request ID |
+| `CustomerReference` | string | Filter by customer reference |
+
+## Webhook Payload Fields
+
+### `numberOrderStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.event_type` | string | The type of event being sent |
+| `data.id` | uuid | Unique identifier for the event |
+| `data.occurred_at` | date-time | ISO 8601 timestamp of when the event occurred |
+| `data.payload.id` | uuid |  |
+| `data.payload.record_type` | string |  |
+| `data.payload.phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `data.payload.connection_id` | string | Identifies the connection associated with this phone number. |
+| `data.payload.messaging_profile_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.billing_group_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.phone_numbers` | array[object] |  |
+| `data.payload.sub_number_orders_ids` | array[string] |  |
+| `data.payload.status` | enum: pending, success, failure | The status of the order. |
+| `data.payload.customer_reference` | string | A customer reference string for customer look ups. |
+| `data.payload.created_at` | date-time | An ISO 8901 datetime string denoting when the number order was created. |
+| `data.payload.updated_at` | date-time | An ISO 8901 datetime string for when the number order was updated. |
+| `data.payload.requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `data.record_type` | string | Type of record |
+| `meta.attempt` | integer | Webhook delivery attempt number |
+| `meta.delivered_to` | uri | URL where the webhook was delivered |

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/go/voice.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/go/voice.md
@@ -39,7 +39,7 @@ response, err := client.Calls.Dial(context.Background(), telnyx.CallDialParams{
 		ConnectionID: "7267xxxxxxxxxxxxxx",
 		From:         "+18005550101",
 		To: telnyx.CallDialParamsToUnion{
-			OfString: telnyx.String("+18005550100"),
+			OfString: telnyx.String("+18005550100;secure=srtp"),
 		},
 	})
 if err != nil {
@@ -79,8 +79,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -98,14 +98,14 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `TimeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `BillingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `ClientState` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in the API Details section below |
+| ... | | | +56 optional params in the API Details section below |
 
 ```go
 	response, err := client.Calls.Dial(context.Background(), telnyx.CallDialParams{
 		ConnectionID: "7267xxxxxxxxxxxxxx",
 		From:         "+18005550101",
 		To: telnyx.CallDialParamsToUnion{
-			OfString: telnyx.String("+18005550100"),
+			OfString: telnyx.String("+18005550100;secure=srtp"),
 		},
 	})
 	if err != nil {
@@ -134,7 +134,7 @@ Primary inbound call-control command.
 | `BillingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `ClientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `WebhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in the API Details section below |
+| ... | | | +29 optional params in the API Details section below |
 
 ```go
 	response, err := client.Calls.Actions.Answer(
@@ -165,14 +165,14 @@ Common post-answer control path with downstream webhook implications.
 | `TimeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `ClientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `WebhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in the API Details section below |
+| ... | | | +35 optional params in the API Details section below |
 
 ```go
 	response, err := client.Calls.Actions.Transfer(
 		context.Background(),
 		"call_control_id",
 		telnyx.CallActionTransferParams{
-			To: "+18005550100",
+			To: "+18005550100;secure=srtp",
 		},
 	)
 	if err != nil {
@@ -249,7 +249,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
 | `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -445,7 +445,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -465,3 +465,427 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Voice (Go) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List call control applications, Create a call control application, Retrieve a call control application, Update a call control application, Delete a call control application
+
+| Field | Type |
+|-------|------|
+| `active` | boolean |
+| `anchorsite_override` | enum: Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, Chennai, IN, Amsterdam, Netherlands, Toronto, Canada, Sydney, Australia |
+| `application_name` | string |
+| `call_cost_in_webhooks` | boolean |
+| `created_at` | string |
+| `dtmf_type` | enum: RFC 2833, Inband, SIP INFO |
+| `first_command_timeout` | boolean |
+| `first_command_timeout_secs` | integer |
+| `id` | string |
+| `inbound` | object |
+| `outbound` | object |
+| `record_type` | enum: call_control_application |
+| `redact_dtmf_debug_logging` | boolean |
+| `tags` | array[string] |
+| `updated_at` | string |
+| `webhook_api_version` | enum: 1, 2 |
+| `webhook_event_failover_url` | url |
+| `webhook_event_url` | url |
+| `webhook_timeout_secs` | integer \| null |
+
+**Returned by:** Dial
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `recording_id` | uuid |
+| `start_time` | string |
+
+**Returned by:** Retrieve a call status
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `start_time` | string |
+
+**Returned by:** Answer call
+
+| Field | Type |
+|-------|------|
+| `recording_id` | uuid |
+| `result` | string |
+
+**Returned by:** Bridge calls, Hangup call, SIP Refer a call, Reject a call, Send SIP info, Transfer call
+
+| Field | Type |
+|-------|------|
+| `result` | string |
+
+**Returned by:** List all active calls for given connection
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `record_type` | enum: call |
+
+## Optional Parameters
+
+### Create a call control application — `client.CallControlApplications.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Active` | boolean | Specifies whether the connection can be used. |
+| `AnchorsiteOverride` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `DtmfType` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `FirstCommandTimeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `FirstCommandTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `Inbound` | object |  |
+| `Outbound` | object |  |
+| `WebhookApiVersion` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `WebhookEventFailoverUrl` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `WebhookTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `CallCostInWebhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `RedactDtmfDebugLogging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Update a call control application — `client.CallControlApplications.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `CallCostInWebhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `Active` | boolean | Specifies whether the connection can be used. |
+| `AnchorsiteOverride` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `DtmfType` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `FirstCommandTimeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `FirstCommandTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `Tags` | array[string] | Tags assigned to the Call Control Application. |
+| `Inbound` | object |  |
+| `Outbound` | object |  |
+| `WebhookApiVersion` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `WebhookEventFailoverUrl` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `WebhookTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `RedactDtmfDebugLogging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Dial — `client.Calls.Dial()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Assistant` | object | AI Assistant configuration. |
+| `ConversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `FromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `Privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `AudioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `SendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
+| `MediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
+| `PreferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `TimeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `TimeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `AnsweringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `AnsweringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `DeepfakeDetection` | object | Enables deepfake detection on the call. |
+| `ConferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
+| `CustomHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `BillingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `ClientState` | string | Use this field to add state to every subsequent webhook. |
+| `CommandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `LinkTo` | string | Use another call's control id for sharing the same call session id |
+| `BridgeIntent` | boolean | Indicates the intent to bridge this call with the call specified in link_to. |
+| `BridgeOnAnswer` | boolean | Whether to automatically bridge answered call to the call specified in link_to. |
+| `PreventDoubleBridge` | boolean | Prevents bridging and hangs up the call if the target is already bridged. |
+| `ParkAfterUnbridge` | string | If supplied with the value `self`, the current leg will be parked after unbri... |
+| `MediaEncryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the call. |
+| `SipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
+| `SipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
+| `SipHeaders` | array[object] | SIP headers to be added to the SIP INVITE request. |
+| `SipTransportProtocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `SoundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `StreamUrl` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `StreamTrack` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `StreamCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `StreamBidirectionalMode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `StreamBidirectionalCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `StreamBidirectionalTargetLegs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `StreamBidirectionalSamplingRate` | enum (8000, 16000, 22050, 24000, 48000) | Audio sampling rate. |
+| `StreamEstablishBeforeCallOriginate` | boolean | Establish websocket connection before dialing the destination. |
+| `SendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
+| `WebhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `WebhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `WebhookUrls` | object | A map of event types to webhook URLs. |
+| `WebhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `WebhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `Record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `RecordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `RecordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `RecordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `RecordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `RecordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `RecordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `RecordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `SuperviseCallControlId` | string (UUID) | The call leg which will be supervised by the new call. |
+| `SupervisorRole` | enum (barge, whisper, monitor) | The role of the supervisor call. |
+| `EnableDialogflow` | boolean | Enables Dialogflow for the current call. |
+| `DialogflowConfig` | object |  |
+| `Transcription` | boolean | Enable transcription upon call answer. |
+| `TranscriptionConfig` | object |  |
+| `SipRegion` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `StreamAuthToken` | string | An authentication token to be sent as part of the WebSocket connection when u... |
+
+### Answer call — `client.Calls.Actions.Answer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Assistant` | object | AI Assistant configuration. |
+| `ConversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `BillingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `ClientState` | string | Use this field to add state to every subsequent webhook. |
+| `CommandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `CustomHeaders` | array[object] | Custom headers to be added to the SIP INVITE response. |
+| `PreferredCodecs` | enum (G722,PCMU,PCMA,G729,OPUS,VP8,H264) | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `SipHeaders` | array[object] | SIP headers to be added to the SIP INVITE response. |
+| `SoundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `StreamUrl` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `StreamTrack` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `StreamCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `StreamBidirectionalMode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `StreamBidirectionalCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `StreamBidirectionalTargetLegs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `SendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
+| `WebhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `WebhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `Transcription` | boolean | Enable transcription upon call answer. |
+| `TranscriptionConfig` | object |  |
+| `Record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `RecordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `RecordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `RecordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `RecordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `RecordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `RecordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `RecordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `WebhookUrls` | object | A map of event types to webhook URLs. |
+| `WebhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `WebhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `DeepfakeDetection` | object | Enables deepfake detection on the call. |
+
+### Bridge calls — `client.Calls.Actions.Bridge()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ClientState` | string | Use this field to add state to every subsequent webhook. |
+| `CommandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `Queue` | string | The name of the queue you want to bridge with, can't be used together with ca... |
+| `VideoRoomId` | string (UUID) | The ID of the video room you want to bridge with, can't be used together with... |
+| `VideoRoomContext` | string | The additional parameter that will be passed to the video conference. |
+| `PreventDoubleBridge` | boolean | When set to `true`, it prevents bridging if the target call is already bridge... |
+| `ParkAfterUnbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `PlayRingtone` | boolean | Specifies whether to play a ringtone if the call you want to bridge with has ... |
+| `Ringtone` | enum (at, au, be, bg, br, ...) | Specifies which country ringtone to play when `play_ringtone` is set to `true`. |
+| `Record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `RecordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `RecordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `RecordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `RecordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `RecordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `RecordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `RecordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `MuteDtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `HoldAfterUnbridge` | boolean | Specifies behavior after the bridge ends. |
+
+### Hangup call — `client.Calls.Actions.Hangup()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ClientState` | string | Use this field to add state to every subsequent webhook. |
+| `CommandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `CustomHeaders` | array[object] | Custom headers to be added to the SIP BYE message. |
+
+### SIP Refer a call — `client.Calls.Actions.Refer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ClientState` | string | Use this field to add state to every subsequent webhook. |
+| `CommandId` | string (UUID) | Use this field to avoid execution of duplicate commands. |
+| `CustomHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `SipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
+| `SipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
+| `SipHeaders` | array[object] | SIP headers to be added to the request. |
+
+### Reject a call — `client.Calls.Actions.Reject()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ClientState` | string | Use this field to add state to every subsequent webhook. |
+| `CommandId` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Send SIP info — `client.Calls.Actions.SendSipInfo()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ClientState` | string | Use this field to add state to every subsequent webhook. |
+| `CommandId` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Transfer call — `client.Calls.Actions.Transfer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `From` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
+| `FromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `Privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `AudioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `SendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
+| `EarlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
+| `MediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
+| `TimeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `TimeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `ParkAfterUnbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `AnsweringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `AnsweringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `CustomHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `ClientState` | string | Use this field to add state to every subsequent webhook. |
+| `TargetLegClientState` | string | Use this field to add state to every subsequent webhook for the new leg. |
+| `CommandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `MediaEncryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the new call leg. |
+| `SipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
+| `SipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
+| `SipHeaders` | array[object] | SIP headers to be added to the SIP INVITE. |
+| `SipTransportProtocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `SoundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `WebhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `WebhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `MuteDtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `Record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `RecordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `RecordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `RecordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `RecordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `RecordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `RecordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `RecordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `SipRegion` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `PreferredCodecs` | string | The list of comma-separated codecs in order of preference to be used during t... |
+| `WebhookUrls` | object | A map of event types to webhook URLs. |
+| `WebhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `WebhookRetriesPolicies` | object | A map of event types to retry policies. |
+
+## Webhook Payload Fields
+
+### `callAnswered`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.answered | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: answered | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### `callBridged`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.bridged | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+
+### `callHangup`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.hangup | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: hangup | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+| `data.payload.hangup_cause` | enum: call_rejected, normal_clearing, originator_cancel, timeout, time_limit, user_busy, not_found, no_answer, unspecified | The reason the call was ended (`call_rejected`, `normal_clearing`, `originator_cancel`, `timeout`, `time_limit`, `use... |
+| `data.payload.hangup_source` | enum: caller, callee, unknown | The party who ended the call (`callee`, `caller`, `unknown`). |
+| `data.payload.sip_hangup_cause` | string | The reason the call was ended (SIP response code). |
+| `data.payload.call_quality_stats` | object \| null | Call quality statistics aggregated from the CHANNEL_HANGUP_COMPLETE event. |
+
+### `callInitiated`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.initiated | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
+| `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.custom_headers` | array[object] | Custom headers from sip invite |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.shaken_stir_attestation` | string | SHAKEN/STIR attestation level. |
+| `data.payload.shaken_stir_validated` | boolean | Whether attestation was successfully validated or not. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.caller_id_name` | string | Caller id. |
+| `data.payload.call_screening_result` | string | Call screening result. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.direction` | enum: incoming, outgoing | Whether the call is `incoming` or `outgoing`. |
+| `data.payload.state` | enum: parked, bridging | State received from a command. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### Field Type Notes
+
+- `from` in webhook payloads: string (E.164 phone number)
+- `to` in webhook payloads: string (E.164 phone number)
+- The return value of `client.webhooks.unwrap()` is a parsed event object — access fields via `event.data.event_type`, `event.data.payload.call_control_id`, etc.

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/10dlc.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/10dlc.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -66,8 +66,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -232,7 +232,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `description` | string | Description of the event. |
 | `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -309,7 +309,6 @@ Create or provision an additional resource when the core tasks do not cover this
 ```java
 import com.telnyx.sdk.models.messaging10dlc.phonenumbercampaigns.PhoneNumberCampaign;
 import com.telnyx.sdk.models.messaging10dlc.phonenumbercampaigns.PhoneNumberCampaignCreate;
-import com.telnyx.sdk.models.messaging10dlc.phonenumbercampaigns.PhoneNumberCampaignCreateParams;
 
 PhoneNumberCampaignCreate params = PhoneNumberCampaignCreate.builder()
     .campaignId("4b300178-131c-d902-d54e-72d90ba1620j")
@@ -402,7 +401,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -442,3 +441,471 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# 10DLC (Java) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Brands, List Campaigns, List shared partner campaigns, List Shared Campaigns, List phone number campaigns
+
+| Field | Type |
+|-------|------|
+| `page` | integer |
+| `records` | array[object] |
+| `totalRecords` | integer |
+
+**Returned by:** Create Brand, Update Brand, Revet Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Get Brand Feedback By Id
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `category` | array[object] |
+
+**Returned by:** Get Brand SMS OTP Status, Get Brand SMS OTP Status by Brand ID
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `deliveryStatus` | string |
+| `deliveryStatusDate` | date-time |
+| `deliveryStatusDetails` | string |
+| `mobilePhone` | string |
+| `referenceId` | string |
+| `requestDate` | date-time |
+| `verifyDate` | date-time |
+
+**Returned by:** Get Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `assignedCampaignsCount` | number |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Order Brand External Vetting, Import External Vetting Record
+
+| Field | Type |
+|-------|------|
+| `createDate` | string |
+| `evpId` | string |
+| `vettedDate` | string |
+| `vettingClass` | string |
+| `vettingId` | string |
+| `vettingScore` | integer |
+| `vettingToken` | string |
+
+**Returned by:** Trigger Brand SMS OTP
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `referenceId` | string |
+
+**Returned by:** Get Campaign Cost
+
+| Field | Type |
+|-------|------|
+| `campaignUsecase` | string |
+| `description` | string |
+| `monthlyCost` | string |
+| `upFrontCost` | string |
+
+**Returned by:** Get campaign, Update campaign, Submit Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `autoRenewal` | boolean |
+| `billedDate` | string |
+| `brandDisplayName` | string |
+| `brandId` | string |
+| `campaignId` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createDate` | string |
+| `cspId` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isTMobileNumberPoolingEnabled` | boolean |
+| `isTMobileRegistered` | boolean |
+| `isTMobileSuspended` | boolean |
+| `messageFlow` | string |
+| `mock` | boolean |
+| `nextRenewalOrExpirationDate` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `referenceId` | string |
+| `resellerId` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `status` | string |
+| `subUsecases` | array[string] |
+| `submissionStatus` | enum: CREATED, FAILED, PENDING |
+| `subscriberHelp` | boolean |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `usecase` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Deactivate campaign
+
+| Field | Type |
+|-------|------|
+| `message` | string |
+| `record_type` | string |
+| `time` | number |
+
+**Returned by:** Submit campaign appeal for manual review
+
+| Field | Type |
+|-------|------|
+| `appealed_at` | date-time |
+
+**Returned by:** Get Campaign Mno Metadata
+
+| Field | Type |
+|-------|------|
+| `10999` | object |
+
+**Returned by:** Get Sharing Status
+
+| Field | Type |
+|-------|------|
+| `sharedByMe` | object |
+| `sharedWithMe` | object |
+
+**Returned by:** Qualify By Usecase
+
+| Field | Type |
+|-------|------|
+| `annualFee` | number |
+| `maxSubUsecases` | integer |
+| `minSubUsecases` | integer |
+| `mnoMetadata` | object |
+| `monthlyFee` | number |
+| `quarterlyFee` | number |
+| `usecase` | string |
+
+**Returned by:** Get Single Shared Campaign, Update Single Shared Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `assignedPhoneNumbersCount` | number |
+| `brandDisplayName` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createdAt` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isNumberPoolingEnabled` | boolean |
+| `messageFlow` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `subUsecases` | array[string] |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `updatedAt` | string |
+| `usecase` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Assign Messaging Profile To Campaign
+
+| Field | Type |
+|-------|------|
+| `campaignId` | string |
+| `messagingProfileId` | string |
+| `taskId` | string |
+| `tcrCampaignId` | string |
+
+**Returned by:** Get Assignment Task Status
+
+| Field | Type |
+|-------|------|
+| `createdAt` | date-time |
+| `status` | string |
+| `taskId` | string |
+| `updatedAt` | date-time |
+
+**Returned by:** Get Phone Number Status
+
+| Field | Type |
+|-------|------|
+| `records` | array[object] |
+
+**Returned by:** Create New Phone Number Campaign, Get Single Phone Number Campaign, Create New Phone Number Campaign, Delete Phone Number Campaign
+
+| Field | Type |
+|-------|------|
+| `assignmentStatus` | enum: FAILED_ASSIGNMENT, PENDING_ASSIGNMENT, ASSIGNED, PENDING_UNASSIGNMENT, FAILED_UNASSIGNMENT |
+| `brandId` | string |
+| `campaignId` | string |
+| `createdAt` | string |
+| `failureReasons` | string |
+| `phoneNumber` | string |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `telnyxCampaignId` | string |
+| `updatedAt` | string |
+
+## Optional Parameters
+
+### Create Brand — `client.messaging10dlc().brand().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `companyName` | string | (Required for Non-profit/private/public) Legal company name. |
+| `firstName` | string | First name of business contact. |
+| `lastName` | string | Last name of business contact. |
+| `ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `phone` | string | Valid phone number in e.164 international format. |
+| `street` | string | Street number and name. |
+| `city` | string | City name |
+| `state` | string | State. |
+| `postalCode` | string | Postal codes. |
+| `stockSymbol` | string | (Required for public company) stock symbol. |
+| `stockExchange` | object | (Required for public company) stock exchange. |
+| `ipAddress` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `website` | string | Brand website URL. |
+| `isReseller` | boolean |  |
+| `mock` | boolean | Mock brand for testing purposes. |
+| `mobilePhone` | string | Valid mobile phone number in e.164 international format. |
+| `businessContactEmail` | string | Business contact email. |
+| `webhookURL` | string | Webhook URL for brand status updates. |
+| `webhookFailoverURL` | string | Webhook failover URL for brand status updates. |
+
+### Update Brand — `client.messaging10dlc().brand().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `companyName` | string | (Required for Non-profit/private/public) Legal company name. |
+| `firstName` | string | First name of business contact. |
+| `lastName` | string | Last name of business contact. |
+| `ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `phone` | string | Valid phone number in e.164 international format. |
+| `street` | string | Street number and name. |
+| `city` | string | City name |
+| `state` | string | State. |
+| `postalCode` | string | Postal codes. |
+| `stockSymbol` | string | (Required for public company) stock symbol. |
+| `stockExchange` | object | (Required for public company) stock exchange. |
+| `ipAddress` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `website` | string | Brand website URL. |
+| `altBusinessIdType` | enum (NONE, DUNS, GIIN, LEI) | An enumeration. |
+| `isReseller` | boolean |  |
+| `identityStatus` | enum (VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED) | The verification status of an active brand |
+| `businessContactEmail` | string | Business contact email. |
+| `webhookURL` | string | Webhook URL for brand status updates. |
+| `webhookFailoverURL` | string | Webhook failover URL for brand status updates. |
+| `altBusinessId` | string (UUID) | Alternate business identifier such as DUNS, LEI, or GIIN |
+
+### Import External Vetting Record — `client.messaging10dlc().brand().externalVetting().imports()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `vettingToken` | string | Required by some providers for vetting record confirmation. |
+
+### Update campaign — `client.messaging10dlc().campaign().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `resellerId` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `sample1` | string | Message sample. |
+| `sample2` | string | Message sample. |
+| `sample3` | string | Message sample. |
+| `sample4` | string | Message sample. |
+| `sample5` | string | Message sample. |
+| `messageFlow` | string | Message flow description. |
+| `helpMessage` | string | Help message of the campaign. |
+| `autoRenewal` | boolean | Help message of the campaign. |
+| `webhookURL` | string | Webhook to which campaign status updates are sent. |
+| `webhookFailoverURL` | string | Webhook failover to which campaign status updates are sent. |
+
+### Submit Campaign — `client.messaging10dlc().campaignBuilder().submit()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ageGated` | boolean | Age gated message content in campaign. |
+| `autoRenewal` | boolean | Campaign subscription auto-renewal option. |
+| `directLending` | boolean | Direct lending or loan arrangement |
+| `embeddedLink` | boolean | Does message generated by the campaign include URL link in SMS? |
+| `embeddedPhone` | boolean | Does message generated by the campaign include phone number in SMS? |
+| `helpKeywords` | string | Subscriber help keywords. |
+| `helpMessage` | string | Help message of the campaign. |
+| `messageFlow` | string | Message flow description. |
+| `mnoIds` | array[integer] | Submit campaign to given list of MNOs by MNO's network ID. |
+| `numberPool` | boolean | Does campaign utilize pool of phone numbers? |
+| `optinKeywords` | string | Subscriber opt-in keywords. |
+| `optinMessage` | string | Subscriber opt-in message. |
+| `optoutKeywords` | string | Subscriber opt-out keywords. |
+| `optoutMessage` | string | Subscriber opt-out message. |
+| `referenceId` | string (UUID) | Caller supplied campaign reference ID. |
+| `resellerId` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `sample1` | string | Message sample. |
+| `sample2` | string | Message sample. |
+| `sample3` | string | Message sample. |
+| `sample4` | string | Message sample. |
+| `sample5` | string | Message sample. |
+| `subUsecases` | array[string] | Campaign sub-usecases. |
+| `subscriberHelp` | boolean | Does campaign responds to help keyword(s)? |
+| `subscriberOptin` | boolean | Does campaign require subscriber to opt-in before SMS is sent to subscriber? |
+| `subscriberOptout` | boolean | Does campaign support subscriber opt-out keyword(s)? |
+| `tag` | array[string] | Tags to be set on the Campaign. |
+| `termsAndConditions` | boolean | Is terms and conditions accepted? |
+| `privacyPolicyLink` | string | Link to the campaign's privacy policy. |
+| `termsAndConditionsLink` | string | Link to the campaign's terms and conditions. |
+| `embeddedLinkSample` | string | Sample of an embedded link that will be sent to subscribers. |
+| `webhookURL` | string | Webhook to which campaign status updates are sent. |
+| `webhookFailoverURL` | string | Failover webhook to which campaign status updates are sent. |
+
+### Update Single Shared Campaign — `client.messaging10dlc().partnerCampaigns().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `webhookURL` | string | Webhook to which campaign status updates are sent. |
+| `webhookFailoverURL` | string | Webhook failover to which campaign status updates are sent. |
+
+### Assign Messaging Profile To Campaign — `client.messaging10dlc().phoneNumberAssignmentByProfile().assign()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `tcrCampaignId` | string (UUID) | The TCR ID of the shared campaign you want to link to the specified messaging... |
+| `campaignId` | string (UUID) | The ID of the campaign you want to link to the specified messaging profile. |
+
+## Webhook Payload Fields
+
+### `campaignStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `brandId` | string | Brand ID associated with the campaign. |
+| `campaignId` | string | The ID of the campaign. |
+| `createDate` | string | Unix timestamp when campaign was created. |
+| `cspId` | string | Alphanumeric identifier of the CSP associated with this campaign. |
+| `isTMobileRegistered` | boolean | Indicates whether the campaign is registered with T-Mobile. |
+| `type` | enum: TELNYX_EVENT, REGISTRATION, MNO_REVIEW, TELNYX_REVIEW, NUMBER_POOL_PROVISIONED, NUMBER_POOL_DEPROVISIONED, TCR_EVENT, VERIFIED |  |
+| `description` | string | Description of the event. |
+| `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/ai-assistants.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/ai-assistants.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -37,8 +37,8 @@ import com.telnyx.sdk.models.ai.assistants.AssistantCreateParams;
 import com.telnyx.sdk.models.ai.assistants.InferenceEmbedding;
 AssistantCreateParams params = AssistantCreateParams.builder()
     .instructions("You are a helpful assistant.")
-    .model("openai/gpt-4o")
     .name("my-resource")
+    .model("openai/gpt-4o")
     .build();
 InferenceEmbedding assistant = client.ai().assistants().create(params);
 ```
@@ -57,7 +57,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -70,12 +70,11 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `description` | string | No |  |
-| `greeting` | string | No | Text that the assistant will use to start the conversation. |
-| ... | | | +11 optional params in the API Details section below |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in the API Details section below |
 
 ```java
 import com.telnyx.sdk.models.ai.assistants.AssistantCreateParams;
@@ -83,8 +82,8 @@ import com.telnyx.sdk.models.ai.assistants.InferenceEmbedding;
 
 AssistantCreateParams params = AssistantCreateParams.builder()
     .instructions("You are a helpful assistant.")
-    .model("openai/gpt-4o")
     .name("my-resource")
+    .model("openai/gpt-4o")
     .build();
 InferenceEmbedding assistant = client.ai().assistants().create(params);
 ```
@@ -203,7 +202,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### Update an assistant
 
@@ -214,10 +213,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistantId` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +15 optional params in the API Details section below |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in the API Details section below |
 
 ```java
 import com.telnyx.sdk.models.ai.assistants.AssistantUpdateParams;
@@ -232,7 +231,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### List assistants
 
@@ -256,7 +255,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Import assistants from external provider
 
@@ -290,7 +289,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Get All Tags
 
@@ -396,7 +395,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -409,8 +408,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai().assistants().tests().runs().retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId`, `runId` |
 | Delete an assistant | `client.ai().assistants().delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Get Canary Deploy | `client.ai().assistants().canaryDeploys().retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Create Canary Deploy | `client.ai().assistants().canaryDeploys().create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistantId` |
-| Update Canary Deploy | `client.ai().assistants().canaryDeploys().update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistantId` |
+| Create Canary Deploy | `client.ai().assistants().canaryDeploys().create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId` |
+| Update Canary Deploy | `client.ai().assistants().canaryDeploys().update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistantId` |
 | Delete Canary Deploy | `client.ai().assistants().canaryDeploys().delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Assistant Sms Chat | `client.ai().assistants().sendSms()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistantId` |
 | Clone Assistant | `client.ai().assistants().clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId` |
@@ -421,6 +420,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Add Assistant Tag | `client.ai().assistants().tags().add()` | `POST /ai/assistants/{assistant_id}/tags` | Create or provision an additional resource when the core tasks do not cover this flow. | `tag`, `assistantId` |
 | Remove Assistant Tag | `client.ai().assistants().tags().remove()` | `DELETE /ai/assistants/{assistant_id}/tags/{tag}` | Remove, detach, or clean up an existing resource. | `assistantId`, `tag` |
 | Get assistant texml | `client.ai().assistants().getTexml()` | `GET /ai/assistants/{assistant_id}/texml` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
+| Add Assistant Tool | `client.ai().assistants().tools().add()` | `PUT /ai/assistants/{assistant_id}/tools/{tool_id}` | Modify an existing resource without recreating it. | `assistantId`, `toolId` |
+| Remove Assistant Tool | `client.ai().assistants().tools().remove()` | `DELETE /ai/assistants/{assistant_id}/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `assistantId`, `toolId` |
 | Test Assistant Tool | `client.ai().assistants().tools().test()` | `POST /ai/assistants/{assistant_id}/tools/{tool_id}/test` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId`, `toolId` |
 | Get all versions of an assistant | `client.ai().assistants().versions().list()` | `GET /ai/assistants/{assistant_id}/versions` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
 | Get a specific assistant version | `client.ai().assistants().versions().retrieve()` | `GET /ai/assistants/{assistant_id}/versions/{version_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId`, `versionId` |
@@ -432,7 +433,398 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get MCP Server | `client.ai().mcpServers().retrieve()` | `GET /ai/mcp_servers/{mcp_server_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `mcpServerId` |
 | Update MCP Server | `client.ai().mcpServers().update()` | `PUT /ai/mcp_servers/{mcp_server_id}` | Modify an existing resource without recreating it. | `mcpServerId` |
 | Delete MCP Server | `client.ai().mcpServers().delete()` | `DELETE /ai/mcp_servers/{mcp_server_id}` | Remove, detach, or clean up an existing resource. | `mcpServerId` |
+| List Tools | `client.ai().tools().list()` | `GET /ai/tools` | Inspect available resources or choose an existing resource before mutating it. | None |
+| Create Tool | `client.ai().tools().create()` | `POST /ai/tools` | Create or provision an additional resource when the core tasks do not cover this flow. | `type`, `displayName` |
+| Get Tool | `client.ai().tools().retrieve()` | `GET /ai/tools/{tool_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `toolId` |
+| Update Tool | `client.ai().tools().update()` | `PATCH /ai/tools/{tool_id}` | Modify an existing resource without recreating it. | `toolId` |
+| Delete Tool | `client.ai().tools().delete()` | `DELETE /ai/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `toolId` |
 
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# AI Assistants (Java) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+
+## Response Schemas
+
+**Returned by:** List assistants, Create an assistant, Import assistants from external provider, Get an assistant, Update an assistant, Clone Assistant, Get all versions of an assistant, Get a specific assistant version, Update a specific assistant version, Promote an assistant version to main
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
+| `dynamic_variables_webhook_url` | string |
+| `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
+| `greeting` | string |
+| `id` | string |
+| `import_metadata` | object |
+| `insight_settings` | object |
+| `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
+| `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
+| `messaging_settings` | object |
+| `model` | string |
+| `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
+| `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
+| `telephony_settings` | object |
+| `tools` | array[object] |
+| `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
+| `voice_settings` | object |
+| `widget_settings` | object |
+
+**Returned by:** Get All Tags, Add Assistant Tag, Remove Assistant Tag
+
+| Field | Type |
+|-------|------|
+| `tags` | array[string] |
+
+**Returned by:** List assistant tests with pagination, Create a new assistant test, Get assistant test by ID, Update an assistant test
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `destination` | string |
+| `instructions` | string |
+| `max_duration_seconds` | integer |
+| `name` | string |
+| `rubric` | array[object] |
+| `telnyx_conversation_channel` | object |
+| `test_id` | uuid |
+| `test_suite` | string |
+
+**Returned by:** Get all test suite names
+
+| Field | Type |
+|-------|------|
+| `data` | array[string] |
+
+**Returned by:** Get test suite run history, Get test run history for a specific test, Trigger a manual test run, Get specific test run details
+
+| Field | Type |
+|-------|------|
+| `completed_at` | date-time |
+| `conversation_id` | string |
+| `conversation_insights_id` | string |
+| `created_at` | date-time |
+| `detail_status` | array[object] |
+| `logs` | string |
+| `run_id` | uuid |
+| `status` | enum: pending, starting, running, passed, failed, error |
+| `test_id` | uuid |
+| `test_suite_run_id` | uuid |
+| `triggered_by` | string |
+| `updated_at` | date-time |
+
+**Returned by:** Delete an assistant
+
+| Field | Type |
+|-------|------|
+| `deleted` | boolean |
+| `id` | string |
+| `object` | string |
+
+**Returned by:** Get Canary Deploy, Create Canary Deploy, Update Canary Deploy
+
+| Field | Type |
+|-------|------|
+| `assistant_id` | string |
+| `created_at` | date-time |
+| `rules` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Assistant Chat (BETA)
+
+| Field | Type |
+|-------|------|
+| `content` | string |
+
+**Returned by:** Assistant Sms Chat
+
+| Field | Type |
+|-------|------|
+| `conversation_id` | string |
+
+**Returned by:** List scheduled events
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Test Assistant Tool
+
+| Field | Type |
+|-------|------|
+| `content_type` | string |
+| `request` | object |
+| `response` | string |
+| `status_code` | integer |
+| `success` | boolean |
+
+**Returned by:** Create MCP Server, Get MCP Server, Update MCP Server
+
+| Field | Type |
+|-------|------|
+| `allowed_tools` | array \| null |
+| `api_key_ref` | string \| null |
+| `created_at` | date-time |
+| `id` | string |
+| `name` | string |
+| `type` | string |
+| `url` | string |
+
+**Returned by:** List Tools, Create Tool, Get Tool, Update Tool
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `display_name` | string |
+| `id` | string |
+| `timeout_ms` | integer |
+| `tool_definition` | object |
+| `type` | string |
+
+## Optional Parameters
+
+### Create an assistant — `client.ai().assistants().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
+| `voiceSettings` | object |  |
+| `transcription` | object |  |
+| `telephonySettings` | object |  |
+| `messagingSettings` | object |  |
+| `enabledFeatures` | array[object] |  |
+| `insightSettings` | object |  |
+| `privacySettings` | object |  |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamicVariables` | object | Map of dynamic variables and their default values |
+| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
+
+### Import assistants from external provider — `client.ai().assistants().imports()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `importIds` | array[string] | Optional list of assistant IDs to import from the external provider. |
+
+### Create a new assistant test — `client.ai().assistants().tests().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `description` | string | Optional detailed description of what this test evaluates and its purpose. |
+| `telnyxConversationChannel` | object | The communication channel through which the test will be conducted. |
+| `maxDurationSeconds` | integer | Maximum duration in seconds that the test conversation should run before timi... |
+| `testSuite` | string | Optional test suite name to group related tests together. |
+
+### Trigger test suite execution — `client.ai().assistants().tests().testSuites().runs().trigger()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `destinationVersionId` | string (UUID) | Optional assistant version ID to use for all test runs in this suite. |
+
+### Update an assistant test — `client.ai().assistants().tests().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | Updated name for the assistant test. |
+| `description` | string | Updated description of the test's purpose and evaluation criteria. |
+| `telnyxConversationChannel` | enum (phone_call, web_call, sms_chat, web_chat) |  |
+| `destination` | string | Updated target destination for test conversations. |
+| `maxDurationSeconds` | integer | Updated maximum test duration in seconds. |
+| `testSuite` | string | Updated test suite assignment for better organization. |
+| `instructions` | string | Updated test scenario instructions and objectives. |
+| `rubric` | array[object] | Updated evaluation criteria for assessing assistant performance. |
+
+### Trigger a manual test run — `client.ai().assistants().tests().runs().trigger()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `destinationVersionId` | string (UUID) | Optional assistant version ID to use for this test run. |
+
+### Update an assistant — `client.ai().assistants().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `instructions` | string | System instructions for the assistant. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
+| `voiceSettings` | object |  |
+| `transcription` | object |  |
+| `telephonySettings` | object |  |
+| `messagingSettings` | object |  |
+| `enabledFeatures` | array[object] |  |
+| `insightSettings` | object |  |
+| `privacySettings` | object |  |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamicVariables` | object | Map of dynamic variables and their default values |
+| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
+| `promoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai().assistants().canaryDeploys().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai().assistants().canaryDeploys().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Assistant Chat (BETA) — `client.ai().assistants().chat()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | The optional display name of the user sending the message |
+
+### Assistant Sms Chat — `client.ai().assistants().sendSms()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string |  |
+| `conversationMetadata` | object |  |
+| `shouldCreateConversation` | boolean |  |
+
+### Create a scheduled event — `client.ai().assistants().scheduledEvents().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Required for sms scheduled events. |
+| `conversationMetadata` | object | Metadata associated with the conversation. |
+| `dynamicVariables` | object | A map of dynamic variable names to values. |
+| `maxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retryIntervalSecs` | integer |  |
+
+### Test Assistant Tool — `client.ai().assistants().tools().test()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `arguments` | object | Key-value arguments to use for the webhook test |
+| `dynamicVariables` | object | Key-value dynamic variables to use for the webhook test |
+
+### Update a specific assistant version — `client.ai().assistants().versions().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `instructions` | string | System instructions for the assistant. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
+| `voiceSettings` | object |  |
+| `transcription` | object |  |
+| `telephonySettings` | object |  |
+| `messagingSettings` | object |  |
+| `enabledFeatures` | array[object] |  |
+| `insightSettings` | object |  |
+| `privacySettings` | object |  |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamicVariables` | object | Map of dynamic variables and their default values |
+| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
+
+### Create MCP Server — `client.ai().mcpServers().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `apiKeyRef` | string |  |
+| `allowedTools` | array[string] |  |
+
+### Update MCP Server — `client.ai().mcpServers().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `name` | string |  |
+| `type` | string |  |
+| `url` | string (URL) |  |
+| `apiKeyRef` | string |  |
+| `allowedTools` | array[string] |  |
+| `createdAt` | string (date-time) |  |
+
+### Create Tool — `client.ai().tools().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `function` | object |  |
+| `retrieval` | object |  |
+| `handoff` | object |  |
+| `invite` | object |  |
+| `webhook` | object |  |
+| `timeoutMs` | integer |  |
+
+### Update Tool — `client.ai().tools().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type` | string |  |
+| `displayName` | string |  |
+| `function` | object |  |
+| `retrieval` | object |  |
+| `handoff` | object |  |
+| `invite` | object |  |
+| `webhook` | object |  |
+| `timeoutMs` | integer |  |

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/messaging.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/messaging.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -63,8 +63,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -208,7 +208,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.media` | array[object] |  |
 | `data.record_type` | enum: event | Identifies the type of the resource. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -407,6 +407,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsappMessage` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```java
 import com.telnyx.sdk.models.messages.MessageSendWhatsappParams;
@@ -434,7 +435,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -468,3 +469,425 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Messaging (Java) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List alphanumeric sender IDs, Create an alphanumeric sender ID, Retrieve an alphanumeric sender ID, Delete an alphanumeric sender ID, List alphanumeric sender IDs for a messaging profile
+
+| Field | Type |
+|-------|------|
+| `alphanumeric_sender_id` | string |
+| `id` | uuid |
+| `messaging_profile_id` | uuid |
+| `organization_id` | string |
+| `record_type` | enum: alphanumeric_sender_id |
+| `us_long_code_fallback` | string |
+
+**Returned by:** Send a message, Send a message using an alphanumeric sender ID, Retrieve group MMS messages, Send a group MMS message, Send a long code message, Send a message using number pool, Schedule a message, Send a short code message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `wait_seconds` | float |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** Send a WhatsApp message
+
+| Field | Type |
+|-------|------|
+| `body` | object |
+| `direction` | string |
+| `encoding` | string |
+| `from` | object |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `organization_id` | string |
+| `received_at` | date-time |
+| `record_type` | string |
+| `to` | array[object] |
+| `type` | string |
+| `wait_seconds` | float |
+
+**Returned by:** Retrieve a message, Get detailed messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Cancel a scheduled message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** List messaging hosted numbers, Retrieve a messaging hosted number, Update a messaging hosted number
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `eligible_messaging_products` | array[string] |
+| `features` | object |
+| `health` | object |
+| `id` | string |
+| `messaging_product` | string |
+| `messaging_profile_id` | string \| null |
+| `organization_id` | string |
+| `phone_number` | string |
+| `record_type` | enum: messaging_phone_number, messaging_settings |
+| `tags` | array[string] |
+| `traffic_type` | string |
+| `type` | enum: long-code, toll-free, short-code, longcode, tollfree, shortcode |
+| `updated_at` | date-time |
+
+**Returned by:** List opt-outs
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `from` | string |
+| `keyword` | string \| null |
+| `messaging_profile_id` | string \| null |
+| `to` | string |
+
+**Returned by:** List high-level messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Regenerate messaging profile secret
+
+| Field | Type |
+|-------|------|
+| `ai_assistant_id` | string \| null |
+| `alpha_sender` | string \| null |
+| `created_at` | date-time |
+| `daily_spend_limit` | string |
+| `daily_spend_limit_enabled` | boolean |
+| `enabled` | boolean |
+| `health_webhook_url` | url |
+| `id` | uuid |
+| `mms_fall_back_to_sms` | boolean |
+| `mms_transcoding` | boolean |
+| `mobile_only` | boolean |
+| `name` | string |
+| `number_pool_settings` | object \| null |
+| `organization_id` | string |
+| `record_type` | enum: messaging_profile |
+| `redaction_enabled` | boolean |
+| `redaction_level` | integer |
+| `resource_group_id` | string \| null |
+| `smart_encoding` | boolean |
+| `updated_at` | date-time |
+| `url_shortener_settings` | object \| null |
+| `v1_secret` | string |
+| `webhook_api_version` | enum: 1, 2, 2010-04-01 |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+| `whitelisted_destinations` | array[string] |
+
+**Returned by:** List Auto-Response Settings, Create auto-response setting, Get Auto-Response Setting, Update Auto-Response Setting
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `id` | string |
+| `keywords` | array[string] |
+| `op` | enum: start, stop, info |
+| `resp_text` | string |
+| `updated_at` | date-time |
+
+## Optional Parameters
+
+### Create an alphanumeric sender ID — `client.alphanumericSenderIds().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `usLongCodeFallback` | string | A US long code number to use as fallback when sending to US destinations. |
+
+### Send a message — `client.messages().send()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using an alphanumeric sender ID — `client.messages().sendWithAlphanumericSender()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `webhookUrl` | string (URL) | Callback URL for delivery status updates. |
+| `webhookFailoverUrl` | string (URL) | Failover callback URL for delivery status updates. |
+| `useProfileWebhooks` | boolean | If true, use the messaging profile's webhook settings. |
+
+### Send a group MMS message — `client.messages().sendGroupMms()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+
+### Send a long code message — `client.messages().sendLongCode()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using number pool — `client.messages().sendNumberPool()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Schedule a message — `client.messages().schedule()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+
+### Send a short code message — `client.messages().sendShortCode()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a WhatsApp message — `client.messages().sendWhatsapp()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
+
+### Update a messaging hosted number — `client.messagingHostedNumbers().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `messagingProfileId` | string (UUID) | Configure the messaging profile this phone number is assigned to:
+
+* Omit thi... |
+| `messagingProduct` | string | Configure the messaging product for this number:
+
+* Omit this field or set it... |
+| `tags` | array[string] | Tags to set on this phone number. |
+
+### Create auto-response setting — `client.messagingProfiles().autorespConfigs().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `respText` | string |  |
+
+### Update Auto-Response Setting — `client.messagingProfiles().autorespConfigs().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `respText` | string |  |
+
+## Webhook Payload Fields
+
+### `deliveryUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.sent, message.finalized | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: outbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | uuid | The id of the organization the messaging profile belongs to. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Subject of multimedia message |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | ISO 8601 formatted date indicating when the message was sent. |
+| `data.payload.completed_at` | date-time | ISO 8601 formatted date indicating when the message was finalized. |
+| `data.payload.valid_until` | date-time | Message must be out of the queue by this time or else it will be discarded and marked as 'sending_failed'. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+| `data.payload.smart_encoding_applied` | boolean | Indicates whether smart encoding was applied to this message. |
+| `data.payload.wait_seconds` | float | Seconds the message is queued due to rate limiting before being sent to the carrier. |
+| `meta.attempt` | integer | Number of attempts to deliver the webhook event. |
+| `meta.delivered_to` | url | The webhook URL the event was delivered to. |
+
+### `inboundMessage`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.received | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: inbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Message subject. |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | Not used for inbound messages. |
+| `data.payload.completed_at` | date-time | Not used for inbound messages. |
+| `data.payload.valid_until` | date-time | Not used for inbound messages. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+
+### `replacedLinkClick`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | string | Identifies the type of the resource. |
+| `data.url` | string | The original link that was sent in the message. |
+| `data.to` | string | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or short code). |
+| `data.message_id` | uuid | The message ID associated with the clicked link. |
+| `data.time_clicked` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+
+### Field Type Notes
+
+- `from` in responses/webhooks: object with sub-fields `phone_number` (string), `carrier` (string), `line_type` (string)
+- `to` in responses/webhooks: array of objects, each with `phone_number` (string), `carrier` (string), `line_type` (string), `status` (string)
+- `cost`: object with `amount` (string, decimal), `currency` (string, e.g., 'USD')

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/numbers.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/numbers.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -52,7 +52,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -266,7 +266,6 @@ Create or provision an additional resource when the core tasks do not cover this
 
 ```java
 import com.telnyx.sdk.models.advancedorders.AdvancedOrder;
-import com.telnyx.sdk.models.advancedorders.AdvancedOrderCreateParams;
 import com.telnyx.sdk.models.advancedorders.AdvancedOrderCreateResponse;
 
 AdvancedOrder params = AdvancedOrder.builder().build();
@@ -403,7 +402,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -453,3 +452,433 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Numbers (Java) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Advanced Orders, Create Advanced Order, Update Advanced Order, Get Advanced Order
+
+| Field | Type |
+|-------|------|
+| `area_code` | string |
+| `comments` | string |
+| `country_code` | string |
+| `customer_reference` | string |
+| `features` | array[object] |
+| `id` | uuid |
+| `orders` | array[string] |
+| `phone_number_type` | object |
+| `quantity` | integer |
+| `requirement_group_id` | uuid |
+| `status` | object |
+
+**Returned by:** List available phone number blocks
+
+| Field | Type |
+|-------|------|
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `range` | integer |
+| `record_type` | enum: available_phone_number_block |
+| `region_information` | array[object] |
+
+**Returned by:** List available phone numbers
+
+| Field | Type |
+|-------|------|
+| `best_effort` | boolean |
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `quickship` | boolean |
+| `record_type` | enum: available_phone_number |
+| `region_information` | array[object] |
+| `reservable` | boolean |
+| `vanity_format` | string |
+
+**Returned by:** Retrieve all comments
+
+| Field | Type |
+|-------|------|
+| `body` | string |
+| `comment_record_id` | uuid |
+| `comment_record_type` | enum: sub_number_order, requirement_group |
+| `commenter` | string |
+| `commenter_type` | enum: admin, user |
+| `created_at` | date-time |
+| `id` | uuid |
+| `read_at` | date-time |
+| `updated_at` | date-time |
+
+**Returned by:** Create a comment, Retrieve a comment, Mark a comment as read, Get country coverage
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Get coverage for a specific country
+
+| Field | Type |
+|-------|------|
+| `code` | string |
+| `features` | array[string] |
+| `international_sms` | boolean |
+| `inventory_coverage` | boolean |
+| `local` | object |
+| `mobile` | object |
+| `national` | object |
+| `numbers` | boolean |
+| `p2p` | boolean |
+| `phone_number_type` | array[string] |
+| `quickship` | boolean |
+| `region` | string \| null |
+| `reservable` | boolean |
+| `shared_cost` | object |
+| `toll_free` | object |
+
+**Returned by:** List customer service records, Create a customer service record, Get a customer service record
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `error_message` | string \| null |
+| `id` | uuid |
+| `phone_number` | string |
+| `record_type` | string |
+| `result` | object \| null |
+| `status` | enum: pending, completed, failed |
+| `updated_at` | date-time |
+| `webhook_url` | string |
+
+**Returned by:** Verify CSR phone number coverage
+
+| Field | Type |
+|-------|------|
+| `additional_data_required` | array[string] |
+| `has_csr_coverage` | boolean |
+| `phone_number` | string |
+| `reason` | string |
+| `record_type` | string |
+
+**Returned by:** List inexplicit number orders, Create an inexplicit number order, Retrieve an inexplicit number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `ordering_groups` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Create an inventory coverage request
+
+| Field | Type |
+|-------|------|
+| `administrative_area` | string |
+| `advance_requirements` | boolean |
+| `count` | integer |
+| `coverage_type` | enum: number, block |
+| `group` | string |
+| `group_type` | string |
+| `number_range` | integer |
+| `number_type` | enum: did, toll-free |
+| `phone_number_type` | enum: local, toll_free, national, landline, shared_cost, mobile |
+| `record_type` | string |
+
+**Returned by:** List mobile network operators
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `id` | uuid |
+| `mcc` | string |
+| `mnc` | string |
+| `name` | string |
+| `network_preferences_enabled` | boolean |
+| `record_type` | string |
+| `tadig` | string |
+
+**Returned by:** List network coverage locations
+
+| Field | Type |
+|-------|------|
+| `available_services` | array[object] |
+| `location` | object |
+| `record_type` | string |
+
+**Returned by:** List number block orders, Create a number block order, Retrieve a number block order
+
+| Field | Type |
+|-------|------|
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers_count` | integer |
+| `range` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `starting_number` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve a list of phone numbers associated to orders, Retrieve a single phone number within a number order., Update requirements for a single phone number within a number order.
+
+| Field | Type |
+|-------|------|
+| `bundle_id` | uuid |
+| `country_code` | string |
+| `deadline` | date-time |
+| `id` | uuid |
+| `is_block_number` | boolean |
+| `locality` | string |
+| `order_request_id` | uuid |
+| `phone_number` | string |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `requirements_status` | enum: pending, approved, cancelled, deleted, requirement-info-exception, requirement-info-pending, requirement-info-under-review |
+| `status` | enum: pending, success, failure |
+| `sub_number_order_id` | uuid |
+
+**Returned by:** List number orders, Create a number order, Retrieve a number order, Update a number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers` | array[object] |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `sub_number_orders_ids` | array[string] |
+| `updated_at` | date-time |
+
+**Returned by:** List number reservations, Create a number reservation, Retrieve a number reservation, Extend a number reservation
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `errors` | string |
+| `id` | uuid |
+| `phone_numbers` | array[object] |
+| `record_type` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve the features for a list of numbers
+
+| Field | Type |
+|-------|------|
+| `features` | array[string] |
+| `phone_number` | string |
+
+**Returned by:** Lists the phone number blocks jobs, Deletes all numbers associated with a phone number block, Retrieves a phone number blocks job
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `etc` | date-time |
+| `failed_operations` | array[object] |
+| `id` | uuid |
+| `record_type` | string |
+| `status` | enum: pending, in_progress, completed, failed |
+| `successful_operations` | array[object] |
+| `type` | enum: delete_phone_number_block |
+| `updated_at` | string |
+
+**Returned by:** List sub number orders, Retrieve a sub number order, Update a sub number order's requirements, Cancel a sub number order
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `is_block_sub_number_order` | boolean |
+| `order_request_id` | uuid |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+**Returned by:** Create a sub number orders report, Retrieve a sub number orders report
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `filters` | object |
+| `id` | uuid |
+| `order_type` | string |
+| `status` | enum: pending, success, failed, expired |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+## Optional Parameters
+
+### Create Advanced Order — `client.advancedOrders().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `countryCode` | string (ISO 3166-1 alpha-2) |  |
+| `comments` | string |  |
+| `quantity` | integer |  |
+| `areaCode` | string |  |
+| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `features` | array[object] |  |
+| `customerReference` | string |  |
+| `requirementGroupId` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Update Advanced Order — `client.advancedOrders().updateRequirementGroup()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `countryCode` | string (ISO 3166-1 alpha-2) |  |
+| `comments` | string |  |
+| `quantity` | integer |  |
+| `areaCode` | string |  |
+| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `features` | array[object] |  |
+| `customerReference` | string |  |
+| `requirementGroupId` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Create a comment — `client.comments().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `body` | string |  |
+| `commenter` | string |  |
+| `commenterType` | enum (admin, user) |  |
+| `commentRecordType` | enum (sub_number_order, requirement_group) |  |
+| `commentRecordId` | string (UUID) |  |
+| `readAt` | string (date-time) | An ISO 8901 datetime string for when the comment was read. |
+| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the comment was created. |
+| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the comment was updated. |
+
+### Create an inexplicit number order — `client.inexplicitNumberOrders().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `connectionId` | string (UUID) | Connection id to apply to phone numbers that are purchased |
+| `messagingProfileId` | string (UUID) | Messaging profile id to apply to phone numbers that are purchased |
+| `customerReference` | string | Reference label for the customer |
+| `billingGroupId` | string (UUID) | Billing group id to apply to phone numbers that are purchased |
+
+### Create a number block order — `client.numberBlockOrders().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `recordType` | string |  |
+| `phoneNumbersCount` | integer | The count of phone numbers in the number order. |
+| `connectionId` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messagingProfileId` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `status` | enum (pending, success, failure) | The status of the order. |
+| `customerReference` | string | A customer reference string for customer look ups. |
+| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the number order was created. |
+| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the number order was updated. |
+| `requirementsMet` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `errors` | string | Errors the reservation could happen upon |
+
+### Update requirements for a single phone number within a number order. — `client.numberOrderPhoneNumbers().updateRequirements()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatoryRequirements` | array[object] |  |
+
+### Create a number order — `client.numberOrders().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `phoneNumbers` | array[object] |  |
+| `connectionId` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messagingProfileId` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `billingGroupId` | string (UUID) | Identifies the billing group associated with the phone number. |
+| `customerReference` | string | A customer reference string for customer look ups. |
+
+### Update a number order — `client.numberOrders().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatoryRequirements` | array[object] |  |
+| `customerReference` | string | A customer reference string for customer look ups. |
+
+### Create a number reservation — `client.numberReservations().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `recordType` | string |  |
+| `phoneNumbers` | array[object] |  |
+| `status` | enum (pending, success, failure) | The status of the entire reservation. |
+| `customerReference` | string | A customer reference string for customer look ups. |
+| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the numbers reservation was created. |
+| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the number reservation was updated. |
+
+### Update a sub number order's requirements — `client.subNumberOrders().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatoryRequirements` | array[object] |  |
+
+### Create a sub number orders report — `client.subNumberOrdersReport().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `status` | enum (pending, success, failure) | Filter by order status |
+| `countryCode` | string (ISO 3166-1 alpha-2) | Filter by country code |
+| `createdAtGt` | string (date-time) | Filter for orders created after this date |
+| `createdAtLt` | string (date-time) | Filter for orders created before this date |
+| `orderRequestId` | string (UUID) | Filter by specific order request ID |
+| `customerReference` | string | Filter by customer reference |
+
+## Webhook Payload Fields
+
+### `numberOrderStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.event_type` | string | The type of event being sent |
+| `data.id` | uuid | Unique identifier for the event |
+| `data.occurred_at` | date-time | ISO 8601 timestamp of when the event occurred |
+| `data.payload.id` | uuid |  |
+| `data.payload.record_type` | string |  |
+| `data.payload.phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `data.payload.connection_id` | string | Identifies the connection associated with this phone number. |
+| `data.payload.messaging_profile_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.billing_group_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.phone_numbers` | array[object] |  |
+| `data.payload.sub_number_orders_ids` | array[string] |  |
+| `data.payload.status` | enum: pending, success, failure | The status of the order. |
+| `data.payload.customer_reference` | string | A customer reference string for customer look ups. |
+| `data.payload.created_at` | date-time | An ISO 8901 datetime string denoting when the number order was created. |
+| `data.payload.updated_at` | date-time | An ISO 8901 datetime string for when the number order was updated. |
+| `data.payload.requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `data.record_type` | string | Type of record |
+| `meta.attempt` | integer | Webhook delivery attempt number |
+| `meta.delivered_to` | uri | URL where the webhook was delivered |

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/voice.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/voice.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -38,7 +38,7 @@ import com.telnyx.sdk.models.calls.CallDialResponse;
 CallDialParams params = CallDialParams.builder()
     .connectionId("7267xxxxxxxxxxxxxx")
     .from("+18005550101")
-    .to("+18005550100")
+    .to("+18005550100;secure=srtp")
     .build();
 CallDialResponse response = client.calls().dial(params);
 ```
@@ -63,8 +63,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -82,7 +82,7 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in the API Details section below |
+| ... | | | +56 optional params in the API Details section below |
 
 ```java
 import com.telnyx.sdk.models.calls.CallDialParams;
@@ -91,7 +91,7 @@ import com.telnyx.sdk.models.calls.CallDialResponse;
 CallDialParams params = CallDialParams.builder()
     .connectionId("7267xxxxxxxxxxxxxx")
     .from("+18005550101")
-    .to("+18005550100")
+    .to("+18005550100;secure=srtp")
     .build();
 CallDialResponse response = client.calls().dial(params);
 ```
@@ -116,7 +116,7 @@ Primary inbound call-control command.
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in the API Details section below |
+| ... | | | +29 optional params in the API Details section below |
 
 ```java
 import com.telnyx.sdk.models.calls.actions.ActionAnswerParams;
@@ -142,7 +142,7 @@ Common post-answer control path with downstream webhook implications.
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in the API Details section below |
+| ... | | | +35 optional params in the API Details section below |
 
 ```java
 import com.telnyx.sdk.models.calls.actions.ActionTransferParams;
@@ -150,7 +150,7 @@ import com.telnyx.sdk.models.calls.actions.ActionTransferResponse;
 
 ActionTransferParams params = ActionTransferParams.builder()
     .callControlId("v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ")
-    .to("+18005550100")
+    .to("+18005550100;secure=srtp")
     .build();
 ActionTransferResponse response = client.calls().actions().transfer(params);
 ```
@@ -237,7 +237,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
 | `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -415,7 +415,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -435,3 +435,427 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Voice (Java) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List call control applications, Create a call control application, Retrieve a call control application, Update a call control application, Delete a call control application
+
+| Field | Type |
+|-------|------|
+| `active` | boolean |
+| `anchorsite_override` | enum: Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, Chennai, IN, Amsterdam, Netherlands, Toronto, Canada, Sydney, Australia |
+| `application_name` | string |
+| `call_cost_in_webhooks` | boolean |
+| `created_at` | string |
+| `dtmf_type` | enum: RFC 2833, Inband, SIP INFO |
+| `first_command_timeout` | boolean |
+| `first_command_timeout_secs` | integer |
+| `id` | string |
+| `inbound` | object |
+| `outbound` | object |
+| `record_type` | enum: call_control_application |
+| `redact_dtmf_debug_logging` | boolean |
+| `tags` | array[string] |
+| `updated_at` | string |
+| `webhook_api_version` | enum: 1, 2 |
+| `webhook_event_failover_url` | url |
+| `webhook_event_url` | url |
+| `webhook_timeout_secs` | integer \| null |
+
+**Returned by:** Dial
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `recording_id` | uuid |
+| `start_time` | string |
+
+**Returned by:** Retrieve a call status
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `start_time` | string |
+
+**Returned by:** Answer call
+
+| Field | Type |
+|-------|------|
+| `recording_id` | uuid |
+| `result` | string |
+
+**Returned by:** Bridge calls, Hangup call, SIP Refer a call, Reject a call, Send SIP info, Transfer call
+
+| Field | Type |
+|-------|------|
+| `result` | string |
+
+**Returned by:** List all active calls for given connection
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `record_type` | enum: call |
+
+## Optional Parameters
+
+### Create a call control application — `client.callControlApplications().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `active` | boolean | Specifies whether the connection can be used. |
+| `anchorsiteOverride` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmfType` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `firstCommandTimeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `firstCommandTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `inbound` | object |  |
+| `outbound` | object |  |
+| `webhookApiVersion` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhookEventFailoverUrl` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhookTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `callCostInWebhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `redactDtmfDebugLogging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Update a call control application — `client.callControlApplications().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `callCostInWebhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `active` | boolean | Specifies whether the connection can be used. |
+| `anchorsiteOverride` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmfType` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `firstCommandTimeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `firstCommandTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `tags` | array[string] | Tags assigned to the Call Control Application. |
+| `inbound` | object |  |
+| `outbound` | object |  |
+| `webhookApiVersion` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhookEventFailoverUrl` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhookTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `redactDtmfDebugLogging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Dial — `client.calls().dial()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `audioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
+| `mediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
+| `preferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
+| `conferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
+| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `linkTo` | string | Use another call's control id for sharing the same call session id |
+| `bridgeIntent` | boolean | Indicates the intent to bridge this call with the call specified in link_to. |
+| `bridgeOnAnswer` | boolean | Whether to automatically bridge answered call to the call specified in link_to. |
+| `preventDoubleBridge` | boolean | Prevents bridging and hangs up the call if the target is already bridged. |
+| `parkAfterUnbridge` | string | If supplied with the value `self`, the current leg will be parked after unbri... |
+| `mediaEncryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the call. |
+| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
+| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
+| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE request. |
+| `sipTransportProtocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `streamUrl` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `streamTrack` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `streamCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `streamBidirectionalMode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `streamBidirectionalCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `streamBidirectionalTargetLegs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `streamBidirectionalSamplingRate` | enum (8000, 16000, 22050, 24000, 48000) | Audio sampling rate. |
+| `streamEstablishBeforeCallOriginate` | boolean | Establish websocket connection before dialing the destination. |
+| `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhookUrls` | object | A map of event types to webhook URLs. |
+| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `superviseCallControlId` | string (UUID) | The call leg which will be supervised by the new call. |
+| `supervisorRole` | enum (barge, whisper, monitor) | The role of the supervisor call. |
+| `enableDialogflow` | boolean | Enables Dialogflow for the current call. |
+| `dialogflowConfig` | object |  |
+| `transcription` | boolean | Enable transcription upon call answer. |
+| `transcriptionConfig` | object |  |
+| `sipRegion` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `streamAuthToken` | string | An authentication token to be sent as part of the WebSocket connection when u... |
+
+### Answer call — `client.calls().actions().answer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE response. |
+| `preferredCodecs` | enum (G722,PCMU,PCMA,G729,OPUS,VP8,H264) | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE response. |
+| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `streamUrl` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `streamTrack` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `streamCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `streamBidirectionalMode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `streamBidirectionalCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `streamBidirectionalTargetLegs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `transcription` | boolean | Enable transcription upon call answer. |
+| `transcriptionConfig` | object |  |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `webhookUrls` | object | A map of event types to webhook URLs. |
+| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
+
+### Bridge calls — `client.calls().actions().bridge()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `queue` | string | The name of the queue you want to bridge with, can't be used together with ca... |
+| `videoRoomId` | string (UUID) | The ID of the video room you want to bridge with, can't be used together with... |
+| `videoRoomContext` | string | The additional parameter that will be passed to the video conference. |
+| `preventDoubleBridge` | boolean | When set to `true`, it prevents bridging if the target call is already bridge... |
+| `parkAfterUnbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `playRingtone` | boolean | Specifies whether to play a ringtone if the call you want to bridge with has ... |
+| `ringtone` | enum (at, au, be, bg, br, ...) | Specifies which country ringtone to play when `play_ringtone` is set to `true`. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `muteDtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `holdAfterUnbridge` | boolean | Specifies behavior after the bridge ends. |
+
+### Hangup call — `client.calls().actions().hangup()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `customHeaders` | array[object] | Custom headers to be added to the SIP BYE message. |
+
+### SIP Refer a call — `client.calls().actions().refer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid execution of duplicate commands. |
+| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
+| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
+| `sipHeaders` | array[object] | SIP headers to be added to the request. |
+
+### Reject a call — `client.calls().actions().reject()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Send SIP info — `client.calls().actions().sendSipInfo()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Transfer call — `client.calls().actions().transfer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
+| `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `audioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
+| `earlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
+| `mediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
+| `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `parkAfterUnbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `targetLegClientState` | string | Use this field to add state to every subsequent webhook for the new leg. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `mediaEncryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the new call leg. |
+| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
+| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
+| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE. |
+| `sipTransportProtocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `muteDtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `sipRegion` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `preferredCodecs` | string | The list of comma-separated codecs in order of preference to be used during t... |
+| `webhookUrls` | object | A map of event types to webhook URLs. |
+| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+
+## Webhook Payload Fields
+
+### `callAnswered`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.answered | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: answered | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### `callBridged`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.bridged | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+
+### `callHangup`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.hangup | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: hangup | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+| `data.payload.hangup_cause` | enum: call_rejected, normal_clearing, originator_cancel, timeout, time_limit, user_busy, not_found, no_answer, unspecified | The reason the call was ended (`call_rejected`, `normal_clearing`, `originator_cancel`, `timeout`, `time_limit`, `use... |
+| `data.payload.hangup_source` | enum: caller, callee, unknown | The party who ended the call (`callee`, `caller`, `unknown`). |
+| `data.payload.sip_hangup_cause` | string | The reason the call was ended (SIP response code). |
+| `data.payload.call_quality_stats` | object \| null | Call quality statistics aggregated from the CHANNEL_HANGUP_COMPLETE event. |
+
+### `callInitiated`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.initiated | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
+| `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.custom_headers` | array[object] | Custom headers from sip invite |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.shaken_stir_attestation` | string | SHAKEN/STIR attestation level. |
+| `data.payload.shaken_stir_validated` | boolean | Whether attestation was successfully validated or not. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.caller_id_name` | string | Caller id. |
+| `data.payload.call_screening_result` | string | Call screening result. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.direction` | enum: incoming, outgoing | Whether the call is `incoming` or `outgoing`. |
+| `data.payload.state` | enum: parked, bridging | State received from a command. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### Field Type Notes
+
+- `from` in webhook payloads: string (E.164 phone number)
+- `to` in webhook payloads: string (E.164 phone number)
+- The return value of `client.webhooks.unwrap()` is a parsed event object — access fields via `event.data.event_type`, `event.data.payload.call_control_id`, etc.

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/10dlc.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/10dlc.md
@@ -68,8 +68,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -214,7 +214,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `description` | string | Description of the event. |
 | `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -375,7 +375,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -415,3 +415,471 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# 10DLC (JavaScript) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Brands, List Campaigns, List shared partner campaigns, List Shared Campaigns, List phone number campaigns
+
+| Field | Type |
+|-------|------|
+| `page` | integer |
+| `records` | array[object] |
+| `totalRecords` | integer |
+
+**Returned by:** Create Brand, Update Brand, Revet Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Get Brand Feedback By Id
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `category` | array[object] |
+
+**Returned by:** Get Brand SMS OTP Status, Get Brand SMS OTP Status by Brand ID
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `deliveryStatus` | string |
+| `deliveryStatusDate` | date-time |
+| `deliveryStatusDetails` | string |
+| `mobilePhone` | string |
+| `referenceId` | string |
+| `requestDate` | date-time |
+| `verifyDate` | date-time |
+
+**Returned by:** Get Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `assignedCampaignsCount` | number |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Order Brand External Vetting, Import External Vetting Record
+
+| Field | Type |
+|-------|------|
+| `createDate` | string |
+| `evpId` | string |
+| `vettedDate` | string |
+| `vettingClass` | string |
+| `vettingId` | string |
+| `vettingScore` | integer |
+| `vettingToken` | string |
+
+**Returned by:** Trigger Brand SMS OTP
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `referenceId` | string |
+
+**Returned by:** Get Campaign Cost
+
+| Field | Type |
+|-------|------|
+| `campaignUsecase` | string |
+| `description` | string |
+| `monthlyCost` | string |
+| `upFrontCost` | string |
+
+**Returned by:** Get campaign, Update campaign, Submit Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `autoRenewal` | boolean |
+| `billedDate` | string |
+| `brandDisplayName` | string |
+| `brandId` | string |
+| `campaignId` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createDate` | string |
+| `cspId` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isTMobileNumberPoolingEnabled` | boolean |
+| `isTMobileRegistered` | boolean |
+| `isTMobileSuspended` | boolean |
+| `messageFlow` | string |
+| `mock` | boolean |
+| `nextRenewalOrExpirationDate` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `referenceId` | string |
+| `resellerId` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `status` | string |
+| `subUsecases` | array[string] |
+| `submissionStatus` | enum: CREATED, FAILED, PENDING |
+| `subscriberHelp` | boolean |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `usecase` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Deactivate campaign
+
+| Field | Type |
+|-------|------|
+| `message` | string |
+| `record_type` | string |
+| `time` | number |
+
+**Returned by:** Submit campaign appeal for manual review
+
+| Field | Type |
+|-------|------|
+| `appealed_at` | date-time |
+
+**Returned by:** Get Campaign Mno Metadata
+
+| Field | Type |
+|-------|------|
+| `10999` | object |
+
+**Returned by:** Get Sharing Status
+
+| Field | Type |
+|-------|------|
+| `sharedByMe` | object |
+| `sharedWithMe` | object |
+
+**Returned by:** Qualify By Usecase
+
+| Field | Type |
+|-------|------|
+| `annualFee` | number |
+| `maxSubUsecases` | integer |
+| `minSubUsecases` | integer |
+| `mnoMetadata` | object |
+| `monthlyFee` | number |
+| `quarterlyFee` | number |
+| `usecase` | string |
+
+**Returned by:** Get Single Shared Campaign, Update Single Shared Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `assignedPhoneNumbersCount` | number |
+| `brandDisplayName` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createdAt` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isNumberPoolingEnabled` | boolean |
+| `messageFlow` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `subUsecases` | array[string] |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `updatedAt` | string |
+| `usecase` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Assign Messaging Profile To Campaign
+
+| Field | Type |
+|-------|------|
+| `campaignId` | string |
+| `messagingProfileId` | string |
+| `taskId` | string |
+| `tcrCampaignId` | string |
+
+**Returned by:** Get Assignment Task Status
+
+| Field | Type |
+|-------|------|
+| `createdAt` | date-time |
+| `status` | string |
+| `taskId` | string |
+| `updatedAt` | date-time |
+
+**Returned by:** Get Phone Number Status
+
+| Field | Type |
+|-------|------|
+| `records` | array[object] |
+
+**Returned by:** Create New Phone Number Campaign, Get Single Phone Number Campaign, Create New Phone Number Campaign, Delete Phone Number Campaign
+
+| Field | Type |
+|-------|------|
+| `assignmentStatus` | enum: FAILED_ASSIGNMENT, PENDING_ASSIGNMENT, ASSIGNED, PENDING_UNASSIGNMENT, FAILED_UNASSIGNMENT |
+| `brandId` | string |
+| `campaignId` | string |
+| `createdAt` | string |
+| `failureReasons` | string |
+| `phoneNumber` | string |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `telnyxCampaignId` | string |
+| `updatedAt` | string |
+
+## Optional Parameters
+
+### Create Brand — `client.messaging10dlc.brand.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `companyName` | string | (Required for Non-profit/private/public) Legal company name. |
+| `firstName` | string | First name of business contact. |
+| `lastName` | string | Last name of business contact. |
+| `ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `phone` | string | Valid phone number in e.164 international format. |
+| `street` | string | Street number and name. |
+| `city` | string | City name |
+| `state` | string | State. |
+| `postalCode` | string | Postal codes. |
+| `stockSymbol` | string | (Required for public company) stock symbol. |
+| `stockExchange` | object | (Required for public company) stock exchange. |
+| `ipAddress` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `website` | string | Brand website URL. |
+| `isReseller` | boolean |  |
+| `mock` | boolean | Mock brand for testing purposes. |
+| `mobilePhone` | string | Valid mobile phone number in e.164 international format. |
+| `businessContactEmail` | string | Business contact email. |
+| `webhookURL` | string | Webhook URL for brand status updates. |
+| `webhookFailoverURL` | string | Webhook failover URL for brand status updates. |
+
+### Update Brand — `client.messaging10dlc.brand.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `companyName` | string | (Required for Non-profit/private/public) Legal company name. |
+| `firstName` | string | First name of business contact. |
+| `lastName` | string | Last name of business contact. |
+| `ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `phone` | string | Valid phone number in e.164 international format. |
+| `street` | string | Street number and name. |
+| `city` | string | City name |
+| `state` | string | State. |
+| `postalCode` | string | Postal codes. |
+| `stockSymbol` | string | (Required for public company) stock symbol. |
+| `stockExchange` | object | (Required for public company) stock exchange. |
+| `ipAddress` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `website` | string | Brand website URL. |
+| `altBusinessIdType` | enum (NONE, DUNS, GIIN, LEI) | An enumeration. |
+| `isReseller` | boolean |  |
+| `identityStatus` | enum (VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED) | The verification status of an active brand |
+| `businessContactEmail` | string | Business contact email. |
+| `webhookURL` | string | Webhook URL for brand status updates. |
+| `webhookFailoverURL` | string | Webhook failover URL for brand status updates. |
+| `altBusinessId` | string (UUID) | Alternate business identifier such as DUNS, LEI, or GIIN |
+
+### Import External Vetting Record — `client.messaging10dlc.brand.externalVetting.imports()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `vettingToken` | string | Required by some providers for vetting record confirmation. |
+
+### Update campaign — `client.messaging10dlc.campaign.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `resellerId` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `sample1` | string | Message sample. |
+| `sample2` | string | Message sample. |
+| `sample3` | string | Message sample. |
+| `sample4` | string | Message sample. |
+| `sample5` | string | Message sample. |
+| `messageFlow` | string | Message flow description. |
+| `helpMessage` | string | Help message of the campaign. |
+| `autoRenewal` | boolean | Help message of the campaign. |
+| `webhookURL` | string | Webhook to which campaign status updates are sent. |
+| `webhookFailoverURL` | string | Webhook failover to which campaign status updates are sent. |
+
+### Submit Campaign — `client.messaging10dlc.campaignBuilder.submit()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ageGated` | boolean | Age gated message content in campaign. |
+| `autoRenewal` | boolean | Campaign subscription auto-renewal option. |
+| `directLending` | boolean | Direct lending or loan arrangement |
+| `embeddedLink` | boolean | Does message generated by the campaign include URL link in SMS? |
+| `embeddedPhone` | boolean | Does message generated by the campaign include phone number in SMS? |
+| `helpKeywords` | string | Subscriber help keywords. |
+| `helpMessage` | string | Help message of the campaign. |
+| `messageFlow` | string | Message flow description. |
+| `mnoIds` | array[integer] | Submit campaign to given list of MNOs by MNO's network ID. |
+| `numberPool` | boolean | Does campaign utilize pool of phone numbers? |
+| `optinKeywords` | string | Subscriber opt-in keywords. |
+| `optinMessage` | string | Subscriber opt-in message. |
+| `optoutKeywords` | string | Subscriber opt-out keywords. |
+| `optoutMessage` | string | Subscriber opt-out message. |
+| `referenceId` | string (UUID) | Caller supplied campaign reference ID. |
+| `resellerId` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `sample1` | string | Message sample. |
+| `sample2` | string | Message sample. |
+| `sample3` | string | Message sample. |
+| `sample4` | string | Message sample. |
+| `sample5` | string | Message sample. |
+| `subUsecases` | array[string] | Campaign sub-usecases. |
+| `subscriberHelp` | boolean | Does campaign responds to help keyword(s)? |
+| `subscriberOptin` | boolean | Does campaign require subscriber to opt-in before SMS is sent to subscriber? |
+| `subscriberOptout` | boolean | Does campaign support subscriber opt-out keyword(s)? |
+| `tag` | array[string] | Tags to be set on the Campaign. |
+| `termsAndConditions` | boolean | Is terms and conditions accepted? |
+| `privacyPolicyLink` | string | Link to the campaign's privacy policy. |
+| `termsAndConditionsLink` | string | Link to the campaign's terms and conditions. |
+| `embeddedLinkSample` | string | Sample of an embedded link that will be sent to subscribers. |
+| `webhookURL` | string | Webhook to which campaign status updates are sent. |
+| `webhookFailoverURL` | string | Failover webhook to which campaign status updates are sent. |
+
+### Update Single Shared Campaign — `client.messaging10dlc.partnerCampaigns.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `webhookURL` | string | Webhook to which campaign status updates are sent. |
+| `webhookFailoverURL` | string | Webhook failover to which campaign status updates are sent. |
+
+### Assign Messaging Profile To Campaign — `client.messaging10dlc.phoneNumberAssignmentByProfile.assign()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `tcrCampaignId` | string (UUID) | The TCR ID of the shared campaign you want to link to the specified messaging... |
+| `campaignId` | string (UUID) | The ID of the campaign you want to link to the specified messaging profile. |
+
+## Webhook Payload Fields
+
+### `campaignStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `brandId` | string | Brand ID associated with the campaign. |
+| `campaignId` | string | The ID of the campaign. |
+| `createDate` | string | Unix timestamp when campaign was created. |
+| `cspId` | string | Alphanumeric identifier of the CSP associated with this campaign. |
+| `isTMobileRegistered` | boolean | Indicates whether the campaign is registered with T-Mobile. |
+| `type` | enum: TELNYX_EVENT, REGISTRATION, MNO_REVIEW, TELNYX_REVIEW, NUMBER_POOL_PROVISIONED, NUMBER_POOL_DEPROVISIONED, TCR_EVENT, VERIFIED |  |
+| `description` | string | Description of the event. |
+| `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/ai-assistants.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/ai-assistants.md
@@ -29,8 +29,8 @@ or authentication errors (401). Always handle errors in production code:
 try {
   const assistant = await client.ai.assistants.create({
     instructions: 'You are a helpful assistant.',
-    model: 'openai/gpt-4o',
     name: 'my-resource',
+      model: 'openai/gpt-4o',
   });
 } catch (err) {
   if (err instanceof Telnyx.APIConnectionError) {
@@ -61,7 +61,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -74,18 +74,17 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `description` | string | No |  |
-| `greeting` | string | No | Text that the assistant will use to start the conversation. |
-| ... | | | +11 optional params in the API Details section below |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in the API Details section below |
 
 ```javascript
 const assistant = await client.ai.assistants.create({
   instructions: 'You are a helpful assistant.',
-  model: 'openai/gpt-4o',
   name: 'my-resource',
+    model: 'openai/gpt-4o',
 });
 
 console.log(assistant.id);
@@ -196,7 +195,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### Update an assistant
 
@@ -207,10 +206,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistantId` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +15 optional params in the API Details section below |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in the API Details section below |
 
 ```javascript
 const assistant = await client.ai.assistants.update('550e8400-e29b-41d4-a716-446655440000');
@@ -224,7 +223,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### List assistants
 
@@ -247,7 +246,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Import assistants from external provider
 
@@ -279,7 +278,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Get All Tags
 
@@ -383,7 +382,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -396,8 +395,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId`, `runId` |
 | Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Get Canary Deploy | `client.ai.assistants.canaryDeploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Create Canary Deploy | `client.ai.assistants.canaryDeploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistantId` |
-| Update Canary Deploy | `client.ai.assistants.canaryDeploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistantId` |
+| Create Canary Deploy | `client.ai.assistants.canaryDeploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId` |
+| Update Canary Deploy | `client.ai.assistants.canaryDeploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistantId` |
 | Delete Canary Deploy | `client.ai.assistants.canaryDeploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Assistant Sms Chat | `client.ai.assistants.sendSMS()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistantId` |
 | Clone Assistant | `client.ai.assistants.clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId` |
@@ -408,6 +407,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Add Assistant Tag | `client.ai.assistants.tags.add()` | `POST /ai/assistants/{assistant_id}/tags` | Create or provision an additional resource when the core tasks do not cover this flow. | `tag`, `assistantId` |
 | Remove Assistant Tag | `client.ai.assistants.tags.remove()` | `DELETE /ai/assistants/{assistant_id}/tags/{tag}` | Remove, detach, or clean up an existing resource. | `assistantId`, `tag` |
 | Get assistant texml | `client.ai.assistants.getTexml()` | `GET /ai/assistants/{assistant_id}/texml` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
+| Add Assistant Tool | `client.ai.assistants.tools.add()` | `PUT /ai/assistants/{assistant_id}/tools/{tool_id}` | Modify an existing resource without recreating it. | `assistantId`, `toolId` |
+| Remove Assistant Tool | `client.ai.assistants.tools.remove()` | `DELETE /ai/assistants/{assistant_id}/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `assistantId`, `toolId` |
 | Test Assistant Tool | `client.ai.assistants.tools.test()` | `POST /ai/assistants/{assistant_id}/tools/{tool_id}/test` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId`, `toolId` |
 | Get all versions of an assistant | `client.ai.assistants.versions.list()` | `GET /ai/assistants/{assistant_id}/versions` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
 | Get a specific assistant version | `client.ai.assistants.versions.retrieve()` | `GET /ai/assistants/{assistant_id}/versions/{version_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId`, `versionId` |
@@ -419,7 +420,398 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get MCP Server | `client.ai.mcpServers.retrieve()` | `GET /ai/mcp_servers/{mcp_server_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `mcpServerId` |
 | Update MCP Server | `client.ai.mcpServers.update()` | `PUT /ai/mcp_servers/{mcp_server_id}` | Modify an existing resource without recreating it. | `mcpServerId` |
 | Delete MCP Server | `client.ai.mcpServers.delete()` | `DELETE /ai/mcp_servers/{mcp_server_id}` | Remove, detach, or clean up an existing resource. | `mcpServerId` |
+| List Tools | `client.ai.tools.list()` | `GET /ai/tools` | Inspect available resources or choose an existing resource before mutating it. | None |
+| Create Tool | `client.ai.tools.create()` | `POST /ai/tools` | Create or provision an additional resource when the core tasks do not cover this flow. | `type`, `displayName` |
+| Get Tool | `client.ai.tools.retrieve()` | `GET /ai/tools/{tool_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `toolId` |
+| Update Tool | `client.ai.tools.update()` | `PATCH /ai/tools/{tool_id}` | Modify an existing resource without recreating it. | `toolId` |
+| Delete Tool | `client.ai.tools.delete()` | `DELETE /ai/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `toolId` |
 
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# AI Assistants (JavaScript) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+
+## Response Schemas
+
+**Returned by:** List assistants, Create an assistant, Import assistants from external provider, Get an assistant, Update an assistant, Clone Assistant, Get all versions of an assistant, Get a specific assistant version, Update a specific assistant version, Promote an assistant version to main
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
+| `dynamic_variables_webhook_url` | string |
+| `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
+| `greeting` | string |
+| `id` | string |
+| `import_metadata` | object |
+| `insight_settings` | object |
+| `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
+| `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
+| `messaging_settings` | object |
+| `model` | string |
+| `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
+| `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
+| `telephony_settings` | object |
+| `tools` | array[object] |
+| `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
+| `voice_settings` | object |
+| `widget_settings` | object |
+
+**Returned by:** Get All Tags, Add Assistant Tag, Remove Assistant Tag
+
+| Field | Type |
+|-------|------|
+| `tags` | array[string] |
+
+**Returned by:** List assistant tests with pagination, Create a new assistant test, Get assistant test by ID, Update an assistant test
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `destination` | string |
+| `instructions` | string |
+| `max_duration_seconds` | integer |
+| `name` | string |
+| `rubric` | array[object] |
+| `telnyx_conversation_channel` | object |
+| `test_id` | uuid |
+| `test_suite` | string |
+
+**Returned by:** Get all test suite names
+
+| Field | Type |
+|-------|------|
+| `data` | array[string] |
+
+**Returned by:** Get test suite run history, Get test run history for a specific test, Trigger a manual test run, Get specific test run details
+
+| Field | Type |
+|-------|------|
+| `completed_at` | date-time |
+| `conversation_id` | string |
+| `conversation_insights_id` | string |
+| `created_at` | date-time |
+| `detail_status` | array[object] |
+| `logs` | string |
+| `run_id` | uuid |
+| `status` | enum: pending, starting, running, passed, failed, error |
+| `test_id` | uuid |
+| `test_suite_run_id` | uuid |
+| `triggered_by` | string |
+| `updated_at` | date-time |
+
+**Returned by:** Delete an assistant
+
+| Field | Type |
+|-------|------|
+| `deleted` | boolean |
+| `id` | string |
+| `object` | string |
+
+**Returned by:** Get Canary Deploy, Create Canary Deploy, Update Canary Deploy
+
+| Field | Type |
+|-------|------|
+| `assistant_id` | string |
+| `created_at` | date-time |
+| `rules` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Assistant Chat (BETA)
+
+| Field | Type |
+|-------|------|
+| `content` | string |
+
+**Returned by:** Assistant Sms Chat
+
+| Field | Type |
+|-------|------|
+| `conversation_id` | string |
+
+**Returned by:** List scheduled events
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Test Assistant Tool
+
+| Field | Type |
+|-------|------|
+| `content_type` | string |
+| `request` | object |
+| `response` | string |
+| `status_code` | integer |
+| `success` | boolean |
+
+**Returned by:** Create MCP Server, Get MCP Server, Update MCP Server
+
+| Field | Type |
+|-------|------|
+| `allowed_tools` | array \| null |
+| `api_key_ref` | string \| null |
+| `created_at` | date-time |
+| `id` | string |
+| `name` | string |
+| `type` | string |
+| `url` | string |
+
+**Returned by:** List Tools, Create Tool, Get Tool, Update Tool
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `display_name` | string |
+| `id` | string |
+| `timeout_ms` | integer |
+| `tool_definition` | object |
+| `type` | string |
+
+## Optional Parameters
+
+### Create an assistant — `client.ai.assistants.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
+| `voiceSettings` | object |  |
+| `transcription` | object |  |
+| `telephonySettings` | object |  |
+| `messagingSettings` | object |  |
+| `enabledFeatures` | array[object] |  |
+| `insightSettings` | object |  |
+| `privacySettings` | object |  |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamicVariables` | object | Map of dynamic variables and their default values |
+| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
+
+### Import assistants from external provider — `client.ai.assistants.imports()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `importIds` | array[string] | Optional list of assistant IDs to import from the external provider. |
+
+### Create a new assistant test — `client.ai.assistants.tests.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `description` | string | Optional detailed description of what this test evaluates and its purpose. |
+| `telnyxConversationChannel` | object | The communication channel through which the test will be conducted. |
+| `maxDurationSeconds` | integer | Maximum duration in seconds that the test conversation should run before timi... |
+| `testSuite` | string | Optional test suite name to group related tests together. |
+
+### Trigger test suite execution — `client.ai.assistants.tests.testSuites.runs.trigger()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `destinationVersionId` | string (UUID) | Optional assistant version ID to use for all test runs in this suite. |
+
+### Update an assistant test — `client.ai.assistants.tests.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | Updated name for the assistant test. |
+| `description` | string | Updated description of the test's purpose and evaluation criteria. |
+| `telnyxConversationChannel` | enum (phone_call, web_call, sms_chat, web_chat) |  |
+| `destination` | string | Updated target destination for test conversations. |
+| `maxDurationSeconds` | integer | Updated maximum test duration in seconds. |
+| `testSuite` | string | Updated test suite assignment for better organization. |
+| `instructions` | string | Updated test scenario instructions and objectives. |
+| `rubric` | array[object] | Updated evaluation criteria for assessing assistant performance. |
+
+### Trigger a manual test run — `client.ai.assistants.tests.runs.trigger()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `destinationVersionId` | string (UUID) | Optional assistant version ID to use for this test run. |
+
+### Update an assistant — `client.ai.assistants.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `instructions` | string | System instructions for the assistant. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
+| `voiceSettings` | object |  |
+| `transcription` | object |  |
+| `telephonySettings` | object |  |
+| `messagingSettings` | object |  |
+| `enabledFeatures` | array[object] |  |
+| `insightSettings` | object |  |
+| `privacySettings` | object |  |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamicVariables` | object | Map of dynamic variables and their default values |
+| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
+| `promoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai.assistants.canaryDeploys.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai.assistants.canaryDeploys.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Assistant Chat (BETA) — `client.ai.assistants.chat()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | The optional display name of the user sending the message |
+
+### Assistant Sms Chat — `client.ai.assistants.sendSMS()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string |  |
+| `conversationMetadata` | object |  |
+| `shouldCreateConversation` | boolean |  |
+
+### Create a scheduled event — `client.ai.assistants.scheduledEvents.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Required for sms scheduled events. |
+| `conversationMetadata` | object | Metadata associated with the conversation. |
+| `dynamicVariables` | object | A map of dynamic variable names to values. |
+| `maxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retryIntervalSecs` | integer |  |
+
+### Test Assistant Tool — `client.ai.assistants.tools.test()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `arguments` | object | Key-value arguments to use for the webhook test |
+| `dynamicVariables` | object | Key-value dynamic variables to use for the webhook test |
+
+### Update a specific assistant version — `client.ai.assistants.versions.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `instructions` | string | System instructions for the assistant. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
+| `voiceSettings` | object |  |
+| `transcription` | object |  |
+| `telephonySettings` | object |  |
+| `messagingSettings` | object |  |
+| `enabledFeatures` | array[object] |  |
+| `insightSettings` | object |  |
+| `privacySettings` | object |  |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamicVariables` | object | Map of dynamic variables and their default values |
+| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
+
+### Create MCP Server — `client.ai.mcpServers.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `apiKeyRef` | string |  |
+| `allowedTools` | array[string] |  |
+
+### Update MCP Server — `client.ai.mcpServers.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `name` | string |  |
+| `type` | string |  |
+| `url` | string (URL) |  |
+| `apiKeyRef` | string |  |
+| `allowedTools` | array[string] |  |
+| `createdAt` | string (date-time) |  |
+
+### Create Tool — `client.ai.tools.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `function` | object |  |
+| `retrieval` | object |  |
+| `handoff` | object |  |
+| `invite` | object |  |
+| `webhook` | object |  |
+| `timeoutMs` | integer |  |
+
+### Update Tool — `client.ai.tools.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type` | string |  |
+| `displayName` | string |  |
+| `function` | object |  |
+| `retrieval` | object |  |
+| `handoff` | object |  |
+| `invite` | object |  |
+| `webhook` | object |  |
+| `timeoutMs` | integer |  |

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/messaging.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/messaging.md
@@ -67,8 +67,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -195,7 +195,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.media` | array[object] |  |
 | `data.record_type` | enum: event | Identifies the type of the resource. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -379,6 +379,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsappMessage` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```javascript
 const response = await client.messages.sendWhatsapp({
@@ -403,7 +404,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -437,3 +438,425 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Messaging (JavaScript) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List alphanumeric sender IDs, Create an alphanumeric sender ID, Retrieve an alphanumeric sender ID, Delete an alphanumeric sender ID, List alphanumeric sender IDs for a messaging profile
+
+| Field | Type |
+|-------|------|
+| `alphanumeric_sender_id` | string |
+| `id` | uuid |
+| `messaging_profile_id` | uuid |
+| `organization_id` | string |
+| `record_type` | enum: alphanumeric_sender_id |
+| `us_long_code_fallback` | string |
+
+**Returned by:** Send a message, Send a message using an alphanumeric sender ID, Retrieve group MMS messages, Send a group MMS message, Send a long code message, Send a message using number pool, Schedule a message, Send a short code message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `wait_seconds` | float |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** Send a WhatsApp message
+
+| Field | Type |
+|-------|------|
+| `body` | object |
+| `direction` | string |
+| `encoding` | string |
+| `from` | object |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `organization_id` | string |
+| `received_at` | date-time |
+| `record_type` | string |
+| `to` | array[object] |
+| `type` | string |
+| `wait_seconds` | float |
+
+**Returned by:** Retrieve a message, Get detailed messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Cancel a scheduled message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** List messaging hosted numbers, Retrieve a messaging hosted number, Update a messaging hosted number
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `eligible_messaging_products` | array[string] |
+| `features` | object |
+| `health` | object |
+| `id` | string |
+| `messaging_product` | string |
+| `messaging_profile_id` | string \| null |
+| `organization_id` | string |
+| `phone_number` | string |
+| `record_type` | enum: messaging_phone_number, messaging_settings |
+| `tags` | array[string] |
+| `traffic_type` | string |
+| `type` | enum: long-code, toll-free, short-code, longcode, tollfree, shortcode |
+| `updated_at` | date-time |
+
+**Returned by:** List opt-outs
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `from` | string |
+| `keyword` | string \| null |
+| `messaging_profile_id` | string \| null |
+| `to` | string |
+
+**Returned by:** List high-level messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Regenerate messaging profile secret
+
+| Field | Type |
+|-------|------|
+| `ai_assistant_id` | string \| null |
+| `alpha_sender` | string \| null |
+| `created_at` | date-time |
+| `daily_spend_limit` | string |
+| `daily_spend_limit_enabled` | boolean |
+| `enabled` | boolean |
+| `health_webhook_url` | url |
+| `id` | uuid |
+| `mms_fall_back_to_sms` | boolean |
+| `mms_transcoding` | boolean |
+| `mobile_only` | boolean |
+| `name` | string |
+| `number_pool_settings` | object \| null |
+| `organization_id` | string |
+| `record_type` | enum: messaging_profile |
+| `redaction_enabled` | boolean |
+| `redaction_level` | integer |
+| `resource_group_id` | string \| null |
+| `smart_encoding` | boolean |
+| `updated_at` | date-time |
+| `url_shortener_settings` | object \| null |
+| `v1_secret` | string |
+| `webhook_api_version` | enum: 1, 2, 2010-04-01 |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+| `whitelisted_destinations` | array[string] |
+
+**Returned by:** List Auto-Response Settings, Create auto-response setting, Get Auto-Response Setting, Update Auto-Response Setting
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `id` | string |
+| `keywords` | array[string] |
+| `op` | enum: start, stop, info |
+| `resp_text` | string |
+| `updated_at` | date-time |
+
+## Optional Parameters
+
+### Create an alphanumeric sender ID — `client.alphanumericSenderIDs.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `usLongCodeFallback` | string | A US long code number to use as fallback when sending to US destinations. |
+
+### Send a message — `client.messages.send()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using an alphanumeric sender ID — `client.messages.sendWithAlphanumericSender()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `webhookUrl` | string (URL) | Callback URL for delivery status updates. |
+| `webhookFailoverUrl` | string (URL) | Failover callback URL for delivery status updates. |
+| `useProfileWebhooks` | boolean | If true, use the messaging profile's webhook settings. |
+
+### Send a group MMS message — `client.messages.sendGroupMms()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+
+### Send a long code message — `client.messages.sendLongCode()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using number pool — `client.messages.sendNumberPool()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Schedule a message — `client.messages.schedule()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+
+### Send a short code message — `client.messages.sendShortCode()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a WhatsApp message — `client.messages.sendWhatsapp()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
+
+### Update a messaging hosted number — `client.messagingHostedNumbers.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `messagingProfileId` | string (UUID) | Configure the messaging profile this phone number is assigned to:
+
+* Omit thi... |
+| `messagingProduct` | string | Configure the messaging product for this number:
+
+* Omit this field or set it... |
+| `tags` | array[string] | Tags to set on this phone number. |
+
+### Create auto-response setting — `client.messagingProfiles.autorespConfigs.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `respText` | string |  |
+
+### Update Auto-Response Setting — `client.messagingProfiles.autorespConfigs.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `respText` | string |  |
+
+## Webhook Payload Fields
+
+### `deliveryUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.sent, message.finalized | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: outbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | uuid | The id of the organization the messaging profile belongs to. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Subject of multimedia message |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | ISO 8601 formatted date indicating when the message was sent. |
+| `data.payload.completed_at` | date-time | ISO 8601 formatted date indicating when the message was finalized. |
+| `data.payload.valid_until` | date-time | Message must be out of the queue by this time or else it will be discarded and marked as 'sending_failed'. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+| `data.payload.smart_encoding_applied` | boolean | Indicates whether smart encoding was applied to this message. |
+| `data.payload.wait_seconds` | float | Seconds the message is queued due to rate limiting before being sent to the carrier. |
+| `meta.attempt` | integer | Number of attempts to deliver the webhook event. |
+| `meta.delivered_to` | url | The webhook URL the event was delivered to. |
+
+### `inboundMessage`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.received | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: inbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Message subject. |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | Not used for inbound messages. |
+| `data.payload.completed_at` | date-time | Not used for inbound messages. |
+| `data.payload.valid_until` | date-time | Not used for inbound messages. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+
+### `replacedLinkClick`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | string | Identifies the type of the resource. |
+| `data.url` | string | The original link that was sent in the message. |
+| `data.to` | string | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or short code). |
+| `data.message_id` | uuid | The message ID associated with the clicked link. |
+| `data.time_clicked` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+
+### Field Type Notes
+
+- `from` in responses/webhooks: object with sub-fields `phone_number` (string), `carrier` (string), `line_type` (string)
+- `to` in responses/webhooks: array of objects, each with `phone_number` (string), `carrier` (string), `line_type` (string), `status` (string)
+- `cost`: object with `amount` (string, decimal), `currency` (string, e.g., 'USD')

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/numbers.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/numbers.md
@@ -57,7 +57,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -368,7 +368,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -418,3 +418,433 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Numbers (JavaScript) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Advanced Orders, Create Advanced Order, Update Advanced Order, Get Advanced Order
+
+| Field | Type |
+|-------|------|
+| `area_code` | string |
+| `comments` | string |
+| `country_code` | string |
+| `customer_reference` | string |
+| `features` | array[object] |
+| `id` | uuid |
+| `orders` | array[string] |
+| `phone_number_type` | object |
+| `quantity` | integer |
+| `requirement_group_id` | uuid |
+| `status` | object |
+
+**Returned by:** List available phone number blocks
+
+| Field | Type |
+|-------|------|
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `range` | integer |
+| `record_type` | enum: available_phone_number_block |
+| `region_information` | array[object] |
+
+**Returned by:** List available phone numbers
+
+| Field | Type |
+|-------|------|
+| `best_effort` | boolean |
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `quickship` | boolean |
+| `record_type` | enum: available_phone_number |
+| `region_information` | array[object] |
+| `reservable` | boolean |
+| `vanity_format` | string |
+
+**Returned by:** Retrieve all comments
+
+| Field | Type |
+|-------|------|
+| `body` | string |
+| `comment_record_id` | uuid |
+| `comment_record_type` | enum: sub_number_order, requirement_group |
+| `commenter` | string |
+| `commenter_type` | enum: admin, user |
+| `created_at` | date-time |
+| `id` | uuid |
+| `read_at` | date-time |
+| `updated_at` | date-time |
+
+**Returned by:** Create a comment, Retrieve a comment, Mark a comment as read, Get country coverage
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Get coverage for a specific country
+
+| Field | Type |
+|-------|------|
+| `code` | string |
+| `features` | array[string] |
+| `international_sms` | boolean |
+| `inventory_coverage` | boolean |
+| `local` | object |
+| `mobile` | object |
+| `national` | object |
+| `numbers` | boolean |
+| `p2p` | boolean |
+| `phone_number_type` | array[string] |
+| `quickship` | boolean |
+| `region` | string \| null |
+| `reservable` | boolean |
+| `shared_cost` | object |
+| `toll_free` | object |
+
+**Returned by:** List customer service records, Create a customer service record, Get a customer service record
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `error_message` | string \| null |
+| `id` | uuid |
+| `phone_number` | string |
+| `record_type` | string |
+| `result` | object \| null |
+| `status` | enum: pending, completed, failed |
+| `updated_at` | date-time |
+| `webhook_url` | string |
+
+**Returned by:** Verify CSR phone number coverage
+
+| Field | Type |
+|-------|------|
+| `additional_data_required` | array[string] |
+| `has_csr_coverage` | boolean |
+| `phone_number` | string |
+| `reason` | string |
+| `record_type` | string |
+
+**Returned by:** List inexplicit number orders, Create an inexplicit number order, Retrieve an inexplicit number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `ordering_groups` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Create an inventory coverage request
+
+| Field | Type |
+|-------|------|
+| `administrative_area` | string |
+| `advance_requirements` | boolean |
+| `count` | integer |
+| `coverage_type` | enum: number, block |
+| `group` | string |
+| `group_type` | string |
+| `number_range` | integer |
+| `number_type` | enum: did, toll-free |
+| `phone_number_type` | enum: local, toll_free, national, landline, shared_cost, mobile |
+| `record_type` | string |
+
+**Returned by:** List mobile network operators
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `id` | uuid |
+| `mcc` | string |
+| `mnc` | string |
+| `name` | string |
+| `network_preferences_enabled` | boolean |
+| `record_type` | string |
+| `tadig` | string |
+
+**Returned by:** List network coverage locations
+
+| Field | Type |
+|-------|------|
+| `available_services` | array[object] |
+| `location` | object |
+| `record_type` | string |
+
+**Returned by:** List number block orders, Create a number block order, Retrieve a number block order
+
+| Field | Type |
+|-------|------|
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers_count` | integer |
+| `range` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `starting_number` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve a list of phone numbers associated to orders, Retrieve a single phone number within a number order., Update requirements for a single phone number within a number order.
+
+| Field | Type |
+|-------|------|
+| `bundle_id` | uuid |
+| `country_code` | string |
+| `deadline` | date-time |
+| `id` | uuid |
+| `is_block_number` | boolean |
+| `locality` | string |
+| `order_request_id` | uuid |
+| `phone_number` | string |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `requirements_status` | enum: pending, approved, cancelled, deleted, requirement-info-exception, requirement-info-pending, requirement-info-under-review |
+| `status` | enum: pending, success, failure |
+| `sub_number_order_id` | uuid |
+
+**Returned by:** List number orders, Create a number order, Retrieve a number order, Update a number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers` | array[object] |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `sub_number_orders_ids` | array[string] |
+| `updated_at` | date-time |
+
+**Returned by:** List number reservations, Create a number reservation, Retrieve a number reservation, Extend a number reservation
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `errors` | string |
+| `id` | uuid |
+| `phone_numbers` | array[object] |
+| `record_type` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve the features for a list of numbers
+
+| Field | Type |
+|-------|------|
+| `features` | array[string] |
+| `phone_number` | string |
+
+**Returned by:** Lists the phone number blocks jobs, Deletes all numbers associated with a phone number block, Retrieves a phone number blocks job
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `etc` | date-time |
+| `failed_operations` | array[object] |
+| `id` | uuid |
+| `record_type` | string |
+| `status` | enum: pending, in_progress, completed, failed |
+| `successful_operations` | array[object] |
+| `type` | enum: delete_phone_number_block |
+| `updated_at` | string |
+
+**Returned by:** List sub number orders, Retrieve a sub number order, Update a sub number order's requirements, Cancel a sub number order
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `is_block_sub_number_order` | boolean |
+| `order_request_id` | uuid |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+**Returned by:** Create a sub number orders report, Retrieve a sub number orders report
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `filters` | object |
+| `id` | uuid |
+| `order_type` | string |
+| `status` | enum: pending, success, failed, expired |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+## Optional Parameters
+
+### Create Advanced Order — `client.advancedOrders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `countryCode` | string (ISO 3166-1 alpha-2) |  |
+| `comments` | string |  |
+| `quantity` | integer |  |
+| `areaCode` | string |  |
+| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `features` | array[object] |  |
+| `customerReference` | string |  |
+| `requirementGroupId` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Update Advanced Order — `client.advancedOrders.updateRequirementGroup()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `countryCode` | string (ISO 3166-1 alpha-2) |  |
+| `comments` | string |  |
+| `quantity` | integer |  |
+| `areaCode` | string |  |
+| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `features` | array[object] |  |
+| `customerReference` | string |  |
+| `requirementGroupId` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Create a comment — `client.comments.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `body` | string |  |
+| `commenter` | string |  |
+| `commenterType` | enum (admin, user) |  |
+| `commentRecordType` | enum (sub_number_order, requirement_group) |  |
+| `commentRecordId` | string (UUID) |  |
+| `readAt` | string (date-time) | An ISO 8901 datetime string for when the comment was read. |
+| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the comment was created. |
+| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the comment was updated. |
+
+### Create an inexplicit number order — `client.inexplicitNumberOrders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `connectionId` | string (UUID) | Connection id to apply to phone numbers that are purchased |
+| `messagingProfileId` | string (UUID) | Messaging profile id to apply to phone numbers that are purchased |
+| `customerReference` | string | Reference label for the customer |
+| `billingGroupId` | string (UUID) | Billing group id to apply to phone numbers that are purchased |
+
+### Create a number block order — `client.numberBlockOrders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `recordType` | string |  |
+| `phoneNumbersCount` | integer | The count of phone numbers in the number order. |
+| `connectionId` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messagingProfileId` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `status` | enum (pending, success, failure) | The status of the order. |
+| `customerReference` | string | A customer reference string for customer look ups. |
+| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the number order was created. |
+| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the number order was updated. |
+| `requirementsMet` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `errors` | string | Errors the reservation could happen upon |
+
+### Update requirements for a single phone number within a number order. — `client.numberOrderPhoneNumbers.updateRequirements()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatoryRequirements` | array[object] |  |
+
+### Create a number order — `client.numberOrders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `phoneNumbers` | array[object] |  |
+| `connectionId` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messagingProfileId` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `billingGroupId` | string (UUID) | Identifies the billing group associated with the phone number. |
+| `customerReference` | string | A customer reference string for customer look ups. |
+
+### Update a number order — `client.numberOrders.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatoryRequirements` | array[object] |  |
+| `customerReference` | string | A customer reference string for customer look ups. |
+
+### Create a number reservation — `client.numberReservations.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `recordType` | string |  |
+| `phoneNumbers` | array[object] |  |
+| `status` | enum (pending, success, failure) | The status of the entire reservation. |
+| `customerReference` | string | A customer reference string for customer look ups. |
+| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the numbers reservation was created. |
+| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the number reservation was updated. |
+
+### Update a sub number order's requirements — `client.subNumberOrders.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatoryRequirements` | array[object] |  |
+
+### Create a sub number orders report — `client.subNumberOrdersReport.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `status` | enum (pending, success, failure) | Filter by order status |
+| `countryCode` | string (ISO 3166-1 alpha-2) | Filter by country code |
+| `createdAtGt` | string (date-time) | Filter for orders created after this date |
+| `createdAtLt` | string (date-time) | Filter for orders created before this date |
+| `orderRequestId` | string (UUID) | Filter by specific order request ID |
+| `customerReference` | string | Filter by customer reference |
+
+## Webhook Payload Fields
+
+### `numberOrderStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.event_type` | string | The type of event being sent |
+| `data.id` | uuid | Unique identifier for the event |
+| `data.occurred_at` | date-time | ISO 8601 timestamp of when the event occurred |
+| `data.payload.id` | uuid |  |
+| `data.payload.record_type` | string |  |
+| `data.payload.phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `data.payload.connection_id` | string | Identifies the connection associated with this phone number. |
+| `data.payload.messaging_profile_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.billing_group_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.phone_numbers` | array[object] |  |
+| `data.payload.sub_number_orders_ids` | array[string] |  |
+| `data.payload.status` | enum: pending, success, failure | The status of the order. |
+| `data.payload.customer_reference` | string | A customer reference string for customer look ups. |
+| `data.payload.created_at` | date-time | An ISO 8901 datetime string denoting when the number order was created. |
+| `data.payload.updated_at` | date-time | An ISO 8901 datetime string for when the number order was updated. |
+| `data.payload.requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `data.record_type` | string | Type of record |
+| `meta.attempt` | integer | Webhook delivery attempt number |
+| `meta.delivered_to` | uri | URL where the webhook was delivered |

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/voice.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/voice.md
@@ -30,7 +30,7 @@ try {
   const response = await client.calls.dial({
     connection_id: '7267xxxxxxxxxxxxxx',
     from: '+18005550101',
-    to: '+18005550100',
+    to: '+18005550100;secure=srtp',
   });
 } catch (err) {
   if (err instanceof Telnyx.APIConnectionError) {
@@ -67,8 +67,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -86,13 +86,13 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in the API Details section below |
+| ... | | | +56 optional params in the API Details section below |
 
 ```javascript
 const response = await client.calls.dial({
   connection_id: '7267xxxxxxxxxxxxxx',
   from: '+18005550101',
-  to: '+18005550100',
+  to: '+18005550100;secure=srtp',
 });
 
 console.log(response.data);
@@ -118,7 +118,7 @@ Primary inbound call-control command.
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in the API Details section below |
+| ... | | | +29 optional params in the API Details section below |
 
 ```javascript
 const response = await client.calls.actions.answer('v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ');
@@ -143,11 +143,11 @@ Common post-answer control path with downstream webhook implications.
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in the API Details section below |
+| ... | | | +35 optional params in the API Details section below |
 
 ```javascript
 const response = await client.calls.actions.transfer('call_control_id', {
-  to: '+18005550100',
+  to: '+18005550100;secure=srtp',
 });
 
 console.log(response.data);
@@ -223,7 +223,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
 | `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -393,7 +393,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -413,3 +413,427 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Voice (JavaScript) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List call control applications, Create a call control application, Retrieve a call control application, Update a call control application, Delete a call control application
+
+| Field | Type |
+|-------|------|
+| `active` | boolean |
+| `anchorsite_override` | enum: Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, Chennai, IN, Amsterdam, Netherlands, Toronto, Canada, Sydney, Australia |
+| `application_name` | string |
+| `call_cost_in_webhooks` | boolean |
+| `created_at` | string |
+| `dtmf_type` | enum: RFC 2833, Inband, SIP INFO |
+| `first_command_timeout` | boolean |
+| `first_command_timeout_secs` | integer |
+| `id` | string |
+| `inbound` | object |
+| `outbound` | object |
+| `record_type` | enum: call_control_application |
+| `redact_dtmf_debug_logging` | boolean |
+| `tags` | array[string] |
+| `updated_at` | string |
+| `webhook_api_version` | enum: 1, 2 |
+| `webhook_event_failover_url` | url |
+| `webhook_event_url` | url |
+| `webhook_timeout_secs` | integer \| null |
+
+**Returned by:** Dial
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `recording_id` | uuid |
+| `start_time` | string |
+
+**Returned by:** Retrieve a call status
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `start_time` | string |
+
+**Returned by:** Answer call
+
+| Field | Type |
+|-------|------|
+| `recording_id` | uuid |
+| `result` | string |
+
+**Returned by:** Bridge calls, Hangup call, SIP Refer a call, Reject a call, Send SIP info, Transfer call
+
+| Field | Type |
+|-------|------|
+| `result` | string |
+
+**Returned by:** List all active calls for given connection
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `record_type` | enum: call |
+
+## Optional Parameters
+
+### Create a call control application — `client.callControlApplications.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `active` | boolean | Specifies whether the connection can be used. |
+| `anchorsiteOverride` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmfType` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `firstCommandTimeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `firstCommandTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `inbound` | object |  |
+| `outbound` | object |  |
+| `webhookApiVersion` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhookEventFailoverUrl` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhookTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `callCostInWebhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `redactDtmfDebugLogging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Update a call control application — `client.callControlApplications.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `callCostInWebhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `active` | boolean | Specifies whether the connection can be used. |
+| `anchorsiteOverride` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmfType` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `firstCommandTimeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `firstCommandTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `tags` | array[string] | Tags assigned to the Call Control Application. |
+| `inbound` | object |  |
+| `outbound` | object |  |
+| `webhookApiVersion` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhookEventFailoverUrl` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhookTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `redactDtmfDebugLogging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Dial — `client.calls.dial()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `audioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
+| `mediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
+| `preferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
+| `conferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
+| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `linkTo` | string | Use another call's control id for sharing the same call session id |
+| `bridgeIntent` | boolean | Indicates the intent to bridge this call with the call specified in link_to. |
+| `bridgeOnAnswer` | boolean | Whether to automatically bridge answered call to the call specified in link_to. |
+| `preventDoubleBridge` | boolean | Prevents bridging and hangs up the call if the target is already bridged. |
+| `parkAfterUnbridge` | string | If supplied with the value `self`, the current leg will be parked after unbri... |
+| `mediaEncryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the call. |
+| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
+| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
+| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE request. |
+| `sipTransportProtocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `streamUrl` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `streamTrack` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `streamCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `streamBidirectionalMode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `streamBidirectionalCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `streamBidirectionalTargetLegs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `streamBidirectionalSamplingRate` | enum (8000, 16000, 22050, 24000, 48000) | Audio sampling rate. |
+| `streamEstablishBeforeCallOriginate` | boolean | Establish websocket connection before dialing the destination. |
+| `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhookUrls` | object | A map of event types to webhook URLs. |
+| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `superviseCallControlId` | string (UUID) | The call leg which will be supervised by the new call. |
+| `supervisorRole` | enum (barge, whisper, monitor) | The role of the supervisor call. |
+| `enableDialogflow` | boolean | Enables Dialogflow for the current call. |
+| `dialogflowConfig` | object |  |
+| `transcription` | boolean | Enable transcription upon call answer. |
+| `transcriptionConfig` | object |  |
+| `sipRegion` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `streamAuthToken` | string | An authentication token to be sent as part of the WebSocket connection when u... |
+
+### Answer call — `client.calls.actions.answer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE response. |
+| `preferredCodecs` | enum (G722,PCMU,PCMA,G729,OPUS,VP8,H264) | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE response. |
+| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `streamUrl` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `streamTrack` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `streamCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `streamBidirectionalMode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `streamBidirectionalCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `streamBidirectionalTargetLegs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `transcription` | boolean | Enable transcription upon call answer. |
+| `transcriptionConfig` | object |  |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `webhookUrls` | object | A map of event types to webhook URLs. |
+| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
+
+### Bridge calls — `client.calls.actions.bridge()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `queue` | string | The name of the queue you want to bridge with, can't be used together with ca... |
+| `videoRoomId` | string (UUID) | The ID of the video room you want to bridge with, can't be used together with... |
+| `videoRoomContext` | string | The additional parameter that will be passed to the video conference. |
+| `preventDoubleBridge` | boolean | When set to `true`, it prevents bridging if the target call is already bridge... |
+| `parkAfterUnbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `playRingtone` | boolean | Specifies whether to play a ringtone if the call you want to bridge with has ... |
+| `ringtone` | enum (at, au, be, bg, br, ...) | Specifies which country ringtone to play when `play_ringtone` is set to `true`. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `muteDtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `holdAfterUnbridge` | boolean | Specifies behavior after the bridge ends. |
+
+### Hangup call — `client.calls.actions.hangup()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `customHeaders` | array[object] | Custom headers to be added to the SIP BYE message. |
+
+### SIP Refer a call — `client.calls.actions.refer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid execution of duplicate commands. |
+| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
+| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
+| `sipHeaders` | array[object] | SIP headers to be added to the request. |
+
+### Reject a call — `client.calls.actions.reject()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Send SIP info — `client.calls.actions.sendSipInfo()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Transfer call — `client.calls.actions.transfer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
+| `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `audioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
+| `earlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
+| `mediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
+| `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `parkAfterUnbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `targetLegClientState` | string | Use this field to add state to every subsequent webhook for the new leg. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `mediaEncryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the new call leg. |
+| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
+| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
+| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE. |
+| `sipTransportProtocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `muteDtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `sipRegion` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `preferredCodecs` | string | The list of comma-separated codecs in order of preference to be used during t... |
+| `webhookUrls` | object | A map of event types to webhook URLs. |
+| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+
+## Webhook Payload Fields
+
+### `callAnswered`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.answered | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: answered | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### `callBridged`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.bridged | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+
+### `callHangup`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.hangup | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: hangup | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+| `data.payload.hangup_cause` | enum: call_rejected, normal_clearing, originator_cancel, timeout, time_limit, user_busy, not_found, no_answer, unspecified | The reason the call was ended (`call_rejected`, `normal_clearing`, `originator_cancel`, `timeout`, `time_limit`, `use... |
+| `data.payload.hangup_source` | enum: caller, callee, unknown | The party who ended the call (`callee`, `caller`, `unknown`). |
+| `data.payload.sip_hangup_cause` | string | The reason the call was ended (SIP response code). |
+| `data.payload.call_quality_stats` | object \| null | Call quality statistics aggregated from the CHANNEL_HANGUP_COMPLETE event. |
+
+### `callInitiated`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.initiated | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
+| `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.custom_headers` | array[object] | Custom headers from sip invite |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.shaken_stir_attestation` | string | SHAKEN/STIR attestation level. |
+| `data.payload.shaken_stir_validated` | boolean | Whether attestation was successfully validated or not. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.caller_id_name` | string | Caller id. |
+| `data.payload.call_screening_result` | string | Call screening result. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.direction` | enum: incoming, outgoing | Whether the call is `incoming` or `outgoing`. |
+| `data.payload.state` | enum: parked, bridging | State received from a command. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### Field Type Notes
+
+- `from` in webhook payloads: string (E.164 phone number)
+- `to` in webhook payloads: string (E.164 phone number)
+- The return value of `client.webhooks.unwrap()` is a parsed event object — access fields via `event.data.event_type`, `event.data.payload.call_control_id`, etc.

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/python/10dlc.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/python/10dlc.md
@@ -67,8 +67,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -209,7 +209,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `description` | string | Description of the event. |
 | `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -371,7 +371,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -411,3 +411,471 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# 10DLC (Python) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Brands, List Campaigns, List shared partner campaigns, List Shared Campaigns, List phone number campaigns
+
+| Field | Type |
+|-------|------|
+| `page` | integer |
+| `records` | array[object] |
+| `totalRecords` | integer |
+
+**Returned by:** Create Brand, Update Brand, Revet Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Get Brand Feedback By Id
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `category` | array[object] |
+
+**Returned by:** Get Brand SMS OTP Status, Get Brand SMS OTP Status by Brand ID
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `deliveryStatus` | string |
+| `deliveryStatusDate` | date-time |
+| `deliveryStatusDetails` | string |
+| `mobilePhone` | string |
+| `referenceId` | string |
+| `requestDate` | date-time |
+| `verifyDate` | date-time |
+
+**Returned by:** Get Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `assignedCampaignsCount` | number |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Order Brand External Vetting, Import External Vetting Record
+
+| Field | Type |
+|-------|------|
+| `createDate` | string |
+| `evpId` | string |
+| `vettedDate` | string |
+| `vettingClass` | string |
+| `vettingId` | string |
+| `vettingScore` | integer |
+| `vettingToken` | string |
+
+**Returned by:** Trigger Brand SMS OTP
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `referenceId` | string |
+
+**Returned by:** Get Campaign Cost
+
+| Field | Type |
+|-------|------|
+| `campaignUsecase` | string |
+| `description` | string |
+| `monthlyCost` | string |
+| `upFrontCost` | string |
+
+**Returned by:** Get campaign, Update campaign, Submit Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `autoRenewal` | boolean |
+| `billedDate` | string |
+| `brandDisplayName` | string |
+| `brandId` | string |
+| `campaignId` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createDate` | string |
+| `cspId` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isTMobileNumberPoolingEnabled` | boolean |
+| `isTMobileRegistered` | boolean |
+| `isTMobileSuspended` | boolean |
+| `messageFlow` | string |
+| `mock` | boolean |
+| `nextRenewalOrExpirationDate` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `referenceId` | string |
+| `resellerId` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `status` | string |
+| `subUsecases` | array[string] |
+| `submissionStatus` | enum: CREATED, FAILED, PENDING |
+| `subscriberHelp` | boolean |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `usecase` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Deactivate campaign
+
+| Field | Type |
+|-------|------|
+| `message` | string |
+| `record_type` | string |
+| `time` | number |
+
+**Returned by:** Submit campaign appeal for manual review
+
+| Field | Type |
+|-------|------|
+| `appealed_at` | date-time |
+
+**Returned by:** Get Campaign Mno Metadata
+
+| Field | Type |
+|-------|------|
+| `10999` | object |
+
+**Returned by:** Get Sharing Status
+
+| Field | Type |
+|-------|------|
+| `sharedByMe` | object |
+| `sharedWithMe` | object |
+
+**Returned by:** Qualify By Usecase
+
+| Field | Type |
+|-------|------|
+| `annualFee` | number |
+| `maxSubUsecases` | integer |
+| `minSubUsecases` | integer |
+| `mnoMetadata` | object |
+| `monthlyFee` | number |
+| `quarterlyFee` | number |
+| `usecase` | string |
+
+**Returned by:** Get Single Shared Campaign, Update Single Shared Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `assignedPhoneNumbersCount` | number |
+| `brandDisplayName` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createdAt` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isNumberPoolingEnabled` | boolean |
+| `messageFlow` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `subUsecases` | array[string] |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `updatedAt` | string |
+| `usecase` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Assign Messaging Profile To Campaign
+
+| Field | Type |
+|-------|------|
+| `campaignId` | string |
+| `messagingProfileId` | string |
+| `taskId` | string |
+| `tcrCampaignId` | string |
+
+**Returned by:** Get Assignment Task Status
+
+| Field | Type |
+|-------|------|
+| `createdAt` | date-time |
+| `status` | string |
+| `taskId` | string |
+| `updatedAt` | date-time |
+
+**Returned by:** Get Phone Number Status
+
+| Field | Type |
+|-------|------|
+| `records` | array[object] |
+
+**Returned by:** Create New Phone Number Campaign, Get Single Phone Number Campaign, Create New Phone Number Campaign, Delete Phone Number Campaign
+
+| Field | Type |
+|-------|------|
+| `assignmentStatus` | enum: FAILED_ASSIGNMENT, PENDING_ASSIGNMENT, ASSIGNED, PENDING_UNASSIGNMENT, FAILED_UNASSIGNMENT |
+| `brandId` | string |
+| `campaignId` | string |
+| `createdAt` | string |
+| `failureReasons` | string |
+| `phoneNumber` | string |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `telnyxCampaignId` | string |
+| `updatedAt` | string |
+
+## Optional Parameters
+
+### Create Brand — `client.messaging_10dlc.brand.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `company_name` | string | (Required for Non-profit/private/public) Legal company name. |
+| `first_name` | string | First name of business contact. |
+| `last_name` | string | Last name of business contact. |
+| `ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `phone` | string | Valid phone number in e.164 international format. |
+| `street` | string | Street number and name. |
+| `city` | string | City name |
+| `state` | string | State. |
+| `postal_code` | string | Postal codes. |
+| `stock_symbol` | string | (Required for public company) stock symbol. |
+| `stock_exchange` | object | (Required for public company) stock exchange. |
+| `ip_address` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `website` | string | Brand website URL. |
+| `is_reseller` | boolean |  |
+| `mock` | boolean | Mock brand for testing purposes. |
+| `mobile_phone` | string | Valid mobile phone number in e.164 international format. |
+| `business_contact_email` | string | Business contact email. |
+| `webhook_url` | string | Webhook URL for brand status updates. |
+| `webhook_failover_url` | string | Webhook failover URL for brand status updates. |
+
+### Update Brand — `client.messaging_10dlc.brand.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `company_name` | string | (Required for Non-profit/private/public) Legal company name. |
+| `first_name` | string | First name of business contact. |
+| `last_name` | string | Last name of business contact. |
+| `ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `phone` | string | Valid phone number in e.164 international format. |
+| `street` | string | Street number and name. |
+| `city` | string | City name |
+| `state` | string | State. |
+| `postal_code` | string | Postal codes. |
+| `stock_symbol` | string | (Required for public company) stock symbol. |
+| `stock_exchange` | object | (Required for public company) stock exchange. |
+| `ip_address` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `website` | string | Brand website URL. |
+| `alt_business_id_type` | enum (NONE, DUNS, GIIN, LEI) | An enumeration. |
+| `is_reseller` | boolean |  |
+| `identity_status` | enum (VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED) | The verification status of an active brand |
+| `business_contact_email` | string | Business contact email. |
+| `webhook_url` | string | Webhook URL for brand status updates. |
+| `webhook_failover_url` | string | Webhook failover URL for brand status updates. |
+| `alt_business_id` | string (UUID) | Alternate business identifier such as DUNS, LEI, or GIIN |
+
+### Import External Vetting Record — `client.messaging_10dlc.brand.external_vetting.imports()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `vetting_token` | string | Required by some providers for vetting record confirmation. |
+
+### Update campaign — `client.messaging_10dlc.campaign.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `reseller_id` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `sample1` | string | Message sample. |
+| `sample2` | string | Message sample. |
+| `sample3` | string | Message sample. |
+| `sample4` | string | Message sample. |
+| `sample5` | string | Message sample. |
+| `message_flow` | string | Message flow description. |
+| `help_message` | string | Help message of the campaign. |
+| `auto_renewal` | boolean | Help message of the campaign. |
+| `webhook_url` | string | Webhook to which campaign status updates are sent. |
+| `webhook_failover_url` | string | Webhook failover to which campaign status updates are sent. |
+
+### Submit Campaign — `client.messaging_10dlc.campaign_builder.submit()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `age_gated` | boolean | Age gated message content in campaign. |
+| `auto_renewal` | boolean | Campaign subscription auto-renewal option. |
+| `direct_lending` | boolean | Direct lending or loan arrangement |
+| `embedded_link` | boolean | Does message generated by the campaign include URL link in SMS? |
+| `embedded_phone` | boolean | Does message generated by the campaign include phone number in SMS? |
+| `help_keywords` | string | Subscriber help keywords. |
+| `help_message` | string | Help message of the campaign. |
+| `message_flow` | string | Message flow description. |
+| `mno_ids` | array[integer] | Submit campaign to given list of MNOs by MNO's network ID. |
+| `number_pool` | boolean | Does campaign utilize pool of phone numbers? |
+| `optin_keywords` | string | Subscriber opt-in keywords. |
+| `optin_message` | string | Subscriber opt-in message. |
+| `optout_keywords` | string | Subscriber opt-out keywords. |
+| `optout_message` | string | Subscriber opt-out message. |
+| `reference_id` | string (UUID) | Caller supplied campaign reference ID. |
+| `reseller_id` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `sample1` | string | Message sample. |
+| `sample2` | string | Message sample. |
+| `sample3` | string | Message sample. |
+| `sample4` | string | Message sample. |
+| `sample5` | string | Message sample. |
+| `sub_usecases` | array[string] | Campaign sub-usecases. |
+| `subscriber_help` | boolean | Does campaign responds to help keyword(s)? |
+| `subscriber_optin` | boolean | Does campaign require subscriber to opt-in before SMS is sent to subscriber? |
+| `subscriber_optout` | boolean | Does campaign support subscriber opt-out keyword(s)? |
+| `tag` | array[string] | Tags to be set on the Campaign. |
+| `terms_and_conditions` | boolean | Is terms and conditions accepted? |
+| `privacy_policy_link` | string | Link to the campaign's privacy policy. |
+| `terms_and_conditions_link` | string | Link to the campaign's terms and conditions. |
+| `embedded_link_sample` | string | Sample of an embedded link that will be sent to subscribers. |
+| `webhook_url` | string | Webhook to which campaign status updates are sent. |
+| `webhook_failover_url` | string | Failover webhook to which campaign status updates are sent. |
+
+### Update Single Shared Campaign — `client.messaging_10dlc.partner_campaigns.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `webhook_url` | string | Webhook to which campaign status updates are sent. |
+| `webhook_failover_url` | string | Webhook failover to which campaign status updates are sent. |
+
+### Assign Messaging Profile To Campaign — `client.messaging_10dlc.phone_number_assignment_by_profile.assign()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `tcr_campaign_id` | string (UUID) | The TCR ID of the shared campaign you want to link to the specified messaging... |
+| `campaign_id` | string (UUID) | The ID of the campaign you want to link to the specified messaging profile. |
+
+## Webhook Payload Fields
+
+### `campaignStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `brandId` | string | Brand ID associated with the campaign. |
+| `campaignId` | string | The ID of the campaign. |
+| `createDate` | string | Unix timestamp when campaign was created. |
+| `cspId` | string | Alphanumeric identifier of the CSP associated with this campaign. |
+| `isTMobileRegistered` | boolean | Indicates whether the campaign is registered with T-Mobile. |
+| `type` | enum: TELNYX_EVENT, REGISTRATION, MNO_REVIEW, TELNYX_REVIEW, NUMBER_POOL_PROVISIONED, NUMBER_POOL_DEPROVISIONED, TCR_EVENT, VERIFIED |  |
+| `description` | string | Description of the event. |
+| `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/python/ai-assistants.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/python/ai-assistants.md
@@ -32,8 +32,8 @@ import telnyx
 try:
     assistant = client.ai.assistants.create(
         instructions="You are a helpful assistant.",
-        model="openai/gpt-4o",
         name="my-resource",
+        model="openai/gpt-4o",
     )
 except telnyx.APIConnectionError:
     print("Network error — check connectivity and retry")
@@ -61,7 +61,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -74,18 +74,17 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `description` | string | No |  |
-| `greeting` | string | No | Text that the assistant will use to start the conversation. |
-| ... | | | +11 optional params in the API Details section below |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in the API Details section below |
 
 ```python
 assistant = client.ai.assistants.create(
     instructions="You are a helpful assistant.",
-    model="openai/gpt-4o",
     name="my-resource",
+    model="openai/gpt-4o",
 )
 print(assistant.id)
 ```
@@ -197,7 +196,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### Update an assistant
 
@@ -208,10 +207,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistant_id` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +15 optional params in the API Details section below |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in the API Details section below |
 
 ```python
 assistant = client.ai.assistants.update(
@@ -226,7 +225,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### List assistants
 
@@ -248,7 +247,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Import assistants from external provider
 
@@ -279,7 +278,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Get All Tags
 
@@ -381,7 +380,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -394,8 +393,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
 | Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Get Canary Deploy | `client.ai.assistants.canary_deploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
-| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistant_id` |
-| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistant_id` |
+| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
 | Delete Canary Deploy | `client.ai.assistants.canary_deploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Assistant Sms Chat | `client.ai.assistants.send_sms()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from_`, `to`, `assistant_id` |
 | Clone Assistant | `client.ai.assistants.clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |
@@ -406,6 +405,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Add Assistant Tag | `client.ai.assistants.tags.add()` | `POST /ai/assistants/{assistant_id}/tags` | Create or provision an additional resource when the core tasks do not cover this flow. | `tag`, `assistant_id` |
 | Remove Assistant Tag | `client.ai.assistants.tags.remove()` | `DELETE /ai/assistants/{assistant_id}/tags/{tag}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `tag` |
 | Get assistant texml | `client.ai.assistants.get_texml()` | `GET /ai/assistants/{assistant_id}/texml` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Add Assistant Tool | `client.ai.assistants.tools.add()` | `PUT /ai/assistants/{assistant_id}/tools/{tool_id}` | Modify an existing resource without recreating it. | `assistant_id`, `tool_id` |
+| Remove Assistant Tool | `client.ai.assistants.tools.remove()` | `DELETE /ai/assistants/{assistant_id}/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `tool_id` |
 | Test Assistant Tool | `client.ai.assistants.tools.test()` | `POST /ai/assistants/{assistant_id}/tools/{tool_id}/test` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id`, `tool_id` |
 | Get all versions of an assistant | `client.ai.assistants.versions.list()` | `GET /ai/assistants/{assistant_id}/versions` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
 | Get a specific assistant version | `client.ai.assistants.versions.retrieve()` | `GET /ai/assistants/{assistant_id}/versions/{version_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id`, `version_id` |
@@ -417,7 +418,398 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get MCP Server | `client.ai.mcp_servers.retrieve()` | `GET /ai/mcp_servers/{mcp_server_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `mcp_server_id` |
 | Update MCP Server | `client.ai.mcp_servers.update()` | `PUT /ai/mcp_servers/{mcp_server_id}` | Modify an existing resource without recreating it. | `mcp_server_id` |
 | Delete MCP Server | `client.ai.mcp_servers.delete()` | `DELETE /ai/mcp_servers/{mcp_server_id}` | Remove, detach, or clean up an existing resource. | `mcp_server_id` |
+| List Tools | `client.ai.tools.list()` | `GET /ai/tools` | Inspect available resources or choose an existing resource before mutating it. | None |
+| Create Tool | `client.ai.tools.create()` | `POST /ai/tools` | Create or provision an additional resource when the core tasks do not cover this flow. | `type_`, `display_name` |
+| Get Tool | `client.ai.tools.retrieve()` | `GET /ai/tools/{tool_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `tool_id` |
+| Update Tool | `client.ai.tools.update()` | `PATCH /ai/tools/{tool_id}` | Modify an existing resource without recreating it. | `tool_id` |
+| Delete Tool | `client.ai.tools.delete()` | `DELETE /ai/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `tool_id` |
 
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# AI Assistants (Python) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+
+## Response Schemas
+
+**Returned by:** List assistants, Create an assistant, Import assistants from external provider, Get an assistant, Update an assistant, Clone Assistant, Get all versions of an assistant, Get a specific assistant version, Update a specific assistant version, Promote an assistant version to main
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
+| `dynamic_variables_webhook_url` | string |
+| `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
+| `greeting` | string |
+| `id` | string |
+| `import_metadata` | object |
+| `insight_settings` | object |
+| `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
+| `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
+| `messaging_settings` | object |
+| `model` | string |
+| `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
+| `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
+| `telephony_settings` | object |
+| `tools` | array[object] |
+| `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
+| `voice_settings` | object |
+| `widget_settings` | object |
+
+**Returned by:** Get All Tags, Add Assistant Tag, Remove Assistant Tag
+
+| Field | Type |
+|-------|------|
+| `tags` | array[string] |
+
+**Returned by:** List assistant tests with pagination, Create a new assistant test, Get assistant test by ID, Update an assistant test
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `destination` | string |
+| `instructions` | string |
+| `max_duration_seconds` | integer |
+| `name` | string |
+| `rubric` | array[object] |
+| `telnyx_conversation_channel` | object |
+| `test_id` | uuid |
+| `test_suite` | string |
+
+**Returned by:** Get all test suite names
+
+| Field | Type |
+|-------|------|
+| `data` | array[string] |
+
+**Returned by:** Get test suite run history, Get test run history for a specific test, Trigger a manual test run, Get specific test run details
+
+| Field | Type |
+|-------|------|
+| `completed_at` | date-time |
+| `conversation_id` | string |
+| `conversation_insights_id` | string |
+| `created_at` | date-time |
+| `detail_status` | array[object] |
+| `logs` | string |
+| `run_id` | uuid |
+| `status` | enum: pending, starting, running, passed, failed, error |
+| `test_id` | uuid |
+| `test_suite_run_id` | uuid |
+| `triggered_by` | string |
+| `updated_at` | date-time |
+
+**Returned by:** Delete an assistant
+
+| Field | Type |
+|-------|------|
+| `deleted` | boolean |
+| `id` | string |
+| `object` | string |
+
+**Returned by:** Get Canary Deploy, Create Canary Deploy, Update Canary Deploy
+
+| Field | Type |
+|-------|------|
+| `assistant_id` | string |
+| `created_at` | date-time |
+| `rules` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Assistant Chat (BETA)
+
+| Field | Type |
+|-------|------|
+| `content` | string |
+
+**Returned by:** Assistant Sms Chat
+
+| Field | Type |
+|-------|------|
+| `conversation_id` | string |
+
+**Returned by:** List scheduled events
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Test Assistant Tool
+
+| Field | Type |
+|-------|------|
+| `content_type` | string |
+| `request` | object |
+| `response` | string |
+| `status_code` | integer |
+| `success` | boolean |
+
+**Returned by:** Create MCP Server, Get MCP Server, Update MCP Server
+
+| Field | Type |
+|-------|------|
+| `allowed_tools` | array \| null |
+| `api_key_ref` | string \| null |
+| `created_at` | date-time |
+| `id` | string |
+| `name` | string |
+| `type` | string |
+| `url` | string |
+
+**Returned by:** List Tools, Create Tool, Get Tool, Update Tool
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `display_name` | string |
+| `id` | string |
+| `timeout_ms` | integer |
+| `tool_definition` | object |
+| `type` | string |
+
+## Optional Parameters
+
+### Create an assistant — `client.ai.assistants.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
+| `transcription` | object |  |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+
+### Import assistants from external provider — `client.ai.assistants.imports()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `import_ids` | array[string] | Optional list of assistant IDs to import from the external provider. |
+
+### Create a new assistant test — `client.ai.assistants.tests.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `description` | string | Optional detailed description of what this test evaluates and its purpose. |
+| `telnyx_conversation_channel` | object | The communication channel through which the test will be conducted. |
+| `max_duration_seconds` | integer | Maximum duration in seconds that the test conversation should run before timi... |
+| `test_suite` | string | Optional test suite name to group related tests together. |
+
+### Trigger test suite execution — `client.ai.assistants.tests.test_suites.runs.trigger()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `destination_version_id` | string (UUID) | Optional assistant version ID to use for all test runs in this suite. |
+
+### Update an assistant test — `client.ai.assistants.tests.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | Updated name for the assistant test. |
+| `description` | string | Updated description of the test's purpose and evaluation criteria. |
+| `telnyx_conversation_channel` | enum (phone_call, web_call, sms_chat, web_chat) |  |
+| `destination` | string | Updated target destination for test conversations. |
+| `max_duration_seconds` | integer | Updated maximum test duration in seconds. |
+| `test_suite` | string | Updated test suite assignment for better organization. |
+| `instructions` | string | Updated test scenario instructions and objectives. |
+| `rubric` | array[object] | Updated evaluation criteria for assessing assistant performance. |
+
+### Trigger a manual test run — `client.ai.assistants.tests.runs.trigger()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `destination_version_id` | string (UUID) | Optional assistant version ID to use for this test run. |
+
+### Update an assistant — `client.ai.assistants.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `instructions` | string | System instructions for the assistant. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
+| `transcription` | object |  |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+| `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai.assistants.canary_deploys.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai.assistants.canary_deploys.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Assistant Chat (BETA) — `client.ai.assistants.chat()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | The optional display name of the user sending the message |
+
+### Assistant Sms Chat — `client.ai.assistants.send_sms()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string |  |
+| `conversation_metadata` | object |  |
+| `should_create_conversation` | boolean |  |
+
+### Create a scheduled event — `client.ai.assistants.scheduled_events.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Required for sms scheduled events. |
+| `conversation_metadata` | object | Metadata associated with the conversation. |
+| `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
+
+### Test Assistant Tool — `client.ai.assistants.tools.test()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `arguments` | object | Key-value arguments to use for the webhook test |
+| `dynamic_variables` | object | Key-value dynamic variables to use for the webhook test |
+
+### Update a specific assistant version — `client.ai.assistants.versions.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `instructions` | string | System instructions for the assistant. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
+| `transcription` | object |  |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+
+### Create MCP Server — `client.ai.mcp_servers.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `api_key_ref` | string |  |
+| `allowed_tools` | array[string] |  |
+
+### Update MCP Server — `client.ai.mcp_servers.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `name` | string |  |
+| `type_` | string |  |
+| `url` | string (URL) |  |
+| `api_key_ref` | string |  |
+| `allowed_tools` | array[string] |  |
+| `created_at` | string (date-time) |  |
+
+### Create Tool — `client.ai.tools.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `function` | object |  |
+| `retrieval` | object |  |
+| `handoff` | object |  |
+| `invite` | object |  |
+| `webhook` | object |  |
+| `timeout_ms` | integer |  |
+
+### Update Tool — `client.ai.tools.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type_` | string |  |
+| `display_name` | string |  |
+| `function` | object |  |
+| `retrieval` | object |  |
+| `handoff` | object |  |
+| `invite` | object |  |
+| `webhook` | object |  |
+| `timeout_ms` | integer |  |

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/python/messaging.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/python/messaging.md
@@ -66,8 +66,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -191,7 +191,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.media` | array[object] |  |
 | `data.record_type` | enum: event | Identifies the type of the resource. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -372,6 +372,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsapp_message` | object | Yes |  |
 | `type_` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```python
 response = client.messages.send_whatsapp(
@@ -395,7 +396,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -429,3 +430,425 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Messaging (Python) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List alphanumeric sender IDs, Create an alphanumeric sender ID, Retrieve an alphanumeric sender ID, Delete an alphanumeric sender ID, List alphanumeric sender IDs for a messaging profile
+
+| Field | Type |
+|-------|------|
+| `alphanumeric_sender_id` | string |
+| `id` | uuid |
+| `messaging_profile_id` | uuid |
+| `organization_id` | string |
+| `record_type` | enum: alphanumeric_sender_id |
+| `us_long_code_fallback` | string |
+
+**Returned by:** Send a message, Send a message using an alphanumeric sender ID, Retrieve group MMS messages, Send a group MMS message, Send a long code message, Send a message using number pool, Schedule a message, Send a short code message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `wait_seconds` | float |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** Send a WhatsApp message
+
+| Field | Type |
+|-------|------|
+| `body` | object |
+| `direction` | string |
+| `encoding` | string |
+| `from` | object |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `organization_id` | string |
+| `received_at` | date-time |
+| `record_type` | string |
+| `to` | array[object] |
+| `type` | string |
+| `wait_seconds` | float |
+
+**Returned by:** Retrieve a message, Get detailed messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Cancel a scheduled message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** List messaging hosted numbers, Retrieve a messaging hosted number, Update a messaging hosted number
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `eligible_messaging_products` | array[string] |
+| `features` | object |
+| `health` | object |
+| `id` | string |
+| `messaging_product` | string |
+| `messaging_profile_id` | string \| null |
+| `organization_id` | string |
+| `phone_number` | string |
+| `record_type` | enum: messaging_phone_number, messaging_settings |
+| `tags` | array[string] |
+| `traffic_type` | string |
+| `type` | enum: long-code, toll-free, short-code, longcode, tollfree, shortcode |
+| `updated_at` | date-time |
+
+**Returned by:** List opt-outs
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `from` | string |
+| `keyword` | string \| null |
+| `messaging_profile_id` | string \| null |
+| `to` | string |
+
+**Returned by:** List high-level messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Regenerate messaging profile secret
+
+| Field | Type |
+|-------|------|
+| `ai_assistant_id` | string \| null |
+| `alpha_sender` | string \| null |
+| `created_at` | date-time |
+| `daily_spend_limit` | string |
+| `daily_spend_limit_enabled` | boolean |
+| `enabled` | boolean |
+| `health_webhook_url` | url |
+| `id` | uuid |
+| `mms_fall_back_to_sms` | boolean |
+| `mms_transcoding` | boolean |
+| `mobile_only` | boolean |
+| `name` | string |
+| `number_pool_settings` | object \| null |
+| `organization_id` | string |
+| `record_type` | enum: messaging_profile |
+| `redaction_enabled` | boolean |
+| `redaction_level` | integer |
+| `resource_group_id` | string \| null |
+| `smart_encoding` | boolean |
+| `updated_at` | date-time |
+| `url_shortener_settings` | object \| null |
+| `v1_secret` | string |
+| `webhook_api_version` | enum: 1, 2, 2010-04-01 |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+| `whitelisted_destinations` | array[string] |
+
+**Returned by:** List Auto-Response Settings, Create auto-response setting, Get Auto-Response Setting, Update Auto-Response Setting
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `id` | string |
+| `keywords` | array[string] |
+| `op` | enum: start, stop, info |
+| `resp_text` | string |
+| `updated_at` | date-time |
+
+## Optional Parameters
+
+### Create an alphanumeric sender ID — `client.alphanumeric_sender_ids.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `us_long_code_fallback` | string | A US long code number to use as fallback when sending to US destinations. |
+
+### Send a message — `client.messages.send()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from_` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type_` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using an alphanumeric sender ID — `client.messages.send_with_alphanumeric_sender()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `webhook_url` | string (URL) | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | If true, use the messaging profile's webhook settings. |
+
+### Send a group MMS message — `client.messages.send_group_mms()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+
+### Send a long code message — `client.messages.send_long_code()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type_` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using number pool — `client.messages.send_number_pool()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type_` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Schedule a message — `client.messages.schedule()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from_` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type_` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+
+### Send a short code message — `client.messages.send_short_code()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type_` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a WhatsApp message — `client.messages.send_whatsapp()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type_` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
+
+### Update a messaging hosted number — `client.messaging_hosted_numbers.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `messaging_profile_id` | string (UUID) | Configure the messaging profile this phone number is assigned to:
+
+* Omit thi... |
+| `messaging_product` | string | Configure the messaging product for this number:
+
+* Omit this field or set it... |
+| `tags` | array[string] | Tags to set on this phone number. |
+
+### Create auto-response setting — `client.messaging_profiles.autoresp_configs.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `resp_text` | string |  |
+
+### Update Auto-Response Setting — `client.messaging_profiles.autoresp_configs.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `resp_text` | string |  |
+
+## Webhook Payload Fields
+
+### `deliveryUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.sent, message.finalized | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: outbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | uuid | The id of the organization the messaging profile belongs to. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Subject of multimedia message |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | ISO 8601 formatted date indicating when the message was sent. |
+| `data.payload.completed_at` | date-time | ISO 8601 formatted date indicating when the message was finalized. |
+| `data.payload.valid_until` | date-time | Message must be out of the queue by this time or else it will be discarded and marked as 'sending_failed'. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+| `data.payload.smart_encoding_applied` | boolean | Indicates whether smart encoding was applied to this message. |
+| `data.payload.wait_seconds` | float | Seconds the message is queued due to rate limiting before being sent to the carrier. |
+| `meta.attempt` | integer | Number of attempts to deliver the webhook event. |
+| `meta.delivered_to` | url | The webhook URL the event was delivered to. |
+
+### `inboundMessage`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.received | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: inbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Message subject. |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | Not used for inbound messages. |
+| `data.payload.completed_at` | date-time | Not used for inbound messages. |
+| `data.payload.valid_until` | date-time | Not used for inbound messages. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+
+### `replacedLinkClick`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | string | Identifies the type of the resource. |
+| `data.url` | string | The original link that was sent in the message. |
+| `data.to` | string | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or short code). |
+| `data.message_id` | uuid | The message ID associated with the clicked link. |
+| `data.time_clicked` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+
+### Field Type Notes
+
+- `from` in responses/webhooks: object with sub-fields `phone_number` (string), `carrier` (string), `line_type` (string)
+- `to` in responses/webhooks: array of objects, each with `phone_number` (string), `carrier` (string), `line_type` (string), `status` (string)
+- `cost`: object with `amount` (string, decimal), `currency` (string, e.g., 'USD')

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/python/numbers.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/python/numbers.md
@@ -56,7 +56,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -362,7 +362,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -412,3 +412,433 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Numbers (Python) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Advanced Orders, Create Advanced Order, Update Advanced Order, Get Advanced Order
+
+| Field | Type |
+|-------|------|
+| `area_code` | string |
+| `comments` | string |
+| `country_code` | string |
+| `customer_reference` | string |
+| `features` | array[object] |
+| `id` | uuid |
+| `orders` | array[string] |
+| `phone_number_type` | object |
+| `quantity` | integer |
+| `requirement_group_id` | uuid |
+| `status` | object |
+
+**Returned by:** List available phone number blocks
+
+| Field | Type |
+|-------|------|
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `range` | integer |
+| `record_type` | enum: available_phone_number_block |
+| `region_information` | array[object] |
+
+**Returned by:** List available phone numbers
+
+| Field | Type |
+|-------|------|
+| `best_effort` | boolean |
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `quickship` | boolean |
+| `record_type` | enum: available_phone_number |
+| `region_information` | array[object] |
+| `reservable` | boolean |
+| `vanity_format` | string |
+
+**Returned by:** Retrieve all comments
+
+| Field | Type |
+|-------|------|
+| `body` | string |
+| `comment_record_id` | uuid |
+| `comment_record_type` | enum: sub_number_order, requirement_group |
+| `commenter` | string |
+| `commenter_type` | enum: admin, user |
+| `created_at` | date-time |
+| `id` | uuid |
+| `read_at` | date-time |
+| `updated_at` | date-time |
+
+**Returned by:** Create a comment, Retrieve a comment, Mark a comment as read, Get country coverage
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Get coverage for a specific country
+
+| Field | Type |
+|-------|------|
+| `code` | string |
+| `features` | array[string] |
+| `international_sms` | boolean |
+| `inventory_coverage` | boolean |
+| `local` | object |
+| `mobile` | object |
+| `national` | object |
+| `numbers` | boolean |
+| `p2p` | boolean |
+| `phone_number_type` | array[string] |
+| `quickship` | boolean |
+| `region` | string \| null |
+| `reservable` | boolean |
+| `shared_cost` | object |
+| `toll_free` | object |
+
+**Returned by:** List customer service records, Create a customer service record, Get a customer service record
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `error_message` | string \| null |
+| `id` | uuid |
+| `phone_number` | string |
+| `record_type` | string |
+| `result` | object \| null |
+| `status` | enum: pending, completed, failed |
+| `updated_at` | date-time |
+| `webhook_url` | string |
+
+**Returned by:** Verify CSR phone number coverage
+
+| Field | Type |
+|-------|------|
+| `additional_data_required` | array[string] |
+| `has_csr_coverage` | boolean |
+| `phone_number` | string |
+| `reason` | string |
+| `record_type` | string |
+
+**Returned by:** List inexplicit number orders, Create an inexplicit number order, Retrieve an inexplicit number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `ordering_groups` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Create an inventory coverage request
+
+| Field | Type |
+|-------|------|
+| `administrative_area` | string |
+| `advance_requirements` | boolean |
+| `count` | integer |
+| `coverage_type` | enum: number, block |
+| `group` | string |
+| `group_type` | string |
+| `number_range` | integer |
+| `number_type` | enum: did, toll-free |
+| `phone_number_type` | enum: local, toll_free, national, landline, shared_cost, mobile |
+| `record_type` | string |
+
+**Returned by:** List mobile network operators
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `id` | uuid |
+| `mcc` | string |
+| `mnc` | string |
+| `name` | string |
+| `network_preferences_enabled` | boolean |
+| `record_type` | string |
+| `tadig` | string |
+
+**Returned by:** List network coverage locations
+
+| Field | Type |
+|-------|------|
+| `available_services` | array[object] |
+| `location` | object |
+| `record_type` | string |
+
+**Returned by:** List number block orders, Create a number block order, Retrieve a number block order
+
+| Field | Type |
+|-------|------|
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers_count` | integer |
+| `range` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `starting_number` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve a list of phone numbers associated to orders, Retrieve a single phone number within a number order., Update requirements for a single phone number within a number order.
+
+| Field | Type |
+|-------|------|
+| `bundle_id` | uuid |
+| `country_code` | string |
+| `deadline` | date-time |
+| `id` | uuid |
+| `is_block_number` | boolean |
+| `locality` | string |
+| `order_request_id` | uuid |
+| `phone_number` | string |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `requirements_status` | enum: pending, approved, cancelled, deleted, requirement-info-exception, requirement-info-pending, requirement-info-under-review |
+| `status` | enum: pending, success, failure |
+| `sub_number_order_id` | uuid |
+
+**Returned by:** List number orders, Create a number order, Retrieve a number order, Update a number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers` | array[object] |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `sub_number_orders_ids` | array[string] |
+| `updated_at` | date-time |
+
+**Returned by:** List number reservations, Create a number reservation, Retrieve a number reservation, Extend a number reservation
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `errors` | string |
+| `id` | uuid |
+| `phone_numbers` | array[object] |
+| `record_type` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve the features for a list of numbers
+
+| Field | Type |
+|-------|------|
+| `features` | array[string] |
+| `phone_number` | string |
+
+**Returned by:** Lists the phone number blocks jobs, Deletes all numbers associated with a phone number block, Retrieves a phone number blocks job
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `etc` | date-time |
+| `failed_operations` | array[object] |
+| `id` | uuid |
+| `record_type` | string |
+| `status` | enum: pending, in_progress, completed, failed |
+| `successful_operations` | array[object] |
+| `type` | enum: delete_phone_number_block |
+| `updated_at` | string |
+
+**Returned by:** List sub number orders, Retrieve a sub number order, Update a sub number order's requirements, Cancel a sub number order
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `is_block_sub_number_order` | boolean |
+| `order_request_id` | uuid |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+**Returned by:** Create a sub number orders report, Retrieve a sub number orders report
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `filters` | object |
+| `id` | uuid |
+| `order_type` | string |
+| `status` | enum: pending, success, failed, expired |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+## Optional Parameters
+
+### Create Advanced Order — `client.advanced_orders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `country_code` | string (ISO 3166-1 alpha-2) |  |
+| `comments` | string |  |
+| `quantity` | integer |  |
+| `area_code` | string |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `features` | array[object] |  |
+| `customer_reference` | string |  |
+| `requirement_group_id` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Update Advanced Order — `client.advanced_orders.update_requirement_group()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `country_code` | string (ISO 3166-1 alpha-2) |  |
+| `comments` | string |  |
+| `quantity` | integer |  |
+| `area_code` | string |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `features` | array[object] |  |
+| `customer_reference` | string |  |
+| `requirement_group_id` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Create a comment — `client.comments.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `body` | string |  |
+| `commenter` | string |  |
+| `commenter_type` | enum (admin, user) |  |
+| `comment_record_type` | enum (sub_number_order, requirement_group) |  |
+| `comment_record_id` | string (UUID) |  |
+| `read_at` | string (date-time) | An ISO 8901 datetime string for when the comment was read. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the comment was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the comment was updated. |
+
+### Create an inexplicit number order — `client.inexplicit_number_orders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `connection_id` | string (UUID) | Connection id to apply to phone numbers that are purchased |
+| `messaging_profile_id` | string (UUID) | Messaging profile id to apply to phone numbers that are purchased |
+| `customer_reference` | string | Reference label for the customer |
+| `billing_group_id` | string (UUID) | Billing group id to apply to phone numbers that are purchased |
+
+### Create a number block order — `client.number_block_orders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `record_type` | string |  |
+| `phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `connection_id` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `status` | enum (pending, success, failure) | The status of the order. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the number order was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the number order was updated. |
+| `requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `errors` | string | Errors the reservation could happen upon |
+
+### Update requirements for a single phone number within a number order. — `client.number_order_phone_numbers.update_requirements()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatory_requirements` | array[object] |  |
+
+### Create a number order — `client.number_orders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `phone_numbers` | array[object] |  |
+| `connection_id` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `billing_group_id` | string (UUID) | Identifies the billing group associated with the phone number. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+
+### Update a number order — `client.number_orders.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatory_requirements` | array[object] |  |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+
+### Create a number reservation — `client.number_reservations.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `record_type` | string |  |
+| `phone_numbers` | array[object] |  |
+| `status` | enum (pending, success, failure) | The status of the entire reservation. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the numbers reservation was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the number reservation was updated. |
+
+### Update a sub number order's requirements — `client.sub_number_orders.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatory_requirements` | array[object] |  |
+
+### Create a sub number orders report — `client.sub_number_orders_report.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `status` | enum (pending, success, failure) | Filter by order status |
+| `country_code` | string (ISO 3166-1 alpha-2) | Filter by country code |
+| `created_at_gt` | string (date-time) | Filter for orders created after this date |
+| `created_at_lt` | string (date-time) | Filter for orders created before this date |
+| `order_request_id` | string (UUID) | Filter by specific order request ID |
+| `customer_reference` | string | Filter by customer reference |
+
+## Webhook Payload Fields
+
+### `numberOrderStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.event_type` | string | The type of event being sent |
+| `data.id` | uuid | Unique identifier for the event |
+| `data.occurred_at` | date-time | ISO 8601 timestamp of when the event occurred |
+| `data.payload.id` | uuid |  |
+| `data.payload.record_type` | string |  |
+| `data.payload.phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `data.payload.connection_id` | string | Identifies the connection associated with this phone number. |
+| `data.payload.messaging_profile_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.billing_group_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.phone_numbers` | array[object] |  |
+| `data.payload.sub_number_orders_ids` | array[string] |  |
+| `data.payload.status` | enum: pending, success, failure | The status of the order. |
+| `data.payload.customer_reference` | string | A customer reference string for customer look ups. |
+| `data.payload.created_at` | date-time | An ISO 8901 datetime string denoting when the number order was created. |
+| `data.payload.updated_at` | date-time | An ISO 8901 datetime string for when the number order was updated. |
+| `data.payload.requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `data.record_type` | string | Type of record |
+| `meta.attempt` | integer | Webhook delivery attempt number |
+| `meta.delivered_to` | uri | URL where the webhook was delivered |

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/python/voice.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/python/voice.md
@@ -33,7 +33,7 @@ try:
     response = client.calls.dial(
         connection_id="7267xxxxxxxxxxxxxx",
         from_="+18005550101",
-        to="+18005550100",
+        to="+18005550100;secure=srtp",
     )
 except telnyx.APIConnectionError:
     print("Network error — check connectivity and retry")
@@ -66,8 +66,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -85,13 +85,13 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in the API Details section below |
+| ... | | | +56 optional params in the API Details section below |
 
 ```python
 response = client.calls.dial(
     connection_id="7267xxxxxxxxxxxxxx",
     from_="+18005550101",
-    to="+18005550100",
+    to="+18005550100;secure=srtp",
 )
 print(response.data)
 ```
@@ -116,7 +116,7 @@ Primary inbound call-control command.
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in the API Details section below |
+| ... | | | +29 optional params in the API Details section below |
 
 ```python
 response = client.calls.actions.answer(
@@ -142,12 +142,12 @@ Common post-answer control path with downstream webhook implications.
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in the API Details section below |
+| ... | | | +35 optional params in the API Details section below |
 
 ```python
 response = client.calls.actions.transfer(
     call_control_id="550e8400-e29b-41d4-a716-446655440000",
-    to="+18005550100",
+    to="+18005550100;secure=srtp",
 )
 print(response.data)
 ```
@@ -221,7 +221,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
 | `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -393,7 +393,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -413,3 +413,427 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Voice (Python) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List call control applications, Create a call control application, Retrieve a call control application, Update a call control application, Delete a call control application
+
+| Field | Type |
+|-------|------|
+| `active` | boolean |
+| `anchorsite_override` | enum: Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, Chennai, IN, Amsterdam, Netherlands, Toronto, Canada, Sydney, Australia |
+| `application_name` | string |
+| `call_cost_in_webhooks` | boolean |
+| `created_at` | string |
+| `dtmf_type` | enum: RFC 2833, Inband, SIP INFO |
+| `first_command_timeout` | boolean |
+| `first_command_timeout_secs` | integer |
+| `id` | string |
+| `inbound` | object |
+| `outbound` | object |
+| `record_type` | enum: call_control_application |
+| `redact_dtmf_debug_logging` | boolean |
+| `tags` | array[string] |
+| `updated_at` | string |
+| `webhook_api_version` | enum: 1, 2 |
+| `webhook_event_failover_url` | url |
+| `webhook_event_url` | url |
+| `webhook_timeout_secs` | integer \| null |
+
+**Returned by:** Dial
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `recording_id` | uuid |
+| `start_time` | string |
+
+**Returned by:** Retrieve a call status
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `start_time` | string |
+
+**Returned by:** Answer call
+
+| Field | Type |
+|-------|------|
+| `recording_id` | uuid |
+| `result` | string |
+
+**Returned by:** Bridge calls, Hangup call, SIP Refer a call, Reject a call, Send SIP info, Transfer call
+
+| Field | Type |
+|-------|------|
+| `result` | string |
+
+**Returned by:** List all active calls for given connection
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `record_type` | enum: call |
+
+## Optional Parameters
+
+### Create a call control application — `client.call_control_applications.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `active` | boolean | Specifies whether the connection can be used. |
+| `anchorsite_override` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmf_type` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `first_command_timeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `first_command_timeout_secs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `inbound` | object |  |
+| `outbound` | object |  |
+| `webhook_api_version` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhook_event_failover_url` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhook_timeout_secs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `call_cost_in_webhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `redact_dtmf_debug_logging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Update a call control application — `client.call_control_applications.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `call_cost_in_webhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `active` | boolean | Specifies whether the connection can be used. |
+| `anchorsite_override` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmf_type` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `first_command_timeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `first_command_timeout_secs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `tags` | array[string] | Tags assigned to the Call Control Application. |
+| `inbound` | object |  |
+| `outbound` | object |  |
+| `webhook_api_version` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhook_event_failover_url` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhook_timeout_secs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `redact_dtmf_debug_logging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Dial — `client.calls.dial()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
+| `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
+| `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
+| `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `link_to` | string | Use another call's control id for sharing the same call session id |
+| `bridge_intent` | boolean | Indicates the intent to bridge this call with the call specified in link_to. |
+| `bridge_on_answer` | boolean | Whether to automatically bridge answered call to the call specified in link_to. |
+| `prevent_double_bridge` | boolean | Prevents bridging and hangs up the call if the target is already bridged. |
+| `park_after_unbridge` | string | If supplied with the value `self`, the current leg will be parked after unbri... |
+| `media_encryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the call. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE request. |
+| `sip_transport_protocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `stream_url` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `stream_track` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `stream_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `stream_bidirectional_mode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `stream_bidirectional_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `stream_bidirectional_target_legs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `stream_bidirectional_sampling_rate` | enum (8000, 16000, 22050, 24000, 48000) | Audio sampling rate. |
+| `stream_establish_before_call_originate` | boolean | Establish websocket connection before dialing the destination. |
+| `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `supervise_call_control_id` | string (UUID) | The call leg which will be supervised by the new call. |
+| `supervisor_role` | enum (barge, whisper, monitor) | The role of the supervisor call. |
+| `enable_dialogflow` | boolean | Enables Dialogflow for the current call. |
+| `dialogflow_config` | object |  |
+| `transcription` | boolean | Enable transcription upon call answer. |
+| `transcription_config` | object |  |
+| `sip_region` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `stream_auth_token` | string | An authentication token to be sent as part of the WebSocket connection when u... |
+
+### Answer call — `client.calls.actions.answer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE response. |
+| `preferred_codecs` | enum (G722,PCMU,PCMA,G729,OPUS,VP8,H264) | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE response. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `stream_url` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `stream_track` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `stream_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `stream_bidirectional_mode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `stream_bidirectional_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `stream_bidirectional_target_legs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `transcription` | boolean | Enable transcription upon call answer. |
+| `transcription_config` | object |  |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
+
+### Bridge calls — `client.calls.actions.bridge()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `queue` | string | The name of the queue you want to bridge with, can't be used together with ca... |
+| `video_room_id` | string (UUID) | The ID of the video room you want to bridge with, can't be used together with... |
+| `video_room_context` | string | The additional parameter that will be passed to the video conference. |
+| `prevent_double_bridge` | boolean | When set to `true`, it prevents bridging if the target call is already bridge... |
+| `park_after_unbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `play_ringtone` | boolean | Specifies whether to play a ringtone if the call you want to bridge with has ... |
+| `ringtone` | enum (at, au, be, bg, br, ...) | Specifies which country ringtone to play when `play_ringtone` is set to `true`. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `mute_dtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `hold_after_unbridge` | boolean | Specifies behavior after the bridge ends. |
+
+### Hangup call — `client.calls.actions.hangup()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP BYE message. |
+
+### SIP Refer a call — `client.calls.actions.refer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid execution of duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the request. |
+
+### Reject a call — `client.calls.actions.reject()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Send SIP info — `client.calls.actions.send_sip_info()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Transfer call — `client.calls.actions.transfer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from_` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
+| `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
+| `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
+| `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
+| `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `park_after_unbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `target_leg_client_state` | string | Use this field to add state to every subsequent webhook for the new leg. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `media_encryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the new call leg. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE. |
+| `sip_transport_protocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `mute_dtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `sip_region` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `preferred_codecs` | string | The list of comma-separated codecs in order of preference to be used during t... |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+
+## Webhook Payload Fields
+
+### `callAnswered`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.answered | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: answered | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### `callBridged`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.bridged | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+
+### `callHangup`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.hangup | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: hangup | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+| `data.payload.hangup_cause` | enum: call_rejected, normal_clearing, originator_cancel, timeout, time_limit, user_busy, not_found, no_answer, unspecified | The reason the call was ended (`call_rejected`, `normal_clearing`, `originator_cancel`, `timeout`, `time_limit`, `use... |
+| `data.payload.hangup_source` | enum: caller, callee, unknown | The party who ended the call (`callee`, `caller`, `unknown`). |
+| `data.payload.sip_hangup_cause` | string | The reason the call was ended (SIP response code). |
+| `data.payload.call_quality_stats` | object \| null | Call quality statistics aggregated from the CHANNEL_HANGUP_COMPLETE event. |
+
+### `callInitiated`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.initiated | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
+| `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.custom_headers` | array[object] | Custom headers from sip invite |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.shaken_stir_attestation` | string | SHAKEN/STIR attestation level. |
+| `data.payload.shaken_stir_validated` | boolean | Whether attestation was successfully validated or not. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.caller_id_name` | string | Caller id. |
+| `data.payload.call_screening_result` | string | Call screening result. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.direction` | enum: incoming, outgoing | Whether the call is `incoming` or `outgoing`. |
+| `data.payload.state` | enum: parked, bridging | State received from a command. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### Field Type Notes
+
+- `from` in webhook payloads: string (E.164 phone number)
+- `to` in webhook payloads: string (E.164 phone number)
+- The return value of `client.webhooks.unwrap()` is a parsed event object — access fields via `event.data.event_type`, `event.data.payload.call_control_id`, etc.

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/ruby/10dlc.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/ruby/10dlc.md
@@ -55,8 +55,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -203,7 +203,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `description` | string | Description of the event. |
 | `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -361,7 +361,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -401,3 +401,471 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# 10DLC (Ruby) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Brands, List Campaigns, List shared partner campaigns, List Shared Campaigns, List phone number campaigns
+
+| Field | Type |
+|-------|------|
+| `page` | integer |
+| `records` | array[object] |
+| `totalRecords` | integer |
+
+**Returned by:** Create Brand, Update Brand, Revet Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Get Brand Feedback By Id
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `category` | array[object] |
+
+**Returned by:** Get Brand SMS OTP Status, Get Brand SMS OTP Status by Brand ID
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `deliveryStatus` | string |
+| `deliveryStatusDate` | date-time |
+| `deliveryStatusDetails` | string |
+| `mobilePhone` | string |
+| `referenceId` | string |
+| `requestDate` | date-time |
+| `verifyDate` | date-time |
+
+**Returned by:** Get Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `assignedCampaignsCount` | number |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Order Brand External Vetting, Import External Vetting Record
+
+| Field | Type |
+|-------|------|
+| `createDate` | string |
+| `evpId` | string |
+| `vettedDate` | string |
+| `vettingClass` | string |
+| `vettingId` | string |
+| `vettingScore` | integer |
+| `vettingToken` | string |
+
+**Returned by:** Trigger Brand SMS OTP
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `referenceId` | string |
+
+**Returned by:** Get Campaign Cost
+
+| Field | Type |
+|-------|------|
+| `campaignUsecase` | string |
+| `description` | string |
+| `monthlyCost` | string |
+| `upFrontCost` | string |
+
+**Returned by:** Get campaign, Update campaign, Submit Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `autoRenewal` | boolean |
+| `billedDate` | string |
+| `brandDisplayName` | string |
+| `brandId` | string |
+| `campaignId` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createDate` | string |
+| `cspId` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isTMobileNumberPoolingEnabled` | boolean |
+| `isTMobileRegistered` | boolean |
+| `isTMobileSuspended` | boolean |
+| `messageFlow` | string |
+| `mock` | boolean |
+| `nextRenewalOrExpirationDate` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `referenceId` | string |
+| `resellerId` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `status` | string |
+| `subUsecases` | array[string] |
+| `submissionStatus` | enum: CREATED, FAILED, PENDING |
+| `subscriberHelp` | boolean |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `usecase` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Deactivate campaign
+
+| Field | Type |
+|-------|------|
+| `message` | string |
+| `record_type` | string |
+| `time` | number |
+
+**Returned by:** Submit campaign appeal for manual review
+
+| Field | Type |
+|-------|------|
+| `appealed_at` | date-time |
+
+**Returned by:** Get Campaign Mno Metadata
+
+| Field | Type |
+|-------|------|
+| `10999` | object |
+
+**Returned by:** Get Sharing Status
+
+| Field | Type |
+|-------|------|
+| `sharedByMe` | object |
+| `sharedWithMe` | object |
+
+**Returned by:** Qualify By Usecase
+
+| Field | Type |
+|-------|------|
+| `annualFee` | number |
+| `maxSubUsecases` | integer |
+| `minSubUsecases` | integer |
+| `mnoMetadata` | object |
+| `monthlyFee` | number |
+| `quarterlyFee` | number |
+| `usecase` | string |
+
+**Returned by:** Get Single Shared Campaign, Update Single Shared Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `assignedPhoneNumbersCount` | number |
+| `brandDisplayName` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createdAt` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isNumberPoolingEnabled` | boolean |
+| `messageFlow` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `subUsecases` | array[string] |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `updatedAt` | string |
+| `usecase` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Assign Messaging Profile To Campaign
+
+| Field | Type |
+|-------|------|
+| `campaignId` | string |
+| `messagingProfileId` | string |
+| `taskId` | string |
+| `tcrCampaignId` | string |
+
+**Returned by:** Get Assignment Task Status
+
+| Field | Type |
+|-------|------|
+| `createdAt` | date-time |
+| `status` | string |
+| `taskId` | string |
+| `updatedAt` | date-time |
+
+**Returned by:** Get Phone Number Status
+
+| Field | Type |
+|-------|------|
+| `records` | array[object] |
+
+**Returned by:** Create New Phone Number Campaign, Get Single Phone Number Campaign, Create New Phone Number Campaign, Delete Phone Number Campaign
+
+| Field | Type |
+|-------|------|
+| `assignmentStatus` | enum: FAILED_ASSIGNMENT, PENDING_ASSIGNMENT, ASSIGNED, PENDING_UNASSIGNMENT, FAILED_UNASSIGNMENT |
+| `brandId` | string |
+| `campaignId` | string |
+| `createdAt` | string |
+| `failureReasons` | string |
+| `phoneNumber` | string |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `telnyxCampaignId` | string |
+| `updatedAt` | string |
+
+## Optional Parameters
+
+### Create Brand — `client.messaging_10dlc.brand.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `company_name` | string | (Required for Non-profit/private/public) Legal company name. |
+| `first_name` | string | First name of business contact. |
+| `last_name` | string | Last name of business contact. |
+| `ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `phone` | string | Valid phone number in e.164 international format. |
+| `street` | string | Street number and name. |
+| `city` | string | City name |
+| `state` | string | State. |
+| `postal_code` | string | Postal codes. |
+| `stock_symbol` | string | (Required for public company) stock symbol. |
+| `stock_exchange` | object | (Required for public company) stock exchange. |
+| `ip_address` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `website` | string | Brand website URL. |
+| `is_reseller` | boolean |  |
+| `mock` | boolean | Mock brand for testing purposes. |
+| `mobile_phone` | string | Valid mobile phone number in e.164 international format. |
+| `business_contact_email` | string | Business contact email. |
+| `webhook_url` | string | Webhook URL for brand status updates. |
+| `webhook_failover_url` | string | Webhook failover URL for brand status updates. |
+
+### Update Brand — `client.messaging_10dlc.brand.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `company_name` | string | (Required for Non-profit/private/public) Legal company name. |
+| `first_name` | string | First name of business contact. |
+| `last_name` | string | Last name of business contact. |
+| `ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `phone` | string | Valid phone number in e.164 international format. |
+| `street` | string | Street number and name. |
+| `city` | string | City name |
+| `state` | string | State. |
+| `postal_code` | string | Postal codes. |
+| `stock_symbol` | string | (Required for public company) stock symbol. |
+| `stock_exchange` | object | (Required for public company) stock exchange. |
+| `ip_address` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `website` | string | Brand website URL. |
+| `alt_business_id_type` | enum (NONE, DUNS, GIIN, LEI) | An enumeration. |
+| `is_reseller` | boolean |  |
+| `identity_status` | enum (VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED) | The verification status of an active brand |
+| `business_contact_email` | string | Business contact email. |
+| `webhook_url` | string | Webhook URL for brand status updates. |
+| `webhook_failover_url` | string | Webhook failover URL for brand status updates. |
+| `alt_business_id` | string (UUID) | Alternate business identifier such as DUNS, LEI, or GIIN |
+
+### Import External Vetting Record — `client.messaging_10dlc.brand.external_vetting.imports()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `vetting_token` | string | Required by some providers for vetting record confirmation. |
+
+### Update campaign — `client.messaging_10dlc.campaign.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `reseller_id` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `sample1` | string | Message sample. |
+| `sample2` | string | Message sample. |
+| `sample3` | string | Message sample. |
+| `sample4` | string | Message sample. |
+| `sample5` | string | Message sample. |
+| `message_flow` | string | Message flow description. |
+| `help_message` | string | Help message of the campaign. |
+| `auto_renewal` | boolean | Help message of the campaign. |
+| `webhook_url` | string | Webhook to which campaign status updates are sent. |
+| `webhook_failover_url` | string | Webhook failover to which campaign status updates are sent. |
+
+### Submit Campaign — `client.messaging_10dlc.campaign_builder.submit()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `age_gated` | boolean | Age gated message content in campaign. |
+| `auto_renewal` | boolean | Campaign subscription auto-renewal option. |
+| `direct_lending` | boolean | Direct lending or loan arrangement |
+| `embedded_link` | boolean | Does message generated by the campaign include URL link in SMS? |
+| `embedded_phone` | boolean | Does message generated by the campaign include phone number in SMS? |
+| `help_keywords` | string | Subscriber help keywords. |
+| `help_message` | string | Help message of the campaign. |
+| `message_flow` | string | Message flow description. |
+| `mno_ids` | array[integer] | Submit campaign to given list of MNOs by MNO's network ID. |
+| `number_pool` | boolean | Does campaign utilize pool of phone numbers? |
+| `optin_keywords` | string | Subscriber opt-in keywords. |
+| `optin_message` | string | Subscriber opt-in message. |
+| `optout_keywords` | string | Subscriber opt-out keywords. |
+| `optout_message` | string | Subscriber opt-out message. |
+| `reference_id` | string (UUID) | Caller supplied campaign reference ID. |
+| `reseller_id` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `sample1` | string | Message sample. |
+| `sample2` | string | Message sample. |
+| `sample3` | string | Message sample. |
+| `sample4` | string | Message sample. |
+| `sample5` | string | Message sample. |
+| `sub_usecases` | array[string] | Campaign sub-usecases. |
+| `subscriber_help` | boolean | Does campaign responds to help keyword(s)? |
+| `subscriber_optin` | boolean | Does campaign require subscriber to opt-in before SMS is sent to subscriber? |
+| `subscriber_optout` | boolean | Does campaign support subscriber opt-out keyword(s)? |
+| `tag` | array[string] | Tags to be set on the Campaign. |
+| `terms_and_conditions` | boolean | Is terms and conditions accepted? |
+| `privacy_policy_link` | string | Link to the campaign's privacy policy. |
+| `terms_and_conditions_link` | string | Link to the campaign's terms and conditions. |
+| `embedded_link_sample` | string | Sample of an embedded link that will be sent to subscribers. |
+| `webhook_url` | string | Webhook to which campaign status updates are sent. |
+| `webhook_failover_url` | string | Failover webhook to which campaign status updates are sent. |
+
+### Update Single Shared Campaign — `client.messaging_10dlc.partner_campaigns.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `webhook_url` | string | Webhook to which campaign status updates are sent. |
+| `webhook_failover_url` | string | Webhook failover to which campaign status updates are sent. |
+
+### Assign Messaging Profile To Campaign — `client.messaging_10dlc.phone_number_assignment_by_profile.assign()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `tcr_campaign_id` | string (UUID) | The TCR ID of the shared campaign you want to link to the specified messaging... |
+| `campaign_id` | string (UUID) | The ID of the campaign you want to link to the specified messaging profile. |
+
+## Webhook Payload Fields
+
+### `campaignStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `brandId` | string | Brand ID associated with the campaign. |
+| `campaignId` | string | The ID of the campaign. |
+| `createDate` | string | Unix timestamp when campaign was created. |
+| `cspId` | string | Alphanumeric identifier of the CSP associated with this campaign. |
+| `isTMobileRegistered` | boolean | Indicates whether the campaign is registered with T-Mobile. |
+| `type` | enum: TELNYX_EVENT, REGISTRATION, MNO_REVIEW, TELNYX_REVIEW, NUMBER_POOL_PROVISIONED, NUMBER_POOL_DEPROVISIONED, TCR_EVENT, VERIFIED |  |
+| `description` | string | Description of the event. |
+| `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/ruby/ai-assistants.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/ruby/ai-assistants.md
@@ -26,7 +26,7 @@ All API calls can fail with network errors, rate limits (429), validation errors
 or authentication errors (401). Always handle errors in production code:
 
 ```ruby
-assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", model: "openai/gpt-4o", name: "my-resource")
+assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", name: "my-resource", model: "openai/gpt-4o")
 puts(assistant)
 ```
 
@@ -44,7 +44,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -57,16 +57,14 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `description` | string | No |  |
-| `greeting` | string | No | Text that the assistant will use to start the conversation. |
-| ... | | | +11 optional params in the API Details section below |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in the API Details section below |
 
 ```ruby
-assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", model: "openai/gpt-4o", name: "my-resource")
-
+assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", name: "my-resource", model: "openai/gpt-4o")
 puts(assistant)
 ```
 
@@ -175,7 +173,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### Update an assistant
 
@@ -186,10 +184,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistant_id` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +15 optional params in the API Details section below |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in the API Details section below |
 
 ```ruby
 assistant = client.ai.assistants.update("550e8400-e29b-41d4-a716-446655440000")
@@ -203,7 +201,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### List assistants
 
@@ -226,7 +224,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Import assistants from external provider
 
@@ -255,7 +253,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Get All Tags
 
@@ -357,7 +355,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -370,8 +368,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
 | Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Get Canary Deploy | `client.ai.assistants.canary_deploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
-| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistant_id` |
-| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistant_id` |
+| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
 | Delete Canary Deploy | `client.ai.assistants.canary_deploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Assistant Sms Chat | `client.ai.assistants.send_sms()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistant_id` |
 | Clone Assistant | `client.ai.assistants.clone_()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |
@@ -382,6 +380,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Add Assistant Tag | `client.ai.assistants.tags.add()` | `POST /ai/assistants/{assistant_id}/tags` | Create or provision an additional resource when the core tasks do not cover this flow. | `tag`, `assistant_id` |
 | Remove Assistant Tag | `client.ai.assistants.tags.remove()` | `DELETE /ai/assistants/{assistant_id}/tags/{tag}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `tag` |
 | Get assistant texml | `client.ai.assistants.get_texml()` | `GET /ai/assistants/{assistant_id}/texml` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Add Assistant Tool | `client.ai.assistants.tools.add()` | `PUT /ai/assistants/{assistant_id}/tools/{tool_id}` | Modify an existing resource without recreating it. | `assistant_id`, `tool_id` |
+| Remove Assistant Tool | `client.ai.assistants.tools.remove()` | `DELETE /ai/assistants/{assistant_id}/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `tool_id` |
 | Test Assistant Tool | `client.ai.assistants.tools.test_()` | `POST /ai/assistants/{assistant_id}/tools/{tool_id}/test` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id`, `tool_id` |
 | Get all versions of an assistant | `client.ai.assistants.versions.list()` | `GET /ai/assistants/{assistant_id}/versions` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
 | Get a specific assistant version | `client.ai.assistants.versions.retrieve()` | `GET /ai/assistants/{assistant_id}/versions/{version_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id`, `version_id` |
@@ -393,7 +393,398 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get MCP Server | `client.ai.mcp_servers.retrieve()` | `GET /ai/mcp_servers/{mcp_server_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `mcp_server_id` |
 | Update MCP Server | `client.ai.mcp_servers.update()` | `PUT /ai/mcp_servers/{mcp_server_id}` | Modify an existing resource without recreating it. | `mcp_server_id` |
 | Delete MCP Server | `client.ai.mcp_servers.delete()` | `DELETE /ai/mcp_servers/{mcp_server_id}` | Remove, detach, or clean up an existing resource. | `mcp_server_id` |
+| List Tools | `client.ai.tools.list()` | `GET /ai/tools` | Inspect available resources or choose an existing resource before mutating it. | None |
+| Create Tool | `client.ai.tools.create()` | `POST /ai/tools` | Create or provision an additional resource when the core tasks do not cover this flow. | `type`, `display_name` |
+| Get Tool | `client.ai.tools.retrieve()` | `GET /ai/tools/{tool_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `tool_id` |
+| Update Tool | `client.ai.tools.update()` | `PATCH /ai/tools/{tool_id}` | Modify an existing resource without recreating it. | `tool_id` |
+| Delete Tool | `client.ai.tools.delete()` | `DELETE /ai/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `tool_id` |
 
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# AI Assistants (Ruby) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+
+## Response Schemas
+
+**Returned by:** List assistants, Create an assistant, Import assistants from external provider, Get an assistant, Update an assistant, Clone Assistant, Get all versions of an assistant, Get a specific assistant version, Update a specific assistant version, Promote an assistant version to main
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
+| `dynamic_variables_webhook_url` | string |
+| `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
+| `greeting` | string |
+| `id` | string |
+| `import_metadata` | object |
+| `insight_settings` | object |
+| `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
+| `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
+| `messaging_settings` | object |
+| `model` | string |
+| `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
+| `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
+| `telephony_settings` | object |
+| `tools` | array[object] |
+| `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
+| `voice_settings` | object |
+| `widget_settings` | object |
+
+**Returned by:** Get All Tags, Add Assistant Tag, Remove Assistant Tag
+
+| Field | Type |
+|-------|------|
+| `tags` | array[string] |
+
+**Returned by:** List assistant tests with pagination, Create a new assistant test, Get assistant test by ID, Update an assistant test
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `destination` | string |
+| `instructions` | string |
+| `max_duration_seconds` | integer |
+| `name` | string |
+| `rubric` | array[object] |
+| `telnyx_conversation_channel` | object |
+| `test_id` | uuid |
+| `test_suite` | string |
+
+**Returned by:** Get all test suite names
+
+| Field | Type |
+|-------|------|
+| `data` | array[string] |
+
+**Returned by:** Get test suite run history, Get test run history for a specific test, Trigger a manual test run, Get specific test run details
+
+| Field | Type |
+|-------|------|
+| `completed_at` | date-time |
+| `conversation_id` | string |
+| `conversation_insights_id` | string |
+| `created_at` | date-time |
+| `detail_status` | array[object] |
+| `logs` | string |
+| `run_id` | uuid |
+| `status` | enum: pending, starting, running, passed, failed, error |
+| `test_id` | uuid |
+| `test_suite_run_id` | uuid |
+| `triggered_by` | string |
+| `updated_at` | date-time |
+
+**Returned by:** Delete an assistant
+
+| Field | Type |
+|-------|------|
+| `deleted` | boolean |
+| `id` | string |
+| `object` | string |
+
+**Returned by:** Get Canary Deploy, Create Canary Deploy, Update Canary Deploy
+
+| Field | Type |
+|-------|------|
+| `assistant_id` | string |
+| `created_at` | date-time |
+| `rules` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Assistant Chat (BETA)
+
+| Field | Type |
+|-------|------|
+| `content` | string |
+
+**Returned by:** Assistant Sms Chat
+
+| Field | Type |
+|-------|------|
+| `conversation_id` | string |
+
+**Returned by:** List scheduled events
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Test Assistant Tool
+
+| Field | Type |
+|-------|------|
+| `content_type` | string |
+| `request` | object |
+| `response` | string |
+| `status_code` | integer |
+| `success` | boolean |
+
+**Returned by:** Create MCP Server, Get MCP Server, Update MCP Server
+
+| Field | Type |
+|-------|------|
+| `allowed_tools` | array \| null |
+| `api_key_ref` | string \| null |
+| `created_at` | date-time |
+| `id` | string |
+| `name` | string |
+| `type` | string |
+| `url` | string |
+
+**Returned by:** List Tools, Create Tool, Get Tool, Update Tool
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `display_name` | string |
+| `id` | string |
+| `timeout_ms` | integer |
+| `tool_definition` | object |
+| `type` | string |
+
+## Optional Parameters
+
+### Create an assistant — `client.ai.assistants.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
+| `transcription` | object |  |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+
+### Import assistants from external provider — `client.ai.assistants.imports()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `import_ids` | array[string] | Optional list of assistant IDs to import from the external provider. |
+
+### Create a new assistant test — `client.ai.assistants.tests.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `description` | string | Optional detailed description of what this test evaluates and its purpose. |
+| `telnyx_conversation_channel` | object | The communication channel through which the test will be conducted. |
+| `max_duration_seconds` | integer | Maximum duration in seconds that the test conversation should run before timi... |
+| `test_suite` | string | Optional test suite name to group related tests together. |
+
+### Trigger test suite execution — `client.ai.assistants.tests.test_suites.runs.trigger()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `destination_version_id` | string (UUID) | Optional assistant version ID to use for all test runs in this suite. |
+
+### Update an assistant test — `client.ai.assistants.tests.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | Updated name for the assistant test. |
+| `description` | string | Updated description of the test's purpose and evaluation criteria. |
+| `telnyx_conversation_channel` | enum (phone_call, web_call, sms_chat, web_chat) |  |
+| `destination` | string | Updated target destination for test conversations. |
+| `max_duration_seconds` | integer | Updated maximum test duration in seconds. |
+| `test_suite` | string | Updated test suite assignment for better organization. |
+| `instructions` | string | Updated test scenario instructions and objectives. |
+| `rubric` | array[object] | Updated evaluation criteria for assessing assistant performance. |
+
+### Trigger a manual test run — `client.ai.assistants.tests.runs.trigger()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `destination_version_id` | string (UUID) | Optional assistant version ID to use for this test run. |
+
+### Update an assistant — `client.ai.assistants.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `instructions` | string | System instructions for the assistant. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
+| `transcription` | object |  |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+| `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai.assistants.canary_deploys.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai.assistants.canary_deploys.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Assistant Chat (BETA) — `client.ai.assistants.chat()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | The optional display name of the user sending the message |
+
+### Assistant Sms Chat — `client.ai.assistants.send_sms()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string |  |
+| `conversation_metadata` | object |  |
+| `should_create_conversation` | boolean |  |
+
+### Create a scheduled event — `client.ai.assistants.scheduled_events.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Required for sms scheduled events. |
+| `conversation_metadata` | object | Metadata associated with the conversation. |
+| `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
+
+### Test Assistant Tool — `client.ai.assistants.tools.test_()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `arguments` | object | Key-value arguments to use for the webhook test |
+| `dynamic_variables` | object | Key-value dynamic variables to use for the webhook test |
+
+### Update a specific assistant version — `client.ai.assistants.versions.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `instructions` | string | System instructions for the assistant. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
+| `transcription` | object |  |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+
+### Create MCP Server — `client.ai.mcp_servers.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `api_key_ref` | string |  |
+| `allowed_tools` | array[string] |  |
+
+### Update MCP Server — `client.ai.mcp_servers.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `name` | string |  |
+| `type` | string |  |
+| `url` | string (URL) |  |
+| `api_key_ref` | string |  |
+| `allowed_tools` | array[string] |  |
+| `created_at` | string (date-time) |  |
+
+### Create Tool — `client.ai.tools.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `function` | object |  |
+| `retrieval` | object |  |
+| `handoff` | object |  |
+| `invite` | object |  |
+| `webhook` | object |  |
+| `timeout_ms` | integer |  |
+
+### Update Tool — `client.ai.tools.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type` | string |  |
+| `display_name` | string |  |
+| `function` | object |  |
+| `retrieval` | object |  |
+| `handoff` | object |  |
+| `invite` | object |  |
+| `webhook` | object |  |
+| `timeout_ms` | integer |  |

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/ruby/messaging.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/ruby/messaging.md
@@ -50,8 +50,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -175,7 +175,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.media` | array[object] |  |
 | `data.record_type` | enum: event | Identifies the type of the resource. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -340,6 +340,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsapp_message` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```ruby
 response = client.messages.send_whatsapp(from: "+13125551234", to: "+13125551234", whatsapp_message: {})
@@ -360,7 +361,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -394,3 +395,425 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Messaging (Ruby) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List alphanumeric sender IDs, Create an alphanumeric sender ID, Retrieve an alphanumeric sender ID, Delete an alphanumeric sender ID, List alphanumeric sender IDs for a messaging profile
+
+| Field | Type |
+|-------|------|
+| `alphanumeric_sender_id` | string |
+| `id` | uuid |
+| `messaging_profile_id` | uuid |
+| `organization_id` | string |
+| `record_type` | enum: alphanumeric_sender_id |
+| `us_long_code_fallback` | string |
+
+**Returned by:** Send a message, Send a message using an alphanumeric sender ID, Retrieve group MMS messages, Send a group MMS message, Send a long code message, Send a message using number pool, Schedule a message, Send a short code message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `wait_seconds` | float |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** Send a WhatsApp message
+
+| Field | Type |
+|-------|------|
+| `body` | object |
+| `direction` | string |
+| `encoding` | string |
+| `from` | object |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `organization_id` | string |
+| `received_at` | date-time |
+| `record_type` | string |
+| `to` | array[object] |
+| `type` | string |
+| `wait_seconds` | float |
+
+**Returned by:** Retrieve a message, Get detailed messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Cancel a scheduled message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** List messaging hosted numbers, Retrieve a messaging hosted number, Update a messaging hosted number
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `eligible_messaging_products` | array[string] |
+| `features` | object |
+| `health` | object |
+| `id` | string |
+| `messaging_product` | string |
+| `messaging_profile_id` | string \| null |
+| `organization_id` | string |
+| `phone_number` | string |
+| `record_type` | enum: messaging_phone_number, messaging_settings |
+| `tags` | array[string] |
+| `traffic_type` | string |
+| `type` | enum: long-code, toll-free, short-code, longcode, tollfree, shortcode |
+| `updated_at` | date-time |
+
+**Returned by:** List opt-outs
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `from` | string |
+| `keyword` | string \| null |
+| `messaging_profile_id` | string \| null |
+| `to` | string |
+
+**Returned by:** List high-level messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Regenerate messaging profile secret
+
+| Field | Type |
+|-------|------|
+| `ai_assistant_id` | string \| null |
+| `alpha_sender` | string \| null |
+| `created_at` | date-time |
+| `daily_spend_limit` | string |
+| `daily_spend_limit_enabled` | boolean |
+| `enabled` | boolean |
+| `health_webhook_url` | url |
+| `id` | uuid |
+| `mms_fall_back_to_sms` | boolean |
+| `mms_transcoding` | boolean |
+| `mobile_only` | boolean |
+| `name` | string |
+| `number_pool_settings` | object \| null |
+| `organization_id` | string |
+| `record_type` | enum: messaging_profile |
+| `redaction_enabled` | boolean |
+| `redaction_level` | integer |
+| `resource_group_id` | string \| null |
+| `smart_encoding` | boolean |
+| `updated_at` | date-time |
+| `url_shortener_settings` | object \| null |
+| `v1_secret` | string |
+| `webhook_api_version` | enum: 1, 2, 2010-04-01 |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+| `whitelisted_destinations` | array[string] |
+
+**Returned by:** List Auto-Response Settings, Create auto-response setting, Get Auto-Response Setting, Update Auto-Response Setting
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `id` | string |
+| `keywords` | array[string] |
+| `op` | enum: start, stop, info |
+| `resp_text` | string |
+| `updated_at` | date-time |
+
+## Optional Parameters
+
+### Create an alphanumeric sender ID — `client.alphanumeric_sender_ids.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `us_long_code_fallback` | string | A US long code number to use as fallback when sending to US destinations. |
+
+### Send a message — `client.messages.send_()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using an alphanumeric sender ID — `client.messages.send_with_alphanumeric_sender()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `webhook_url` | string (URL) | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | If true, use the messaging profile's webhook settings. |
+
+### Send a group MMS message — `client.messages.send_group_mms()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+
+### Send a long code message — `client.messages.send_long_code()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using number pool — `client.messages.send_number_pool()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Schedule a message — `client.messages.schedule()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+
+### Send a short code message — `client.messages.send_short_code()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a WhatsApp message — `client.messages.send_whatsapp()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
+
+### Update a messaging hosted number — `client.messaging_hosted_numbers.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `messaging_profile_id` | string (UUID) | Configure the messaging profile this phone number is assigned to:
+
+* Omit thi... |
+| `messaging_product` | string | Configure the messaging product for this number:
+
+* Omit this field or set it... |
+| `tags` | array[string] | Tags to set on this phone number. |
+
+### Create auto-response setting — `client.messaging_profiles.autoresp_configs.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `resp_text` | string |  |
+
+### Update Auto-Response Setting — `client.messaging_profiles.autoresp_configs.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `resp_text` | string |  |
+
+## Webhook Payload Fields
+
+### `deliveryUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.sent, message.finalized | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: outbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | uuid | The id of the organization the messaging profile belongs to. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Subject of multimedia message |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | ISO 8601 formatted date indicating when the message was sent. |
+| `data.payload.completed_at` | date-time | ISO 8601 formatted date indicating when the message was finalized. |
+| `data.payload.valid_until` | date-time | Message must be out of the queue by this time or else it will be discarded and marked as 'sending_failed'. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+| `data.payload.smart_encoding_applied` | boolean | Indicates whether smart encoding was applied to this message. |
+| `data.payload.wait_seconds` | float | Seconds the message is queued due to rate limiting before being sent to the carrier. |
+| `meta.attempt` | integer | Number of attempts to deliver the webhook event. |
+| `meta.delivered_to` | url | The webhook URL the event was delivered to. |
+
+### `inboundMessage`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.received | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: inbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Message subject. |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | Not used for inbound messages. |
+| `data.payload.completed_at` | date-time | Not used for inbound messages. |
+| `data.payload.valid_until` | date-time | Not used for inbound messages. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+
+### `replacedLinkClick`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | string | Identifies the type of the resource. |
+| `data.url` | string | The original link that was sent in the message. |
+| `data.to` | string | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or short code). |
+| `data.message_id` | uuid | The message ID associated with the clicked link. |
+| `data.time_clicked` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+
+### Field Type Notes
+
+- `from` in responses/webhooks: object with sub-fields `phone_number` (string), `carrier` (string), `line_type` (string)
+- `to` in responses/webhooks: array of objects, each with `phone_number` (string), `carrier` (string), `line_type` (string), `status` (string)
+- `cost`: object with `amount` (string, decimal), `currency` (string, e.g., 'USD')

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/ruby/numbers.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/ruby/numbers.md
@@ -44,7 +44,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -347,7 +347,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -397,3 +397,433 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Numbers (Ruby) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Advanced Orders, Create Advanced Order, Update Advanced Order, Get Advanced Order
+
+| Field | Type |
+|-------|------|
+| `area_code` | string |
+| `comments` | string |
+| `country_code` | string |
+| `customer_reference` | string |
+| `features` | array[object] |
+| `id` | uuid |
+| `orders` | array[string] |
+| `phone_number_type` | object |
+| `quantity` | integer |
+| `requirement_group_id` | uuid |
+| `status` | object |
+
+**Returned by:** List available phone number blocks
+
+| Field | Type |
+|-------|------|
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `range` | integer |
+| `record_type` | enum: available_phone_number_block |
+| `region_information` | array[object] |
+
+**Returned by:** List available phone numbers
+
+| Field | Type |
+|-------|------|
+| `best_effort` | boolean |
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `quickship` | boolean |
+| `record_type` | enum: available_phone_number |
+| `region_information` | array[object] |
+| `reservable` | boolean |
+| `vanity_format` | string |
+
+**Returned by:** Retrieve all comments
+
+| Field | Type |
+|-------|------|
+| `body` | string |
+| `comment_record_id` | uuid |
+| `comment_record_type` | enum: sub_number_order, requirement_group |
+| `commenter` | string |
+| `commenter_type` | enum: admin, user |
+| `created_at` | date-time |
+| `id` | uuid |
+| `read_at` | date-time |
+| `updated_at` | date-time |
+
+**Returned by:** Create a comment, Retrieve a comment, Mark a comment as read, Get country coverage
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Get coverage for a specific country
+
+| Field | Type |
+|-------|------|
+| `code` | string |
+| `features` | array[string] |
+| `international_sms` | boolean |
+| `inventory_coverage` | boolean |
+| `local` | object |
+| `mobile` | object |
+| `national` | object |
+| `numbers` | boolean |
+| `p2p` | boolean |
+| `phone_number_type` | array[string] |
+| `quickship` | boolean |
+| `region` | string \| null |
+| `reservable` | boolean |
+| `shared_cost` | object |
+| `toll_free` | object |
+
+**Returned by:** List customer service records, Create a customer service record, Get a customer service record
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `error_message` | string \| null |
+| `id` | uuid |
+| `phone_number` | string |
+| `record_type` | string |
+| `result` | object \| null |
+| `status` | enum: pending, completed, failed |
+| `updated_at` | date-time |
+| `webhook_url` | string |
+
+**Returned by:** Verify CSR phone number coverage
+
+| Field | Type |
+|-------|------|
+| `additional_data_required` | array[string] |
+| `has_csr_coverage` | boolean |
+| `phone_number` | string |
+| `reason` | string |
+| `record_type` | string |
+
+**Returned by:** List inexplicit number orders, Create an inexplicit number order, Retrieve an inexplicit number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `ordering_groups` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Create an inventory coverage request
+
+| Field | Type |
+|-------|------|
+| `administrative_area` | string |
+| `advance_requirements` | boolean |
+| `count` | integer |
+| `coverage_type` | enum: number, block |
+| `group` | string |
+| `group_type` | string |
+| `number_range` | integer |
+| `number_type` | enum: did, toll-free |
+| `phone_number_type` | enum: local, toll_free, national, landline, shared_cost, mobile |
+| `record_type` | string |
+
+**Returned by:** List mobile network operators
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `id` | uuid |
+| `mcc` | string |
+| `mnc` | string |
+| `name` | string |
+| `network_preferences_enabled` | boolean |
+| `record_type` | string |
+| `tadig` | string |
+
+**Returned by:** List network coverage locations
+
+| Field | Type |
+|-------|------|
+| `available_services` | array[object] |
+| `location` | object |
+| `record_type` | string |
+
+**Returned by:** List number block orders, Create a number block order, Retrieve a number block order
+
+| Field | Type |
+|-------|------|
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers_count` | integer |
+| `range` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `starting_number` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve a list of phone numbers associated to orders, Retrieve a single phone number within a number order., Update requirements for a single phone number within a number order.
+
+| Field | Type |
+|-------|------|
+| `bundle_id` | uuid |
+| `country_code` | string |
+| `deadline` | date-time |
+| `id` | uuid |
+| `is_block_number` | boolean |
+| `locality` | string |
+| `order_request_id` | uuid |
+| `phone_number` | string |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `requirements_status` | enum: pending, approved, cancelled, deleted, requirement-info-exception, requirement-info-pending, requirement-info-under-review |
+| `status` | enum: pending, success, failure |
+| `sub_number_order_id` | uuid |
+
+**Returned by:** List number orders, Create a number order, Retrieve a number order, Update a number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers` | array[object] |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `sub_number_orders_ids` | array[string] |
+| `updated_at` | date-time |
+
+**Returned by:** List number reservations, Create a number reservation, Retrieve a number reservation, Extend a number reservation
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `errors` | string |
+| `id` | uuid |
+| `phone_numbers` | array[object] |
+| `record_type` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve the features for a list of numbers
+
+| Field | Type |
+|-------|------|
+| `features` | array[string] |
+| `phone_number` | string |
+
+**Returned by:** Lists the phone number blocks jobs, Deletes all numbers associated with a phone number block, Retrieves a phone number blocks job
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `etc` | date-time |
+| `failed_operations` | array[object] |
+| `id` | uuid |
+| `record_type` | string |
+| `status` | enum: pending, in_progress, completed, failed |
+| `successful_operations` | array[object] |
+| `type` | enum: delete_phone_number_block |
+| `updated_at` | string |
+
+**Returned by:** List sub number orders, Retrieve a sub number order, Update a sub number order's requirements, Cancel a sub number order
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `is_block_sub_number_order` | boolean |
+| `order_request_id` | uuid |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+**Returned by:** Create a sub number orders report, Retrieve a sub number orders report
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `filters` | object |
+| `id` | uuid |
+| `order_type` | string |
+| `status` | enum: pending, success, failed, expired |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+## Optional Parameters
+
+### Create Advanced Order — `client.advanced_orders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `country_code` | string (ISO 3166-1 alpha-2) |  |
+| `comments` | string |  |
+| `quantity` | integer |  |
+| `area_code` | string |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `features` | array[object] |  |
+| `customer_reference` | string |  |
+| `requirement_group_id` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Update Advanced Order — `client.advanced_orders.update_requirement_group()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `country_code` | string (ISO 3166-1 alpha-2) |  |
+| `comments` | string |  |
+| `quantity` | integer |  |
+| `area_code` | string |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `features` | array[object] |  |
+| `customer_reference` | string |  |
+| `requirement_group_id` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Create a comment — `client.comments.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `body` | string |  |
+| `commenter` | string |  |
+| `commenter_type` | enum (admin, user) |  |
+| `comment_record_type` | enum (sub_number_order, requirement_group) |  |
+| `comment_record_id` | string (UUID) |  |
+| `read_at` | string (date-time) | An ISO 8901 datetime string for when the comment was read. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the comment was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the comment was updated. |
+
+### Create an inexplicit number order — `client.inexplicit_number_orders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `connection_id` | string (UUID) | Connection id to apply to phone numbers that are purchased |
+| `messaging_profile_id` | string (UUID) | Messaging profile id to apply to phone numbers that are purchased |
+| `customer_reference` | string | Reference label for the customer |
+| `billing_group_id` | string (UUID) | Billing group id to apply to phone numbers that are purchased |
+
+### Create a number block order — `client.number_block_orders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `record_type` | string |  |
+| `phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `connection_id` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `status` | enum (pending, success, failure) | The status of the order. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the number order was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the number order was updated. |
+| `requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `errors` | string | Errors the reservation could happen upon |
+
+### Update requirements for a single phone number within a number order. — `client.number_order_phone_numbers.update_requirements()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatory_requirements` | array[object] |  |
+
+### Create a number order — `client.number_orders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `phone_numbers` | array[object] |  |
+| `connection_id` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `billing_group_id` | string (UUID) | Identifies the billing group associated with the phone number. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+
+### Update a number order — `client.number_orders.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatory_requirements` | array[object] |  |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+
+### Create a number reservation — `client.number_reservations.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `record_type` | string |  |
+| `phone_numbers` | array[object] |  |
+| `status` | enum (pending, success, failure) | The status of the entire reservation. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the numbers reservation was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the number reservation was updated. |
+
+### Update a sub number order's requirements — `client.sub_number_orders.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatory_requirements` | array[object] |  |
+
+### Create a sub number orders report — `client.sub_number_orders_report.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `status` | enum (pending, success, failure) | Filter by order status |
+| `country_code` | string (ISO 3166-1 alpha-2) | Filter by country code |
+| `created_at_gt` | string (date-time) | Filter for orders created after this date |
+| `created_at_lt` | string (date-time) | Filter for orders created before this date |
+| `order_request_id` | string (UUID) | Filter by specific order request ID |
+| `customer_reference` | string | Filter by customer reference |
+
+## Webhook Payload Fields
+
+### `numberOrderStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.event_type` | string | The type of event being sent |
+| `data.id` | uuid | Unique identifier for the event |
+| `data.occurred_at` | date-time | ISO 8601 timestamp of when the event occurred |
+| `data.payload.id` | uuid |  |
+| `data.payload.record_type` | string |  |
+| `data.payload.phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `data.payload.connection_id` | string | Identifies the connection associated with this phone number. |
+| `data.payload.messaging_profile_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.billing_group_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.phone_numbers` | array[object] |  |
+| `data.payload.sub_number_orders_ids` | array[string] |  |
+| `data.payload.status` | enum: pending, success, failure | The status of the order. |
+| `data.payload.customer_reference` | string | A customer reference string for customer look ups. |
+| `data.payload.created_at` | date-time | An ISO 8901 datetime string denoting when the number order was created. |
+| `data.payload.updated_at` | date-time | An ISO 8901 datetime string for when the number order was updated. |
+| `data.payload.requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `data.record_type` | string | Type of record |
+| `meta.attempt` | integer | Webhook delivery attempt number |
+| `meta.delivered_to` | uri | URL where the webhook was delivered |

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/ruby/voice.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/ruby/voice.md
@@ -29,7 +29,7 @@ or authentication errors (401). Always handle errors in production code:
 response = client.calls.dial(
   connection_id: "7267xxxxxxxxxxxxxx",
   from: "+18005550101",
-  to: "+18005550100"
+  to: "+18005550100;secure=srtp"
 )
 puts(response)
 ```
@@ -54,8 +54,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -73,13 +73,13 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in the API Details section below |
+| ... | | | +56 optional params in the API Details section below |
 
 ```ruby
 response = client.calls.dial(
   connection_id: "7267xxxxxxxxxxxxxx",
   from: "+18005550101",
-  to: "+18005550100"
+  to: "+18005550100;secure=srtp"
 )
 
 puts(response)
@@ -105,7 +105,7 @@ Primary inbound call-control command.
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in the API Details section below |
+| ... | | | +29 optional params in the API Details section below |
 
 ```ruby
 response = client.calls.actions.answer("v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ")
@@ -130,10 +130,13 @@ Common post-answer control path with downstream webhook implications.
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in the API Details section below |
+| ... | | | +35 optional params in the API Details section below |
 
 ```ruby
-response = client.calls.actions.transfer("call_control_id", to: "+18005550100")
+response = client.calls.actions.transfer(
+  "call_control_id",
+  to: "+18005550100;secure=srtp"
+)
 
 puts(response)
 ```
@@ -210,7 +213,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
 | `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -377,7 +380,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -397,3 +400,427 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Voice (Ruby) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List call control applications, Create a call control application, Retrieve a call control application, Update a call control application, Delete a call control application
+
+| Field | Type |
+|-------|------|
+| `active` | boolean |
+| `anchorsite_override` | enum: Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, Chennai, IN, Amsterdam, Netherlands, Toronto, Canada, Sydney, Australia |
+| `application_name` | string |
+| `call_cost_in_webhooks` | boolean |
+| `created_at` | string |
+| `dtmf_type` | enum: RFC 2833, Inband, SIP INFO |
+| `first_command_timeout` | boolean |
+| `first_command_timeout_secs` | integer |
+| `id` | string |
+| `inbound` | object |
+| `outbound` | object |
+| `record_type` | enum: call_control_application |
+| `redact_dtmf_debug_logging` | boolean |
+| `tags` | array[string] |
+| `updated_at` | string |
+| `webhook_api_version` | enum: 1, 2 |
+| `webhook_event_failover_url` | url |
+| `webhook_event_url` | url |
+| `webhook_timeout_secs` | integer \| null |
+
+**Returned by:** Dial
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `recording_id` | uuid |
+| `start_time` | string |
+
+**Returned by:** Retrieve a call status
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `start_time` | string |
+
+**Returned by:** Answer call
+
+| Field | Type |
+|-------|------|
+| `recording_id` | uuid |
+| `result` | string |
+
+**Returned by:** Bridge calls, Hangup call, SIP Refer a call, Reject a call, Send SIP info, Transfer call
+
+| Field | Type |
+|-------|------|
+| `result` | string |
+
+**Returned by:** List all active calls for given connection
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `record_type` | enum: call |
+
+## Optional Parameters
+
+### Create a call control application — `client.call_control_applications.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `active` | boolean | Specifies whether the connection can be used. |
+| `anchorsite_override` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmf_type` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `first_command_timeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `first_command_timeout_secs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `inbound` | object |  |
+| `outbound` | object |  |
+| `webhook_api_version` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhook_event_failover_url` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhook_timeout_secs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `call_cost_in_webhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `redact_dtmf_debug_logging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Update a call control application — `client.call_control_applications.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `call_cost_in_webhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `active` | boolean | Specifies whether the connection can be used. |
+| `anchorsite_override` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmf_type` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `first_command_timeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `first_command_timeout_secs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `tags` | array[string] | Tags assigned to the Call Control Application. |
+| `inbound` | object |  |
+| `outbound` | object |  |
+| `webhook_api_version` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhook_event_failover_url` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhook_timeout_secs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `redact_dtmf_debug_logging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Dial — `client.calls.dial()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
+| `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
+| `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
+| `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `link_to` | string | Use another call's control id for sharing the same call session id |
+| `bridge_intent` | boolean | Indicates the intent to bridge this call with the call specified in link_to. |
+| `bridge_on_answer` | boolean | Whether to automatically bridge answered call to the call specified in link_to. |
+| `prevent_double_bridge` | boolean | Prevents bridging and hangs up the call if the target is already bridged. |
+| `park_after_unbridge` | string | If supplied with the value `self`, the current leg will be parked after unbri... |
+| `media_encryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the call. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE request. |
+| `sip_transport_protocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `stream_url` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `stream_track` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `stream_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `stream_bidirectional_mode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `stream_bidirectional_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `stream_bidirectional_target_legs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `stream_bidirectional_sampling_rate` | enum (8000, 16000, 22050, 24000, 48000) | Audio sampling rate. |
+| `stream_establish_before_call_originate` | boolean | Establish websocket connection before dialing the destination. |
+| `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `supervise_call_control_id` | string (UUID) | The call leg which will be supervised by the new call. |
+| `supervisor_role` | enum (barge, whisper, monitor) | The role of the supervisor call. |
+| `enable_dialogflow` | boolean | Enables Dialogflow for the current call. |
+| `dialogflow_config` | object |  |
+| `transcription` | boolean | Enable transcription upon call answer. |
+| `transcription_config` | object |  |
+| `sip_region` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `stream_auth_token` | string | An authentication token to be sent as part of the WebSocket connection when u... |
+
+### Answer call — `client.calls.actions.answer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE response. |
+| `preferred_codecs` | enum (G722,PCMU,PCMA,G729,OPUS,VP8,H264) | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE response. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `stream_url` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `stream_track` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `stream_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `stream_bidirectional_mode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `stream_bidirectional_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `stream_bidirectional_target_legs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `transcription` | boolean | Enable transcription upon call answer. |
+| `transcription_config` | object |  |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
+
+### Bridge calls — `client.calls.actions.bridge()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `queue` | string | The name of the queue you want to bridge with, can't be used together with ca... |
+| `video_room_id` | string (UUID) | The ID of the video room you want to bridge with, can't be used together with... |
+| `video_room_context` | string | The additional parameter that will be passed to the video conference. |
+| `prevent_double_bridge` | boolean | When set to `true`, it prevents bridging if the target call is already bridge... |
+| `park_after_unbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `play_ringtone` | boolean | Specifies whether to play a ringtone if the call you want to bridge with has ... |
+| `ringtone` | enum (at, au, be, bg, br, ...) | Specifies which country ringtone to play when `play_ringtone` is set to `true`. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `mute_dtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `hold_after_unbridge` | boolean | Specifies behavior after the bridge ends. |
+
+### Hangup call — `client.calls.actions.hangup()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP BYE message. |
+
+### SIP Refer a call — `client.calls.actions.refer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid execution of duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the request. |
+
+### Reject a call — `client.calls.actions.reject()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Send SIP info — `client.calls.actions.send_sip_info()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Transfer call — `client.calls.actions.transfer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
+| `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
+| `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
+| `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
+| `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `park_after_unbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `target_leg_client_state` | string | Use this field to add state to every subsequent webhook for the new leg. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `media_encryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the new call leg. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE. |
+| `sip_transport_protocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `mute_dtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `sip_region` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `preferred_codecs` | string | The list of comma-separated codecs in order of preference to be used during t... |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+
+## Webhook Payload Fields
+
+### `callAnswered`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.answered | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: answered | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### `callBridged`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.bridged | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+
+### `callHangup`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.hangup | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: hangup | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+| `data.payload.hangup_cause` | enum: call_rejected, normal_clearing, originator_cancel, timeout, time_limit, user_busy, not_found, no_answer, unspecified | The reason the call was ended (`call_rejected`, `normal_clearing`, `originator_cancel`, `timeout`, `time_limit`, `use... |
+| `data.payload.hangup_source` | enum: caller, callee, unknown | The party who ended the call (`callee`, `caller`, `unknown`). |
+| `data.payload.sip_hangup_cause` | string | The reason the call was ended (SIP response code). |
+| `data.payload.call_quality_stats` | object \| null | Call quality statistics aggregated from the CHANNEL_HANGUP_COMPLETE event. |
+
+### `callInitiated`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.initiated | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
+| `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.custom_headers` | array[object] | Custom headers from sip invite |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.shaken_stir_attestation` | string | SHAKEN/STIR attestation level. |
+| `data.payload.shaken_stir_validated` | boolean | Whether attestation was successfully validated or not. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.caller_id_name` | string | Caller id. |
+| `data.payload.call_screening_result` | string | Call screening result. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.direction` | enum: incoming, outgoing | Whether the call is `incoming` or `outgoing`. |
+| `data.payload.state` | enum: parked, bridging | State received from a command. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### Field Type Notes
+
+- `from` in webhook payloads: string (E.164 phone number)
+- `to` in webhook payloads: string (E.164 phone number)
+- The return value of `client.webhooks.unwrap()` is a parsed event object — access fields via `event.data.event_type`, `event.data.payload.call_control_id`, etc.

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/webrtc-client/android.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/webrtc-client/android.md
@@ -385,7 +385,7 @@ If using code obfuscation, add to `proguard-rules.pro`:
 
 <!-- BEGIN AUTO-GENERATED API REFERENCE -- do not edit below this line -->
 
-**[references/webrtc-server-api.md](references/webrtc-server-api.md) has the server-side WebRTC API — credential creation, token generation, and push notification setup. You MUST read it when setting up authentication or push notifications.**
+**[../curl/webrtc.md](../curl/webrtc.md) has the server-side WebRTC API — credential creation, token generation, and push notification setup. You MUST read it when setting up authentication or push notifications.**
 
 ## API Reference
 

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/webrtc-client/flutter.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/webrtc-client/flutter.md
@@ -493,7 +493,7 @@ final config = CredentialConfig(
 
 <!-- BEGIN AUTO-GENERATED API REFERENCE -- do not edit below this line -->
 
-**[references/webrtc-server-api.md](references/webrtc-server-api.md) has the server-side WebRTC API — credential creation, token generation, and push notification setup. You MUST read it when setting up authentication or push notifications.**
+**[../curl/webrtc.md](../curl/webrtc.md) has the server-side WebRTC API — credential creation, token generation, and push notification setup. You MUST read it when setting up authentication or push notifications.**
 
 ## API Reference
 

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/webrtc-client/ios.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/webrtc-client/ios.md
@@ -439,7 +439,7 @@ let txConfig = TxConfig(
 
 <!-- BEGIN AUTO-GENERATED API REFERENCE -- do not edit below this line -->
 
-**[references/webrtc-server-api.md](references/webrtc-server-api.md) has the server-side WebRTC API — credential creation, token generation, and push notification setup. You MUST read it when setting up authentication or push notifications.**
+**[../curl/webrtc.md](../curl/webrtc.md) has the server-side WebRTC API — credential creation, token generation, and push notification setup. You MUST read it when setting up authentication or push notifications.**
 
 ## API Reference
 

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/webrtc-client/javascript.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/webrtc-client/javascript.md
@@ -320,7 +320,7 @@ console.log('WebRTC supported:', webRTCInfo.supportWebRTC);
 
 <!-- BEGIN AUTO-GENERATED API REFERENCE -- do not edit below this line -->
 
-**[references/webrtc-server-api.md](references/webrtc-server-api.md) has the server-side WebRTC API — credential creation, token generation, and push notification setup. You MUST read it when setting up authentication or push notifications.**
+**[../curl/webrtc.md](../curl/webrtc.md) has the server-side WebRTC API — credential creation, token generation, and push notification setup. You MUST read it when setting up authentication or push notifications.**
 
 ## API Reference
 

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/webrtc-client/react-native.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/webrtc-client/react-native.md
@@ -307,7 +307,7 @@ await AsyncStorage.multiRemove([
 
 <!-- BEGIN AUTO-GENERATED API REFERENCE -- do not edit below this line -->
 
-**[references/webrtc-server-api.md](references/webrtc-server-api.md) has the server-side WebRTC API — credential creation, token generation, and push notification setup. You MUST read it when setting up authentication or push notifications.**
+**[../curl/webrtc.md](../curl/webrtc.md) has the server-side WebRTC API — credential creation, token generation, and push notification setup. You MUST read it when setting up authentication or push notifications.**
 
 ## API Reference
 

--- a/providers/cursor/plugin/skills/telnyx-voice-curl/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-curl/SKILL.md
@@ -86,7 +86,7 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +56 optional params in [references/api-details.md](references/api-details.md) |
 
 ```bash
 curl \
@@ -121,7 +121,7 @@ Primary inbound call-control command.
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +29 optional params in [references/api-details.md](references/api-details.md) |
 
 ```bash
 curl \
@@ -148,7 +148,7 @@ Common post-answer control path with downstream webhook implications.
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```bash
 curl \
@@ -156,7 +156,7 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-  "to": "+18005550100"
+  "to": "+18005550100;secure=srtp"
 }' \
   "https://api.telnyx.com/v2/calls/v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ/actions/transfer"
 ```

--- a/providers/cursor/plugin/skills/telnyx-voice-curl/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-curl/references/api-details.md
@@ -128,14 +128,19 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
 | `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 | `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
 | `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +168,9 @@
 | `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
 | `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +192,8 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | Use this field to add state to every subsequent webhook. |
 | `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +223,7 @@
 | `webhook_urls` | object | A map of event types to webhook URLs. |
 | `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls
 
@@ -277,7 +288,9 @@
 |-----------|------|-------------|
 | `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/providers/cursor/plugin/skills/telnyx-voice-go/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-go/SKILL.md
@@ -52,7 +52,7 @@ response, err := client.Calls.Dial(context.Background(), telnyx.CallDialParams{
 		ConnectionID: "7267xxxxxxxxxxxxxx",
 		From:         "+18005550101",
 		To: telnyx.CallDialParamsToUnion{
-			OfString: telnyx.String("+18005550100"),
+			OfString: telnyx.String("+18005550100;secure=srtp"),
 		},
 	})
 if err != nil {
@@ -111,14 +111,14 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `TimeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `BillingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `ClientState` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +56 optional params in [references/api-details.md](references/api-details.md) |
 
 ```go
 	response, err := client.Calls.Dial(context.Background(), telnyx.CallDialParams{
 		ConnectionID: "7267xxxxxxxxxxxxxx",
 		From:         "+18005550101",
 		To: telnyx.CallDialParamsToUnion{
-			OfString: telnyx.String("+18005550100"),
+			OfString: telnyx.String("+18005550100;secure=srtp"),
 		},
 	})
 	if err != nil {
@@ -147,7 +147,7 @@ Primary inbound call-control command.
 | `BillingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `ClientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `WebhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +29 optional params in [references/api-details.md](references/api-details.md) |
 
 ```go
 	response, err := client.Calls.Actions.Answer(
@@ -178,14 +178,14 @@ Common post-answer control path with downstream webhook implications.
 | `TimeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `ClientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `WebhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```go
 	response, err := client.Calls.Actions.Transfer(
 		context.Background(),
 		"call_control_id",
 		telnyx.CallActionTransferParams{
-			To: "+18005550100",
+			To: "+18005550100;secure=srtp",
 		},
 	)
 	if err != nil {

--- a/providers/cursor/plugin/skills/telnyx-voice-go/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-go/references/api-details.md
@@ -128,14 +128,19 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `Assistant` | object | AI Assistant configuration. |
+| `ConversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `FromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `Privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `AudioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `SendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
 | `MediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `PreferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `TimeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `TimeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `AnsweringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `AnsweringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `DeepfakeDetection` | object | Enables deepfake detection on the call. |
 | `ConferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
 | `CustomHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `BillingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +168,9 @@
 | `SendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
 | `WebhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `WebhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `WebhookUrls` | object | A map of event types to webhook URLs. |
+| `WebhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `WebhookRetriesPolicies` | object | A map of event types to retry policies. |
 | `Record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `RecordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `RecordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +192,8 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `Assistant` | object | AI Assistant configuration. |
+| `ConversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `BillingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `ClientState` | string | Use this field to add state to every subsequent webhook. |
 | `CommandId` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +223,7 @@
 | `WebhookUrls` | object | A map of event types to webhook URLs. |
 | `WebhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `WebhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `DeepfakeDetection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.Calls.Actions.Bridge()`
 
@@ -277,7 +288,9 @@
 |-----------|------|-------------|
 | `From` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `FromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `Privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `AudioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `SendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `EarlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `MediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `TimeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/providers/cursor/plugin/skills/telnyx-voice-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -51,7 +51,7 @@ import com.telnyx.sdk.models.calls.CallDialResponse;
 CallDialParams params = CallDialParams.builder()
     .connectionId("7267xxxxxxxxxxxxxx")
     .from("+18005550101")
-    .to("+18005550100")
+    .to("+18005550100;secure=srtp")
     .build();
 CallDialResponse response = client.calls().dial(params);
 ```
@@ -95,7 +95,7 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +56 optional params in [references/api-details.md](references/api-details.md) |
 
 ```java
 import com.telnyx.sdk.models.calls.CallDialParams;
@@ -104,7 +104,7 @@ import com.telnyx.sdk.models.calls.CallDialResponse;
 CallDialParams params = CallDialParams.builder()
     .connectionId("7267xxxxxxxxxxxxxx")
     .from("+18005550101")
-    .to("+18005550100")
+    .to("+18005550100;secure=srtp")
     .build();
 CallDialResponse response = client.calls().dial(params);
 ```
@@ -129,7 +129,7 @@ Primary inbound call-control command.
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +29 optional params in [references/api-details.md](references/api-details.md) |
 
 ```java
 import com.telnyx.sdk.models.calls.actions.ActionAnswerParams;
@@ -155,7 +155,7 @@ Common post-answer control path with downstream webhook implications.
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```java
 import com.telnyx.sdk.models.calls.actions.ActionTransferParams;
@@ -163,7 +163,7 @@ import com.telnyx.sdk.models.calls.actions.ActionTransferResponse;
 
 ActionTransferParams params = ActionTransferParams.builder()
     .callControlId("v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ")
-    .to("+18005550100")
+    .to("+18005550100;secure=srtp")
     .build();
 ActionTransferResponse response = client.calls().actions().transfer(params);
 ```

--- a/providers/cursor/plugin/skills/telnyx-voice-java/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-java/references/api-details.md
@@ -128,14 +128,19 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
 | `mediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `preferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
 | `conferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
 | `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +168,9 @@
 | `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
 | `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhookUrls` | object | A map of event types to webhook URLs. |
+| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +192,8 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | Use this field to add state to every subsequent webhook. |
 | `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +223,7 @@
 | `webhookUrls` | object | A map of event types to webhook URLs. |
 | `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.calls().actions().bridge()`
 
@@ -277,7 +288,9 @@
 |-----------|------|-------------|
 | `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `earlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `mediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/providers/cursor/plugin/skills/telnyx-voice-javascript/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-javascript/SKILL.md
@@ -43,7 +43,7 @@ try {
   const response = await client.calls.dial({
     connection_id: '7267xxxxxxxxxxxxxx',
     from: '+18005550101',
-    to: '+18005550100',
+    to: '+18005550100;secure=srtp',
   });
 } catch (err) {
   if (err instanceof Telnyx.APIConnectionError) {
@@ -99,13 +99,13 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +56 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const response = await client.calls.dial({
   connection_id: '7267xxxxxxxxxxxxxx',
   from: '+18005550101',
-  to: '+18005550100',
+  to: '+18005550100;secure=srtp',
 });
 
 console.log(response.data);
@@ -131,7 +131,7 @@ Primary inbound call-control command.
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +29 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const response = await client.calls.actions.answer('v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ');
@@ -156,11 +156,11 @@ Common post-answer control path with downstream webhook implications.
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const response = await client.calls.actions.transfer('call_control_id', {
-  to: '+18005550100',
+  to: '+18005550100;secure=srtp',
 });
 
 console.log(response.data);

--- a/providers/cursor/plugin/skills/telnyx-voice-javascript/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-javascript/references/api-details.md
@@ -128,14 +128,19 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
 | `mediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `preferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
 | `conferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
 | `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +168,9 @@
 | `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
 | `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhookUrls` | object | A map of event types to webhook URLs. |
+| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +192,8 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | Use this field to add state to every subsequent webhook. |
 | `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +223,7 @@
 | `webhookUrls` | object | A map of event types to webhook URLs. |
 | `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.calls.actions.bridge()`
 
@@ -277,7 +288,9 @@
 |-----------|------|-------------|
 | `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `earlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `mediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/providers/cursor/plugin/skills/telnyx-voice-python/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-python/SKILL.md
@@ -46,7 +46,7 @@ try:
     response = client.calls.dial(
         connection_id="7267xxxxxxxxxxxxxx",
         from_="+18005550101",
-        to="+18005550100",
+        to="+18005550100;secure=srtp",
     )
 except telnyx.APIConnectionError:
     print("Network error — check connectivity and retry")
@@ -98,13 +98,13 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +56 optional params in [references/api-details.md](references/api-details.md) |
 
 ```python
 response = client.calls.dial(
     connection_id="7267xxxxxxxxxxxxxx",
     from_="+18005550101",
-    to="+18005550100",
+    to="+18005550100;secure=srtp",
 )
 print(response.data)
 ```
@@ -129,7 +129,7 @@ Primary inbound call-control command.
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +29 optional params in [references/api-details.md](references/api-details.md) |
 
 ```python
 response = client.calls.actions.answer(
@@ -155,12 +155,12 @@ Common post-answer control path with downstream webhook implications.
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```python
 response = client.calls.actions.transfer(
     call_control_id="550e8400-e29b-41d4-a716-446655440000",
-    to="+18005550100",
+    to="+18005550100;secure=srtp",
 )
 print(response.data)
 ```

--- a/providers/cursor/plugin/skills/telnyx-voice-python/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-python/references/api-details.md
@@ -128,14 +128,19 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
 | `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 | `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
 | `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +168,9 @@
 | `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
 | `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +192,8 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | Use this field to add state to every subsequent webhook. |
 | `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +223,7 @@
 | `webhook_urls` | object | A map of event types to webhook URLs. |
 | `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.calls.actions.bridge()`
 
@@ -277,7 +288,9 @@
 |-----------|------|-------------|
 | `from_` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/providers/cursor/plugin/skills/telnyx-voice-ruby/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-ruby/SKILL.md
@@ -42,7 +42,7 @@ or authentication errors (401). Always handle errors in production code:
 response = client.calls.dial(
   connection_id: "7267xxxxxxxxxxxxxx",
   from: "+18005550101",
-  to: "+18005550100"
+  to: "+18005550100;secure=srtp"
 )
 puts(response)
 ```
@@ -86,13 +86,13 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +56 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
 response = client.calls.dial(
   connection_id: "7267xxxxxxxxxxxxxx",
   from: "+18005550101",
-  to: "+18005550100"
+  to: "+18005550100;secure=srtp"
 )
 
 puts(response)
@@ -118,7 +118,7 @@ Primary inbound call-control command.
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +29 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
 response = client.calls.actions.answer("v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ")
@@ -143,10 +143,13 @@ Common post-answer control path with downstream webhook implications.
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
-response = client.calls.actions.transfer("call_control_id", to: "+18005550100")
+response = client.calls.actions.transfer(
+  "call_control_id",
+  to: "+18005550100;secure=srtp"
+)
 
 puts(response)
 ```

--- a/providers/cursor/plugin/skills/telnyx-voice-ruby/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-ruby/references/api-details.md
@@ -128,14 +128,19 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
 | `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 | `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
 | `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +168,9 @@
 | `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
 | `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +192,8 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | Use this field to add state to every subsequent webhook. |
 | `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +223,7 @@
 | `webhook_urls` | object | A map of event types to webhook URLs. |
 | `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.calls.actions.bridge()`
 
@@ -277,7 +288,9 @@
 |-----------|------|-------------|
 | `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/skills/telnyx-10dlc-java/SKILL.md
+++ b/skills/telnyx-10dlc-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -322,7 +322,6 @@ Create or provision an additional resource when the core tasks do not cover this
 ```java
 import com.telnyx.sdk.models.messaging10dlc.phonenumbercampaigns.PhoneNumberCampaign;
 import com.telnyx.sdk.models.messaging10dlc.phonenumbercampaigns.PhoneNumberCampaignCreate;
-import com.telnyx.sdk.models.messaging10dlc.phonenumbercampaigns.PhoneNumberCampaignCreateParams;
 
 PhoneNumberCampaignCreate params = PhoneNumberCampaignCreate.builder()
     .campaignId("4b300178-131c-d902-d54e-72d90ba1620j")

--- a/skills/telnyx-ai-assistants-curl/SKILL.md
+++ b/skills/telnyx-ai-assistants-curl/SKILL.md
@@ -40,10 +40,10 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-  "name": "my-resource",
-  "model": "openai/gpt-4o",
-  "instructions": "You are a helpful assistant."
-}' \
+      "name": "my-resource",
+      "instructions": "You are a helpful assistant.",
+      "model": "openai/gpt-4o"
+  }' \
   "https://api.telnyx.com/v2/ai/assistants"
 ```
 
@@ -74,12 +74,11 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `tool_ids` | array[string] | No |  |
-| `description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```bash
 curl \
@@ -87,10 +86,10 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-  "name": "my-resource",
-  "model": "openai/gpt-4o",
-  "instructions": "You are a helpful assistant."
-}' \
+      "name": "my-resource",
+      "instructions": "You are a helpful assistant.",
+      "model": "openai/gpt-4o"
+  }' \
   "https://api.telnyx.com/v2/ai/assistants"
 ```
 
@@ -208,7 +207,7 @@ Primary response fields:
 - `.data.created_at`
 - `.data.description`
 - `.data.dynamic_variables`
-- `.data.dynamic_variables_webhook_url`
+- `.data.dynamic_variables_webhook_timeout_ms`
 
 ### Update an assistant
 
@@ -219,10 +218,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistant_id` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```bash
 curl \
@@ -238,7 +237,7 @@ Primary response fields:
 - `.data.created_at`
 - `.data.description`
 - `.data.dynamic_variables`
-- `.data.dynamic_variables_webhook_url`
+- `.data.dynamic_variables_webhook_timeout_ms`
 
 ### List assistants
 
@@ -259,7 +258,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Import assistants from external provider
 
@@ -294,7 +293,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Get All Tags
 
@@ -401,8 +400,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | HTTP only | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
 | Delete an assistant | HTTP only | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Get Canary Deploy | HTTP only | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
-| Create Canary Deploy | HTTP only | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistant_id` |
-| Update Canary Deploy | HTTP only | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistant_id` |
+| Create Canary Deploy | HTTP only | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | HTTP only | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
 | Delete Canary Deploy | HTTP only | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Assistant Sms Chat | HTTP only | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistant_id` |
 | Clone Assistant | HTTP only | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |

--- a/skills/telnyx-ai-assistants-curl/references/api-details.md
+++ b/skills/telnyx-ai-assistants-curl/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -165,9 +182,15 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -228,10 +254,29 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 | `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
 
 ### Assistant Chat (BETA)
 
@@ -254,6 +299,8 @@
 | `text` | string | Required for sms scheduled events. |
 | `conversation_metadata` | object | Metadata associated with the conversation. |
 | `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
 
 ### Test Assistant Tool
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -281,9 +331,16 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server
 

--- a/skills/telnyx-ai-assistants-go/SKILL.md
+++ b/skills/telnyx-ai-assistants-go/SKILL.md
@@ -50,8 +50,8 @@ import "errors"
 
 assistant, err := client.AI.Assistants.New(context.Background(), telnyx.AIAssistantNewParams{
 		Instructions: "You are a helpful assistant.",
-		Model: "openai/gpt-4o",
 		Name: "my-resource",
+		Model: "openai/gpt-4o",
 	})
 if err != nil {
   var apiErr *telnyx.Error
@@ -97,18 +97,17 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `Name` | string | Yes |  |
-| `Model` | string | Yes | ID of the model to use. |
 | `Instructions` | string | Yes | System instructions for the assistant. |
-| `Tools` | array[object] | No | The tools that the assistant can use. |
-| `ToolIds` | array[string] | No |  |
-| `Description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `Tags` | array[string] | No | Tags associated with the assistant. |
+| `Model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `Tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```go
 	assistant, err := client.AI.Assistants.New(context.Background(), telnyx.AIAssistantNewParams{
 		Instructions: "You are a helpful assistant.",
-		Model: "openai/gpt-4o",
 		Name: "my-resource",
+		Model: "openai/gpt-4o",
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -237,7 +236,7 @@ Primary response fields:
 - `assistant.CreatedAt`
 - `assistant.Description`
 - `assistant.DynamicVariables`
-- `assistant.DynamicVariablesWebhookURL`
+- `assistant.DynamicVariablesWebhookTimeoutMs`
 
 ### Update an assistant
 
@@ -248,10 +247,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `AssistantId` | string (UUID) | Yes |  |
+| `Tags` | array[string] | No | Tags associated with the assistant. |
 | `Name` | string | No |  |
-| `Model` | string | No | ID of the model to use. |
-| `Instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `Model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```go
 	assistant, err := client.AI.Assistants.Update(
@@ -271,7 +270,7 @@ Primary response fields:
 - `assistant.CreatedAt`
 - `assistant.Description`
 - `assistant.DynamicVariables`
-- `assistant.DynamicVariablesWebhookURL`
+- `assistant.DynamicVariablesWebhookTimeoutMs`
 
 ### List assistants
 
@@ -296,7 +295,7 @@ Primary item fields:
 - `CreatedAt`
 - `Description`
 - `DynamicVariables`
-- `DynamicVariablesWebhookURL`
+- `DynamicVariablesWebhookTimeoutMs`
 
 ### Import assistants from external provider
 
@@ -330,7 +329,7 @@ Primary item fields:
 - `CreatedAt`
 - `Description`
 - `DynamicVariables`
-- `DynamicVariablesWebhookURL`
+- `DynamicVariablesWebhookTimeoutMs`
 
 ### Get All Tags
 
@@ -457,8 +456,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.AI.Assistants.Tests.Runs.Get()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `TestId`, `RunId` |
 | Delete an assistant | `client.AI.Assistants.Delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `AssistantId` |
 | Get Canary Deploy | `client.AI.Assistants.CanaryDeploys.Get()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `AssistantId` |
-| Create Canary Deploy | `client.AI.Assistants.CanaryDeploys.New()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `Versions`, `AssistantId` |
-| Update Canary Deploy | `client.AI.Assistants.CanaryDeploys.Update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `Versions`, `AssistantId` |
+| Create Canary Deploy | `client.AI.Assistants.CanaryDeploys.New()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `AssistantId` |
+| Update Canary Deploy | `client.AI.Assistants.CanaryDeploys.Update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `AssistantId` |
 | Delete Canary Deploy | `client.AI.Assistants.CanaryDeploys.Delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `AssistantId` |
 | Assistant Sms Chat | `client.AI.Assistants.SendSMS()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `From`, `To`, `AssistantId` |
 | Clone Assistant | `client.AI.Assistants.Clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `AssistantId` |

--- a/skills/telnyx-ai-assistants-go/references/api-details.md
+++ b/skills/telnyx-ai-assistants-go/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `Tools` | array[object] | The tools that the assistant can use. |
-| `ToolIds` | array[string] |  |
+| `Model` | string | ID of the model to use when `external_llm` is not set. |
+| `Tools` | array[object] | Deprecated for new integrations. |
+| `McpServers` | array[object] | MCP servers attached to the assistant. |
+| `ToolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `Description` | string |  |
 | `Greeting` | string | Text that the assistant will use to start the conversation. |
-| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `ExternalLlm` | object |  |
+| `FallbackConfig` | object |  |
 | `VoiceSettings` | object |  |
 | `Transcription` | object |  |
 | `TelephonySettings` | object |  |
@@ -165,9 +182,15 @@
 | `EnabledFeatures` | array[object] |  |
 | `InsightSettings` | object |  |
 | `PrivacySettings` | object |  |
-| `DynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `DynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `DynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `DynamicVariables` | object | Map of dynamic variables and their default values |
 | `WidgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `InterruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `Integrations` | array[object] | Connected integrations attached to the assistant. |
+| `ObservabilitySettings` | object |  |
+| `Tags` | array[string] | Tags associated with the assistant. |
+| `PostConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider — `client.AI.Assistants.Imports()`
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `Name` | string |  |
-| `Model` | string | ID of the model to use. |
+| `Model` | string | ID of the model to use when `external_llm` is not set. |
 | `Instructions` | string | System instructions for the assistant. |
-| `Tools` | array[object] | The tools that the assistant can use. |
-| `ToolIds` | array[string] |  |
+| `Tools` | array[object] | Deprecated for new integrations. |
+| `McpServers` | array[object] | MCP servers attached to the assistant. |
+| `ToolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `Description` | string |  |
 | `Greeting` | string | Text that the assistant will use to start the conversation. |
-| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `ExternalLlm` | object |  |
+| `FallbackConfig` | object |  |
 | `VoiceSettings` | object |  |
 | `Transcription` | object |  |
 | `TelephonySettings` | object |  |
@@ -228,10 +254,29 @@
 | `EnabledFeatures` | array[object] |  |
 | `InsightSettings` | object |  |
 | `PrivacySettings` | object |  |
-| `DynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `DynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `DynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `DynamicVariables` | object | Map of dynamic variables and their default values |
 | `WidgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `InterruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `Integrations` | array[object] | Connected integrations attached to the assistant. |
+| `ObservabilitySettings` | object |  |
+| `Tags` | array[string] | Tags associated with the assistant. |
+| `VersionName` | string | Human-readable name for the assistant version. |
+| `PostConversationSettings` | object | Configuration for post-conversation processing. |
 | `PromoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.AI.Assistants.CanaryDeploys.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Rules` | array[object] |  |
+
+### Update Canary Deploy — `client.AI.Assistants.CanaryDeploys.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Rules` | array[object] |  |
 
 ### Assistant Chat (BETA) — `client.AI.Assistants.Chat()`
 
@@ -254,6 +299,8 @@
 | `Text` | string | Required for sms scheduled events. |
 | `ConversationMetadata` | object | Metadata associated with the conversation. |
 | `DynamicVariables` | object | A map of dynamic variable names to values. |
+| `MaxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `RetryIntervalSecs` | integer |  |
 
 ### Test Assistant Tool — `client.AI.Assistants.Tools.Test()`
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `Name` | string |  |
-| `Model` | string | ID of the model to use. |
+| `Model` | string | ID of the model to use when `external_llm` is not set. |
 | `Instructions` | string | System instructions for the assistant. |
-| `Tools` | array[object] | The tools that the assistant can use. |
-| `ToolIds` | array[string] |  |
+| `Tools` | array[object] | Deprecated for new integrations. |
+| `McpServers` | array[object] | MCP servers attached to the assistant. |
+| `ToolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `Description` | string |  |
 | `Greeting` | string | Text that the assistant will use to start the conversation. |
-| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `ExternalLlm` | object |  |
+| `FallbackConfig` | object |  |
 | `VoiceSettings` | object |  |
 | `Transcription` | object |  |
 | `TelephonySettings` | object |  |
@@ -281,9 +331,16 @@
 | `EnabledFeatures` | array[object] |  |
 | `InsightSettings` | object |  |
 | `PrivacySettings` | object |  |
-| `DynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `DynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `DynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `DynamicVariables` | object | Map of dynamic variables and their default values |
 | `WidgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `InterruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `Integrations` | array[object] | Connected integrations attached to the assistant. |
+| `ObservabilitySettings` | object |  |
+| `Tags` | array[string] | Tags associated with the assistant. |
+| `VersionName` | string | Human-readable name for the assistant version. |
+| `PostConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server — `client.AI.McpServers.New()`
 

--- a/skills/telnyx-ai-assistants-java/SKILL.md
+++ b/skills/telnyx-ai-assistants-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -50,8 +50,8 @@ import com.telnyx.sdk.models.ai.assistants.AssistantCreateParams;
 import com.telnyx.sdk.models.ai.assistants.InferenceEmbedding;
 AssistantCreateParams params = AssistantCreateParams.builder()
     .instructions("You are a helpful assistant.")
-    .model("openai/gpt-4o")
     .name("my-resource")
+    .model("openai/gpt-4o")
     .build();
 InferenceEmbedding assistant = client.ai().assistants().create(params);
 ```
@@ -83,12 +83,11 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `toolIds` | array[string] | No |  |
-| `description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```java
 import com.telnyx.sdk.models.ai.assistants.AssistantCreateParams;
@@ -96,8 +95,8 @@ import com.telnyx.sdk.models.ai.assistants.InferenceEmbedding;
 
 AssistantCreateParams params = AssistantCreateParams.builder()
     .instructions("You are a helpful assistant.")
-    .model("openai/gpt-4o")
     .name("my-resource")
+    .model("openai/gpt-4o")
     .build();
 InferenceEmbedding assistant = client.ai().assistants().create(params);
 ```
@@ -216,7 +215,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### Update an assistant
 
@@ -227,10 +226,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistantId` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```java
 import com.telnyx.sdk.models.ai.assistants.AssistantUpdateParams;
@@ -245,7 +244,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### List assistants
 
@@ -269,7 +268,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Import assistants from external provider
 
@@ -303,7 +302,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Get All Tags
 
@@ -422,8 +421,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai().assistants().tests().runs().retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId`, `runId` |
 | Delete an assistant | `client.ai().assistants().delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Get Canary Deploy | `client.ai().assistants().canaryDeploys().retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Create Canary Deploy | `client.ai().assistants().canaryDeploys().create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistantId` |
-| Update Canary Deploy | `client.ai().assistants().canaryDeploys().update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistantId` |
+| Create Canary Deploy | `client.ai().assistants().canaryDeploys().create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId` |
+| Update Canary Deploy | `client.ai().assistants().canaryDeploys().update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistantId` |
 | Delete Canary Deploy | `client.ai().assistants().canaryDeploys().delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Assistant Sms Chat | `client.ai().assistants().sendSms()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistantId` |
 | Clone Assistant | `client.ai().assistants().clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId` |

--- a/skills/telnyx-ai-assistants-java/references/api-details.md
+++ b/skills/telnyx-ai-assistants-java/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -165,9 +182,15 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider — `client.ai().assistants().imports()`
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -228,10 +254,29 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 | `promoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai().assistants().canaryDeploys().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai().assistants().canaryDeploys().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
 
 ### Assistant Chat (BETA) — `client.ai().assistants().chat()`
 
@@ -254,6 +299,8 @@
 | `text` | string | Required for sms scheduled events. |
 | `conversationMetadata` | object | Metadata associated with the conversation. |
 | `dynamicVariables` | object | A map of dynamic variable names to values. |
+| `maxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retryIntervalSecs` | integer |  |
 
 ### Test Assistant Tool — `client.ai().assistants().tools().test()`
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -281,9 +331,16 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server — `client.ai().mcpServers().create()`
 

--- a/skills/telnyx-ai-assistants-javascript/SKILL.md
+++ b/skills/telnyx-ai-assistants-javascript/SKILL.md
@@ -42,8 +42,8 @@ or authentication errors (401). Always handle errors in production code:
 try {
   const assistant = await client.ai.assistants.create({
     instructions: 'You are a helpful assistant.',
-    model: 'openai/gpt-4o',
     name: 'my-resource',
+      model: 'openai/gpt-4o',
   });
 } catch (err) {
   if (err instanceof Telnyx.APIConnectionError) {
@@ -87,18 +87,17 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `toolIds` | array[string] | No |  |
-| `description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const assistant = await client.ai.assistants.create({
   instructions: 'You are a helpful assistant.',
-  model: 'openai/gpt-4o',
   name: 'my-resource',
+    model: 'openai/gpt-4o',
 });
 
 console.log(assistant.id);
@@ -209,7 +208,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### Update an assistant
 
@@ -220,10 +219,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistantId` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const assistant = await client.ai.assistants.update('550e8400-e29b-41d4-a716-446655440000');
@@ -237,7 +236,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### List assistants
 
@@ -260,7 +259,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Import assistants from external provider
 
@@ -292,7 +291,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Get All Tags
 
@@ -409,8 +408,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId`, `runId` |
 | Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Get Canary Deploy | `client.ai.assistants.canaryDeploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Create Canary Deploy | `client.ai.assistants.canaryDeploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistantId` |
-| Update Canary Deploy | `client.ai.assistants.canaryDeploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistantId` |
+| Create Canary Deploy | `client.ai.assistants.canaryDeploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId` |
+| Update Canary Deploy | `client.ai.assistants.canaryDeploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistantId` |
 | Delete Canary Deploy | `client.ai.assistants.canaryDeploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Assistant Sms Chat | `client.ai.assistants.sendSMS()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistantId` |
 | Clone Assistant | `client.ai.assistants.clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId` |

--- a/skills/telnyx-ai-assistants-javascript/references/api-details.md
+++ b/skills/telnyx-ai-assistants-javascript/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -165,9 +182,15 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider — `client.ai.assistants.imports()`
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -228,10 +254,29 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 | `promoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai.assistants.canaryDeploys.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai.assistants.canaryDeploys.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
 
 ### Assistant Chat (BETA) — `client.ai.assistants.chat()`
 
@@ -254,6 +299,8 @@
 | `text` | string | Required for sms scheduled events. |
 | `conversationMetadata` | object | Metadata associated with the conversation. |
 | `dynamicVariables` | object | A map of dynamic variable names to values. |
+| `maxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retryIntervalSecs` | integer |  |
 
 ### Test Assistant Tool — `client.ai.assistants.tools.test()`
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `toolIds` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
 | `voiceSettings` | object |  |
 | `transcription` | object |  |
 | `telephonySettings` | object |  |
@@ -281,9 +331,16 @@
 | `enabledFeatures` | array[object] |  |
 | `insightSettings` | object |  |
 | `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamicVariables` | object | Map of dynamic variables and their default values |
 | `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server — `client.ai.mcpServers.create()`
 

--- a/skills/telnyx-ai-assistants-python/SKILL.md
+++ b/skills/telnyx-ai-assistants-python/SKILL.md
@@ -45,8 +45,8 @@ import telnyx
 try:
     assistant = client.ai.assistants.create(
         instructions="You are a helpful assistant.",
-        model="openai/gpt-4o",
         name="my-resource",
+        model="openai/gpt-4o",
     )
 except telnyx.APIConnectionError:
     print("Network error — check connectivity and retry")
@@ -87,18 +87,17 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `tool_ids` | array[string] | No |  |
-| `description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```python
 assistant = client.ai.assistants.create(
     instructions="You are a helpful assistant.",
-    model="openai/gpt-4o",
     name="my-resource",
+    model="openai/gpt-4o",
 )
 print(assistant.id)
 ```
@@ -210,7 +209,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### Update an assistant
 
@@ -221,10 +220,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistant_id` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```python
 assistant = client.ai.assistants.update(
@@ -239,7 +238,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### List assistants
 
@@ -261,7 +260,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Import assistants from external provider
 
@@ -292,7 +291,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Get All Tags
 
@@ -407,8 +406,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
 | Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Get Canary Deploy | `client.ai.assistants.canary_deploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
-| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistant_id` |
-| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistant_id` |
+| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
 | Delete Canary Deploy | `client.ai.assistants.canary_deploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Assistant Sms Chat | `client.ai.assistants.send_sms()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from_`, `to`, `assistant_id` |
 | Clone Assistant | `client.ai.assistants.clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |

--- a/skills/telnyx-ai-assistants-python/references/api-details.md
+++ b/skills/telnyx-ai-assistants-python/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -165,9 +182,15 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider — `client.ai.assistants.imports()`
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -228,10 +254,29 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 | `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai.assistants.canary_deploys.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai.assistants.canary_deploys.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
 
 ### Assistant Chat (BETA) — `client.ai.assistants.chat()`
 
@@ -254,6 +299,8 @@
 | `text` | string | Required for sms scheduled events. |
 | `conversation_metadata` | object | Metadata associated with the conversation. |
 | `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
 
 ### Test Assistant Tool — `client.ai.assistants.tools.test()`
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -281,9 +331,16 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server — `client.ai.mcp_servers.create()`
 

--- a/skills/telnyx-ai-assistants-ruby/SKILL.md
+++ b/skills/telnyx-ai-assistants-ruby/SKILL.md
@@ -39,7 +39,7 @@ All API calls can fail with network errors, rate limits (429), validation errors
 or authentication errors (401). Always handle errors in production code:
 
 ```ruby
-assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", model: "openai/gpt-4o", name: "my-resource")
+assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", name: "my-resource", model: "openai/gpt-4o")
 puts(assistant)
 ```
 
@@ -70,16 +70,14 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `tool_ids` | array[string] | No |  |
-| `description` | string | No |  |
-| ... | | | +12 optional params in [references/api-details.md](references/api-details.md) |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
-assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", model: "openai/gpt-4o", name: "my-resource")
-
+assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", name: "my-resource", model: "openai/gpt-4o")
 puts(assistant)
 ```
 
@@ -188,7 +186,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### Update an assistant
 
@@ -199,10 +197,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistant_id` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
 assistant = client.ai.assistants.update("550e8400-e29b-41d4-a716-446655440000")
@@ -216,7 +214,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### List assistants
 
@@ -239,7 +237,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Import assistants from external provider
 
@@ -268,7 +266,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Get All Tags
 
@@ -383,8 +381,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
 | Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Get Canary Deploy | `client.ai.assistants.canary_deploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
-| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistant_id` |
-| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistant_id` |
+| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
 | Delete Canary Deploy | `client.ai.assistants.canary_deploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Assistant Sms Chat | `client.ai.assistants.send_sms()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistant_id` |
 | Clone Assistant | `client.ai.assistants.clone_()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |

--- a/skills/telnyx-ai-assistants-ruby/references/api-details.md
+++ b/skills/telnyx-ai-assistants-ruby/references/api-details.md
@@ -16,21 +16,34 @@
 | `created_at` | date-time |
 | `description` | string |
 | `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
 | `dynamic_variables_webhook_url` | string |
 | `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
 | `greeting` | string |
 | `id` | string |
 | `import_metadata` | object |
 | `insight_settings` | object |
 | `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
 | `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
 | `messaging_settings` | object |
 | `model` | string |
 | `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
 | `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
 | `telephony_settings` | object |
 | `tools` | array[object] |
 | `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
 | `voice_settings` | object |
 | `widget_settings` | object |
 
@@ -92,8 +105,8 @@
 |-------|------|
 | `assistant_id` | string |
 | `created_at` | date-time |
+| `rules` | array[object] |
 | `updated_at` | date-time |
-| `versions` | array[object] |
 
 **Returned by:** Assistant Chat (BETA)
 
@@ -153,11 +166,15 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -165,9 +182,15 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Import assistants from external provider — `client.ai.assistants.imports()`
 
@@ -214,13 +237,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -228,10 +254,29 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 | `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai.assistants.canary_deploys.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai.assistants.canary_deploys.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
 
 ### Assistant Chat (BETA) — `client.ai.assistants.chat()`
 
@@ -254,6 +299,8 @@
 | `text` | string | Required for sms scheduled events. |
 | `conversation_metadata` | object | Metadata associated with the conversation. |
 | `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
 
 ### Test Assistant Tool — `client.ai.assistants.tools.test_()`
 
@@ -267,13 +314,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string |  |
-| `model` | string | ID of the model to use. |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
-| `tools` | array[object] | The tools that the assistant can use. |
-| `tool_ids` | array[string] |  |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llm_api_key_ref` | string | This is only needed when using third-party inference providers. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
 | `voice_settings` | object |  |
 | `transcription` | object |  |
 | `telephony_settings` | object |  |
@@ -281,9 +331,16 @@
 | `enabled_features` | array[object] |  |
 | `insight_settings` | object |  |
 | `privacy_settings` | object |  |
-| `dynamic_variables_webhook_url` | string (URL) | If the dynamic_variables_webhook_url is set for the assistant, we will send a... |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
 | `dynamic_variables` | object | Map of dynamic variables and their default values |
 | `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
 
 ### Create MCP Server — `client.ai.mcp_servers.create()`
 

--- a/skills/telnyx-messaging-curl/SKILL.md
+++ b/skills/telnyx-messaging-curl/SKILL.md
@@ -399,6 +399,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsapp_message` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```bash
 curl \

--- a/skills/telnyx-messaging-curl/references/api-details.md
+++ b/skills/telnyx-messaging-curl/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/skills/telnyx-messaging-go/SKILL.md
+++ b/skills/telnyx-messaging-go/SKILL.md
@@ -416,6 +416,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `WhatsappMessage` | object | Yes |  |
 | `Type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `WebhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `MessagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```go
 	response, err := client.Messages.SendWhatsapp(context.Background(), telnyx.MessageSendWhatsappParams{

--- a/skills/telnyx-messaging-go/references/api-details.md
+++ b/skills/telnyx-messaging-go/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `Type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `WebhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `MessagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.MessagingHostedNumbers.Update()`
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/skills/telnyx-messaging-java/SKILL.md
+++ b/skills/telnyx-messaging-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -420,6 +420,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsappMessage` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```java
 import com.telnyx.sdk.models.messages.MessageSendWhatsappParams;

--- a/skills/telnyx-messaging-java/references/api-details.md
+++ b/skills/telnyx-messaging-java/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messagingHostedNumbers().update()`
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/skills/telnyx-messaging-javascript/SKILL.md
+++ b/skills/telnyx-messaging-javascript/SKILL.md
@@ -392,6 +392,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsappMessage` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```javascript
 const response = await client.messages.sendWhatsapp({

--- a/skills/telnyx-messaging-javascript/references/api-details.md
+++ b/skills/telnyx-messaging-javascript/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messagingHostedNumbers.update()`
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/skills/telnyx-messaging-python/SKILL.md
+++ b/skills/telnyx-messaging-python/SKILL.md
@@ -385,6 +385,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsapp_message` | object | Yes |  |
 | `type_` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```python
 response = client.messages.send_whatsapp(

--- a/skills/telnyx-messaging-python/references/api-details.md
+++ b/skills/telnyx-messaging-python/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `type_` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messaging_hosted_numbers.update()`
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/skills/telnyx-messaging-ruby/SKILL.md
+++ b/skills/telnyx-messaging-ruby/SKILL.md
@@ -353,6 +353,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsapp_message` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```ruby
 response = client.messages.send_whatsapp(from: "+13125551234", to: "+13125551234", whatsapp_message: {})

--- a/skills/telnyx-messaging-ruby/references/api-details.md
+++ b/skills/telnyx-messaging-ruby/references/api-details.md
@@ -36,6 +36,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -93,6 +94,7 @@
 | `id` | uuid |
 | `media` | array[object] |
 | `messaging_profile_id` | string |
+| `num_chars` | integer |
 | `organization_id` | uuid |
 | `parts` | integer |
 | `received_at` | date-time |
@@ -299,6 +301,7 @@
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messaging_hosted_numbers.update()`
 
@@ -343,6 +346,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Subject of multimedia message |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
@@ -382,6 +386,7 @@
 | `data.payload.to` | array[object] |  |
 | `data.payload.cc` | array[object] |  |
 | `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
 | `data.payload.subject` | string \| null | Message subject. |
 | `data.payload.media` | array[object] |  |
 | `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |

--- a/skills/telnyx-numbers-java/SKILL.md
+++ b/skills/telnyx-numbers-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -278,7 +278,6 @@ Create or provision an additional resource when the core tasks do not cover this
 
 ```java
 import com.telnyx.sdk.models.advancedorders.AdvancedOrder;
-import com.telnyx.sdk.models.advancedorders.AdvancedOrderCreateParams;
 import com.telnyx.sdk.models.advancedorders.AdvancedOrderCreateResponse;
 
 AdvancedOrder params = AdvancedOrder.builder().build();

--- a/skills/telnyx-twilio-migration/sdk-reference/curl/10dlc.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/curl/10dlc.md
@@ -55,8 +55,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -207,7 +207,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `description` | string | Description of the event. |
 | `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -358,7 +358,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -398,3 +398,471 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# 10DLC (curl) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Brands, List Campaigns, List shared partner campaigns, List Shared Campaigns, List phone number campaigns
+
+| Field | Type |
+|-------|------|
+| `page` | integer |
+| `records` | array[object] |
+| `totalRecords` | integer |
+
+**Returned by:** Create Brand, Update Brand, Revet Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Get Brand Feedback By Id
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `category` | array[object] |
+
+**Returned by:** Get Brand SMS OTP Status, Get Brand SMS OTP Status by Brand ID
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `deliveryStatus` | string |
+| `deliveryStatusDate` | date-time |
+| `deliveryStatusDetails` | string |
+| `mobilePhone` | string |
+| `referenceId` | string |
+| `requestDate` | date-time |
+| `verifyDate` | date-time |
+
+**Returned by:** Get Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `assignedCampaignsCount` | number |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Order Brand External Vetting, Import External Vetting Record
+
+| Field | Type |
+|-------|------|
+| `createDate` | string |
+| `evpId` | string |
+| `vettedDate` | string |
+| `vettingClass` | string |
+| `vettingId` | string |
+| `vettingScore` | integer |
+| `vettingToken` | string |
+
+**Returned by:** Trigger Brand SMS OTP
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `referenceId` | string |
+
+**Returned by:** Get Campaign Cost
+
+| Field | Type |
+|-------|------|
+| `campaignUsecase` | string |
+| `description` | string |
+| `monthlyCost` | string |
+| `upFrontCost` | string |
+
+**Returned by:** Get campaign, Update campaign, Submit Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `autoRenewal` | boolean |
+| `billedDate` | string |
+| `brandDisplayName` | string |
+| `brandId` | string |
+| `campaignId` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createDate` | string |
+| `cspId` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isTMobileNumberPoolingEnabled` | boolean |
+| `isTMobileRegistered` | boolean |
+| `isTMobileSuspended` | boolean |
+| `messageFlow` | string |
+| `mock` | boolean |
+| `nextRenewalOrExpirationDate` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `referenceId` | string |
+| `resellerId` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `status` | string |
+| `subUsecases` | array[string] |
+| `submissionStatus` | enum: CREATED, FAILED, PENDING |
+| `subscriberHelp` | boolean |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `usecase` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Deactivate campaign
+
+| Field | Type |
+|-------|------|
+| `message` | string |
+| `record_type` | string |
+| `time` | number |
+
+**Returned by:** Submit campaign appeal for manual review
+
+| Field | Type |
+|-------|------|
+| `appealed_at` | date-time |
+
+**Returned by:** Get Campaign Mno Metadata
+
+| Field | Type |
+|-------|------|
+| `10999` | object |
+
+**Returned by:** Get Sharing Status
+
+| Field | Type |
+|-------|------|
+| `sharedByMe` | object |
+| `sharedWithMe` | object |
+
+**Returned by:** Qualify By Usecase
+
+| Field | Type |
+|-------|------|
+| `annualFee` | number |
+| `maxSubUsecases` | integer |
+| `minSubUsecases` | integer |
+| `mnoMetadata` | object |
+| `monthlyFee` | number |
+| `quarterlyFee` | number |
+| `usecase` | string |
+
+**Returned by:** Get Single Shared Campaign, Update Single Shared Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `assignedPhoneNumbersCount` | number |
+| `brandDisplayName` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createdAt` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isNumberPoolingEnabled` | boolean |
+| `messageFlow` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `subUsecases` | array[string] |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `updatedAt` | string |
+| `usecase` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Assign Messaging Profile To Campaign
+
+| Field | Type |
+|-------|------|
+| `campaignId` | string |
+| `messagingProfileId` | string |
+| `taskId` | string |
+| `tcrCampaignId` | string |
+
+**Returned by:** Get Assignment Task Status
+
+| Field | Type |
+|-------|------|
+| `createdAt` | date-time |
+| `status` | string |
+| `taskId` | string |
+| `updatedAt` | date-time |
+
+**Returned by:** Get Phone Number Status
+
+| Field | Type |
+|-------|------|
+| `records` | array[object] |
+
+**Returned by:** Create New Phone Number Campaign, Get Single Phone Number Campaign, Create New Phone Number Campaign, Delete Phone Number Campaign
+
+| Field | Type |
+|-------|------|
+| `assignmentStatus` | enum: FAILED_ASSIGNMENT, PENDING_ASSIGNMENT, ASSIGNED, PENDING_UNASSIGNMENT, FAILED_UNASSIGNMENT |
+| `brandId` | string |
+| `campaignId` | string |
+| `createdAt` | string |
+| `failureReasons` | string |
+| `phoneNumber` | string |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `telnyxCampaignId` | string |
+| `updatedAt` | string |
+
+## Optional Parameters
+
+### Create Brand
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `companyName` | string | (Required for Non-profit/private/public) Legal company name. |
+| `firstName` | string | First name of business contact. |
+| `lastName` | string | Last name of business contact. |
+| `ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `phone` | string | Valid phone number in e.164 international format. |
+| `street` | string | Street number and name. |
+| `city` | string | City name |
+| `state` | string | State. |
+| `postalCode` | string | Postal codes. |
+| `stockSymbol` | string | (Required for public company) stock symbol. |
+| `stockExchange` | object | (Required for public company) stock exchange. |
+| `ipAddress` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `website` | string | Brand website URL. |
+| `isReseller` | boolean |  |
+| `mock` | boolean | Mock brand for testing purposes. |
+| `mobilePhone` | string | Valid mobile phone number in e.164 international format. |
+| `businessContactEmail` | string | Business contact email. |
+| `webhookURL` | string | Webhook URL for brand status updates. |
+| `webhookFailoverURL` | string | Webhook failover URL for brand status updates. |
+
+### Update Brand
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `companyName` | string | (Required for Non-profit/private/public) Legal company name. |
+| `firstName` | string | First name of business contact. |
+| `lastName` | string | Last name of business contact. |
+| `ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `phone` | string | Valid phone number in e.164 international format. |
+| `street` | string | Street number and name. |
+| `city` | string | City name |
+| `state` | string | State. |
+| `postalCode` | string | Postal codes. |
+| `stockSymbol` | string | (Required for public company) stock symbol. |
+| `stockExchange` | object | (Required for public company) stock exchange. |
+| `ipAddress` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `website` | string | Brand website URL. |
+| `altBusinessIdType` | enum (NONE, DUNS, GIIN, LEI) | An enumeration. |
+| `isReseller` | boolean |  |
+| `identityStatus` | enum (VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED) | The verification status of an active brand |
+| `businessContactEmail` | string | Business contact email. |
+| `webhookURL` | string | Webhook URL for brand status updates. |
+| `webhookFailoverURL` | string | Webhook failover URL for brand status updates. |
+| `altBusinessId` | string (UUID) | Alternate business identifier such as DUNS, LEI, or GIIN |
+
+### Import External Vetting Record
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `vettingToken` | string | Required by some providers for vetting record confirmation. |
+
+### Update campaign
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `resellerId` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `sample1` | string | Message sample. |
+| `sample2` | string | Message sample. |
+| `sample3` | string | Message sample. |
+| `sample4` | string | Message sample. |
+| `sample5` | string | Message sample. |
+| `messageFlow` | string | Message flow description. |
+| `helpMessage` | string | Help message of the campaign. |
+| `autoRenewal` | boolean | Help message of the campaign. |
+| `webhookURL` | string | Webhook to which campaign status updates are sent. |
+| `webhookFailoverURL` | string | Webhook failover to which campaign status updates are sent. |
+
+### Submit Campaign
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ageGated` | boolean | Age gated message content in campaign. |
+| `autoRenewal` | boolean | Campaign subscription auto-renewal option. |
+| `directLending` | boolean | Direct lending or loan arrangement |
+| `embeddedLink` | boolean | Does message generated by the campaign include URL link in SMS? |
+| `embeddedPhone` | boolean | Does message generated by the campaign include phone number in SMS? |
+| `helpKeywords` | string | Subscriber help keywords. |
+| `helpMessage` | string | Help message of the campaign. |
+| `messageFlow` | string | Message flow description. |
+| `mnoIds` | array[integer] | Submit campaign to given list of MNOs by MNO's network ID. |
+| `numberPool` | boolean | Does campaign utilize pool of phone numbers? |
+| `optinKeywords` | string | Subscriber opt-in keywords. |
+| `optinMessage` | string | Subscriber opt-in message. |
+| `optoutKeywords` | string | Subscriber opt-out keywords. |
+| `optoutMessage` | string | Subscriber opt-out message. |
+| `referenceId` | string (UUID) | Caller supplied campaign reference ID. |
+| `resellerId` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `sample1` | string | Message sample. |
+| `sample2` | string | Message sample. |
+| `sample3` | string | Message sample. |
+| `sample4` | string | Message sample. |
+| `sample5` | string | Message sample. |
+| `subUsecases` | array[string] | Campaign sub-usecases. |
+| `subscriberHelp` | boolean | Does campaign responds to help keyword(s)? |
+| `subscriberOptin` | boolean | Does campaign require subscriber to opt-in before SMS is sent to subscriber? |
+| `subscriberOptout` | boolean | Does campaign support subscriber opt-out keyword(s)? |
+| `tag` | array[string] | Tags to be set on the Campaign. |
+| `termsAndConditions` | boolean | Is terms and conditions accepted? |
+| `privacyPolicyLink` | string | Link to the campaign's privacy policy. |
+| `termsAndConditionsLink` | string | Link to the campaign's terms and conditions. |
+| `embeddedLinkSample` | string | Sample of an embedded link that will be sent to subscribers. |
+| `webhookURL` | string | Webhook to which campaign status updates are sent. |
+| `webhookFailoverURL` | string | Failover webhook to which campaign status updates are sent. |
+
+### Update Single Shared Campaign
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `webhookURL` | string | Webhook to which campaign status updates are sent. |
+| `webhookFailoverURL` | string | Webhook failover to which campaign status updates are sent. |
+
+### Assign Messaging Profile To Campaign
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `tcrCampaignId` | string (UUID) | The TCR ID of the shared campaign you want to link to the specified messaging... |
+| `campaignId` | string (UUID) | The ID of the campaign you want to link to the specified messaging profile. |
+
+## Webhook Payload Fields
+
+### `campaignStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `brandId` | string | Brand ID associated with the campaign. |
+| `campaignId` | string | The ID of the campaign. |
+| `createDate` | string | Unix timestamp when campaign was created. |
+| `cspId` | string | Alphanumeric identifier of the CSP associated with this campaign. |
+| `isTMobileRegistered` | boolean | Indicates whether the campaign is registered with T-Mobile. |
+| `type` | enum: TELNYX_EVENT, REGISTRATION, MNO_REVIEW, TELNYX_REVIEW, NUMBER_POOL_PROVISIONED, NUMBER_POOL_DEPROVISIONED, TCR_EVENT, VERIFIED |  |
+| `description` | string | Description of the event. |
+| `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |

--- a/skills/telnyx-twilio-migration/sdk-reference/curl/ai-assistants.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/curl/ai-assistants.md
@@ -27,10 +27,10 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-  "name": "my-resource",
-  "model": "openai/gpt-4o",
-  "instructions": "You are a helpful assistant."
-}' \
+      "name": "my-resource",
+      "instructions": "You are a helpful assistant.",
+      "model": "openai/gpt-4o"
+  }' \
   "https://api.telnyx.com/v2/ai/assistants"
 ```
 
@@ -48,7 +48,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -61,12 +61,11 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `description` | string | No |  |
-| `greeting` | string | No | Text that the assistant will use to start the conversation. |
-| ... | | | +11 optional params in the API Details section below |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in the API Details section below |
 
 ```bash
 curl \
@@ -74,10 +73,10 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-  "name": "my-resource",
-  "model": "openai/gpt-4o",
-  "instructions": "You are a helpful assistant."
-}' \
+      "name": "my-resource",
+      "instructions": "You are a helpful assistant.",
+      "model": "openai/gpt-4o"
+  }' \
   "https://api.telnyx.com/v2/ai/assistants"
 ```
 
@@ -195,7 +194,7 @@ Primary response fields:
 - `.data.created_at`
 - `.data.description`
 - `.data.dynamic_variables`
-- `.data.dynamic_variables_webhook_url`
+- `.data.dynamic_variables_webhook_timeout_ms`
 
 ### Update an assistant
 
@@ -206,10 +205,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistant_id` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +15 optional params in the API Details section below |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in the API Details section below |
 
 ```bash
 curl \
@@ -225,7 +224,7 @@ Primary response fields:
 - `.data.created_at`
 - `.data.description`
 - `.data.dynamic_variables`
-- `.data.dynamic_variables_webhook_url`
+- `.data.dynamic_variables_webhook_timeout_ms`
 
 ### List assistants
 
@@ -246,7 +245,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Import assistants from external provider
 
@@ -281,7 +280,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Get All Tags
 
@@ -375,7 +374,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -388,8 +387,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | HTTP only | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
 | Delete an assistant | HTTP only | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Get Canary Deploy | HTTP only | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
-| Create Canary Deploy | HTTP only | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistant_id` |
-| Update Canary Deploy | HTTP only | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistant_id` |
+| Create Canary Deploy | HTTP only | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | HTTP only | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
 | Delete Canary Deploy | HTTP only | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Assistant Sms Chat | HTTP only | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistant_id` |
 | Clone Assistant | HTTP only | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |
@@ -400,6 +399,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Add Assistant Tag | HTTP only | `POST /ai/assistants/{assistant_id}/tags` | Create or provision an additional resource when the core tasks do not cover this flow. | `tag`, `assistant_id` |
 | Remove Assistant Tag | HTTP only | `DELETE /ai/assistants/{assistant_id}/tags/{tag}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `tag` |
 | Get assistant texml | HTTP only | `GET /ai/assistants/{assistant_id}/texml` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Add Assistant Tool | HTTP only | `PUT /ai/assistants/{assistant_id}/tools/{tool_id}` | Modify an existing resource without recreating it. | `assistant_id`, `tool_id` |
+| Remove Assistant Tool | HTTP only | `DELETE /ai/assistants/{assistant_id}/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `tool_id` |
 | Test Assistant Tool | HTTP only | `POST /ai/assistants/{assistant_id}/tools/{tool_id}/test` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id`, `tool_id` |
 | Get all versions of an assistant | HTTP only | `GET /ai/assistants/{assistant_id}/versions` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
 | Get a specific assistant version | HTTP only | `GET /ai/assistants/{assistant_id}/versions/{version_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id`, `version_id` |
@@ -411,7 +412,398 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get MCP Server | HTTP only | `GET /ai/mcp_servers/{mcp_server_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `mcp_server_id` |
 | Update MCP Server | HTTP only | `PUT /ai/mcp_servers/{mcp_server_id}` | Modify an existing resource without recreating it. | `mcp_server_id` |
 | Delete MCP Server | HTTP only | `DELETE /ai/mcp_servers/{mcp_server_id}` | Remove, detach, or clean up an existing resource. | `mcp_server_id` |
+| List Tools | HTTP only | `GET /ai/tools` | Inspect available resources or choose an existing resource before mutating it. | None |
+| Create Tool | HTTP only | `POST /ai/tools` | Create or provision an additional resource when the core tasks do not cover this flow. | `type`, `display_name` |
+| Get Tool | HTTP only | `GET /ai/tools/{tool_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `tool_id` |
+| Update Tool | HTTP only | `PATCH /ai/tools/{tool_id}` | Modify an existing resource without recreating it. | `tool_id` |
+| Delete Tool | HTTP only | `DELETE /ai/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `tool_id` |
 
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# AI Assistants (curl) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+
+## Response Schemas
+
+**Returned by:** List assistants, Create an assistant, Import assistants from external provider, Get an assistant, Update an assistant, Clone Assistant, Get all versions of an assistant, Get a specific assistant version, Update a specific assistant version, Promote an assistant version to main
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
+| `dynamic_variables_webhook_url` | string |
+| `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
+| `greeting` | string |
+| `id` | string |
+| `import_metadata` | object |
+| `insight_settings` | object |
+| `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
+| `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
+| `messaging_settings` | object |
+| `model` | string |
+| `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
+| `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
+| `telephony_settings` | object |
+| `tools` | array[object] |
+| `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
+| `voice_settings` | object |
+| `widget_settings` | object |
+
+**Returned by:** Get All Tags, Add Assistant Tag, Remove Assistant Tag
+
+| Field | Type |
+|-------|------|
+| `tags` | array[string] |
+
+**Returned by:** List assistant tests with pagination, Create a new assistant test, Get assistant test by ID, Update an assistant test
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `destination` | string |
+| `instructions` | string |
+| `max_duration_seconds` | integer |
+| `name` | string |
+| `rubric` | array[object] |
+| `telnyx_conversation_channel` | object |
+| `test_id` | uuid |
+| `test_suite` | string |
+
+**Returned by:** Get all test suite names
+
+| Field | Type |
+|-------|------|
+| `data` | array[string] |
+
+**Returned by:** Get test suite run history, Get test run history for a specific test, Trigger a manual test run, Get specific test run details
+
+| Field | Type |
+|-------|------|
+| `completed_at` | date-time |
+| `conversation_id` | string |
+| `conversation_insights_id` | string |
+| `created_at` | date-time |
+| `detail_status` | array[object] |
+| `logs` | string |
+| `run_id` | uuid |
+| `status` | enum: pending, starting, running, passed, failed, error |
+| `test_id` | uuid |
+| `test_suite_run_id` | uuid |
+| `triggered_by` | string |
+| `updated_at` | date-time |
+
+**Returned by:** Delete an assistant
+
+| Field | Type |
+|-------|------|
+| `deleted` | boolean |
+| `id` | string |
+| `object` | string |
+
+**Returned by:** Get Canary Deploy, Create Canary Deploy, Update Canary Deploy
+
+| Field | Type |
+|-------|------|
+| `assistant_id` | string |
+| `created_at` | date-time |
+| `rules` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Assistant Chat (BETA)
+
+| Field | Type |
+|-------|------|
+| `content` | string |
+
+**Returned by:** Assistant Sms Chat
+
+| Field | Type |
+|-------|------|
+| `conversation_id` | string |
+
+**Returned by:** List scheduled events
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Test Assistant Tool
+
+| Field | Type |
+|-------|------|
+| `content_type` | string |
+| `request` | object |
+| `response` | string |
+| `status_code` | integer |
+| `success` | boolean |
+
+**Returned by:** Create MCP Server, Get MCP Server, Update MCP Server
+
+| Field | Type |
+|-------|------|
+| `allowed_tools` | array \| null |
+| `api_key_ref` | string \| null |
+| `created_at` | date-time |
+| `id` | string |
+| `name` | string |
+| `type` | string |
+| `url` | string |
+
+**Returned by:** List Tools, Create Tool, Get Tool, Update Tool
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `display_name` | string |
+| `id` | string |
+| `timeout_ms` | integer |
+| `tool_definition` | object |
+| `type` | string |
+
+## Optional Parameters
+
+### Create an assistant
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
+| `transcription` | object |  |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+
+### Import assistants from external provider
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `import_ids` | array[string] | Optional list of assistant IDs to import from the external provider. |
+
+### Create a new assistant test
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `description` | string | Optional detailed description of what this test evaluates and its purpose. |
+| `telnyx_conversation_channel` | object | The communication channel through which the test will be conducted. |
+| `max_duration_seconds` | integer | Maximum duration in seconds that the test conversation should run before timi... |
+| `test_suite` | string | Optional test suite name to group related tests together. |
+
+### Trigger test suite execution
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `destination_version_id` | string (UUID) | Optional assistant version ID to use for all test runs in this suite. |
+
+### Update an assistant test
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | Updated name for the assistant test. |
+| `description` | string | Updated description of the test's purpose and evaluation criteria. |
+| `telnyx_conversation_channel` | enum (phone_call, web_call, sms_chat, web_chat) |  |
+| `destination` | string | Updated target destination for test conversations. |
+| `max_duration_seconds` | integer | Updated maximum test duration in seconds. |
+| `test_suite` | string | Updated test suite assignment for better organization. |
+| `instructions` | string | Updated test scenario instructions and objectives. |
+| `rubric` | array[object] | Updated evaluation criteria for assessing assistant performance. |
+
+### Trigger a manual test run
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `destination_version_id` | string (UUID) | Optional assistant version ID to use for this test run. |
+
+### Update an assistant
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `instructions` | string | System instructions for the assistant. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
+| `transcription` | object |  |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+| `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Assistant Chat (BETA)
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | The optional display name of the user sending the message |
+
+### Assistant Sms Chat
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string |  |
+| `conversation_metadata` | object |  |
+| `should_create_conversation` | boolean |  |
+
+### Create a scheduled event
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Required for sms scheduled events. |
+| `conversation_metadata` | object | Metadata associated with the conversation. |
+| `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
+
+### Test Assistant Tool
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `arguments` | object | Key-value arguments to use for the webhook test |
+| `dynamic_variables` | object | Key-value dynamic variables to use for the webhook test |
+
+### Update a specific assistant version
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `instructions` | string | System instructions for the assistant. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
+| `transcription` | object |  |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+
+### Create MCP Server
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `api_key_ref` | string |  |
+| `allowed_tools` | array[string] |  |
+
+### Update MCP Server
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `name` | string |  |
+| `type` | string |  |
+| `url` | string (URL) |  |
+| `api_key_ref` | string |  |
+| `allowed_tools` | array[string] |  |
+| `created_at` | string (date-time) |  |
+
+### Create Tool
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `function` | object |  |
+| `retrieval` | object |  |
+| `handoff` | object |  |
+| `invite` | object |  |
+| `webhook` | object |  |
+| `timeout_ms` | integer |  |
+
+### Update Tool
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type` | string |  |
+| `display_name` | string |  |
+| `function` | object |  |
+| `retrieval` | object |  |
+| `handoff` | object |  |
+| `invite` | object |  |
+| `webhook` | object |  |
+| `timeout_ms` | integer |  |

--- a/skills/telnyx-twilio-migration/sdk-reference/curl/messaging.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/curl/messaging.md
@@ -54,8 +54,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -183,7 +183,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.media` | array[object] |  |
 | `data.record_type` | enum: event | Identifies the type of the resource. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -386,6 +386,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsapp_message` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```bash
 curl \
@@ -413,7 +414,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -447,3 +448,425 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Messaging (curl) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List alphanumeric sender IDs, Create an alphanumeric sender ID, Retrieve an alphanumeric sender ID, Delete an alphanumeric sender ID, List alphanumeric sender IDs for a messaging profile
+
+| Field | Type |
+|-------|------|
+| `alphanumeric_sender_id` | string |
+| `id` | uuid |
+| `messaging_profile_id` | uuid |
+| `organization_id` | string |
+| `record_type` | enum: alphanumeric_sender_id |
+| `us_long_code_fallback` | string |
+
+**Returned by:** Send a message, Send a message using an alphanumeric sender ID, Retrieve group MMS messages, Send a group MMS message, Send a long code message, Send a message using number pool, Schedule a message, Send a short code message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `wait_seconds` | float |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** Send a WhatsApp message
+
+| Field | Type |
+|-------|------|
+| `body` | object |
+| `direction` | string |
+| `encoding` | string |
+| `from` | object |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `organization_id` | string |
+| `received_at` | date-time |
+| `record_type` | string |
+| `to` | array[object] |
+| `type` | string |
+| `wait_seconds` | float |
+
+**Returned by:** Retrieve a message, Get detailed messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Cancel a scheduled message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** List messaging hosted numbers, Retrieve a messaging hosted number, Update a messaging hosted number
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `eligible_messaging_products` | array[string] |
+| `features` | object |
+| `health` | object |
+| `id` | string |
+| `messaging_product` | string |
+| `messaging_profile_id` | string \| null |
+| `organization_id` | string |
+| `phone_number` | string |
+| `record_type` | enum: messaging_phone_number, messaging_settings |
+| `tags` | array[string] |
+| `traffic_type` | string |
+| `type` | enum: long-code, toll-free, short-code, longcode, tollfree, shortcode |
+| `updated_at` | date-time |
+
+**Returned by:** List opt-outs
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `from` | string |
+| `keyword` | string \| null |
+| `messaging_profile_id` | string \| null |
+| `to` | string |
+
+**Returned by:** List high-level messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Regenerate messaging profile secret
+
+| Field | Type |
+|-------|------|
+| `ai_assistant_id` | string \| null |
+| `alpha_sender` | string \| null |
+| `created_at` | date-time |
+| `daily_spend_limit` | string |
+| `daily_spend_limit_enabled` | boolean |
+| `enabled` | boolean |
+| `health_webhook_url` | url |
+| `id` | uuid |
+| `mms_fall_back_to_sms` | boolean |
+| `mms_transcoding` | boolean |
+| `mobile_only` | boolean |
+| `name` | string |
+| `number_pool_settings` | object \| null |
+| `organization_id` | string |
+| `record_type` | enum: messaging_profile |
+| `redaction_enabled` | boolean |
+| `redaction_level` | integer |
+| `resource_group_id` | string \| null |
+| `smart_encoding` | boolean |
+| `updated_at` | date-time |
+| `url_shortener_settings` | object \| null |
+| `v1_secret` | string |
+| `webhook_api_version` | enum: 1, 2, 2010-04-01 |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+| `whitelisted_destinations` | array[string] |
+
+**Returned by:** List Auto-Response Settings, Create auto-response setting, Get Auto-Response Setting, Update Auto-Response Setting
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `id` | string |
+| `keywords` | array[string] |
+| `op` | enum: start, stop, info |
+| `resp_text` | string |
+| `updated_at` | date-time |
+
+## Optional Parameters
+
+### Create an alphanumeric sender ID
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `us_long_code_fallback` | string | A US long code number to use as fallback when sending to US destinations. |
+
+### Send a message
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using an alphanumeric sender ID
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `webhook_url` | string (URL) | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | If true, use the messaging profile's webhook settings. |
+
+### Send a group MMS message
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+
+### Send a long code message
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using number pool
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Schedule a message
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+
+### Send a short code message
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a WhatsApp message
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
+
+### Update a messaging hosted number
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `messaging_profile_id` | string (UUID) | Configure the messaging profile this phone number is assigned to:
+
+* Omit thi... |
+| `messaging_product` | string | Configure the messaging product for this number:
+
+* Omit this field or set it... |
+| `tags` | array[string] | Tags to set on this phone number. |
+
+### Create auto-response setting
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `resp_text` | string |  |
+
+### Update Auto-Response Setting
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `resp_text` | string |  |
+
+## Webhook Payload Fields
+
+### `deliveryUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.sent, message.finalized | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: outbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | uuid | The id of the organization the messaging profile belongs to. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Subject of multimedia message |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | ISO 8601 formatted date indicating when the message was sent. |
+| `data.payload.completed_at` | date-time | ISO 8601 formatted date indicating when the message was finalized. |
+| `data.payload.valid_until` | date-time | Message must be out of the queue by this time or else it will be discarded and marked as 'sending_failed'. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+| `data.payload.smart_encoding_applied` | boolean | Indicates whether smart encoding was applied to this message. |
+| `data.payload.wait_seconds` | float | Seconds the message is queued due to rate limiting before being sent to the carrier. |
+| `meta.attempt` | integer | Number of attempts to deliver the webhook event. |
+| `meta.delivered_to` | url | The webhook URL the event was delivered to. |
+
+### `inboundMessage`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.received | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: inbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Message subject. |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | Not used for inbound messages. |
+| `data.payload.completed_at` | date-time | Not used for inbound messages. |
+| `data.payload.valid_until` | date-time | Not used for inbound messages. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+
+### `replacedLinkClick`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | string | Identifies the type of the resource. |
+| `data.url` | string | The original link that was sent in the message. |
+| `data.to` | string | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or short code). |
+| `data.message_id` | uuid | The message ID associated with the clicked link. |
+| `data.time_clicked` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+
+### Field Type Notes
+
+- `from` in responses/webhooks: object with sub-fields `phone_number` (string), `carrier` (string), `line_type` (string)
+- `to` in responses/webhooks: array of objects, each with `phone_number` (string), `carrier` (string), `line_type` (string), `status` (string)
+- `cost`: object with `amount` (string, decimal), `currency` (string, e.g., 'USD')

--- a/skills/telnyx-twilio-migration/sdk-reference/curl/numbers.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/curl/numbers.md
@@ -39,7 +39,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -352,7 +352,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -402,3 +402,433 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Numbers (curl) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Advanced Orders, Create Advanced Order, Update Advanced Order, Get Advanced Order
+
+| Field | Type |
+|-------|------|
+| `area_code` | string |
+| `comments` | string |
+| `country_code` | string |
+| `customer_reference` | string |
+| `features` | array[object] |
+| `id` | uuid |
+| `orders` | array[string] |
+| `phone_number_type` | object |
+| `quantity` | integer |
+| `requirement_group_id` | uuid |
+| `status` | object |
+
+**Returned by:** List available phone number blocks
+
+| Field | Type |
+|-------|------|
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `range` | integer |
+| `record_type` | enum: available_phone_number_block |
+| `region_information` | array[object] |
+
+**Returned by:** List available phone numbers
+
+| Field | Type |
+|-------|------|
+| `best_effort` | boolean |
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `quickship` | boolean |
+| `record_type` | enum: available_phone_number |
+| `region_information` | array[object] |
+| `reservable` | boolean |
+| `vanity_format` | string |
+
+**Returned by:** Retrieve all comments
+
+| Field | Type |
+|-------|------|
+| `body` | string |
+| `comment_record_id` | uuid |
+| `comment_record_type` | enum: sub_number_order, requirement_group |
+| `commenter` | string |
+| `commenter_type` | enum: admin, user |
+| `created_at` | date-time |
+| `id` | uuid |
+| `read_at` | date-time |
+| `updated_at` | date-time |
+
+**Returned by:** Create a comment, Retrieve a comment, Mark a comment as read, Get country coverage
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Get coverage for a specific country
+
+| Field | Type |
+|-------|------|
+| `code` | string |
+| `features` | array[string] |
+| `international_sms` | boolean |
+| `inventory_coverage` | boolean |
+| `local` | object |
+| `mobile` | object |
+| `national` | object |
+| `numbers` | boolean |
+| `p2p` | boolean |
+| `phone_number_type` | array[string] |
+| `quickship` | boolean |
+| `region` | string \| null |
+| `reservable` | boolean |
+| `shared_cost` | object |
+| `toll_free` | object |
+
+**Returned by:** List customer service records, Create a customer service record, Get a customer service record
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `error_message` | string \| null |
+| `id` | uuid |
+| `phone_number` | string |
+| `record_type` | string |
+| `result` | object \| null |
+| `status` | enum: pending, completed, failed |
+| `updated_at` | date-time |
+| `webhook_url` | string |
+
+**Returned by:** Verify CSR phone number coverage
+
+| Field | Type |
+|-------|------|
+| `additional_data_required` | array[string] |
+| `has_csr_coverage` | boolean |
+| `phone_number` | string |
+| `reason` | string |
+| `record_type` | string |
+
+**Returned by:** List inexplicit number orders, Create an inexplicit number order, Retrieve an inexplicit number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `ordering_groups` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Create an inventory coverage request
+
+| Field | Type |
+|-------|------|
+| `administrative_area` | string |
+| `advance_requirements` | boolean |
+| `count` | integer |
+| `coverage_type` | enum: number, block |
+| `group` | string |
+| `group_type` | string |
+| `number_range` | integer |
+| `number_type` | enum: did, toll-free |
+| `phone_number_type` | enum: local, toll_free, national, landline, shared_cost, mobile |
+| `record_type` | string |
+
+**Returned by:** List mobile network operators
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `id` | uuid |
+| `mcc` | string |
+| `mnc` | string |
+| `name` | string |
+| `network_preferences_enabled` | boolean |
+| `record_type` | string |
+| `tadig` | string |
+
+**Returned by:** List network coverage locations
+
+| Field | Type |
+|-------|------|
+| `available_services` | array[object] |
+| `location` | object |
+| `record_type` | string |
+
+**Returned by:** List number block orders, Create a number block order, Retrieve a number block order
+
+| Field | Type |
+|-------|------|
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers_count` | integer |
+| `range` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `starting_number` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve a list of phone numbers associated to orders, Retrieve a single phone number within a number order., Update requirements for a single phone number within a number order.
+
+| Field | Type |
+|-------|------|
+| `bundle_id` | uuid |
+| `country_code` | string |
+| `deadline` | date-time |
+| `id` | uuid |
+| `is_block_number` | boolean |
+| `locality` | string |
+| `order_request_id` | uuid |
+| `phone_number` | string |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `requirements_status` | enum: pending, approved, cancelled, deleted, requirement-info-exception, requirement-info-pending, requirement-info-under-review |
+| `status` | enum: pending, success, failure |
+| `sub_number_order_id` | uuid |
+
+**Returned by:** List number orders, Create a number order, Retrieve a number order, Update a number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers` | array[object] |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `sub_number_orders_ids` | array[string] |
+| `updated_at` | date-time |
+
+**Returned by:** List number reservations, Create a number reservation, Retrieve a number reservation, Extend a number reservation
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `errors` | string |
+| `id` | uuid |
+| `phone_numbers` | array[object] |
+| `record_type` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve the features for a list of numbers
+
+| Field | Type |
+|-------|------|
+| `features` | array[string] |
+| `phone_number` | string |
+
+**Returned by:** Lists the phone number blocks jobs, Deletes all numbers associated with a phone number block, Retrieves a phone number blocks job
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `etc` | date-time |
+| `failed_operations` | array[object] |
+| `id` | uuid |
+| `record_type` | string |
+| `status` | enum: pending, in_progress, completed, failed |
+| `successful_operations` | array[object] |
+| `type` | enum: delete_phone_number_block |
+| `updated_at` | string |
+
+**Returned by:** List sub number orders, Retrieve a sub number order, Update a sub number order's requirements, Cancel a sub number order
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `is_block_sub_number_order` | boolean |
+| `order_request_id` | uuid |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+**Returned by:** Create a sub number orders report, Retrieve a sub number orders report
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `filters` | object |
+| `id` | uuid |
+| `order_type` | string |
+| `status` | enum: pending, success, failed, expired |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+## Optional Parameters
+
+### Create Advanced Order
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `country_code` | string (ISO 3166-1 alpha-2) |  |
+| `comments` | string |  |
+| `quantity` | integer |  |
+| `area_code` | string |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `features` | array[object] |  |
+| `customer_reference` | string |  |
+| `requirement_group_id` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Update Advanced Order
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `country_code` | string (ISO 3166-1 alpha-2) |  |
+| `comments` | string |  |
+| `quantity` | integer |  |
+| `area_code` | string |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `features` | array[object] |  |
+| `customer_reference` | string |  |
+| `requirement_group_id` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Create a comment
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `body` | string |  |
+| `commenter` | string |  |
+| `commenter_type` | enum (admin, user) |  |
+| `comment_record_type` | enum (sub_number_order, requirement_group) |  |
+| `comment_record_id` | string (UUID) |  |
+| `read_at` | string (date-time) | An ISO 8901 datetime string for when the comment was read. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the comment was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the comment was updated. |
+
+### Create an inexplicit number order
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `connection_id` | string (UUID) | Connection id to apply to phone numbers that are purchased |
+| `messaging_profile_id` | string (UUID) | Messaging profile id to apply to phone numbers that are purchased |
+| `customer_reference` | string | Reference label for the customer |
+| `billing_group_id` | string (UUID) | Billing group id to apply to phone numbers that are purchased |
+
+### Create a number block order
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `record_type` | string |  |
+| `phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `connection_id` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `status` | enum (pending, success, failure) | The status of the order. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the number order was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the number order was updated. |
+| `requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `errors` | string | Errors the reservation could happen upon |
+
+### Update requirements for a single phone number within a number order.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatory_requirements` | array[object] |  |
+
+### Create a number order
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `phone_numbers` | array[object] |  |
+| `connection_id` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `billing_group_id` | string (UUID) | Identifies the billing group associated with the phone number. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+
+### Update a number order
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatory_requirements` | array[object] |  |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+
+### Create a number reservation
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `record_type` | string |  |
+| `phone_numbers` | array[object] |  |
+| `status` | enum (pending, success, failure) | The status of the entire reservation. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the numbers reservation was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the number reservation was updated. |
+
+### Update a sub number order's requirements
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatory_requirements` | array[object] |  |
+
+### Create a sub number orders report
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `status` | enum (pending, success, failure) | Filter by order status |
+| `country_code` | string (ISO 3166-1 alpha-2) | Filter by country code |
+| `created_at_gt` | string (date-time) | Filter for orders created after this date |
+| `created_at_lt` | string (date-time) | Filter for orders created before this date |
+| `order_request_id` | string (UUID) | Filter by specific order request ID |
+| `customer_reference` | string | Filter by customer reference |
+
+## Webhook Payload Fields
+
+### `numberOrderStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.event_type` | string | The type of event being sent |
+| `data.id` | uuid | Unique identifier for the event |
+| `data.occurred_at` | date-time | ISO 8601 timestamp of when the event occurred |
+| `data.payload.id` | uuid |  |
+| `data.payload.record_type` | string |  |
+| `data.payload.phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `data.payload.connection_id` | string | Identifies the connection associated with this phone number. |
+| `data.payload.messaging_profile_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.billing_group_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.phone_numbers` | array[object] |  |
+| `data.payload.sub_number_orders_ids` | array[string] |  |
+| `data.payload.status` | enum: pending, success, failure | The status of the order. |
+| `data.payload.customer_reference` | string | A customer reference string for customer look ups. |
+| `data.payload.created_at` | date-time | An ISO 8901 datetime string denoting when the number order was created. |
+| `data.payload.updated_at` | date-time | An ISO 8901 datetime string for when the number order was updated. |
+| `data.payload.requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `data.record_type` | string | Type of record |
+| `meta.attempt` | integer | Webhook delivery attempt number |
+| `meta.delivered_to` | uri | URL where the webhook was delivered |

--- a/skills/telnyx-twilio-migration/sdk-reference/curl/voice.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/curl/voice.md
@@ -54,8 +54,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -73,7 +73,7 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in the API Details section below |
+| ... | | | +56 optional params in the API Details section below |
 
 ```bash
 curl \
@@ -108,7 +108,7 @@ Primary inbound call-control command.
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in the API Details section below |
+| ... | | | +29 optional params in the API Details section below |
 
 ```bash
 curl \
@@ -135,7 +135,7 @@ Common post-answer control path with downstream webhook implications.
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in the API Details section below |
+| ... | | | +35 optional params in the API Details section below |
 
 ```bash
 curl \
@@ -143,7 +143,7 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-  "to": "+18005550100"
+  "to": "+18005550100;secure=srtp"
 }' \
   "https://api.telnyx.com/v2/calls/v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ/actions/transfer"
 ```
@@ -213,7 +213,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
 | `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -383,7 +383,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -403,3 +403,427 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Voice (curl) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List call control applications, Create a call control application, Retrieve a call control application, Update a call control application, Delete a call control application
+
+| Field | Type |
+|-------|------|
+| `active` | boolean |
+| `anchorsite_override` | enum: Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, Chennai, IN, Amsterdam, Netherlands, Toronto, Canada, Sydney, Australia |
+| `application_name` | string |
+| `call_cost_in_webhooks` | boolean |
+| `created_at` | string |
+| `dtmf_type` | enum: RFC 2833, Inband, SIP INFO |
+| `first_command_timeout` | boolean |
+| `first_command_timeout_secs` | integer |
+| `id` | string |
+| `inbound` | object |
+| `outbound` | object |
+| `record_type` | enum: call_control_application |
+| `redact_dtmf_debug_logging` | boolean |
+| `tags` | array[string] |
+| `updated_at` | string |
+| `webhook_api_version` | enum: 1, 2 |
+| `webhook_event_failover_url` | url |
+| `webhook_event_url` | url |
+| `webhook_timeout_secs` | integer \| null |
+
+**Returned by:** Dial
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `recording_id` | uuid |
+| `start_time` | string |
+
+**Returned by:** Retrieve a call status
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `start_time` | string |
+
+**Returned by:** Answer call
+
+| Field | Type |
+|-------|------|
+| `recording_id` | uuid |
+| `result` | string |
+
+**Returned by:** Bridge calls, Hangup call, SIP Refer a call, Reject a call, Send SIP info, Transfer call
+
+| Field | Type |
+|-------|------|
+| `result` | string |
+
+**Returned by:** List all active calls for given connection
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `record_type` | enum: call |
+
+## Optional Parameters
+
+### Create a call control application
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `active` | boolean | Specifies whether the connection can be used. |
+| `anchorsite_override` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmf_type` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `first_command_timeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `first_command_timeout_secs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `inbound` | object |  |
+| `outbound` | object |  |
+| `webhook_api_version` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhook_event_failover_url` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhook_timeout_secs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `call_cost_in_webhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `redact_dtmf_debug_logging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Update a call control application
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `call_cost_in_webhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `active` | boolean | Specifies whether the connection can be used. |
+| `anchorsite_override` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmf_type` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `first_command_timeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `first_command_timeout_secs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `tags` | array[string] | Tags assigned to the Call Control Application. |
+| `inbound` | object |  |
+| `outbound` | object |  |
+| `webhook_api_version` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhook_event_failover_url` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhook_timeout_secs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `redact_dtmf_debug_logging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Dial
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
+| `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
+| `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
+| `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `link_to` | string | Use another call's control id for sharing the same call session id |
+| `bridge_intent` | boolean | Indicates the intent to bridge this call with the call specified in link_to. |
+| `bridge_on_answer` | boolean | Whether to automatically bridge answered call to the call specified in link_to. |
+| `prevent_double_bridge` | boolean | Prevents bridging and hangs up the call if the target is already bridged. |
+| `park_after_unbridge` | string | If supplied with the value `self`, the current leg will be parked after unbri... |
+| `media_encryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the call. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE request. |
+| `sip_transport_protocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `stream_url` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `stream_track` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `stream_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `stream_bidirectional_mode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `stream_bidirectional_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `stream_bidirectional_target_legs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `stream_bidirectional_sampling_rate` | enum (8000, 16000, 22050, 24000, 48000) | Audio sampling rate. |
+| `stream_establish_before_call_originate` | boolean | Establish websocket connection before dialing the destination. |
+| `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `supervise_call_control_id` | string (UUID) | The call leg which will be supervised by the new call. |
+| `supervisor_role` | enum (barge, whisper, monitor) | The role of the supervisor call. |
+| `enable_dialogflow` | boolean | Enables Dialogflow for the current call. |
+| `dialogflow_config` | object |  |
+| `transcription` | boolean | Enable transcription upon call answer. |
+| `transcription_config` | object |  |
+| `sip_region` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `stream_auth_token` | string | An authentication token to be sent as part of the WebSocket connection when u... |
+
+### Answer call
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE response. |
+| `preferred_codecs` | enum (G722,PCMU,PCMA,G729,OPUS,VP8,H264) | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE response. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `stream_url` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `stream_track` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `stream_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `stream_bidirectional_mode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `stream_bidirectional_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `stream_bidirectional_target_legs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `transcription` | boolean | Enable transcription upon call answer. |
+| `transcription_config` | object |  |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
+
+### Bridge calls
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `queue` | string | The name of the queue you want to bridge with, can't be used together with ca... |
+| `video_room_id` | string (UUID) | The ID of the video room you want to bridge with, can't be used together with... |
+| `video_room_context` | string | The additional parameter that will be passed to the video conference. |
+| `prevent_double_bridge` | boolean | When set to `true`, it prevents bridging if the target call is already bridge... |
+| `park_after_unbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `play_ringtone` | boolean | Specifies whether to play a ringtone if the call you want to bridge with has ... |
+| `ringtone` | enum (at, au, be, bg, br, ...) | Specifies which country ringtone to play when `play_ringtone` is set to `true`. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `mute_dtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `hold_after_unbridge` | boolean | Specifies behavior after the bridge ends. |
+
+### Hangup call
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP BYE message. |
+
+### SIP Refer a call
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid execution of duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the request. |
+
+### Reject a call
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Send SIP info
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Transfer call
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
+| `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
+| `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
+| `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
+| `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `park_after_unbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `target_leg_client_state` | string | Use this field to add state to every subsequent webhook for the new leg. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `media_encryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the new call leg. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE. |
+| `sip_transport_protocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `mute_dtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `sip_region` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `preferred_codecs` | string | The list of comma-separated codecs in order of preference to be used during t... |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+
+## Webhook Payload Fields
+
+### `callAnswered`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.answered | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: answered | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### `callBridged`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.bridged | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+
+### `callHangup`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.hangup | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: hangup | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+| `data.payload.hangup_cause` | enum: call_rejected, normal_clearing, originator_cancel, timeout, time_limit, user_busy, not_found, no_answer, unspecified | The reason the call was ended (`call_rejected`, `normal_clearing`, `originator_cancel`, `timeout`, `time_limit`, `use... |
+| `data.payload.hangup_source` | enum: caller, callee, unknown | The party who ended the call (`callee`, `caller`, `unknown`). |
+| `data.payload.sip_hangup_cause` | string | The reason the call was ended (SIP response code). |
+| `data.payload.call_quality_stats` | object \| null | Call quality statistics aggregated from the CHANNEL_HANGUP_COMPLETE event. |
+
+### `callInitiated`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.initiated | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
+| `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.custom_headers` | array[object] | Custom headers from sip invite |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.shaken_stir_attestation` | string | SHAKEN/STIR attestation level. |
+| `data.payload.shaken_stir_validated` | boolean | Whether attestation was successfully validated or not. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.caller_id_name` | string | Caller id. |
+| `data.payload.call_screening_result` | string | Call screening result. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.direction` | enum: incoming, outgoing | Whether the call is `incoming` or `outgoing`. |
+| `data.payload.state` | enum: parked, bridging | State received from a command. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### Field Type Notes
+
+- `from` in webhook payloads: string (E.164 phone number)
+- `to` in webhook payloads: string (E.164 phone number)
+- The return value of `client.webhooks.unwrap()` is a parsed event object — access fields via `event.data.event_type`, `event.data.payload.call_control_id`, etc.

--- a/skills/telnyx-twilio-migration/sdk-reference/go/10dlc.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/go/10dlc.md
@@ -78,8 +78,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -228,7 +228,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `description` | string | Description of the event. |
 | `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -406,7 +406,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -446,3 +446,471 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# 10DLC (Go) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Brands, List Campaigns, List shared partner campaigns, List Shared Campaigns, List phone number campaigns
+
+| Field | Type |
+|-------|------|
+| `page` | integer |
+| `records` | array[object] |
+| `totalRecords` | integer |
+
+**Returned by:** Create Brand, Update Brand, Revet Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Get Brand Feedback By Id
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `category` | array[object] |
+
+**Returned by:** Get Brand SMS OTP Status, Get Brand SMS OTP Status by Brand ID
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `deliveryStatus` | string |
+| `deliveryStatusDate` | date-time |
+| `deliveryStatusDetails` | string |
+| `mobilePhone` | string |
+| `referenceId` | string |
+| `requestDate` | date-time |
+| `verifyDate` | date-time |
+
+**Returned by:** Get Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `assignedCampaignsCount` | number |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Order Brand External Vetting, Import External Vetting Record
+
+| Field | Type |
+|-------|------|
+| `createDate` | string |
+| `evpId` | string |
+| `vettedDate` | string |
+| `vettingClass` | string |
+| `vettingId` | string |
+| `vettingScore` | integer |
+| `vettingToken` | string |
+
+**Returned by:** Trigger Brand SMS OTP
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `referenceId` | string |
+
+**Returned by:** Get Campaign Cost
+
+| Field | Type |
+|-------|------|
+| `campaignUsecase` | string |
+| `description` | string |
+| `monthlyCost` | string |
+| `upFrontCost` | string |
+
+**Returned by:** Get campaign, Update campaign, Submit Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `autoRenewal` | boolean |
+| `billedDate` | string |
+| `brandDisplayName` | string |
+| `brandId` | string |
+| `campaignId` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createDate` | string |
+| `cspId` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isTMobileNumberPoolingEnabled` | boolean |
+| `isTMobileRegistered` | boolean |
+| `isTMobileSuspended` | boolean |
+| `messageFlow` | string |
+| `mock` | boolean |
+| `nextRenewalOrExpirationDate` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `referenceId` | string |
+| `resellerId` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `status` | string |
+| `subUsecases` | array[string] |
+| `submissionStatus` | enum: CREATED, FAILED, PENDING |
+| `subscriberHelp` | boolean |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `usecase` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Deactivate campaign
+
+| Field | Type |
+|-------|------|
+| `message` | string |
+| `record_type` | string |
+| `time` | number |
+
+**Returned by:** Submit campaign appeal for manual review
+
+| Field | Type |
+|-------|------|
+| `appealed_at` | date-time |
+
+**Returned by:** Get Campaign Mno Metadata
+
+| Field | Type |
+|-------|------|
+| `10999` | object |
+
+**Returned by:** Get Sharing Status
+
+| Field | Type |
+|-------|------|
+| `sharedByMe` | object |
+| `sharedWithMe` | object |
+
+**Returned by:** Qualify By Usecase
+
+| Field | Type |
+|-------|------|
+| `annualFee` | number |
+| `maxSubUsecases` | integer |
+| `minSubUsecases` | integer |
+| `mnoMetadata` | object |
+| `monthlyFee` | number |
+| `quarterlyFee` | number |
+| `usecase` | string |
+
+**Returned by:** Get Single Shared Campaign, Update Single Shared Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `assignedPhoneNumbersCount` | number |
+| `brandDisplayName` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createdAt` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isNumberPoolingEnabled` | boolean |
+| `messageFlow` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `subUsecases` | array[string] |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `updatedAt` | string |
+| `usecase` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Assign Messaging Profile To Campaign
+
+| Field | Type |
+|-------|------|
+| `campaignId` | string |
+| `messagingProfileId` | string |
+| `taskId` | string |
+| `tcrCampaignId` | string |
+
+**Returned by:** Get Assignment Task Status
+
+| Field | Type |
+|-------|------|
+| `createdAt` | date-time |
+| `status` | string |
+| `taskId` | string |
+| `updatedAt` | date-time |
+
+**Returned by:** Get Phone Number Status
+
+| Field | Type |
+|-------|------|
+| `records` | array[object] |
+
+**Returned by:** Create New Phone Number Campaign, Get Single Phone Number Campaign, Create New Phone Number Campaign, Delete Phone Number Campaign
+
+| Field | Type |
+|-------|------|
+| `assignmentStatus` | enum: FAILED_ASSIGNMENT, PENDING_ASSIGNMENT, ASSIGNED, PENDING_UNASSIGNMENT, FAILED_UNASSIGNMENT |
+| `brandId` | string |
+| `campaignId` | string |
+| `createdAt` | string |
+| `failureReasons` | string |
+| `phoneNumber` | string |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `telnyxCampaignId` | string |
+| `updatedAt` | string |
+
+## Optional Parameters
+
+### Create Brand — `client.Messaging10dlc.Brand.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `CompanyName` | string | (Required for Non-profit/private/public) Legal company name. |
+| `FirstName` | string | First name of business contact. |
+| `LastName` | string | Last name of business contact. |
+| `Ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `Phone` | string | Valid phone number in e.164 international format. |
+| `Street` | string | Street number and name. |
+| `City` | string | City name |
+| `State` | string | State. |
+| `PostalCode` | string | Postal codes. |
+| `StockSymbol` | string | (Required for public company) stock symbol. |
+| `StockExchange` | object | (Required for public company) stock exchange. |
+| `IpAddress` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `Website` | string | Brand website URL. |
+| `IsReseller` | boolean |  |
+| `Mock` | boolean | Mock brand for testing purposes. |
+| `MobilePhone` | string | Valid mobile phone number in e.164 international format. |
+| `BusinessContactEmail` | string | Business contact email. |
+| `WebhookURL` | string | Webhook URL for brand status updates. |
+| `WebhookFailoverURL` | string | Webhook failover URL for brand status updates. |
+
+### Update Brand — `client.Messaging10dlc.Brand.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `CompanyName` | string | (Required for Non-profit/private/public) Legal company name. |
+| `FirstName` | string | First name of business contact. |
+| `LastName` | string | Last name of business contact. |
+| `Ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `Phone` | string | Valid phone number in e.164 international format. |
+| `Street` | string | Street number and name. |
+| `City` | string | City name |
+| `State` | string | State. |
+| `PostalCode` | string | Postal codes. |
+| `StockSymbol` | string | (Required for public company) stock symbol. |
+| `StockExchange` | object | (Required for public company) stock exchange. |
+| `IpAddress` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `Website` | string | Brand website URL. |
+| `AltBusinessIdType` | enum (NONE, DUNS, GIIN, LEI) | An enumeration. |
+| `IsReseller` | boolean |  |
+| `IdentityStatus` | enum (VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED) | The verification status of an active brand |
+| `BusinessContactEmail` | string | Business contact email. |
+| `WebhookURL` | string | Webhook URL for brand status updates. |
+| `WebhookFailoverURL` | string | Webhook failover URL for brand status updates. |
+| `AltBusinessId` | string (UUID) | Alternate business identifier such as DUNS, LEI, or GIIN |
+
+### Import External Vetting Record — `client.Messaging10dlc.Brand.ExternalVetting.Imports()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `VettingToken` | string | Required by some providers for vetting record confirmation. |
+
+### Update campaign — `client.Messaging10dlc.Campaign.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ResellerId` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `Sample1` | string | Message sample. |
+| `Sample2` | string | Message sample. |
+| `Sample3` | string | Message sample. |
+| `Sample4` | string | Message sample. |
+| `Sample5` | string | Message sample. |
+| `MessageFlow` | string | Message flow description. |
+| `HelpMessage` | string | Help message of the campaign. |
+| `AutoRenewal` | boolean | Help message of the campaign. |
+| `WebhookURL` | string | Webhook to which campaign status updates are sent. |
+| `WebhookFailoverURL` | string | Webhook failover to which campaign status updates are sent. |
+
+### Submit Campaign — `client.Messaging10dlc.CampaignBuilder.Submit()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `AgeGated` | boolean | Age gated message content in campaign. |
+| `AutoRenewal` | boolean | Campaign subscription auto-renewal option. |
+| `DirectLending` | boolean | Direct lending or loan arrangement |
+| `EmbeddedLink` | boolean | Does message generated by the campaign include URL link in SMS? |
+| `EmbeddedPhone` | boolean | Does message generated by the campaign include phone number in SMS? |
+| `HelpKeywords` | string | Subscriber help keywords. |
+| `HelpMessage` | string | Help message of the campaign. |
+| `MessageFlow` | string | Message flow description. |
+| `MnoIds` | array[integer] | Submit campaign to given list of MNOs by MNO's network ID. |
+| `NumberPool` | boolean | Does campaign utilize pool of phone numbers? |
+| `OptinKeywords` | string | Subscriber opt-in keywords. |
+| `OptinMessage` | string | Subscriber opt-in message. |
+| `OptoutKeywords` | string | Subscriber opt-out keywords. |
+| `OptoutMessage` | string | Subscriber opt-out message. |
+| `ReferenceId` | string (UUID) | Caller supplied campaign reference ID. |
+| `ResellerId` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `Sample1` | string | Message sample. |
+| `Sample2` | string | Message sample. |
+| `Sample3` | string | Message sample. |
+| `Sample4` | string | Message sample. |
+| `Sample5` | string | Message sample. |
+| `SubUsecases` | array[string] | Campaign sub-usecases. |
+| `SubscriberHelp` | boolean | Does campaign responds to help keyword(s)? |
+| `SubscriberOptin` | boolean | Does campaign require subscriber to opt-in before SMS is sent to subscriber? |
+| `SubscriberOptout` | boolean | Does campaign support subscriber opt-out keyword(s)? |
+| `Tag` | array[string] | Tags to be set on the Campaign. |
+| `TermsAndConditions` | boolean | Is terms and conditions accepted? |
+| `PrivacyPolicyLink` | string | Link to the campaign's privacy policy. |
+| `TermsAndConditionsLink` | string | Link to the campaign's terms and conditions. |
+| `EmbeddedLinkSample` | string | Sample of an embedded link that will be sent to subscribers. |
+| `WebhookURL` | string | Webhook to which campaign status updates are sent. |
+| `WebhookFailoverURL` | string | Failover webhook to which campaign status updates are sent. |
+
+### Update Single Shared Campaign — `client.Messaging10dlc.PartnerCampaigns.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `WebhookURL` | string | Webhook to which campaign status updates are sent. |
+| `WebhookFailoverURL` | string | Webhook failover to which campaign status updates are sent. |
+
+### Assign Messaging Profile To Campaign — `client.Messaging10dlc.PhoneNumberAssignmentByProfile.Assign()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `TcrCampaignId` | string (UUID) | The TCR ID of the shared campaign you want to link to the specified messaging... |
+| `CampaignId` | string (UUID) | The ID of the campaign you want to link to the specified messaging profile. |
+
+## Webhook Payload Fields
+
+### `campaignStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `brandId` | string | Brand ID associated with the campaign. |
+| `campaignId` | string | The ID of the campaign. |
+| `createDate` | string | Unix timestamp when campaign was created. |
+| `cspId` | string | Alphanumeric identifier of the CSP associated with this campaign. |
+| `isTMobileRegistered` | boolean | Indicates whether the campaign is registered with T-Mobile. |
+| `type` | enum: TELNYX_EVENT, REGISTRATION, MNO_REVIEW, TELNYX_REVIEW, NUMBER_POOL_PROVISIONED, NUMBER_POOL_DEPROVISIONED, TCR_EVENT, VERIFIED |  |
+| `description` | string | Description of the event. |
+| `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |

--- a/skills/telnyx-twilio-migration/sdk-reference/go/ai-assistants.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/go/ai-assistants.md
@@ -37,8 +37,8 @@ import "errors"
 
 assistant, err := client.AI.Assistants.New(context.Background(), telnyx.AIAssistantNewParams{
 		Instructions: "You are a helpful assistant.",
-		Model: "openai/gpt-4o",
 		Name: "my-resource",
+		Model: "openai/gpt-4o",
 	})
 if err != nil {
   var apiErr *telnyx.Error
@@ -71,7 +71,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -84,18 +84,17 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `Name` | string | Yes |  |
-| `Model` | string | Yes | ID of the model to use. |
 | `Instructions` | string | Yes | System instructions for the assistant. |
-| `Tools` | array[object] | No | The tools that the assistant can use. |
-| `Description` | string | No |  |
-| `Greeting` | string | No | Text that the assistant will use to start the conversation. |
-| ... | | | +11 optional params in the API Details section below |
+| `Tags` | array[string] | No | Tags associated with the assistant. |
+| `Model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `Tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in the API Details section below |
 
 ```go
 	assistant, err := client.AI.Assistants.New(context.Background(), telnyx.AIAssistantNewParams{
 		Instructions: "You are a helpful assistant.",
-		Model: "openai/gpt-4o",
 		Name: "my-resource",
+		Model: "openai/gpt-4o",
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -224,7 +223,7 @@ Primary response fields:
 - `assistant.CreatedAt`
 - `assistant.Description`
 - `assistant.DynamicVariables`
-- `assistant.DynamicVariablesWebhookURL`
+- `assistant.DynamicVariablesWebhookTimeoutMs`
 
 ### Update an assistant
 
@@ -235,10 +234,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `AssistantId` | string (UUID) | Yes |  |
+| `Tags` | array[string] | No | Tags associated with the assistant. |
 | `Name` | string | No |  |
-| `Model` | string | No | ID of the model to use. |
-| `Instructions` | string | No | System instructions for the assistant. |
-| ... | | | +15 optional params in the API Details section below |
+| `Model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in the API Details section below |
 
 ```go
 	assistant, err := client.AI.Assistants.Update(
@@ -258,7 +257,7 @@ Primary response fields:
 - `assistant.CreatedAt`
 - `assistant.Description`
 - `assistant.DynamicVariables`
-- `assistant.DynamicVariablesWebhookURL`
+- `assistant.DynamicVariablesWebhookTimeoutMs`
 
 ### List assistants
 
@@ -283,7 +282,7 @@ Primary item fields:
 - `CreatedAt`
 - `Description`
 - `DynamicVariables`
-- `DynamicVariablesWebhookURL`
+- `DynamicVariablesWebhookTimeoutMs`
 
 ### Import assistants from external provider
 
@@ -317,7 +316,7 @@ Primary item fields:
 - `CreatedAt`
 - `Description`
 - `DynamicVariables`
-- `DynamicVariablesWebhookURL`
+- `DynamicVariablesWebhookTimeoutMs`
 
 ### Get All Tags
 
@@ -431,7 +430,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -444,8 +443,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.AI.Assistants.Tests.Runs.Get()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `TestId`, `RunId` |
 | Delete an assistant | `client.AI.Assistants.Delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `AssistantId` |
 | Get Canary Deploy | `client.AI.Assistants.CanaryDeploys.Get()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `AssistantId` |
-| Create Canary Deploy | `client.AI.Assistants.CanaryDeploys.New()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `Versions`, `AssistantId` |
-| Update Canary Deploy | `client.AI.Assistants.CanaryDeploys.Update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `Versions`, `AssistantId` |
+| Create Canary Deploy | `client.AI.Assistants.CanaryDeploys.New()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `AssistantId` |
+| Update Canary Deploy | `client.AI.Assistants.CanaryDeploys.Update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `AssistantId` |
 | Delete Canary Deploy | `client.AI.Assistants.CanaryDeploys.Delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `AssistantId` |
 | Assistant Sms Chat | `client.AI.Assistants.SendSMS()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `From`, `To`, `AssistantId` |
 | Clone Assistant | `client.AI.Assistants.Clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `AssistantId` |
@@ -456,6 +455,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Add Assistant Tag | `client.AI.Assistants.Tags.Add()` | `POST /ai/assistants/{assistant_id}/tags` | Create or provision an additional resource when the core tasks do not cover this flow. | `Tag`, `AssistantId` |
 | Remove Assistant Tag | `client.AI.Assistants.Tags.Remove()` | `DELETE /ai/assistants/{assistant_id}/tags/{tag}` | Remove, detach, or clean up an existing resource. | `AssistantId`, `Tag` |
 | Get assistant texml | `client.AI.Assistants.GetTexml()` | `GET /ai/assistants/{assistant_id}/texml` | Fetch the current state before updating, deleting, or making control-flow decisions. | `AssistantId` |
+| Add Assistant Tool | `client.AI.Assistants.Tools.Add()` | `PUT /ai/assistants/{assistant_id}/tools/{tool_id}` | Modify an existing resource without recreating it. | `AssistantId`, `ToolId` |
+| Remove Assistant Tool | `client.AI.Assistants.Tools.Remove()` | `DELETE /ai/assistants/{assistant_id}/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `AssistantId`, `ToolId` |
 | Test Assistant Tool | `client.AI.Assistants.Tools.Test()` | `POST /ai/assistants/{assistant_id}/tools/{tool_id}/test` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `AssistantId`, `ToolId` |
 | Get all versions of an assistant | `client.AI.Assistants.Versions.List()` | `GET /ai/assistants/{assistant_id}/versions` | Fetch the current state before updating, deleting, or making control-flow decisions. | `AssistantId` |
 | Get a specific assistant version | `client.AI.Assistants.Versions.Get()` | `GET /ai/assistants/{assistant_id}/versions/{version_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `AssistantId`, `VersionId` |
@@ -467,7 +468,398 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get MCP Server | `client.AI.McpServers.Get()` | `GET /ai/mcp_servers/{mcp_server_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `McpServerId` |
 | Update MCP Server | `client.AI.McpServers.Update()` | `PUT /ai/mcp_servers/{mcp_server_id}` | Modify an existing resource without recreating it. | `McpServerId` |
 | Delete MCP Server | `client.AI.McpServers.Delete()` | `DELETE /ai/mcp_servers/{mcp_server_id}` | Remove, detach, or clean up an existing resource. | `McpServerId` |
+| List Tools | `client.AI.Tools.List()` | `GET /ai/tools` | Inspect available resources or choose an existing resource before mutating it. | None |
+| Create Tool | `client.AI.Tools.New()` | `POST /ai/tools` | Create or provision an additional resource when the core tasks do not cover this flow. | `Type`, `DisplayName` |
+| Get Tool | `client.AI.Tools.Get()` | `GET /ai/tools/{tool_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `ToolId` |
+| Update Tool | `client.AI.Tools.Update()` | `PATCH /ai/tools/{tool_id}` | Modify an existing resource without recreating it. | `ToolId` |
+| Delete Tool | `client.AI.Tools.Delete()` | `DELETE /ai/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `ToolId` |
 
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# AI Assistants (Go) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+
+## Response Schemas
+
+**Returned by:** List assistants, Create an assistant, Import assistants from external provider, Get an assistant, Update an assistant, Clone Assistant, Get all versions of an assistant, Get a specific assistant version, Update a specific assistant version, Promote an assistant version to main
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
+| `dynamic_variables_webhook_url` | string |
+| `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
+| `greeting` | string |
+| `id` | string |
+| `import_metadata` | object |
+| `insight_settings` | object |
+| `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
+| `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
+| `messaging_settings` | object |
+| `model` | string |
+| `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
+| `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
+| `telephony_settings` | object |
+| `tools` | array[object] |
+| `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
+| `voice_settings` | object |
+| `widget_settings` | object |
+
+**Returned by:** Get All Tags, Add Assistant Tag, Remove Assistant Tag
+
+| Field | Type |
+|-------|------|
+| `tags` | array[string] |
+
+**Returned by:** List assistant tests with pagination, Create a new assistant test, Get assistant test by ID, Update an assistant test
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `destination` | string |
+| `instructions` | string |
+| `max_duration_seconds` | integer |
+| `name` | string |
+| `rubric` | array[object] |
+| `telnyx_conversation_channel` | object |
+| `test_id` | uuid |
+| `test_suite` | string |
+
+**Returned by:** Get all test suite names
+
+| Field | Type |
+|-------|------|
+| `data` | array[string] |
+
+**Returned by:** Get test suite run history, Get test run history for a specific test, Trigger a manual test run, Get specific test run details
+
+| Field | Type |
+|-------|------|
+| `completed_at` | date-time |
+| `conversation_id` | string |
+| `conversation_insights_id` | string |
+| `created_at` | date-time |
+| `detail_status` | array[object] |
+| `logs` | string |
+| `run_id` | uuid |
+| `status` | enum: pending, starting, running, passed, failed, error |
+| `test_id` | uuid |
+| `test_suite_run_id` | uuid |
+| `triggered_by` | string |
+| `updated_at` | date-time |
+
+**Returned by:** Delete an assistant
+
+| Field | Type |
+|-------|------|
+| `deleted` | boolean |
+| `id` | string |
+| `object` | string |
+
+**Returned by:** Get Canary Deploy, Create Canary Deploy, Update Canary Deploy
+
+| Field | Type |
+|-------|------|
+| `assistant_id` | string |
+| `created_at` | date-time |
+| `rules` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Assistant Chat (BETA)
+
+| Field | Type |
+|-------|------|
+| `content` | string |
+
+**Returned by:** Assistant Sms Chat
+
+| Field | Type |
+|-------|------|
+| `conversation_id` | string |
+
+**Returned by:** List scheduled events
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Test Assistant Tool
+
+| Field | Type |
+|-------|------|
+| `content_type` | string |
+| `request` | object |
+| `response` | string |
+| `status_code` | integer |
+| `success` | boolean |
+
+**Returned by:** Create MCP Server, Get MCP Server, Update MCP Server
+
+| Field | Type |
+|-------|------|
+| `allowed_tools` | array \| null |
+| `api_key_ref` | string \| null |
+| `created_at` | date-time |
+| `id` | string |
+| `name` | string |
+| `type` | string |
+| `url` | string |
+
+**Returned by:** List Tools, Create Tool, Get Tool, Update Tool
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `display_name` | string |
+| `id` | string |
+| `timeout_ms` | integer |
+| `tool_definition` | object |
+| `type` | string |
+
+## Optional Parameters
+
+### Create an assistant — `client.AI.Assistants.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Model` | string | ID of the model to use when `external_llm` is not set. |
+| `Tools` | array[object] | Deprecated for new integrations. |
+| `McpServers` | array[object] | MCP servers attached to the assistant. |
+| `ToolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `Description` | string |  |
+| `Greeting` | string | Text that the assistant will use to start the conversation. |
+| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `ExternalLlm` | object |  |
+| `FallbackConfig` | object |  |
+| `VoiceSettings` | object |  |
+| `Transcription` | object |  |
+| `TelephonySettings` | object |  |
+| `MessagingSettings` | object |  |
+| `EnabledFeatures` | array[object] |  |
+| `InsightSettings` | object |  |
+| `PrivacySettings` | object |  |
+| `DynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `DynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `DynamicVariables` | object | Map of dynamic variables and their default values |
+| `WidgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `InterruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `Integrations` | array[object] | Connected integrations attached to the assistant. |
+| `ObservabilitySettings` | object |  |
+| `Tags` | array[string] | Tags associated with the assistant. |
+| `PostConversationSettings` | object | Configuration for post-conversation processing. |
+
+### Import assistants from external provider — `client.AI.Assistants.Imports()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ImportIds` | array[string] | Optional list of assistant IDs to import from the external provider. |
+
+### Create a new assistant test — `client.AI.Assistants.Tests.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Description` | string | Optional detailed description of what this test evaluates and its purpose. |
+| `TelnyxConversationChannel` | object | The communication channel through which the test will be conducted. |
+| `MaxDurationSeconds` | integer | Maximum duration in seconds that the test conversation should run before timi... |
+| `TestSuite` | string | Optional test suite name to group related tests together. |
+
+### Trigger test suite execution — `client.AI.Assistants.Tests.TestSuites.Runs.Trigger()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `DestinationVersionId` | string (UUID) | Optional assistant version ID to use for all test runs in this suite. |
+
+### Update an assistant test — `client.AI.Assistants.Tests.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Name` | string | Updated name for the assistant test. |
+| `Description` | string | Updated description of the test's purpose and evaluation criteria. |
+| `TelnyxConversationChannel` | enum (phone_call, web_call, sms_chat, web_chat) |  |
+| `Destination` | string | Updated target destination for test conversations. |
+| `MaxDurationSeconds` | integer | Updated maximum test duration in seconds. |
+| `TestSuite` | string | Updated test suite assignment for better organization. |
+| `Instructions` | string | Updated test scenario instructions and objectives. |
+| `Rubric` | array[object] | Updated evaluation criteria for assessing assistant performance. |
+
+### Trigger a manual test run — `client.AI.Assistants.Tests.Runs.Trigger()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `DestinationVersionId` | string (UUID) | Optional assistant version ID to use for this test run. |
+
+### Update an assistant — `client.AI.Assistants.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Name` | string |  |
+| `Model` | string | ID of the model to use when `external_llm` is not set. |
+| `Instructions` | string | System instructions for the assistant. |
+| `Tools` | array[object] | Deprecated for new integrations. |
+| `McpServers` | array[object] | MCP servers attached to the assistant. |
+| `ToolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `Description` | string |  |
+| `Greeting` | string | Text that the assistant will use to start the conversation. |
+| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `ExternalLlm` | object |  |
+| `FallbackConfig` | object |  |
+| `VoiceSettings` | object |  |
+| `Transcription` | object |  |
+| `TelephonySettings` | object |  |
+| `MessagingSettings` | object |  |
+| `EnabledFeatures` | array[object] |  |
+| `InsightSettings` | object |  |
+| `PrivacySettings` | object |  |
+| `DynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `DynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `DynamicVariables` | object | Map of dynamic variables and their default values |
+| `WidgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `InterruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `Integrations` | array[object] | Connected integrations attached to the assistant. |
+| `ObservabilitySettings` | object |  |
+| `Tags` | array[string] | Tags associated with the assistant. |
+| `VersionName` | string | Human-readable name for the assistant version. |
+| `PostConversationSettings` | object | Configuration for post-conversation processing. |
+| `PromoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.AI.Assistants.CanaryDeploys.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Rules` | array[object] |  |
+
+### Update Canary Deploy — `client.AI.Assistants.CanaryDeploys.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Rules` | array[object] |  |
+
+### Assistant Chat (BETA) — `client.AI.Assistants.Chat()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Name` | string | The optional display name of the user sending the message |
+
+### Assistant Sms Chat — `client.AI.Assistants.SendSMS()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Text` | string |  |
+| `ConversationMetadata` | object |  |
+| `ShouldCreateConversation` | boolean |  |
+
+### Create a scheduled event — `client.AI.Assistants.ScheduledEvents.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Text` | string | Required for sms scheduled events. |
+| `ConversationMetadata` | object | Metadata associated with the conversation. |
+| `DynamicVariables` | object | A map of dynamic variable names to values. |
+| `MaxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `RetryIntervalSecs` | integer |  |
+
+### Test Assistant Tool — `client.AI.Assistants.Tools.Test()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Arguments` | object | Key-value arguments to use for the webhook test |
+| `DynamicVariables` | object | Key-value dynamic variables to use for the webhook test |
+
+### Update a specific assistant version — `client.AI.Assistants.Versions.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Name` | string |  |
+| `Model` | string | ID of the model to use when `external_llm` is not set. |
+| `Instructions` | string | System instructions for the assistant. |
+| `Tools` | array[object] | Deprecated for new integrations. |
+| `McpServers` | array[object] | MCP servers attached to the assistant. |
+| `ToolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `Description` | string |  |
+| `Greeting` | string | Text that the assistant will use to start the conversation. |
+| `LlmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `ExternalLlm` | object |  |
+| `FallbackConfig` | object |  |
+| `VoiceSettings` | object |  |
+| `Transcription` | object |  |
+| `TelephonySettings` | object |  |
+| `MessagingSettings` | object |  |
+| `EnabledFeatures` | array[object] |  |
+| `InsightSettings` | object |  |
+| `PrivacySettings` | object |  |
+| `DynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `DynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `DynamicVariables` | object | Map of dynamic variables and their default values |
+| `WidgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `InterruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `Integrations` | array[object] | Connected integrations attached to the assistant. |
+| `ObservabilitySettings` | object |  |
+| `Tags` | array[string] | Tags associated with the assistant. |
+| `VersionName` | string | Human-readable name for the assistant version. |
+| `PostConversationSettings` | object | Configuration for post-conversation processing. |
+
+### Create MCP Server — `client.AI.McpServers.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ApiKeyRef` | string |  |
+| `AllowedTools` | array[string] |  |
+
+### Update MCP Server — `client.AI.McpServers.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Id` | string (UUID) |  |
+| `Name` | string |  |
+| `Type` | string |  |
+| `Url` | string (URL) |  |
+| `ApiKeyRef` | string |  |
+| `AllowedTools` | array[string] |  |
+| `CreatedAt` | string (date-time) |  |
+
+### Create Tool — `client.AI.Tools.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Function` | object |  |
+| `Retrieval` | object |  |
+| `Handoff` | object |  |
+| `Invite` | object |  |
+| `Webhook` | object |  |
+| `TimeoutMs` | integer |  |
+
+### Update Tool — `client.AI.Tools.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Type` | string |  |
+| `DisplayName` | string |  |
+| `Function` | object |  |
+| `Retrieval` | object |  |
+| `Handoff` | object |  |
+| `Invite` | object |  |
+| `Webhook` | object |  |
+| `TimeoutMs` | integer |  |

--- a/skills/telnyx-twilio-migration/sdk-reference/go/messaging.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/go/messaging.md
@@ -77,8 +77,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -207,7 +207,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.media` | array[object] |  |
 | `data.record_type` | enum: event | Identifies the type of the resource. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -403,6 +403,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `WhatsappMessage` | object | Yes |  |
 | `Type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `WebhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `MessagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```go
 	response, err := client.Messages.SendWhatsapp(context.Background(), telnyx.MessageSendWhatsappParams{
@@ -429,7 +430,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -463,3 +464,425 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Messaging (Go) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List alphanumeric sender IDs, Create an alphanumeric sender ID, Retrieve an alphanumeric sender ID, Delete an alphanumeric sender ID, List alphanumeric sender IDs for a messaging profile
+
+| Field | Type |
+|-------|------|
+| `alphanumeric_sender_id` | string |
+| `id` | uuid |
+| `messaging_profile_id` | uuid |
+| `organization_id` | string |
+| `record_type` | enum: alphanumeric_sender_id |
+| `us_long_code_fallback` | string |
+
+**Returned by:** Send a message, Send a message using an alphanumeric sender ID, Retrieve group MMS messages, Send a group MMS message, Send a long code message, Send a message using number pool, Schedule a message, Send a short code message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `wait_seconds` | float |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** Send a WhatsApp message
+
+| Field | Type |
+|-------|------|
+| `body` | object |
+| `direction` | string |
+| `encoding` | string |
+| `from` | object |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `organization_id` | string |
+| `received_at` | date-time |
+| `record_type` | string |
+| `to` | array[object] |
+| `type` | string |
+| `wait_seconds` | float |
+
+**Returned by:** Retrieve a message, Get detailed messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Cancel a scheduled message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** List messaging hosted numbers, Retrieve a messaging hosted number, Update a messaging hosted number
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `eligible_messaging_products` | array[string] |
+| `features` | object |
+| `health` | object |
+| `id` | string |
+| `messaging_product` | string |
+| `messaging_profile_id` | string \| null |
+| `organization_id` | string |
+| `phone_number` | string |
+| `record_type` | enum: messaging_phone_number, messaging_settings |
+| `tags` | array[string] |
+| `traffic_type` | string |
+| `type` | enum: long-code, toll-free, short-code, longcode, tollfree, shortcode |
+| `updated_at` | date-time |
+
+**Returned by:** List opt-outs
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `from` | string |
+| `keyword` | string \| null |
+| `messaging_profile_id` | string \| null |
+| `to` | string |
+
+**Returned by:** List high-level messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Regenerate messaging profile secret
+
+| Field | Type |
+|-------|------|
+| `ai_assistant_id` | string \| null |
+| `alpha_sender` | string \| null |
+| `created_at` | date-time |
+| `daily_spend_limit` | string |
+| `daily_spend_limit_enabled` | boolean |
+| `enabled` | boolean |
+| `health_webhook_url` | url |
+| `id` | uuid |
+| `mms_fall_back_to_sms` | boolean |
+| `mms_transcoding` | boolean |
+| `mobile_only` | boolean |
+| `name` | string |
+| `number_pool_settings` | object \| null |
+| `organization_id` | string |
+| `record_type` | enum: messaging_profile |
+| `redaction_enabled` | boolean |
+| `redaction_level` | integer |
+| `resource_group_id` | string \| null |
+| `smart_encoding` | boolean |
+| `updated_at` | date-time |
+| `url_shortener_settings` | object \| null |
+| `v1_secret` | string |
+| `webhook_api_version` | enum: 1, 2, 2010-04-01 |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+| `whitelisted_destinations` | array[string] |
+
+**Returned by:** List Auto-Response Settings, Create auto-response setting, Get Auto-Response Setting, Update Auto-Response Setting
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `id` | string |
+| `keywords` | array[string] |
+| `op` | enum: start, stop, info |
+| `resp_text` | string |
+| `updated_at` | date-time |
+
+## Optional Parameters
+
+### Create an alphanumeric sender ID — `client.AlphanumericSenderIDs.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `UsLongCodeFallback` | string | A US long code number to use as fallback when sending to US destinations. |
+
+### Send a message — `client.Messages.Send()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `From` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `MessagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `Text` | string | Message body (i.e., content) as a non-empty string. |
+| `Subject` | string | Subject of multimedia message |
+| `MediaUrls` | array[string] | A list of media URLs. |
+| `WebhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `WebhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `UseProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `Type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `AutoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `SendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `Encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using an alphanumeric sender ID — `client.Messages.SendWithAlphanumericSender()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `WebhookUrl` | string (URL) | Callback URL for delivery status updates. |
+| `WebhookFailoverUrl` | string (URL) | Failover callback URL for delivery status updates. |
+| `UseProfileWebhooks` | boolean | If true, use the messaging profile's webhook settings. |
+
+### Send a group MMS message — `client.Messages.SendGroupMms()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Text` | string | Message body (i.e., content) as a non-empty string. |
+| `Subject` | string | Subject of multimedia message |
+| `MediaUrls` | array[string] | A list of media URLs. |
+| `WebhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `WebhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `UseProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+
+### Send a long code message — `client.Messages.SendLongCode()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Text` | string | Message body (i.e., content) as a non-empty string. |
+| `Subject` | string | Subject of multimedia message |
+| `MediaUrls` | array[string] | A list of media URLs. |
+| `WebhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `WebhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `UseProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `Type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `AutoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `Encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using number pool — `client.Messages.SendNumberPool()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Text` | string | Message body (i.e., content) as a non-empty string. |
+| `Subject` | string | Subject of multimedia message |
+| `MediaUrls` | array[string] | A list of media URLs. |
+| `WebhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `WebhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `UseProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `Type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `AutoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `Encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Schedule a message — `client.Messages.Schedule()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `From` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `MessagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `Text` | string | Message body (i.e., content) as a non-empty string. |
+| `Subject` | string | Subject of multimedia message |
+| `MediaUrls` | array[string] | A list of media URLs. |
+| `WebhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `WebhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `UseProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `Type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `AutoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `SendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+
+### Send a short code message — `client.Messages.SendShortCode()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Text` | string | Message body (i.e., content) as a non-empty string. |
+| `Subject` | string | Subject of multimedia message |
+| `MediaUrls` | array[string] | A list of media URLs. |
+| `WebhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `WebhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `UseProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `Type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `AutoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `Encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a WhatsApp message — `client.Messages.SendWhatsapp()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
+| `WebhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `MessagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
+
+### Update a messaging hosted number — `client.MessagingHostedNumbers.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `MessagingProfileId` | string (UUID) | Configure the messaging profile this phone number is assigned to:
+
+* Omit thi... |
+| `MessagingProduct` | string | Configure the messaging product for this number:
+
+* Omit this field or set it... |
+| `Tags` | array[string] | Tags to set on this phone number. |
+
+### Create auto-response setting — `client.MessagingProfiles.AutorespConfigs.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `RespText` | string |  |
+
+### Update Auto-Response Setting — `client.MessagingProfiles.AutorespConfigs.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `RespText` | string |  |
+
+## Webhook Payload Fields
+
+### `deliveryUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.sent, message.finalized | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: outbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | uuid | The id of the organization the messaging profile belongs to. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Subject of multimedia message |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | ISO 8601 formatted date indicating when the message was sent. |
+| `data.payload.completed_at` | date-time | ISO 8601 formatted date indicating when the message was finalized. |
+| `data.payload.valid_until` | date-time | Message must be out of the queue by this time or else it will be discarded and marked as 'sending_failed'. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+| `data.payload.smart_encoding_applied` | boolean | Indicates whether smart encoding was applied to this message. |
+| `data.payload.wait_seconds` | float | Seconds the message is queued due to rate limiting before being sent to the carrier. |
+| `meta.attempt` | integer | Number of attempts to deliver the webhook event. |
+| `meta.delivered_to` | url | The webhook URL the event was delivered to. |
+
+### `inboundMessage`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.received | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: inbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Message subject. |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | Not used for inbound messages. |
+| `data.payload.completed_at` | date-time | Not used for inbound messages. |
+| `data.payload.valid_until` | date-time | Not used for inbound messages. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+
+### `replacedLinkClick`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | string | Identifies the type of the resource. |
+| `data.url` | string | The original link that was sent in the message. |
+| `data.to` | string | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or short code). |
+| `data.message_id` | uuid | The message ID associated with the clicked link. |
+| `data.time_clicked` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+
+### Field Type Notes
+
+- `from` in responses/webhooks: object with sub-fields `phone_number` (string), `carrier` (string), `line_type` (string)
+- `to` in responses/webhooks: array of objects, each with `phone_number` (string), `carrier` (string), `line_type` (string), `status` (string)
+- `cost`: object with `amount` (string, decimal), `currency` (string, e.g., 'USD')

--- a/skills/telnyx-twilio-migration/sdk-reference/go/numbers.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/go/numbers.md
@@ -67,7 +67,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -406,7 +406,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -456,3 +456,433 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Numbers (Go) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Advanced Orders, Create Advanced Order, Update Advanced Order, Get Advanced Order
+
+| Field | Type |
+|-------|------|
+| `area_code` | string |
+| `comments` | string |
+| `country_code` | string |
+| `customer_reference` | string |
+| `features` | array[object] |
+| `id` | uuid |
+| `orders` | array[string] |
+| `phone_number_type` | object |
+| `quantity` | integer |
+| `requirement_group_id` | uuid |
+| `status` | object |
+
+**Returned by:** List available phone number blocks
+
+| Field | Type |
+|-------|------|
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `range` | integer |
+| `record_type` | enum: available_phone_number_block |
+| `region_information` | array[object] |
+
+**Returned by:** List available phone numbers
+
+| Field | Type |
+|-------|------|
+| `best_effort` | boolean |
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `quickship` | boolean |
+| `record_type` | enum: available_phone_number |
+| `region_information` | array[object] |
+| `reservable` | boolean |
+| `vanity_format` | string |
+
+**Returned by:** Retrieve all comments
+
+| Field | Type |
+|-------|------|
+| `body` | string |
+| `comment_record_id` | uuid |
+| `comment_record_type` | enum: sub_number_order, requirement_group |
+| `commenter` | string |
+| `commenter_type` | enum: admin, user |
+| `created_at` | date-time |
+| `id` | uuid |
+| `read_at` | date-time |
+| `updated_at` | date-time |
+
+**Returned by:** Create a comment, Retrieve a comment, Mark a comment as read, Get country coverage
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Get coverage for a specific country
+
+| Field | Type |
+|-------|------|
+| `code` | string |
+| `features` | array[string] |
+| `international_sms` | boolean |
+| `inventory_coverage` | boolean |
+| `local` | object |
+| `mobile` | object |
+| `national` | object |
+| `numbers` | boolean |
+| `p2p` | boolean |
+| `phone_number_type` | array[string] |
+| `quickship` | boolean |
+| `region` | string \| null |
+| `reservable` | boolean |
+| `shared_cost` | object |
+| `toll_free` | object |
+
+**Returned by:** List customer service records, Create a customer service record, Get a customer service record
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `error_message` | string \| null |
+| `id` | uuid |
+| `phone_number` | string |
+| `record_type` | string |
+| `result` | object \| null |
+| `status` | enum: pending, completed, failed |
+| `updated_at` | date-time |
+| `webhook_url` | string |
+
+**Returned by:** Verify CSR phone number coverage
+
+| Field | Type |
+|-------|------|
+| `additional_data_required` | array[string] |
+| `has_csr_coverage` | boolean |
+| `phone_number` | string |
+| `reason` | string |
+| `record_type` | string |
+
+**Returned by:** List inexplicit number orders, Create an inexplicit number order, Retrieve an inexplicit number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `ordering_groups` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Create an inventory coverage request
+
+| Field | Type |
+|-------|------|
+| `administrative_area` | string |
+| `advance_requirements` | boolean |
+| `count` | integer |
+| `coverage_type` | enum: number, block |
+| `group` | string |
+| `group_type` | string |
+| `number_range` | integer |
+| `number_type` | enum: did, toll-free |
+| `phone_number_type` | enum: local, toll_free, national, landline, shared_cost, mobile |
+| `record_type` | string |
+
+**Returned by:** List mobile network operators
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `id` | uuid |
+| `mcc` | string |
+| `mnc` | string |
+| `name` | string |
+| `network_preferences_enabled` | boolean |
+| `record_type` | string |
+| `tadig` | string |
+
+**Returned by:** List network coverage locations
+
+| Field | Type |
+|-------|------|
+| `available_services` | array[object] |
+| `location` | object |
+| `record_type` | string |
+
+**Returned by:** List number block orders, Create a number block order, Retrieve a number block order
+
+| Field | Type |
+|-------|------|
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers_count` | integer |
+| `range` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `starting_number` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve a list of phone numbers associated to orders, Retrieve a single phone number within a number order., Update requirements for a single phone number within a number order.
+
+| Field | Type |
+|-------|------|
+| `bundle_id` | uuid |
+| `country_code` | string |
+| `deadline` | date-time |
+| `id` | uuid |
+| `is_block_number` | boolean |
+| `locality` | string |
+| `order_request_id` | uuid |
+| `phone_number` | string |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `requirements_status` | enum: pending, approved, cancelled, deleted, requirement-info-exception, requirement-info-pending, requirement-info-under-review |
+| `status` | enum: pending, success, failure |
+| `sub_number_order_id` | uuid |
+
+**Returned by:** List number orders, Create a number order, Retrieve a number order, Update a number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers` | array[object] |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `sub_number_orders_ids` | array[string] |
+| `updated_at` | date-time |
+
+**Returned by:** List number reservations, Create a number reservation, Retrieve a number reservation, Extend a number reservation
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `errors` | string |
+| `id` | uuid |
+| `phone_numbers` | array[object] |
+| `record_type` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve the features for a list of numbers
+
+| Field | Type |
+|-------|------|
+| `features` | array[string] |
+| `phone_number` | string |
+
+**Returned by:** Lists the phone number blocks jobs, Deletes all numbers associated with a phone number block, Retrieves a phone number blocks job
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `etc` | date-time |
+| `failed_operations` | array[object] |
+| `id` | uuid |
+| `record_type` | string |
+| `status` | enum: pending, in_progress, completed, failed |
+| `successful_operations` | array[object] |
+| `type` | enum: delete_phone_number_block |
+| `updated_at` | string |
+
+**Returned by:** List sub number orders, Retrieve a sub number order, Update a sub number order's requirements, Cancel a sub number order
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `is_block_sub_number_order` | boolean |
+| `order_request_id` | uuid |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+**Returned by:** Create a sub number orders report, Retrieve a sub number orders report
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `filters` | object |
+| `id` | uuid |
+| `order_type` | string |
+| `status` | enum: pending, success, failed, expired |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+## Optional Parameters
+
+### Create Advanced Order — `client.AdvancedOrders.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `CountryCode` | string (ISO 3166-1 alpha-2) |  |
+| `Comments` | string |  |
+| `Quantity` | integer |  |
+| `AreaCode` | string |  |
+| `PhoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `Features` | array[object] |  |
+| `CustomerReference` | string |  |
+| `RequirementGroupId` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Update Advanced Order — `client.AdvancedOrders.UpdateRequirementGroup()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `CountryCode` | string (ISO 3166-1 alpha-2) |  |
+| `Comments` | string |  |
+| `Quantity` | integer |  |
+| `AreaCode` | string |  |
+| `PhoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `Features` | array[object] |  |
+| `CustomerReference` | string |  |
+| `RequirementGroupId` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Create a comment — `client.Comments.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Id` | string (UUID) |  |
+| `Body` | string |  |
+| `Commenter` | string |  |
+| `CommenterType` | enum (admin, user) |  |
+| `CommentRecordType` | enum (sub_number_order, requirement_group) |  |
+| `CommentRecordId` | string (UUID) |  |
+| `ReadAt` | string (date-time) | An ISO 8901 datetime string for when the comment was read. |
+| `CreatedAt` | string (date-time) | An ISO 8901 datetime string denoting when the comment was created. |
+| `UpdatedAt` | string (date-time) | An ISO 8901 datetime string for when the comment was updated. |
+
+### Create an inexplicit number order — `client.InexplicitNumberOrders.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ConnectionId` | string (UUID) | Connection id to apply to phone numbers that are purchased |
+| `MessagingProfileId` | string (UUID) | Messaging profile id to apply to phone numbers that are purchased |
+| `CustomerReference` | string | Reference label for the customer |
+| `BillingGroupId` | string (UUID) | Billing group id to apply to phone numbers that are purchased |
+
+### Create a number block order — `client.NumberBlockOrders.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Id` | string (UUID) |  |
+| `RecordType` | string |  |
+| `PhoneNumbersCount` | integer | The count of phone numbers in the number order. |
+| `ConnectionId` | string (UUID) | Identifies the connection associated with this phone number. |
+| `MessagingProfileId` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `Status` | enum (pending, success, failure) | The status of the order. |
+| `CustomerReference` | string | A customer reference string for customer look ups. |
+| `CreatedAt` | string (date-time) | An ISO 8901 datetime string denoting when the number order was created. |
+| `UpdatedAt` | string (date-time) | An ISO 8901 datetime string for when the number order was updated. |
+| `RequirementsMet` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `Errors` | string | Errors the reservation could happen upon |
+
+### Update requirements for a single phone number within a number order. — `client.NumberOrderPhoneNumbers.UpdateRequirements()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `RegulatoryRequirements` | array[object] |  |
+
+### Create a number order — `client.NumberOrders.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `PhoneNumbers` | array[object] |  |
+| `ConnectionId` | string (UUID) | Identifies the connection associated with this phone number. |
+| `MessagingProfileId` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `BillingGroupId` | string (UUID) | Identifies the billing group associated with the phone number. |
+| `CustomerReference` | string | A customer reference string for customer look ups. |
+
+### Update a number order — `client.NumberOrders.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `RegulatoryRequirements` | array[object] |  |
+| `CustomerReference` | string | A customer reference string for customer look ups. |
+
+### Create a number reservation — `client.NumberReservations.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Id` | string (UUID) |  |
+| `RecordType` | string |  |
+| `PhoneNumbers` | array[object] |  |
+| `Status` | enum (pending, success, failure) | The status of the entire reservation. |
+| `CustomerReference` | string | A customer reference string for customer look ups. |
+| `CreatedAt` | string (date-time) | An ISO 8901 datetime string denoting when the numbers reservation was created. |
+| `UpdatedAt` | string (date-time) | An ISO 8901 datetime string for when the number reservation was updated. |
+
+### Update a sub number order's requirements — `client.SubNumberOrders.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `RegulatoryRequirements` | array[object] |  |
+
+### Create a sub number orders report — `client.SubNumberOrdersReport.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Status` | enum (pending, success, failure) | Filter by order status |
+| `CountryCode` | string (ISO 3166-1 alpha-2) | Filter by country code |
+| `CreatedAtGt` | string (date-time) | Filter for orders created after this date |
+| `CreatedAtLt` | string (date-time) | Filter for orders created before this date |
+| `OrderRequestId` | string (UUID) | Filter by specific order request ID |
+| `CustomerReference` | string | Filter by customer reference |
+
+## Webhook Payload Fields
+
+### `numberOrderStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.event_type` | string | The type of event being sent |
+| `data.id` | uuid | Unique identifier for the event |
+| `data.occurred_at` | date-time | ISO 8601 timestamp of when the event occurred |
+| `data.payload.id` | uuid |  |
+| `data.payload.record_type` | string |  |
+| `data.payload.phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `data.payload.connection_id` | string | Identifies the connection associated with this phone number. |
+| `data.payload.messaging_profile_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.billing_group_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.phone_numbers` | array[object] |  |
+| `data.payload.sub_number_orders_ids` | array[string] |  |
+| `data.payload.status` | enum: pending, success, failure | The status of the order. |
+| `data.payload.customer_reference` | string | A customer reference string for customer look ups. |
+| `data.payload.created_at` | date-time | An ISO 8901 datetime string denoting when the number order was created. |
+| `data.payload.updated_at` | date-time | An ISO 8901 datetime string for when the number order was updated. |
+| `data.payload.requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `data.record_type` | string | Type of record |
+| `meta.attempt` | integer | Webhook delivery attempt number |
+| `meta.delivered_to` | uri | URL where the webhook was delivered |

--- a/skills/telnyx-twilio-migration/sdk-reference/go/voice.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/go/voice.md
@@ -39,7 +39,7 @@ response, err := client.Calls.Dial(context.Background(), telnyx.CallDialParams{
 		ConnectionID: "7267xxxxxxxxxxxxxx",
 		From:         "+18005550101",
 		To: telnyx.CallDialParamsToUnion{
-			OfString: telnyx.String("+18005550100"),
+			OfString: telnyx.String("+18005550100;secure=srtp"),
 		},
 	})
 if err != nil {
@@ -79,8 +79,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -98,14 +98,14 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `TimeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `BillingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `ClientState` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in the API Details section below |
+| ... | | | +56 optional params in the API Details section below |
 
 ```go
 	response, err := client.Calls.Dial(context.Background(), telnyx.CallDialParams{
 		ConnectionID: "7267xxxxxxxxxxxxxx",
 		From:         "+18005550101",
 		To: telnyx.CallDialParamsToUnion{
-			OfString: telnyx.String("+18005550100"),
+			OfString: telnyx.String("+18005550100;secure=srtp"),
 		},
 	})
 	if err != nil {
@@ -134,7 +134,7 @@ Primary inbound call-control command.
 | `BillingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `ClientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `WebhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in the API Details section below |
+| ... | | | +29 optional params in the API Details section below |
 
 ```go
 	response, err := client.Calls.Actions.Answer(
@@ -165,14 +165,14 @@ Common post-answer control path with downstream webhook implications.
 | `TimeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `ClientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `WebhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in the API Details section below |
+| ... | | | +35 optional params in the API Details section below |
 
 ```go
 	response, err := client.Calls.Actions.Transfer(
 		context.Background(),
 		"call_control_id",
 		telnyx.CallActionTransferParams{
-			To: "+18005550100",
+			To: "+18005550100;secure=srtp",
 		},
 	)
 	if err != nil {
@@ -249,7 +249,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
 | `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -445,7 +445,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -465,3 +465,427 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Voice (Go) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List call control applications, Create a call control application, Retrieve a call control application, Update a call control application, Delete a call control application
+
+| Field | Type |
+|-------|------|
+| `active` | boolean |
+| `anchorsite_override` | enum: Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, Chennai, IN, Amsterdam, Netherlands, Toronto, Canada, Sydney, Australia |
+| `application_name` | string |
+| `call_cost_in_webhooks` | boolean |
+| `created_at` | string |
+| `dtmf_type` | enum: RFC 2833, Inband, SIP INFO |
+| `first_command_timeout` | boolean |
+| `first_command_timeout_secs` | integer |
+| `id` | string |
+| `inbound` | object |
+| `outbound` | object |
+| `record_type` | enum: call_control_application |
+| `redact_dtmf_debug_logging` | boolean |
+| `tags` | array[string] |
+| `updated_at` | string |
+| `webhook_api_version` | enum: 1, 2 |
+| `webhook_event_failover_url` | url |
+| `webhook_event_url` | url |
+| `webhook_timeout_secs` | integer \| null |
+
+**Returned by:** Dial
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `recording_id` | uuid |
+| `start_time` | string |
+
+**Returned by:** Retrieve a call status
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `start_time` | string |
+
+**Returned by:** Answer call
+
+| Field | Type |
+|-------|------|
+| `recording_id` | uuid |
+| `result` | string |
+
+**Returned by:** Bridge calls, Hangup call, SIP Refer a call, Reject a call, Send SIP info, Transfer call
+
+| Field | Type |
+|-------|------|
+| `result` | string |
+
+**Returned by:** List all active calls for given connection
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `record_type` | enum: call |
+
+## Optional Parameters
+
+### Create a call control application — `client.CallControlApplications.New()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Active` | boolean | Specifies whether the connection can be used. |
+| `AnchorsiteOverride` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `DtmfType` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `FirstCommandTimeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `FirstCommandTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `Inbound` | object |  |
+| `Outbound` | object |  |
+| `WebhookApiVersion` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `WebhookEventFailoverUrl` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `WebhookTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `CallCostInWebhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `RedactDtmfDebugLogging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Update a call control application — `client.CallControlApplications.Update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `CallCostInWebhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `Active` | boolean | Specifies whether the connection can be used. |
+| `AnchorsiteOverride` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `DtmfType` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `FirstCommandTimeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `FirstCommandTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `Tags` | array[string] | Tags assigned to the Call Control Application. |
+| `Inbound` | object |  |
+| `Outbound` | object |  |
+| `WebhookApiVersion` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `WebhookEventFailoverUrl` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `WebhookTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `RedactDtmfDebugLogging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Dial — `client.Calls.Dial()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Assistant` | object | AI Assistant configuration. |
+| `ConversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `FromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `Privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `AudioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `SendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
+| `MediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
+| `PreferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `TimeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `TimeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `AnsweringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `AnsweringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `DeepfakeDetection` | object | Enables deepfake detection on the call. |
+| `ConferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
+| `CustomHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `BillingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `ClientState` | string | Use this field to add state to every subsequent webhook. |
+| `CommandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `LinkTo` | string | Use another call's control id for sharing the same call session id |
+| `BridgeIntent` | boolean | Indicates the intent to bridge this call with the call specified in link_to. |
+| `BridgeOnAnswer` | boolean | Whether to automatically bridge answered call to the call specified in link_to. |
+| `PreventDoubleBridge` | boolean | Prevents bridging and hangs up the call if the target is already bridged. |
+| `ParkAfterUnbridge` | string | If supplied with the value `self`, the current leg will be parked after unbri... |
+| `MediaEncryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the call. |
+| `SipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
+| `SipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
+| `SipHeaders` | array[object] | SIP headers to be added to the SIP INVITE request. |
+| `SipTransportProtocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `SoundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `StreamUrl` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `StreamTrack` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `StreamCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `StreamBidirectionalMode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `StreamBidirectionalCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `StreamBidirectionalTargetLegs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `StreamBidirectionalSamplingRate` | enum (8000, 16000, 22050, 24000, 48000) | Audio sampling rate. |
+| `StreamEstablishBeforeCallOriginate` | boolean | Establish websocket connection before dialing the destination. |
+| `SendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
+| `WebhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `WebhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `WebhookUrls` | object | A map of event types to webhook URLs. |
+| `WebhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `WebhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `Record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `RecordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `RecordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `RecordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `RecordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `RecordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `RecordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `RecordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `SuperviseCallControlId` | string (UUID) | The call leg which will be supervised by the new call. |
+| `SupervisorRole` | enum (barge, whisper, monitor) | The role of the supervisor call. |
+| `EnableDialogflow` | boolean | Enables Dialogflow for the current call. |
+| `DialogflowConfig` | object |  |
+| `Transcription` | boolean | Enable transcription upon call answer. |
+| `TranscriptionConfig` | object |  |
+| `SipRegion` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `StreamAuthToken` | string | An authentication token to be sent as part of the WebSocket connection when u... |
+
+### Answer call — `client.Calls.Actions.Answer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `Assistant` | object | AI Assistant configuration. |
+| `ConversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `BillingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `ClientState` | string | Use this field to add state to every subsequent webhook. |
+| `CommandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `CustomHeaders` | array[object] | Custom headers to be added to the SIP INVITE response. |
+| `PreferredCodecs` | enum (G722,PCMU,PCMA,G729,OPUS,VP8,H264) | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `SipHeaders` | array[object] | SIP headers to be added to the SIP INVITE response. |
+| `SoundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `StreamUrl` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `StreamTrack` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `StreamCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `StreamBidirectionalMode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `StreamBidirectionalCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `StreamBidirectionalTargetLegs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `SendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
+| `WebhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `WebhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `Transcription` | boolean | Enable transcription upon call answer. |
+| `TranscriptionConfig` | object |  |
+| `Record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `RecordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `RecordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `RecordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `RecordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `RecordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `RecordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `RecordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `WebhookUrls` | object | A map of event types to webhook URLs. |
+| `WebhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `WebhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `DeepfakeDetection` | object | Enables deepfake detection on the call. |
+
+### Bridge calls — `client.Calls.Actions.Bridge()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ClientState` | string | Use this field to add state to every subsequent webhook. |
+| `CommandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `Queue` | string | The name of the queue you want to bridge with, can't be used together with ca... |
+| `VideoRoomId` | string (UUID) | The ID of the video room you want to bridge with, can't be used together with... |
+| `VideoRoomContext` | string | The additional parameter that will be passed to the video conference. |
+| `PreventDoubleBridge` | boolean | When set to `true`, it prevents bridging if the target call is already bridge... |
+| `ParkAfterUnbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `PlayRingtone` | boolean | Specifies whether to play a ringtone if the call you want to bridge with has ... |
+| `Ringtone` | enum (at, au, be, bg, br, ...) | Specifies which country ringtone to play when `play_ringtone` is set to `true`. |
+| `Record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `RecordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `RecordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `RecordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `RecordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `RecordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `RecordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `RecordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `MuteDtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `HoldAfterUnbridge` | boolean | Specifies behavior after the bridge ends. |
+
+### Hangup call — `client.Calls.Actions.Hangup()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ClientState` | string | Use this field to add state to every subsequent webhook. |
+| `CommandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `CustomHeaders` | array[object] | Custom headers to be added to the SIP BYE message. |
+
+### SIP Refer a call — `client.Calls.Actions.Refer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ClientState` | string | Use this field to add state to every subsequent webhook. |
+| `CommandId` | string (UUID) | Use this field to avoid execution of duplicate commands. |
+| `CustomHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `SipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
+| `SipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
+| `SipHeaders` | array[object] | SIP headers to be added to the request. |
+
+### Reject a call — `client.Calls.Actions.Reject()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ClientState` | string | Use this field to add state to every subsequent webhook. |
+| `CommandId` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Send SIP info — `client.Calls.Actions.SendSipInfo()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ClientState` | string | Use this field to add state to every subsequent webhook. |
+| `CommandId` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Transfer call — `client.Calls.Actions.Transfer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `From` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
+| `FromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `Privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `AudioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `SendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
+| `EarlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
+| `MediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
+| `TimeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `TimeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `ParkAfterUnbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `AnsweringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `AnsweringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `CustomHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `ClientState` | string | Use this field to add state to every subsequent webhook. |
+| `TargetLegClientState` | string | Use this field to add state to every subsequent webhook for the new leg. |
+| `CommandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `MediaEncryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the new call leg. |
+| `SipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
+| `SipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
+| `SipHeaders` | array[object] | SIP headers to be added to the SIP INVITE. |
+| `SipTransportProtocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `SoundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `WebhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `WebhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `MuteDtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `Record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `RecordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `RecordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `RecordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `RecordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `RecordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `RecordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `RecordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `SipRegion` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `PreferredCodecs` | string | The list of comma-separated codecs in order of preference to be used during t... |
+| `WebhookUrls` | object | A map of event types to webhook URLs. |
+| `WebhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `WebhookRetriesPolicies` | object | A map of event types to retry policies. |
+
+## Webhook Payload Fields
+
+### `callAnswered`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.answered | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: answered | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### `callBridged`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.bridged | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+
+### `callHangup`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.hangup | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: hangup | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+| `data.payload.hangup_cause` | enum: call_rejected, normal_clearing, originator_cancel, timeout, time_limit, user_busy, not_found, no_answer, unspecified | The reason the call was ended (`call_rejected`, `normal_clearing`, `originator_cancel`, `timeout`, `time_limit`, `use... |
+| `data.payload.hangup_source` | enum: caller, callee, unknown | The party who ended the call (`callee`, `caller`, `unknown`). |
+| `data.payload.sip_hangup_cause` | string | The reason the call was ended (SIP response code). |
+| `data.payload.call_quality_stats` | object \| null | Call quality statistics aggregated from the CHANNEL_HANGUP_COMPLETE event. |
+
+### `callInitiated`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.initiated | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
+| `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.custom_headers` | array[object] | Custom headers from sip invite |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.shaken_stir_attestation` | string | SHAKEN/STIR attestation level. |
+| `data.payload.shaken_stir_validated` | boolean | Whether attestation was successfully validated or not. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.caller_id_name` | string | Caller id. |
+| `data.payload.call_screening_result` | string | Call screening result. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.direction` | enum: incoming, outgoing | Whether the call is `incoming` or `outgoing`. |
+| `data.payload.state` | enum: parked, bridging | State received from a command. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### Field Type Notes
+
+- `from` in webhook payloads: string (E.164 phone number)
+- `to` in webhook payloads: string (E.164 phone number)
+- The return value of `client.webhooks.unwrap()` is a parsed event object — access fields via `event.data.event_type`, `event.data.payload.call_control_id`, etc.

--- a/skills/telnyx-twilio-migration/sdk-reference/java/10dlc.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/10dlc.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -66,8 +66,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -232,7 +232,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `description` | string | Description of the event. |
 | `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -309,7 +309,6 @@ Create or provision an additional resource when the core tasks do not cover this
 ```java
 import com.telnyx.sdk.models.messaging10dlc.phonenumbercampaigns.PhoneNumberCampaign;
 import com.telnyx.sdk.models.messaging10dlc.phonenumbercampaigns.PhoneNumberCampaignCreate;
-import com.telnyx.sdk.models.messaging10dlc.phonenumbercampaigns.PhoneNumberCampaignCreateParams;
 
 PhoneNumberCampaignCreate params = PhoneNumberCampaignCreate.builder()
     .campaignId("4b300178-131c-d902-d54e-72d90ba1620j")
@@ -402,7 +401,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -442,3 +441,471 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# 10DLC (Java) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Brands, List Campaigns, List shared partner campaigns, List Shared Campaigns, List phone number campaigns
+
+| Field | Type |
+|-------|------|
+| `page` | integer |
+| `records` | array[object] |
+| `totalRecords` | integer |
+
+**Returned by:** Create Brand, Update Brand, Revet Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Get Brand Feedback By Id
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `category` | array[object] |
+
+**Returned by:** Get Brand SMS OTP Status, Get Brand SMS OTP Status by Brand ID
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `deliveryStatus` | string |
+| `deliveryStatusDate` | date-time |
+| `deliveryStatusDetails` | string |
+| `mobilePhone` | string |
+| `referenceId` | string |
+| `requestDate` | date-time |
+| `verifyDate` | date-time |
+
+**Returned by:** Get Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `assignedCampaignsCount` | number |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Order Brand External Vetting, Import External Vetting Record
+
+| Field | Type |
+|-------|------|
+| `createDate` | string |
+| `evpId` | string |
+| `vettedDate` | string |
+| `vettingClass` | string |
+| `vettingId` | string |
+| `vettingScore` | integer |
+| `vettingToken` | string |
+
+**Returned by:** Trigger Brand SMS OTP
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `referenceId` | string |
+
+**Returned by:** Get Campaign Cost
+
+| Field | Type |
+|-------|------|
+| `campaignUsecase` | string |
+| `description` | string |
+| `monthlyCost` | string |
+| `upFrontCost` | string |
+
+**Returned by:** Get campaign, Update campaign, Submit Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `autoRenewal` | boolean |
+| `billedDate` | string |
+| `brandDisplayName` | string |
+| `brandId` | string |
+| `campaignId` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createDate` | string |
+| `cspId` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isTMobileNumberPoolingEnabled` | boolean |
+| `isTMobileRegistered` | boolean |
+| `isTMobileSuspended` | boolean |
+| `messageFlow` | string |
+| `mock` | boolean |
+| `nextRenewalOrExpirationDate` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `referenceId` | string |
+| `resellerId` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `status` | string |
+| `subUsecases` | array[string] |
+| `submissionStatus` | enum: CREATED, FAILED, PENDING |
+| `subscriberHelp` | boolean |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `usecase` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Deactivate campaign
+
+| Field | Type |
+|-------|------|
+| `message` | string |
+| `record_type` | string |
+| `time` | number |
+
+**Returned by:** Submit campaign appeal for manual review
+
+| Field | Type |
+|-------|------|
+| `appealed_at` | date-time |
+
+**Returned by:** Get Campaign Mno Metadata
+
+| Field | Type |
+|-------|------|
+| `10999` | object |
+
+**Returned by:** Get Sharing Status
+
+| Field | Type |
+|-------|------|
+| `sharedByMe` | object |
+| `sharedWithMe` | object |
+
+**Returned by:** Qualify By Usecase
+
+| Field | Type |
+|-------|------|
+| `annualFee` | number |
+| `maxSubUsecases` | integer |
+| `minSubUsecases` | integer |
+| `mnoMetadata` | object |
+| `monthlyFee` | number |
+| `quarterlyFee` | number |
+| `usecase` | string |
+
+**Returned by:** Get Single Shared Campaign, Update Single Shared Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `assignedPhoneNumbersCount` | number |
+| `brandDisplayName` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createdAt` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isNumberPoolingEnabled` | boolean |
+| `messageFlow` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `subUsecases` | array[string] |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `updatedAt` | string |
+| `usecase` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Assign Messaging Profile To Campaign
+
+| Field | Type |
+|-------|------|
+| `campaignId` | string |
+| `messagingProfileId` | string |
+| `taskId` | string |
+| `tcrCampaignId` | string |
+
+**Returned by:** Get Assignment Task Status
+
+| Field | Type |
+|-------|------|
+| `createdAt` | date-time |
+| `status` | string |
+| `taskId` | string |
+| `updatedAt` | date-time |
+
+**Returned by:** Get Phone Number Status
+
+| Field | Type |
+|-------|------|
+| `records` | array[object] |
+
+**Returned by:** Create New Phone Number Campaign, Get Single Phone Number Campaign, Create New Phone Number Campaign, Delete Phone Number Campaign
+
+| Field | Type |
+|-------|------|
+| `assignmentStatus` | enum: FAILED_ASSIGNMENT, PENDING_ASSIGNMENT, ASSIGNED, PENDING_UNASSIGNMENT, FAILED_UNASSIGNMENT |
+| `brandId` | string |
+| `campaignId` | string |
+| `createdAt` | string |
+| `failureReasons` | string |
+| `phoneNumber` | string |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `telnyxCampaignId` | string |
+| `updatedAt` | string |
+
+## Optional Parameters
+
+### Create Brand — `client.messaging10dlc().brand().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `companyName` | string | (Required for Non-profit/private/public) Legal company name. |
+| `firstName` | string | First name of business contact. |
+| `lastName` | string | Last name of business contact. |
+| `ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `phone` | string | Valid phone number in e.164 international format. |
+| `street` | string | Street number and name. |
+| `city` | string | City name |
+| `state` | string | State. |
+| `postalCode` | string | Postal codes. |
+| `stockSymbol` | string | (Required for public company) stock symbol. |
+| `stockExchange` | object | (Required for public company) stock exchange. |
+| `ipAddress` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `website` | string | Brand website URL. |
+| `isReseller` | boolean |  |
+| `mock` | boolean | Mock brand for testing purposes. |
+| `mobilePhone` | string | Valid mobile phone number in e.164 international format. |
+| `businessContactEmail` | string | Business contact email. |
+| `webhookURL` | string | Webhook URL for brand status updates. |
+| `webhookFailoverURL` | string | Webhook failover URL for brand status updates. |
+
+### Update Brand — `client.messaging10dlc().brand().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `companyName` | string | (Required for Non-profit/private/public) Legal company name. |
+| `firstName` | string | First name of business contact. |
+| `lastName` | string | Last name of business contact. |
+| `ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `phone` | string | Valid phone number in e.164 international format. |
+| `street` | string | Street number and name. |
+| `city` | string | City name |
+| `state` | string | State. |
+| `postalCode` | string | Postal codes. |
+| `stockSymbol` | string | (Required for public company) stock symbol. |
+| `stockExchange` | object | (Required for public company) stock exchange. |
+| `ipAddress` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `website` | string | Brand website URL. |
+| `altBusinessIdType` | enum (NONE, DUNS, GIIN, LEI) | An enumeration. |
+| `isReseller` | boolean |  |
+| `identityStatus` | enum (VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED) | The verification status of an active brand |
+| `businessContactEmail` | string | Business contact email. |
+| `webhookURL` | string | Webhook URL for brand status updates. |
+| `webhookFailoverURL` | string | Webhook failover URL for brand status updates. |
+| `altBusinessId` | string (UUID) | Alternate business identifier such as DUNS, LEI, or GIIN |
+
+### Import External Vetting Record — `client.messaging10dlc().brand().externalVetting().imports()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `vettingToken` | string | Required by some providers for vetting record confirmation. |
+
+### Update campaign — `client.messaging10dlc().campaign().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `resellerId` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `sample1` | string | Message sample. |
+| `sample2` | string | Message sample. |
+| `sample3` | string | Message sample. |
+| `sample4` | string | Message sample. |
+| `sample5` | string | Message sample. |
+| `messageFlow` | string | Message flow description. |
+| `helpMessage` | string | Help message of the campaign. |
+| `autoRenewal` | boolean | Help message of the campaign. |
+| `webhookURL` | string | Webhook to which campaign status updates are sent. |
+| `webhookFailoverURL` | string | Webhook failover to which campaign status updates are sent. |
+
+### Submit Campaign — `client.messaging10dlc().campaignBuilder().submit()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ageGated` | boolean | Age gated message content in campaign. |
+| `autoRenewal` | boolean | Campaign subscription auto-renewal option. |
+| `directLending` | boolean | Direct lending or loan arrangement |
+| `embeddedLink` | boolean | Does message generated by the campaign include URL link in SMS? |
+| `embeddedPhone` | boolean | Does message generated by the campaign include phone number in SMS? |
+| `helpKeywords` | string | Subscriber help keywords. |
+| `helpMessage` | string | Help message of the campaign. |
+| `messageFlow` | string | Message flow description. |
+| `mnoIds` | array[integer] | Submit campaign to given list of MNOs by MNO's network ID. |
+| `numberPool` | boolean | Does campaign utilize pool of phone numbers? |
+| `optinKeywords` | string | Subscriber opt-in keywords. |
+| `optinMessage` | string | Subscriber opt-in message. |
+| `optoutKeywords` | string | Subscriber opt-out keywords. |
+| `optoutMessage` | string | Subscriber opt-out message. |
+| `referenceId` | string (UUID) | Caller supplied campaign reference ID. |
+| `resellerId` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `sample1` | string | Message sample. |
+| `sample2` | string | Message sample. |
+| `sample3` | string | Message sample. |
+| `sample4` | string | Message sample. |
+| `sample5` | string | Message sample. |
+| `subUsecases` | array[string] | Campaign sub-usecases. |
+| `subscriberHelp` | boolean | Does campaign responds to help keyword(s)? |
+| `subscriberOptin` | boolean | Does campaign require subscriber to opt-in before SMS is sent to subscriber? |
+| `subscriberOptout` | boolean | Does campaign support subscriber opt-out keyword(s)? |
+| `tag` | array[string] | Tags to be set on the Campaign. |
+| `termsAndConditions` | boolean | Is terms and conditions accepted? |
+| `privacyPolicyLink` | string | Link to the campaign's privacy policy. |
+| `termsAndConditionsLink` | string | Link to the campaign's terms and conditions. |
+| `embeddedLinkSample` | string | Sample of an embedded link that will be sent to subscribers. |
+| `webhookURL` | string | Webhook to which campaign status updates are sent. |
+| `webhookFailoverURL` | string | Failover webhook to which campaign status updates are sent. |
+
+### Update Single Shared Campaign — `client.messaging10dlc().partnerCampaigns().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `webhookURL` | string | Webhook to which campaign status updates are sent. |
+| `webhookFailoverURL` | string | Webhook failover to which campaign status updates are sent. |
+
+### Assign Messaging Profile To Campaign — `client.messaging10dlc().phoneNumberAssignmentByProfile().assign()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `tcrCampaignId` | string (UUID) | The TCR ID of the shared campaign you want to link to the specified messaging... |
+| `campaignId` | string (UUID) | The ID of the campaign you want to link to the specified messaging profile. |
+
+## Webhook Payload Fields
+
+### `campaignStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `brandId` | string | Brand ID associated with the campaign. |
+| `campaignId` | string | The ID of the campaign. |
+| `createDate` | string | Unix timestamp when campaign was created. |
+| `cspId` | string | Alphanumeric identifier of the CSP associated with this campaign. |
+| `isTMobileRegistered` | boolean | Indicates whether the campaign is registered with T-Mobile. |
+| `type` | enum: TELNYX_EVENT, REGISTRATION, MNO_REVIEW, TELNYX_REVIEW, NUMBER_POOL_PROVISIONED, NUMBER_POOL_DEPROVISIONED, TCR_EVENT, VERIFIED |  |
+| `description` | string | Description of the event. |
+| `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |

--- a/skills/telnyx-twilio-migration/sdk-reference/java/ai-assistants.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/ai-assistants.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -37,8 +37,8 @@ import com.telnyx.sdk.models.ai.assistants.AssistantCreateParams;
 import com.telnyx.sdk.models.ai.assistants.InferenceEmbedding;
 AssistantCreateParams params = AssistantCreateParams.builder()
     .instructions("You are a helpful assistant.")
-    .model("openai/gpt-4o")
     .name("my-resource")
+    .model("openai/gpt-4o")
     .build();
 InferenceEmbedding assistant = client.ai().assistants().create(params);
 ```
@@ -57,7 +57,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -70,12 +70,11 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `description` | string | No |  |
-| `greeting` | string | No | Text that the assistant will use to start the conversation. |
-| ... | | | +11 optional params in the API Details section below |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in the API Details section below |
 
 ```java
 import com.telnyx.sdk.models.ai.assistants.AssistantCreateParams;
@@ -83,8 +82,8 @@ import com.telnyx.sdk.models.ai.assistants.InferenceEmbedding;
 
 AssistantCreateParams params = AssistantCreateParams.builder()
     .instructions("You are a helpful assistant.")
-    .model("openai/gpt-4o")
     .name("my-resource")
+    .model("openai/gpt-4o")
     .build();
 InferenceEmbedding assistant = client.ai().assistants().create(params);
 ```
@@ -203,7 +202,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### Update an assistant
 
@@ -214,10 +213,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistantId` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +15 optional params in the API Details section below |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in the API Details section below |
 
 ```java
 import com.telnyx.sdk.models.ai.assistants.AssistantUpdateParams;
@@ -232,7 +231,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### List assistants
 
@@ -256,7 +255,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Import assistants from external provider
 
@@ -290,7 +289,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Get All Tags
 
@@ -396,7 +395,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -409,8 +408,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai().assistants().tests().runs().retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId`, `runId` |
 | Delete an assistant | `client.ai().assistants().delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Get Canary Deploy | `client.ai().assistants().canaryDeploys().retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Create Canary Deploy | `client.ai().assistants().canaryDeploys().create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistantId` |
-| Update Canary Deploy | `client.ai().assistants().canaryDeploys().update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistantId` |
+| Create Canary Deploy | `client.ai().assistants().canaryDeploys().create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId` |
+| Update Canary Deploy | `client.ai().assistants().canaryDeploys().update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistantId` |
 | Delete Canary Deploy | `client.ai().assistants().canaryDeploys().delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Assistant Sms Chat | `client.ai().assistants().sendSms()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistantId` |
 | Clone Assistant | `client.ai().assistants().clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId` |
@@ -421,6 +420,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Add Assistant Tag | `client.ai().assistants().tags().add()` | `POST /ai/assistants/{assistant_id}/tags` | Create or provision an additional resource when the core tasks do not cover this flow. | `tag`, `assistantId` |
 | Remove Assistant Tag | `client.ai().assistants().tags().remove()` | `DELETE /ai/assistants/{assistant_id}/tags/{tag}` | Remove, detach, or clean up an existing resource. | `assistantId`, `tag` |
 | Get assistant texml | `client.ai().assistants().getTexml()` | `GET /ai/assistants/{assistant_id}/texml` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
+| Add Assistant Tool | `client.ai().assistants().tools().add()` | `PUT /ai/assistants/{assistant_id}/tools/{tool_id}` | Modify an existing resource without recreating it. | `assistantId`, `toolId` |
+| Remove Assistant Tool | `client.ai().assistants().tools().remove()` | `DELETE /ai/assistants/{assistant_id}/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `assistantId`, `toolId` |
 | Test Assistant Tool | `client.ai().assistants().tools().test()` | `POST /ai/assistants/{assistant_id}/tools/{tool_id}/test` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId`, `toolId` |
 | Get all versions of an assistant | `client.ai().assistants().versions().list()` | `GET /ai/assistants/{assistant_id}/versions` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
 | Get a specific assistant version | `client.ai().assistants().versions().retrieve()` | `GET /ai/assistants/{assistant_id}/versions/{version_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId`, `versionId` |
@@ -432,7 +433,398 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get MCP Server | `client.ai().mcpServers().retrieve()` | `GET /ai/mcp_servers/{mcp_server_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `mcpServerId` |
 | Update MCP Server | `client.ai().mcpServers().update()` | `PUT /ai/mcp_servers/{mcp_server_id}` | Modify an existing resource without recreating it. | `mcpServerId` |
 | Delete MCP Server | `client.ai().mcpServers().delete()` | `DELETE /ai/mcp_servers/{mcp_server_id}` | Remove, detach, or clean up an existing resource. | `mcpServerId` |
+| List Tools | `client.ai().tools().list()` | `GET /ai/tools` | Inspect available resources or choose an existing resource before mutating it. | None |
+| Create Tool | `client.ai().tools().create()` | `POST /ai/tools` | Create or provision an additional resource when the core tasks do not cover this flow. | `type`, `displayName` |
+| Get Tool | `client.ai().tools().retrieve()` | `GET /ai/tools/{tool_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `toolId` |
+| Update Tool | `client.ai().tools().update()` | `PATCH /ai/tools/{tool_id}` | Modify an existing resource without recreating it. | `toolId` |
+| Delete Tool | `client.ai().tools().delete()` | `DELETE /ai/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `toolId` |
 
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# AI Assistants (Java) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+
+## Response Schemas
+
+**Returned by:** List assistants, Create an assistant, Import assistants from external provider, Get an assistant, Update an assistant, Clone Assistant, Get all versions of an assistant, Get a specific assistant version, Update a specific assistant version, Promote an assistant version to main
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
+| `dynamic_variables_webhook_url` | string |
+| `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
+| `greeting` | string |
+| `id` | string |
+| `import_metadata` | object |
+| `insight_settings` | object |
+| `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
+| `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
+| `messaging_settings` | object |
+| `model` | string |
+| `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
+| `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
+| `telephony_settings` | object |
+| `tools` | array[object] |
+| `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
+| `voice_settings` | object |
+| `widget_settings` | object |
+
+**Returned by:** Get All Tags, Add Assistant Tag, Remove Assistant Tag
+
+| Field | Type |
+|-------|------|
+| `tags` | array[string] |
+
+**Returned by:** List assistant tests with pagination, Create a new assistant test, Get assistant test by ID, Update an assistant test
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `destination` | string |
+| `instructions` | string |
+| `max_duration_seconds` | integer |
+| `name` | string |
+| `rubric` | array[object] |
+| `telnyx_conversation_channel` | object |
+| `test_id` | uuid |
+| `test_suite` | string |
+
+**Returned by:** Get all test suite names
+
+| Field | Type |
+|-------|------|
+| `data` | array[string] |
+
+**Returned by:** Get test suite run history, Get test run history for a specific test, Trigger a manual test run, Get specific test run details
+
+| Field | Type |
+|-------|------|
+| `completed_at` | date-time |
+| `conversation_id` | string |
+| `conversation_insights_id` | string |
+| `created_at` | date-time |
+| `detail_status` | array[object] |
+| `logs` | string |
+| `run_id` | uuid |
+| `status` | enum: pending, starting, running, passed, failed, error |
+| `test_id` | uuid |
+| `test_suite_run_id` | uuid |
+| `triggered_by` | string |
+| `updated_at` | date-time |
+
+**Returned by:** Delete an assistant
+
+| Field | Type |
+|-------|------|
+| `deleted` | boolean |
+| `id` | string |
+| `object` | string |
+
+**Returned by:** Get Canary Deploy, Create Canary Deploy, Update Canary Deploy
+
+| Field | Type |
+|-------|------|
+| `assistant_id` | string |
+| `created_at` | date-time |
+| `rules` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Assistant Chat (BETA)
+
+| Field | Type |
+|-------|------|
+| `content` | string |
+
+**Returned by:** Assistant Sms Chat
+
+| Field | Type |
+|-------|------|
+| `conversation_id` | string |
+
+**Returned by:** List scheduled events
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Test Assistant Tool
+
+| Field | Type |
+|-------|------|
+| `content_type` | string |
+| `request` | object |
+| `response` | string |
+| `status_code` | integer |
+| `success` | boolean |
+
+**Returned by:** Create MCP Server, Get MCP Server, Update MCP Server
+
+| Field | Type |
+|-------|------|
+| `allowed_tools` | array \| null |
+| `api_key_ref` | string \| null |
+| `created_at` | date-time |
+| `id` | string |
+| `name` | string |
+| `type` | string |
+| `url` | string |
+
+**Returned by:** List Tools, Create Tool, Get Tool, Update Tool
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `display_name` | string |
+| `id` | string |
+| `timeout_ms` | integer |
+| `tool_definition` | object |
+| `type` | string |
+
+## Optional Parameters
+
+### Create an assistant — `client.ai().assistants().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
+| `voiceSettings` | object |  |
+| `transcription` | object |  |
+| `telephonySettings` | object |  |
+| `messagingSettings` | object |  |
+| `enabledFeatures` | array[object] |  |
+| `insightSettings` | object |  |
+| `privacySettings` | object |  |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamicVariables` | object | Map of dynamic variables and their default values |
+| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
+
+### Import assistants from external provider — `client.ai().assistants().imports()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `importIds` | array[string] | Optional list of assistant IDs to import from the external provider. |
+
+### Create a new assistant test — `client.ai().assistants().tests().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `description` | string | Optional detailed description of what this test evaluates and its purpose. |
+| `telnyxConversationChannel` | object | The communication channel through which the test will be conducted. |
+| `maxDurationSeconds` | integer | Maximum duration in seconds that the test conversation should run before timi... |
+| `testSuite` | string | Optional test suite name to group related tests together. |
+
+### Trigger test suite execution — `client.ai().assistants().tests().testSuites().runs().trigger()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `destinationVersionId` | string (UUID) | Optional assistant version ID to use for all test runs in this suite. |
+
+### Update an assistant test — `client.ai().assistants().tests().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | Updated name for the assistant test. |
+| `description` | string | Updated description of the test's purpose and evaluation criteria. |
+| `telnyxConversationChannel` | enum (phone_call, web_call, sms_chat, web_chat) |  |
+| `destination` | string | Updated target destination for test conversations. |
+| `maxDurationSeconds` | integer | Updated maximum test duration in seconds. |
+| `testSuite` | string | Updated test suite assignment for better organization. |
+| `instructions` | string | Updated test scenario instructions and objectives. |
+| `rubric` | array[object] | Updated evaluation criteria for assessing assistant performance. |
+
+### Trigger a manual test run — `client.ai().assistants().tests().runs().trigger()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `destinationVersionId` | string (UUID) | Optional assistant version ID to use for this test run. |
+
+### Update an assistant — `client.ai().assistants().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `instructions` | string | System instructions for the assistant. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
+| `voiceSettings` | object |  |
+| `transcription` | object |  |
+| `telephonySettings` | object |  |
+| `messagingSettings` | object |  |
+| `enabledFeatures` | array[object] |  |
+| `insightSettings` | object |  |
+| `privacySettings` | object |  |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamicVariables` | object | Map of dynamic variables and their default values |
+| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
+| `promoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai().assistants().canaryDeploys().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai().assistants().canaryDeploys().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Assistant Chat (BETA) — `client.ai().assistants().chat()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | The optional display name of the user sending the message |
+
+### Assistant Sms Chat — `client.ai().assistants().sendSms()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string |  |
+| `conversationMetadata` | object |  |
+| `shouldCreateConversation` | boolean |  |
+
+### Create a scheduled event — `client.ai().assistants().scheduledEvents().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Required for sms scheduled events. |
+| `conversationMetadata` | object | Metadata associated with the conversation. |
+| `dynamicVariables` | object | A map of dynamic variable names to values. |
+| `maxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retryIntervalSecs` | integer |  |
+
+### Test Assistant Tool — `client.ai().assistants().tools().test()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `arguments` | object | Key-value arguments to use for the webhook test |
+| `dynamicVariables` | object | Key-value dynamic variables to use for the webhook test |
+
+### Update a specific assistant version — `client.ai().assistants().versions().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `instructions` | string | System instructions for the assistant. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
+| `voiceSettings` | object |  |
+| `transcription` | object |  |
+| `telephonySettings` | object |  |
+| `messagingSettings` | object |  |
+| `enabledFeatures` | array[object] |  |
+| `insightSettings` | object |  |
+| `privacySettings` | object |  |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamicVariables` | object | Map of dynamic variables and their default values |
+| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
+
+### Create MCP Server — `client.ai().mcpServers().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `apiKeyRef` | string |  |
+| `allowedTools` | array[string] |  |
+
+### Update MCP Server — `client.ai().mcpServers().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `name` | string |  |
+| `type` | string |  |
+| `url` | string (URL) |  |
+| `apiKeyRef` | string |  |
+| `allowedTools` | array[string] |  |
+| `createdAt` | string (date-time) |  |
+
+### Create Tool — `client.ai().tools().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `function` | object |  |
+| `retrieval` | object |  |
+| `handoff` | object |  |
+| `invite` | object |  |
+| `webhook` | object |  |
+| `timeoutMs` | integer |  |
+
+### Update Tool — `client.ai().tools().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type` | string |  |
+| `displayName` | string |  |
+| `function` | object |  |
+| `retrieval` | object |  |
+| `handoff` | object |  |
+| `invite` | object |  |
+| `webhook` | object |  |
+| `timeoutMs` | integer |  |

--- a/skills/telnyx-twilio-migration/sdk-reference/java/messaging.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/messaging.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -63,8 +63,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -208,7 +208,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.media` | array[object] |  |
 | `data.record_type` | enum: event | Identifies the type of the resource. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -407,6 +407,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsappMessage` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```java
 import com.telnyx.sdk.models.messages.MessageSendWhatsappParams;
@@ -434,7 +435,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -468,3 +469,425 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Messaging (Java) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List alphanumeric sender IDs, Create an alphanumeric sender ID, Retrieve an alphanumeric sender ID, Delete an alphanumeric sender ID, List alphanumeric sender IDs for a messaging profile
+
+| Field | Type |
+|-------|------|
+| `alphanumeric_sender_id` | string |
+| `id` | uuid |
+| `messaging_profile_id` | uuid |
+| `organization_id` | string |
+| `record_type` | enum: alphanumeric_sender_id |
+| `us_long_code_fallback` | string |
+
+**Returned by:** Send a message, Send a message using an alphanumeric sender ID, Retrieve group MMS messages, Send a group MMS message, Send a long code message, Send a message using number pool, Schedule a message, Send a short code message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `wait_seconds` | float |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** Send a WhatsApp message
+
+| Field | Type |
+|-------|------|
+| `body` | object |
+| `direction` | string |
+| `encoding` | string |
+| `from` | object |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `organization_id` | string |
+| `received_at` | date-time |
+| `record_type` | string |
+| `to` | array[object] |
+| `type` | string |
+| `wait_seconds` | float |
+
+**Returned by:** Retrieve a message, Get detailed messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Cancel a scheduled message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** List messaging hosted numbers, Retrieve a messaging hosted number, Update a messaging hosted number
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `eligible_messaging_products` | array[string] |
+| `features` | object |
+| `health` | object |
+| `id` | string |
+| `messaging_product` | string |
+| `messaging_profile_id` | string \| null |
+| `organization_id` | string |
+| `phone_number` | string |
+| `record_type` | enum: messaging_phone_number, messaging_settings |
+| `tags` | array[string] |
+| `traffic_type` | string |
+| `type` | enum: long-code, toll-free, short-code, longcode, tollfree, shortcode |
+| `updated_at` | date-time |
+
+**Returned by:** List opt-outs
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `from` | string |
+| `keyword` | string \| null |
+| `messaging_profile_id` | string \| null |
+| `to` | string |
+
+**Returned by:** List high-level messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Regenerate messaging profile secret
+
+| Field | Type |
+|-------|------|
+| `ai_assistant_id` | string \| null |
+| `alpha_sender` | string \| null |
+| `created_at` | date-time |
+| `daily_spend_limit` | string |
+| `daily_spend_limit_enabled` | boolean |
+| `enabled` | boolean |
+| `health_webhook_url` | url |
+| `id` | uuid |
+| `mms_fall_back_to_sms` | boolean |
+| `mms_transcoding` | boolean |
+| `mobile_only` | boolean |
+| `name` | string |
+| `number_pool_settings` | object \| null |
+| `organization_id` | string |
+| `record_type` | enum: messaging_profile |
+| `redaction_enabled` | boolean |
+| `redaction_level` | integer |
+| `resource_group_id` | string \| null |
+| `smart_encoding` | boolean |
+| `updated_at` | date-time |
+| `url_shortener_settings` | object \| null |
+| `v1_secret` | string |
+| `webhook_api_version` | enum: 1, 2, 2010-04-01 |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+| `whitelisted_destinations` | array[string] |
+
+**Returned by:** List Auto-Response Settings, Create auto-response setting, Get Auto-Response Setting, Update Auto-Response Setting
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `id` | string |
+| `keywords` | array[string] |
+| `op` | enum: start, stop, info |
+| `resp_text` | string |
+| `updated_at` | date-time |
+
+## Optional Parameters
+
+### Create an alphanumeric sender ID — `client.alphanumericSenderIds().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `usLongCodeFallback` | string | A US long code number to use as fallback when sending to US destinations. |
+
+### Send a message — `client.messages().send()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using an alphanumeric sender ID — `client.messages().sendWithAlphanumericSender()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `webhookUrl` | string (URL) | Callback URL for delivery status updates. |
+| `webhookFailoverUrl` | string (URL) | Failover callback URL for delivery status updates. |
+| `useProfileWebhooks` | boolean | If true, use the messaging profile's webhook settings. |
+
+### Send a group MMS message — `client.messages().sendGroupMms()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+
+### Send a long code message — `client.messages().sendLongCode()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using number pool — `client.messages().sendNumberPool()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Schedule a message — `client.messages().schedule()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+
+### Send a short code message — `client.messages().sendShortCode()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a WhatsApp message — `client.messages().sendWhatsapp()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
+
+### Update a messaging hosted number — `client.messagingHostedNumbers().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `messagingProfileId` | string (UUID) | Configure the messaging profile this phone number is assigned to:
+
+* Omit thi... |
+| `messagingProduct` | string | Configure the messaging product for this number:
+
+* Omit this field or set it... |
+| `tags` | array[string] | Tags to set on this phone number. |
+
+### Create auto-response setting — `client.messagingProfiles().autorespConfigs().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `respText` | string |  |
+
+### Update Auto-Response Setting — `client.messagingProfiles().autorespConfigs().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `respText` | string |  |
+
+## Webhook Payload Fields
+
+### `deliveryUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.sent, message.finalized | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: outbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | uuid | The id of the organization the messaging profile belongs to. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Subject of multimedia message |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | ISO 8601 formatted date indicating when the message was sent. |
+| `data.payload.completed_at` | date-time | ISO 8601 formatted date indicating when the message was finalized. |
+| `data.payload.valid_until` | date-time | Message must be out of the queue by this time or else it will be discarded and marked as 'sending_failed'. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+| `data.payload.smart_encoding_applied` | boolean | Indicates whether smart encoding was applied to this message. |
+| `data.payload.wait_seconds` | float | Seconds the message is queued due to rate limiting before being sent to the carrier. |
+| `meta.attempt` | integer | Number of attempts to deliver the webhook event. |
+| `meta.delivered_to` | url | The webhook URL the event was delivered to. |
+
+### `inboundMessage`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.received | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: inbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Message subject. |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | Not used for inbound messages. |
+| `data.payload.completed_at` | date-time | Not used for inbound messages. |
+| `data.payload.valid_until` | date-time | Not used for inbound messages. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+
+### `replacedLinkClick`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | string | Identifies the type of the resource. |
+| `data.url` | string | The original link that was sent in the message. |
+| `data.to` | string | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or short code). |
+| `data.message_id` | uuid | The message ID associated with the clicked link. |
+| `data.time_clicked` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+
+### Field Type Notes
+
+- `from` in responses/webhooks: object with sub-fields `phone_number` (string), `carrier` (string), `line_type` (string)
+- `to` in responses/webhooks: array of objects, each with `phone_number` (string), `carrier` (string), `line_type` (string), `status` (string)
+- `cost`: object with `amount` (string, decimal), `currency` (string, e.g., 'USD')

--- a/skills/telnyx-twilio-migration/sdk-reference/java/numbers.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/numbers.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -52,7 +52,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -266,7 +266,6 @@ Create or provision an additional resource when the core tasks do not cover this
 
 ```java
 import com.telnyx.sdk.models.advancedorders.AdvancedOrder;
-import com.telnyx.sdk.models.advancedorders.AdvancedOrderCreateParams;
 import com.telnyx.sdk.models.advancedorders.AdvancedOrderCreateResponse;
 
 AdvancedOrder params = AdvancedOrder.builder().build();
@@ -403,7 +402,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -453,3 +452,433 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Numbers (Java) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Advanced Orders, Create Advanced Order, Update Advanced Order, Get Advanced Order
+
+| Field | Type |
+|-------|------|
+| `area_code` | string |
+| `comments` | string |
+| `country_code` | string |
+| `customer_reference` | string |
+| `features` | array[object] |
+| `id` | uuid |
+| `orders` | array[string] |
+| `phone_number_type` | object |
+| `quantity` | integer |
+| `requirement_group_id` | uuid |
+| `status` | object |
+
+**Returned by:** List available phone number blocks
+
+| Field | Type |
+|-------|------|
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `range` | integer |
+| `record_type` | enum: available_phone_number_block |
+| `region_information` | array[object] |
+
+**Returned by:** List available phone numbers
+
+| Field | Type |
+|-------|------|
+| `best_effort` | boolean |
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `quickship` | boolean |
+| `record_type` | enum: available_phone_number |
+| `region_information` | array[object] |
+| `reservable` | boolean |
+| `vanity_format` | string |
+
+**Returned by:** Retrieve all comments
+
+| Field | Type |
+|-------|------|
+| `body` | string |
+| `comment_record_id` | uuid |
+| `comment_record_type` | enum: sub_number_order, requirement_group |
+| `commenter` | string |
+| `commenter_type` | enum: admin, user |
+| `created_at` | date-time |
+| `id` | uuid |
+| `read_at` | date-time |
+| `updated_at` | date-time |
+
+**Returned by:** Create a comment, Retrieve a comment, Mark a comment as read, Get country coverage
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Get coverage for a specific country
+
+| Field | Type |
+|-------|------|
+| `code` | string |
+| `features` | array[string] |
+| `international_sms` | boolean |
+| `inventory_coverage` | boolean |
+| `local` | object |
+| `mobile` | object |
+| `national` | object |
+| `numbers` | boolean |
+| `p2p` | boolean |
+| `phone_number_type` | array[string] |
+| `quickship` | boolean |
+| `region` | string \| null |
+| `reservable` | boolean |
+| `shared_cost` | object |
+| `toll_free` | object |
+
+**Returned by:** List customer service records, Create a customer service record, Get a customer service record
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `error_message` | string \| null |
+| `id` | uuid |
+| `phone_number` | string |
+| `record_type` | string |
+| `result` | object \| null |
+| `status` | enum: pending, completed, failed |
+| `updated_at` | date-time |
+| `webhook_url` | string |
+
+**Returned by:** Verify CSR phone number coverage
+
+| Field | Type |
+|-------|------|
+| `additional_data_required` | array[string] |
+| `has_csr_coverage` | boolean |
+| `phone_number` | string |
+| `reason` | string |
+| `record_type` | string |
+
+**Returned by:** List inexplicit number orders, Create an inexplicit number order, Retrieve an inexplicit number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `ordering_groups` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Create an inventory coverage request
+
+| Field | Type |
+|-------|------|
+| `administrative_area` | string |
+| `advance_requirements` | boolean |
+| `count` | integer |
+| `coverage_type` | enum: number, block |
+| `group` | string |
+| `group_type` | string |
+| `number_range` | integer |
+| `number_type` | enum: did, toll-free |
+| `phone_number_type` | enum: local, toll_free, national, landline, shared_cost, mobile |
+| `record_type` | string |
+
+**Returned by:** List mobile network operators
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `id` | uuid |
+| `mcc` | string |
+| `mnc` | string |
+| `name` | string |
+| `network_preferences_enabled` | boolean |
+| `record_type` | string |
+| `tadig` | string |
+
+**Returned by:** List network coverage locations
+
+| Field | Type |
+|-------|------|
+| `available_services` | array[object] |
+| `location` | object |
+| `record_type` | string |
+
+**Returned by:** List number block orders, Create a number block order, Retrieve a number block order
+
+| Field | Type |
+|-------|------|
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers_count` | integer |
+| `range` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `starting_number` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve a list of phone numbers associated to orders, Retrieve a single phone number within a number order., Update requirements for a single phone number within a number order.
+
+| Field | Type |
+|-------|------|
+| `bundle_id` | uuid |
+| `country_code` | string |
+| `deadline` | date-time |
+| `id` | uuid |
+| `is_block_number` | boolean |
+| `locality` | string |
+| `order_request_id` | uuid |
+| `phone_number` | string |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `requirements_status` | enum: pending, approved, cancelled, deleted, requirement-info-exception, requirement-info-pending, requirement-info-under-review |
+| `status` | enum: pending, success, failure |
+| `sub_number_order_id` | uuid |
+
+**Returned by:** List number orders, Create a number order, Retrieve a number order, Update a number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers` | array[object] |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `sub_number_orders_ids` | array[string] |
+| `updated_at` | date-time |
+
+**Returned by:** List number reservations, Create a number reservation, Retrieve a number reservation, Extend a number reservation
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `errors` | string |
+| `id` | uuid |
+| `phone_numbers` | array[object] |
+| `record_type` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve the features for a list of numbers
+
+| Field | Type |
+|-------|------|
+| `features` | array[string] |
+| `phone_number` | string |
+
+**Returned by:** Lists the phone number blocks jobs, Deletes all numbers associated with a phone number block, Retrieves a phone number blocks job
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `etc` | date-time |
+| `failed_operations` | array[object] |
+| `id` | uuid |
+| `record_type` | string |
+| `status` | enum: pending, in_progress, completed, failed |
+| `successful_operations` | array[object] |
+| `type` | enum: delete_phone_number_block |
+| `updated_at` | string |
+
+**Returned by:** List sub number orders, Retrieve a sub number order, Update a sub number order's requirements, Cancel a sub number order
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `is_block_sub_number_order` | boolean |
+| `order_request_id` | uuid |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+**Returned by:** Create a sub number orders report, Retrieve a sub number orders report
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `filters` | object |
+| `id` | uuid |
+| `order_type` | string |
+| `status` | enum: pending, success, failed, expired |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+## Optional Parameters
+
+### Create Advanced Order — `client.advancedOrders().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `countryCode` | string (ISO 3166-1 alpha-2) |  |
+| `comments` | string |  |
+| `quantity` | integer |  |
+| `areaCode` | string |  |
+| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `features` | array[object] |  |
+| `customerReference` | string |  |
+| `requirementGroupId` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Update Advanced Order — `client.advancedOrders().updateRequirementGroup()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `countryCode` | string (ISO 3166-1 alpha-2) |  |
+| `comments` | string |  |
+| `quantity` | integer |  |
+| `areaCode` | string |  |
+| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `features` | array[object] |  |
+| `customerReference` | string |  |
+| `requirementGroupId` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Create a comment — `client.comments().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `body` | string |  |
+| `commenter` | string |  |
+| `commenterType` | enum (admin, user) |  |
+| `commentRecordType` | enum (sub_number_order, requirement_group) |  |
+| `commentRecordId` | string (UUID) |  |
+| `readAt` | string (date-time) | An ISO 8901 datetime string for when the comment was read. |
+| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the comment was created. |
+| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the comment was updated. |
+
+### Create an inexplicit number order — `client.inexplicitNumberOrders().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `connectionId` | string (UUID) | Connection id to apply to phone numbers that are purchased |
+| `messagingProfileId` | string (UUID) | Messaging profile id to apply to phone numbers that are purchased |
+| `customerReference` | string | Reference label for the customer |
+| `billingGroupId` | string (UUID) | Billing group id to apply to phone numbers that are purchased |
+
+### Create a number block order — `client.numberBlockOrders().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `recordType` | string |  |
+| `phoneNumbersCount` | integer | The count of phone numbers in the number order. |
+| `connectionId` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messagingProfileId` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `status` | enum (pending, success, failure) | The status of the order. |
+| `customerReference` | string | A customer reference string for customer look ups. |
+| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the number order was created. |
+| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the number order was updated. |
+| `requirementsMet` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `errors` | string | Errors the reservation could happen upon |
+
+### Update requirements for a single phone number within a number order. — `client.numberOrderPhoneNumbers().updateRequirements()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatoryRequirements` | array[object] |  |
+
+### Create a number order — `client.numberOrders().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `phoneNumbers` | array[object] |  |
+| `connectionId` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messagingProfileId` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `billingGroupId` | string (UUID) | Identifies the billing group associated with the phone number. |
+| `customerReference` | string | A customer reference string for customer look ups. |
+
+### Update a number order — `client.numberOrders().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatoryRequirements` | array[object] |  |
+| `customerReference` | string | A customer reference string for customer look ups. |
+
+### Create a number reservation — `client.numberReservations().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `recordType` | string |  |
+| `phoneNumbers` | array[object] |  |
+| `status` | enum (pending, success, failure) | The status of the entire reservation. |
+| `customerReference` | string | A customer reference string for customer look ups. |
+| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the numbers reservation was created. |
+| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the number reservation was updated. |
+
+### Update a sub number order's requirements — `client.subNumberOrders().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatoryRequirements` | array[object] |  |
+
+### Create a sub number orders report — `client.subNumberOrdersReport().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `status` | enum (pending, success, failure) | Filter by order status |
+| `countryCode` | string (ISO 3166-1 alpha-2) | Filter by country code |
+| `createdAtGt` | string (date-time) | Filter for orders created after this date |
+| `createdAtLt` | string (date-time) | Filter for orders created before this date |
+| `orderRequestId` | string (UUID) | Filter by specific order request ID |
+| `customerReference` | string | Filter by customer reference |
+
+## Webhook Payload Fields
+
+### `numberOrderStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.event_type` | string | The type of event being sent |
+| `data.id` | uuid | Unique identifier for the event |
+| `data.occurred_at` | date-time | ISO 8601 timestamp of when the event occurred |
+| `data.payload.id` | uuid |  |
+| `data.payload.record_type` | string |  |
+| `data.payload.phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `data.payload.connection_id` | string | Identifies the connection associated with this phone number. |
+| `data.payload.messaging_profile_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.billing_group_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.phone_numbers` | array[object] |  |
+| `data.payload.sub_number_orders_ids` | array[string] |  |
+| `data.payload.status` | enum: pending, success, failure | The status of the order. |
+| `data.payload.customer_reference` | string | A customer reference string for customer look ups. |
+| `data.payload.created_at` | date-time | An ISO 8901 datetime string denoting when the number order was created. |
+| `data.payload.updated_at` | date-time | An ISO 8901 datetime string for when the number order was updated. |
+| `data.payload.requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `data.record_type` | string | Type of record |
+| `meta.attempt` | integer | Webhook delivery attempt number |
+| `meta.delivered_to` | uri | URL where the webhook was delivered |

--- a/skills/telnyx-twilio-migration/sdk-reference/java/voice.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/voice.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -38,7 +38,7 @@ import com.telnyx.sdk.models.calls.CallDialResponse;
 CallDialParams params = CallDialParams.builder()
     .connectionId("7267xxxxxxxxxxxxxx")
     .from("+18005550101")
-    .to("+18005550100")
+    .to("+18005550100;secure=srtp")
     .build();
 CallDialResponse response = client.calls().dial(params);
 ```
@@ -63,8 +63,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -82,7 +82,7 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in the API Details section below |
+| ... | | | +56 optional params in the API Details section below |
 
 ```java
 import com.telnyx.sdk.models.calls.CallDialParams;
@@ -91,7 +91,7 @@ import com.telnyx.sdk.models.calls.CallDialResponse;
 CallDialParams params = CallDialParams.builder()
     .connectionId("7267xxxxxxxxxxxxxx")
     .from("+18005550101")
-    .to("+18005550100")
+    .to("+18005550100;secure=srtp")
     .build();
 CallDialResponse response = client.calls().dial(params);
 ```
@@ -116,7 +116,7 @@ Primary inbound call-control command.
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in the API Details section below |
+| ... | | | +29 optional params in the API Details section below |
 
 ```java
 import com.telnyx.sdk.models.calls.actions.ActionAnswerParams;
@@ -142,7 +142,7 @@ Common post-answer control path with downstream webhook implications.
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in the API Details section below |
+| ... | | | +35 optional params in the API Details section below |
 
 ```java
 import com.telnyx.sdk.models.calls.actions.ActionTransferParams;
@@ -150,7 +150,7 @@ import com.telnyx.sdk.models.calls.actions.ActionTransferResponse;
 
 ActionTransferParams params = ActionTransferParams.builder()
     .callControlId("v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ")
-    .to("+18005550100")
+    .to("+18005550100;secure=srtp")
     .build();
 ActionTransferResponse response = client.calls().actions().transfer(params);
 ```
@@ -237,7 +237,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
 | `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -415,7 +415,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -435,3 +435,427 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Voice (Java) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List call control applications, Create a call control application, Retrieve a call control application, Update a call control application, Delete a call control application
+
+| Field | Type |
+|-------|------|
+| `active` | boolean |
+| `anchorsite_override` | enum: Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, Chennai, IN, Amsterdam, Netherlands, Toronto, Canada, Sydney, Australia |
+| `application_name` | string |
+| `call_cost_in_webhooks` | boolean |
+| `created_at` | string |
+| `dtmf_type` | enum: RFC 2833, Inband, SIP INFO |
+| `first_command_timeout` | boolean |
+| `first_command_timeout_secs` | integer |
+| `id` | string |
+| `inbound` | object |
+| `outbound` | object |
+| `record_type` | enum: call_control_application |
+| `redact_dtmf_debug_logging` | boolean |
+| `tags` | array[string] |
+| `updated_at` | string |
+| `webhook_api_version` | enum: 1, 2 |
+| `webhook_event_failover_url` | url |
+| `webhook_event_url` | url |
+| `webhook_timeout_secs` | integer \| null |
+
+**Returned by:** Dial
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `recording_id` | uuid |
+| `start_time` | string |
+
+**Returned by:** Retrieve a call status
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `start_time` | string |
+
+**Returned by:** Answer call
+
+| Field | Type |
+|-------|------|
+| `recording_id` | uuid |
+| `result` | string |
+
+**Returned by:** Bridge calls, Hangup call, SIP Refer a call, Reject a call, Send SIP info, Transfer call
+
+| Field | Type |
+|-------|------|
+| `result` | string |
+
+**Returned by:** List all active calls for given connection
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `record_type` | enum: call |
+
+## Optional Parameters
+
+### Create a call control application — `client.callControlApplications().create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `active` | boolean | Specifies whether the connection can be used. |
+| `anchorsiteOverride` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmfType` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `firstCommandTimeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `firstCommandTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `inbound` | object |  |
+| `outbound` | object |  |
+| `webhookApiVersion` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhookEventFailoverUrl` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhookTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `callCostInWebhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `redactDtmfDebugLogging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Update a call control application — `client.callControlApplications().update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `callCostInWebhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `active` | boolean | Specifies whether the connection can be used. |
+| `anchorsiteOverride` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmfType` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `firstCommandTimeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `firstCommandTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `tags` | array[string] | Tags assigned to the Call Control Application. |
+| `inbound` | object |  |
+| `outbound` | object |  |
+| `webhookApiVersion` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhookEventFailoverUrl` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhookTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `redactDtmfDebugLogging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Dial — `client.calls().dial()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `audioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
+| `mediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
+| `preferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
+| `conferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
+| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `linkTo` | string | Use another call's control id for sharing the same call session id |
+| `bridgeIntent` | boolean | Indicates the intent to bridge this call with the call specified in link_to. |
+| `bridgeOnAnswer` | boolean | Whether to automatically bridge answered call to the call specified in link_to. |
+| `preventDoubleBridge` | boolean | Prevents bridging and hangs up the call if the target is already bridged. |
+| `parkAfterUnbridge` | string | If supplied with the value `self`, the current leg will be parked after unbri... |
+| `mediaEncryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the call. |
+| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
+| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
+| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE request. |
+| `sipTransportProtocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `streamUrl` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `streamTrack` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `streamCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `streamBidirectionalMode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `streamBidirectionalCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `streamBidirectionalTargetLegs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `streamBidirectionalSamplingRate` | enum (8000, 16000, 22050, 24000, 48000) | Audio sampling rate. |
+| `streamEstablishBeforeCallOriginate` | boolean | Establish websocket connection before dialing the destination. |
+| `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhookUrls` | object | A map of event types to webhook URLs. |
+| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `superviseCallControlId` | string (UUID) | The call leg which will be supervised by the new call. |
+| `supervisorRole` | enum (barge, whisper, monitor) | The role of the supervisor call. |
+| `enableDialogflow` | boolean | Enables Dialogflow for the current call. |
+| `dialogflowConfig` | object |  |
+| `transcription` | boolean | Enable transcription upon call answer. |
+| `transcriptionConfig` | object |  |
+| `sipRegion` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `streamAuthToken` | string | An authentication token to be sent as part of the WebSocket connection when u... |
+
+### Answer call — `client.calls().actions().answer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE response. |
+| `preferredCodecs` | enum (G722,PCMU,PCMA,G729,OPUS,VP8,H264) | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE response. |
+| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `streamUrl` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `streamTrack` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `streamCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `streamBidirectionalMode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `streamBidirectionalCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `streamBidirectionalTargetLegs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `transcription` | boolean | Enable transcription upon call answer. |
+| `transcriptionConfig` | object |  |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `webhookUrls` | object | A map of event types to webhook URLs. |
+| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
+
+### Bridge calls — `client.calls().actions().bridge()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `queue` | string | The name of the queue you want to bridge with, can't be used together with ca... |
+| `videoRoomId` | string (UUID) | The ID of the video room you want to bridge with, can't be used together with... |
+| `videoRoomContext` | string | The additional parameter that will be passed to the video conference. |
+| `preventDoubleBridge` | boolean | When set to `true`, it prevents bridging if the target call is already bridge... |
+| `parkAfterUnbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `playRingtone` | boolean | Specifies whether to play a ringtone if the call you want to bridge with has ... |
+| `ringtone` | enum (at, au, be, bg, br, ...) | Specifies which country ringtone to play when `play_ringtone` is set to `true`. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `muteDtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `holdAfterUnbridge` | boolean | Specifies behavior after the bridge ends. |
+
+### Hangup call — `client.calls().actions().hangup()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `customHeaders` | array[object] | Custom headers to be added to the SIP BYE message. |
+
+### SIP Refer a call — `client.calls().actions().refer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid execution of duplicate commands. |
+| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
+| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
+| `sipHeaders` | array[object] | SIP headers to be added to the request. |
+
+### Reject a call — `client.calls().actions().reject()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Send SIP info — `client.calls().actions().sendSipInfo()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Transfer call — `client.calls().actions().transfer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
+| `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `audioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
+| `earlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
+| `mediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
+| `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `parkAfterUnbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `targetLegClientState` | string | Use this field to add state to every subsequent webhook for the new leg. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `mediaEncryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the new call leg. |
+| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
+| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
+| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE. |
+| `sipTransportProtocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `muteDtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `sipRegion` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `preferredCodecs` | string | The list of comma-separated codecs in order of preference to be used during t... |
+| `webhookUrls` | object | A map of event types to webhook URLs. |
+| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+
+## Webhook Payload Fields
+
+### `callAnswered`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.answered | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: answered | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### `callBridged`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.bridged | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+
+### `callHangup`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.hangup | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: hangup | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+| `data.payload.hangup_cause` | enum: call_rejected, normal_clearing, originator_cancel, timeout, time_limit, user_busy, not_found, no_answer, unspecified | The reason the call was ended (`call_rejected`, `normal_clearing`, `originator_cancel`, `timeout`, `time_limit`, `use... |
+| `data.payload.hangup_source` | enum: caller, callee, unknown | The party who ended the call (`callee`, `caller`, `unknown`). |
+| `data.payload.sip_hangup_cause` | string | The reason the call was ended (SIP response code). |
+| `data.payload.call_quality_stats` | object \| null | Call quality statistics aggregated from the CHANNEL_HANGUP_COMPLETE event. |
+
+### `callInitiated`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.initiated | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
+| `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.custom_headers` | array[object] | Custom headers from sip invite |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.shaken_stir_attestation` | string | SHAKEN/STIR attestation level. |
+| `data.payload.shaken_stir_validated` | boolean | Whether attestation was successfully validated or not. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.caller_id_name` | string | Caller id. |
+| `data.payload.call_screening_result` | string | Call screening result. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.direction` | enum: incoming, outgoing | Whether the call is `incoming` or `outgoing`. |
+| `data.payload.state` | enum: parked, bridging | State received from a command. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### Field Type Notes
+
+- `from` in webhook payloads: string (E.164 phone number)
+- `to` in webhook payloads: string (E.164 phone number)
+- The return value of `client.webhooks.unwrap()` is a parsed event object — access fields via `event.data.event_type`, `event.data.payload.call_control_id`, etc.

--- a/skills/telnyx-twilio-migration/sdk-reference/javascript/10dlc.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/javascript/10dlc.md
@@ -68,8 +68,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -214,7 +214,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `description` | string | Description of the event. |
 | `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -375,7 +375,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -415,3 +415,471 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# 10DLC (JavaScript) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Brands, List Campaigns, List shared partner campaigns, List Shared Campaigns, List phone number campaigns
+
+| Field | Type |
+|-------|------|
+| `page` | integer |
+| `records` | array[object] |
+| `totalRecords` | integer |
+
+**Returned by:** Create Brand, Update Brand, Revet Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Get Brand Feedback By Id
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `category` | array[object] |
+
+**Returned by:** Get Brand SMS OTP Status, Get Brand SMS OTP Status by Brand ID
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `deliveryStatus` | string |
+| `deliveryStatusDate` | date-time |
+| `deliveryStatusDetails` | string |
+| `mobilePhone` | string |
+| `referenceId` | string |
+| `requestDate` | date-time |
+| `verifyDate` | date-time |
+
+**Returned by:** Get Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `assignedCampaignsCount` | number |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Order Brand External Vetting, Import External Vetting Record
+
+| Field | Type |
+|-------|------|
+| `createDate` | string |
+| `evpId` | string |
+| `vettedDate` | string |
+| `vettingClass` | string |
+| `vettingId` | string |
+| `vettingScore` | integer |
+| `vettingToken` | string |
+
+**Returned by:** Trigger Brand SMS OTP
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `referenceId` | string |
+
+**Returned by:** Get Campaign Cost
+
+| Field | Type |
+|-------|------|
+| `campaignUsecase` | string |
+| `description` | string |
+| `monthlyCost` | string |
+| `upFrontCost` | string |
+
+**Returned by:** Get campaign, Update campaign, Submit Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `autoRenewal` | boolean |
+| `billedDate` | string |
+| `brandDisplayName` | string |
+| `brandId` | string |
+| `campaignId` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createDate` | string |
+| `cspId` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isTMobileNumberPoolingEnabled` | boolean |
+| `isTMobileRegistered` | boolean |
+| `isTMobileSuspended` | boolean |
+| `messageFlow` | string |
+| `mock` | boolean |
+| `nextRenewalOrExpirationDate` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `referenceId` | string |
+| `resellerId` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `status` | string |
+| `subUsecases` | array[string] |
+| `submissionStatus` | enum: CREATED, FAILED, PENDING |
+| `subscriberHelp` | boolean |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `usecase` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Deactivate campaign
+
+| Field | Type |
+|-------|------|
+| `message` | string |
+| `record_type` | string |
+| `time` | number |
+
+**Returned by:** Submit campaign appeal for manual review
+
+| Field | Type |
+|-------|------|
+| `appealed_at` | date-time |
+
+**Returned by:** Get Campaign Mno Metadata
+
+| Field | Type |
+|-------|------|
+| `10999` | object |
+
+**Returned by:** Get Sharing Status
+
+| Field | Type |
+|-------|------|
+| `sharedByMe` | object |
+| `sharedWithMe` | object |
+
+**Returned by:** Qualify By Usecase
+
+| Field | Type |
+|-------|------|
+| `annualFee` | number |
+| `maxSubUsecases` | integer |
+| `minSubUsecases` | integer |
+| `mnoMetadata` | object |
+| `monthlyFee` | number |
+| `quarterlyFee` | number |
+| `usecase` | string |
+
+**Returned by:** Get Single Shared Campaign, Update Single Shared Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `assignedPhoneNumbersCount` | number |
+| `brandDisplayName` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createdAt` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isNumberPoolingEnabled` | boolean |
+| `messageFlow` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `subUsecases` | array[string] |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `updatedAt` | string |
+| `usecase` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Assign Messaging Profile To Campaign
+
+| Field | Type |
+|-------|------|
+| `campaignId` | string |
+| `messagingProfileId` | string |
+| `taskId` | string |
+| `tcrCampaignId` | string |
+
+**Returned by:** Get Assignment Task Status
+
+| Field | Type |
+|-------|------|
+| `createdAt` | date-time |
+| `status` | string |
+| `taskId` | string |
+| `updatedAt` | date-time |
+
+**Returned by:** Get Phone Number Status
+
+| Field | Type |
+|-------|------|
+| `records` | array[object] |
+
+**Returned by:** Create New Phone Number Campaign, Get Single Phone Number Campaign, Create New Phone Number Campaign, Delete Phone Number Campaign
+
+| Field | Type |
+|-------|------|
+| `assignmentStatus` | enum: FAILED_ASSIGNMENT, PENDING_ASSIGNMENT, ASSIGNED, PENDING_UNASSIGNMENT, FAILED_UNASSIGNMENT |
+| `brandId` | string |
+| `campaignId` | string |
+| `createdAt` | string |
+| `failureReasons` | string |
+| `phoneNumber` | string |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `telnyxCampaignId` | string |
+| `updatedAt` | string |
+
+## Optional Parameters
+
+### Create Brand — `client.messaging10dlc.brand.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `companyName` | string | (Required for Non-profit/private/public) Legal company name. |
+| `firstName` | string | First name of business contact. |
+| `lastName` | string | Last name of business contact. |
+| `ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `phone` | string | Valid phone number in e.164 international format. |
+| `street` | string | Street number and name. |
+| `city` | string | City name |
+| `state` | string | State. |
+| `postalCode` | string | Postal codes. |
+| `stockSymbol` | string | (Required for public company) stock symbol. |
+| `stockExchange` | object | (Required for public company) stock exchange. |
+| `ipAddress` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `website` | string | Brand website URL. |
+| `isReseller` | boolean |  |
+| `mock` | boolean | Mock brand for testing purposes. |
+| `mobilePhone` | string | Valid mobile phone number in e.164 international format. |
+| `businessContactEmail` | string | Business contact email. |
+| `webhookURL` | string | Webhook URL for brand status updates. |
+| `webhookFailoverURL` | string | Webhook failover URL for brand status updates. |
+
+### Update Brand — `client.messaging10dlc.brand.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `companyName` | string | (Required for Non-profit/private/public) Legal company name. |
+| `firstName` | string | First name of business contact. |
+| `lastName` | string | Last name of business contact. |
+| `ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `phone` | string | Valid phone number in e.164 international format. |
+| `street` | string | Street number and name. |
+| `city` | string | City name |
+| `state` | string | State. |
+| `postalCode` | string | Postal codes. |
+| `stockSymbol` | string | (Required for public company) stock symbol. |
+| `stockExchange` | object | (Required for public company) stock exchange. |
+| `ipAddress` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `website` | string | Brand website URL. |
+| `altBusinessIdType` | enum (NONE, DUNS, GIIN, LEI) | An enumeration. |
+| `isReseller` | boolean |  |
+| `identityStatus` | enum (VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED) | The verification status of an active brand |
+| `businessContactEmail` | string | Business contact email. |
+| `webhookURL` | string | Webhook URL for brand status updates. |
+| `webhookFailoverURL` | string | Webhook failover URL for brand status updates. |
+| `altBusinessId` | string (UUID) | Alternate business identifier such as DUNS, LEI, or GIIN |
+
+### Import External Vetting Record — `client.messaging10dlc.brand.externalVetting.imports()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `vettingToken` | string | Required by some providers for vetting record confirmation. |
+
+### Update campaign — `client.messaging10dlc.campaign.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `resellerId` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `sample1` | string | Message sample. |
+| `sample2` | string | Message sample. |
+| `sample3` | string | Message sample. |
+| `sample4` | string | Message sample. |
+| `sample5` | string | Message sample. |
+| `messageFlow` | string | Message flow description. |
+| `helpMessage` | string | Help message of the campaign. |
+| `autoRenewal` | boolean | Help message of the campaign. |
+| `webhookURL` | string | Webhook to which campaign status updates are sent. |
+| `webhookFailoverURL` | string | Webhook failover to which campaign status updates are sent. |
+
+### Submit Campaign — `client.messaging10dlc.campaignBuilder.submit()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ageGated` | boolean | Age gated message content in campaign. |
+| `autoRenewal` | boolean | Campaign subscription auto-renewal option. |
+| `directLending` | boolean | Direct lending or loan arrangement |
+| `embeddedLink` | boolean | Does message generated by the campaign include URL link in SMS? |
+| `embeddedPhone` | boolean | Does message generated by the campaign include phone number in SMS? |
+| `helpKeywords` | string | Subscriber help keywords. |
+| `helpMessage` | string | Help message of the campaign. |
+| `messageFlow` | string | Message flow description. |
+| `mnoIds` | array[integer] | Submit campaign to given list of MNOs by MNO's network ID. |
+| `numberPool` | boolean | Does campaign utilize pool of phone numbers? |
+| `optinKeywords` | string | Subscriber opt-in keywords. |
+| `optinMessage` | string | Subscriber opt-in message. |
+| `optoutKeywords` | string | Subscriber opt-out keywords. |
+| `optoutMessage` | string | Subscriber opt-out message. |
+| `referenceId` | string (UUID) | Caller supplied campaign reference ID. |
+| `resellerId` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `sample1` | string | Message sample. |
+| `sample2` | string | Message sample. |
+| `sample3` | string | Message sample. |
+| `sample4` | string | Message sample. |
+| `sample5` | string | Message sample. |
+| `subUsecases` | array[string] | Campaign sub-usecases. |
+| `subscriberHelp` | boolean | Does campaign responds to help keyword(s)? |
+| `subscriberOptin` | boolean | Does campaign require subscriber to opt-in before SMS is sent to subscriber? |
+| `subscriberOptout` | boolean | Does campaign support subscriber opt-out keyword(s)? |
+| `tag` | array[string] | Tags to be set on the Campaign. |
+| `termsAndConditions` | boolean | Is terms and conditions accepted? |
+| `privacyPolicyLink` | string | Link to the campaign's privacy policy. |
+| `termsAndConditionsLink` | string | Link to the campaign's terms and conditions. |
+| `embeddedLinkSample` | string | Sample of an embedded link that will be sent to subscribers. |
+| `webhookURL` | string | Webhook to which campaign status updates are sent. |
+| `webhookFailoverURL` | string | Failover webhook to which campaign status updates are sent. |
+
+### Update Single Shared Campaign — `client.messaging10dlc.partnerCampaigns.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `webhookURL` | string | Webhook to which campaign status updates are sent. |
+| `webhookFailoverURL` | string | Webhook failover to which campaign status updates are sent. |
+
+### Assign Messaging Profile To Campaign — `client.messaging10dlc.phoneNumberAssignmentByProfile.assign()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `tcrCampaignId` | string (UUID) | The TCR ID of the shared campaign you want to link to the specified messaging... |
+| `campaignId` | string (UUID) | The ID of the campaign you want to link to the specified messaging profile. |
+
+## Webhook Payload Fields
+
+### `campaignStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `brandId` | string | Brand ID associated with the campaign. |
+| `campaignId` | string | The ID of the campaign. |
+| `createDate` | string | Unix timestamp when campaign was created. |
+| `cspId` | string | Alphanumeric identifier of the CSP associated with this campaign. |
+| `isTMobileRegistered` | boolean | Indicates whether the campaign is registered with T-Mobile. |
+| `type` | enum: TELNYX_EVENT, REGISTRATION, MNO_REVIEW, TELNYX_REVIEW, NUMBER_POOL_PROVISIONED, NUMBER_POOL_DEPROVISIONED, TCR_EVENT, VERIFIED |  |
+| `description` | string | Description of the event. |
+| `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |

--- a/skills/telnyx-twilio-migration/sdk-reference/javascript/ai-assistants.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/javascript/ai-assistants.md
@@ -29,8 +29,8 @@ or authentication errors (401). Always handle errors in production code:
 try {
   const assistant = await client.ai.assistants.create({
     instructions: 'You are a helpful assistant.',
-    model: 'openai/gpt-4o',
     name: 'my-resource',
+      model: 'openai/gpt-4o',
   });
 } catch (err) {
   if (err instanceof Telnyx.APIConnectionError) {
@@ -61,7 +61,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -74,18 +74,17 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `description` | string | No |  |
-| `greeting` | string | No | Text that the assistant will use to start the conversation. |
-| ... | | | +11 optional params in the API Details section below |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in the API Details section below |
 
 ```javascript
 const assistant = await client.ai.assistants.create({
   instructions: 'You are a helpful assistant.',
-  model: 'openai/gpt-4o',
   name: 'my-resource',
+    model: 'openai/gpt-4o',
 });
 
 console.log(assistant.id);
@@ -196,7 +195,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### Update an assistant
 
@@ -207,10 +206,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistantId` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +15 optional params in the API Details section below |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in the API Details section below |
 
 ```javascript
 const assistant = await client.ai.assistants.update('550e8400-e29b-41d4-a716-446655440000');
@@ -224,7 +223,7 @@ Primary response fields:
 - `assistant.createdAt`
 - `assistant.description`
 - `assistant.dynamicVariables`
-- `assistant.dynamicVariablesWebhookUrl`
+- `assistant.dynamicVariablesWebhookTimeoutMs`
 
 ### List assistants
 
@@ -247,7 +246,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Import assistants from external provider
 
@@ -279,7 +278,7 @@ Primary item fields:
 - `createdAt`
 - `description`
 - `dynamicVariables`
-- `dynamicVariablesWebhookUrl`
+- `dynamicVariablesWebhookTimeoutMs`
 
 ### Get All Tags
 
@@ -383,7 +382,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -396,8 +395,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId`, `runId` |
 | Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Get Canary Deploy | `client.ai.assistants.canaryDeploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Create Canary Deploy | `client.ai.assistants.canaryDeploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistantId` |
-| Update Canary Deploy | `client.ai.assistants.canaryDeploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistantId` |
+| Create Canary Deploy | `client.ai.assistants.canaryDeploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId` |
+| Update Canary Deploy | `client.ai.assistants.canaryDeploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistantId` |
 | Delete Canary Deploy | `client.ai.assistants.canaryDeploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistantId` |
 | Assistant Sms Chat | `client.ai.assistants.sendSMS()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistantId` |
 | Clone Assistant | `client.ai.assistants.clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId` |
@@ -408,6 +407,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Add Assistant Tag | `client.ai.assistants.tags.add()` | `POST /ai/assistants/{assistant_id}/tags` | Create or provision an additional resource when the core tasks do not cover this flow. | `tag`, `assistantId` |
 | Remove Assistant Tag | `client.ai.assistants.tags.remove()` | `DELETE /ai/assistants/{assistant_id}/tags/{tag}` | Remove, detach, or clean up an existing resource. | `assistantId`, `tag` |
 | Get assistant texml | `client.ai.assistants.getTexml()` | `GET /ai/assistants/{assistant_id}/texml` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
+| Add Assistant Tool | `client.ai.assistants.tools.add()` | `PUT /ai/assistants/{assistant_id}/tools/{tool_id}` | Modify an existing resource without recreating it. | `assistantId`, `toolId` |
+| Remove Assistant Tool | `client.ai.assistants.tools.remove()` | `DELETE /ai/assistants/{assistant_id}/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `assistantId`, `toolId` |
 | Test Assistant Tool | `client.ai.assistants.tools.test()` | `POST /ai/assistants/{assistant_id}/tools/{tool_id}/test` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId`, `toolId` |
 | Get all versions of an assistant | `client.ai.assistants.versions.list()` | `GET /ai/assistants/{assistant_id}/versions` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
 | Get a specific assistant version | `client.ai.assistants.versions.retrieve()` | `GET /ai/assistants/{assistant_id}/versions/{version_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId`, `versionId` |
@@ -419,7 +420,398 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get MCP Server | `client.ai.mcpServers.retrieve()` | `GET /ai/mcp_servers/{mcp_server_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `mcpServerId` |
 | Update MCP Server | `client.ai.mcpServers.update()` | `PUT /ai/mcp_servers/{mcp_server_id}` | Modify an existing resource without recreating it. | `mcpServerId` |
 | Delete MCP Server | `client.ai.mcpServers.delete()` | `DELETE /ai/mcp_servers/{mcp_server_id}` | Remove, detach, or clean up an existing resource. | `mcpServerId` |
+| List Tools | `client.ai.tools.list()` | `GET /ai/tools` | Inspect available resources or choose an existing resource before mutating it. | None |
+| Create Tool | `client.ai.tools.create()` | `POST /ai/tools` | Create or provision an additional resource when the core tasks do not cover this flow. | `type`, `displayName` |
+| Get Tool | `client.ai.tools.retrieve()` | `GET /ai/tools/{tool_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `toolId` |
+| Update Tool | `client.ai.tools.update()` | `PATCH /ai/tools/{tool_id}` | Modify an existing resource without recreating it. | `toolId` |
+| Delete Tool | `client.ai.tools.delete()` | `DELETE /ai/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `toolId` |
 
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# AI Assistants (JavaScript) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+
+## Response Schemas
+
+**Returned by:** List assistants, Create an assistant, Import assistants from external provider, Get an assistant, Update an assistant, Clone Assistant, Get all versions of an assistant, Get a specific assistant version, Update a specific assistant version, Promote an assistant version to main
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
+| `dynamic_variables_webhook_url` | string |
+| `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
+| `greeting` | string |
+| `id` | string |
+| `import_metadata` | object |
+| `insight_settings` | object |
+| `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
+| `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
+| `messaging_settings` | object |
+| `model` | string |
+| `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
+| `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
+| `telephony_settings` | object |
+| `tools` | array[object] |
+| `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
+| `voice_settings` | object |
+| `widget_settings` | object |
+
+**Returned by:** Get All Tags, Add Assistant Tag, Remove Assistant Tag
+
+| Field | Type |
+|-------|------|
+| `tags` | array[string] |
+
+**Returned by:** List assistant tests with pagination, Create a new assistant test, Get assistant test by ID, Update an assistant test
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `destination` | string |
+| `instructions` | string |
+| `max_duration_seconds` | integer |
+| `name` | string |
+| `rubric` | array[object] |
+| `telnyx_conversation_channel` | object |
+| `test_id` | uuid |
+| `test_suite` | string |
+
+**Returned by:** Get all test suite names
+
+| Field | Type |
+|-------|------|
+| `data` | array[string] |
+
+**Returned by:** Get test suite run history, Get test run history for a specific test, Trigger a manual test run, Get specific test run details
+
+| Field | Type |
+|-------|------|
+| `completed_at` | date-time |
+| `conversation_id` | string |
+| `conversation_insights_id` | string |
+| `created_at` | date-time |
+| `detail_status` | array[object] |
+| `logs` | string |
+| `run_id` | uuid |
+| `status` | enum: pending, starting, running, passed, failed, error |
+| `test_id` | uuid |
+| `test_suite_run_id` | uuid |
+| `triggered_by` | string |
+| `updated_at` | date-time |
+
+**Returned by:** Delete an assistant
+
+| Field | Type |
+|-------|------|
+| `deleted` | boolean |
+| `id` | string |
+| `object` | string |
+
+**Returned by:** Get Canary Deploy, Create Canary Deploy, Update Canary Deploy
+
+| Field | Type |
+|-------|------|
+| `assistant_id` | string |
+| `created_at` | date-time |
+| `rules` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Assistant Chat (BETA)
+
+| Field | Type |
+|-------|------|
+| `content` | string |
+
+**Returned by:** Assistant Sms Chat
+
+| Field | Type |
+|-------|------|
+| `conversation_id` | string |
+
+**Returned by:** List scheduled events
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Test Assistant Tool
+
+| Field | Type |
+|-------|------|
+| `content_type` | string |
+| `request` | object |
+| `response` | string |
+| `status_code` | integer |
+| `success` | boolean |
+
+**Returned by:** Create MCP Server, Get MCP Server, Update MCP Server
+
+| Field | Type |
+|-------|------|
+| `allowed_tools` | array \| null |
+| `api_key_ref` | string \| null |
+| `created_at` | date-time |
+| `id` | string |
+| `name` | string |
+| `type` | string |
+| `url` | string |
+
+**Returned by:** List Tools, Create Tool, Get Tool, Update Tool
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `display_name` | string |
+| `id` | string |
+| `timeout_ms` | integer |
+| `tool_definition` | object |
+| `type` | string |
+
+## Optional Parameters
+
+### Create an assistant — `client.ai.assistants.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
+| `voiceSettings` | object |  |
+| `transcription` | object |  |
+| `telephonySettings` | object |  |
+| `messagingSettings` | object |  |
+| `enabledFeatures` | array[object] |  |
+| `insightSettings` | object |  |
+| `privacySettings` | object |  |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamicVariables` | object | Map of dynamic variables and their default values |
+| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
+
+### Import assistants from external provider — `client.ai.assistants.imports()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `importIds` | array[string] | Optional list of assistant IDs to import from the external provider. |
+
+### Create a new assistant test — `client.ai.assistants.tests.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `description` | string | Optional detailed description of what this test evaluates and its purpose. |
+| `telnyxConversationChannel` | object | The communication channel through which the test will be conducted. |
+| `maxDurationSeconds` | integer | Maximum duration in seconds that the test conversation should run before timi... |
+| `testSuite` | string | Optional test suite name to group related tests together. |
+
+### Trigger test suite execution — `client.ai.assistants.tests.testSuites.runs.trigger()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `destinationVersionId` | string (UUID) | Optional assistant version ID to use for all test runs in this suite. |
+
+### Update an assistant test — `client.ai.assistants.tests.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | Updated name for the assistant test. |
+| `description` | string | Updated description of the test's purpose and evaluation criteria. |
+| `telnyxConversationChannel` | enum (phone_call, web_call, sms_chat, web_chat) |  |
+| `destination` | string | Updated target destination for test conversations. |
+| `maxDurationSeconds` | integer | Updated maximum test duration in seconds. |
+| `testSuite` | string | Updated test suite assignment for better organization. |
+| `instructions` | string | Updated test scenario instructions and objectives. |
+| `rubric` | array[object] | Updated evaluation criteria for assessing assistant performance. |
+
+### Trigger a manual test run — `client.ai.assistants.tests.runs.trigger()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `destinationVersionId` | string (UUID) | Optional assistant version ID to use for this test run. |
+
+### Update an assistant — `client.ai.assistants.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `instructions` | string | System instructions for the assistant. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
+| `voiceSettings` | object |  |
+| `transcription` | object |  |
+| `telephonySettings` | object |  |
+| `messagingSettings` | object |  |
+| `enabledFeatures` | array[object] |  |
+| `insightSettings` | object |  |
+| `privacySettings` | object |  |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamicVariables` | object | Map of dynamic variables and their default values |
+| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
+| `promoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai.assistants.canaryDeploys.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai.assistants.canaryDeploys.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Assistant Chat (BETA) — `client.ai.assistants.chat()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | The optional display name of the user sending the message |
+
+### Assistant Sms Chat — `client.ai.assistants.sendSMS()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string |  |
+| `conversationMetadata` | object |  |
+| `shouldCreateConversation` | boolean |  |
+
+### Create a scheduled event — `client.ai.assistants.scheduledEvents.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Required for sms scheduled events. |
+| `conversationMetadata` | object | Metadata associated with the conversation. |
+| `dynamicVariables` | object | A map of dynamic variable names to values. |
+| `maxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retryIntervalSecs` | integer |  |
+
+### Test Assistant Tool — `client.ai.assistants.tools.test()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `arguments` | object | Key-value arguments to use for the webhook test |
+| `dynamicVariables` | object | Key-value dynamic variables to use for the webhook test |
+
+### Update a specific assistant version — `client.ai.assistants.versions.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `instructions` | string | System instructions for the assistant. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcpServers` | array[object] | MCP servers attached to the assistant. |
+| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
+| `externalLlm` | object |  |
+| `fallbackConfig` | object |  |
+| `voiceSettings` | object |  |
+| `transcription` | object |  |
+| `telephonySettings` | object |  |
+| `messagingSettings` | object |  |
+| `enabledFeatures` | array[object] |  |
+| `insightSettings` | object |  |
+| `privacySettings` | object |  |
+| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamicVariables` | object | Map of dynamic variables and their default values |
+| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
+| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observabilitySettings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `versionName` | string | Human-readable name for the assistant version. |
+| `postConversationSettings` | object | Configuration for post-conversation processing. |
+
+### Create MCP Server — `client.ai.mcpServers.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `apiKeyRef` | string |  |
+| `allowedTools` | array[string] |  |
+
+### Update MCP Server — `client.ai.mcpServers.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `name` | string |  |
+| `type` | string |  |
+| `url` | string (URL) |  |
+| `apiKeyRef` | string |  |
+| `allowedTools` | array[string] |  |
+| `createdAt` | string (date-time) |  |
+
+### Create Tool — `client.ai.tools.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `function` | object |  |
+| `retrieval` | object |  |
+| `handoff` | object |  |
+| `invite` | object |  |
+| `webhook` | object |  |
+| `timeoutMs` | integer |  |
+
+### Update Tool — `client.ai.tools.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type` | string |  |
+| `displayName` | string |  |
+| `function` | object |  |
+| `retrieval` | object |  |
+| `handoff` | object |  |
+| `invite` | object |  |
+| `webhook` | object |  |
+| `timeoutMs` | integer |  |

--- a/skills/telnyx-twilio-migration/sdk-reference/javascript/messaging.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/javascript/messaging.md
@@ -67,8 +67,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -195,7 +195,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.media` | array[object] |  |
 | `data.record_type` | enum: event | Identifies the type of the resource. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -379,6 +379,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsappMessage` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```javascript
 const response = await client.messages.sendWhatsapp({
@@ -403,7 +404,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -437,3 +438,425 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Messaging (JavaScript) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List alphanumeric sender IDs, Create an alphanumeric sender ID, Retrieve an alphanumeric sender ID, Delete an alphanumeric sender ID, List alphanumeric sender IDs for a messaging profile
+
+| Field | Type |
+|-------|------|
+| `alphanumeric_sender_id` | string |
+| `id` | uuid |
+| `messaging_profile_id` | uuid |
+| `organization_id` | string |
+| `record_type` | enum: alphanumeric_sender_id |
+| `us_long_code_fallback` | string |
+
+**Returned by:** Send a message, Send a message using an alphanumeric sender ID, Retrieve group MMS messages, Send a group MMS message, Send a long code message, Send a message using number pool, Schedule a message, Send a short code message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `wait_seconds` | float |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** Send a WhatsApp message
+
+| Field | Type |
+|-------|------|
+| `body` | object |
+| `direction` | string |
+| `encoding` | string |
+| `from` | object |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `organization_id` | string |
+| `received_at` | date-time |
+| `record_type` | string |
+| `to` | array[object] |
+| `type` | string |
+| `wait_seconds` | float |
+
+**Returned by:** Retrieve a message, Get detailed messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Cancel a scheduled message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** List messaging hosted numbers, Retrieve a messaging hosted number, Update a messaging hosted number
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `eligible_messaging_products` | array[string] |
+| `features` | object |
+| `health` | object |
+| `id` | string |
+| `messaging_product` | string |
+| `messaging_profile_id` | string \| null |
+| `organization_id` | string |
+| `phone_number` | string |
+| `record_type` | enum: messaging_phone_number, messaging_settings |
+| `tags` | array[string] |
+| `traffic_type` | string |
+| `type` | enum: long-code, toll-free, short-code, longcode, tollfree, shortcode |
+| `updated_at` | date-time |
+
+**Returned by:** List opt-outs
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `from` | string |
+| `keyword` | string \| null |
+| `messaging_profile_id` | string \| null |
+| `to` | string |
+
+**Returned by:** List high-level messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Regenerate messaging profile secret
+
+| Field | Type |
+|-------|------|
+| `ai_assistant_id` | string \| null |
+| `alpha_sender` | string \| null |
+| `created_at` | date-time |
+| `daily_spend_limit` | string |
+| `daily_spend_limit_enabled` | boolean |
+| `enabled` | boolean |
+| `health_webhook_url` | url |
+| `id` | uuid |
+| `mms_fall_back_to_sms` | boolean |
+| `mms_transcoding` | boolean |
+| `mobile_only` | boolean |
+| `name` | string |
+| `number_pool_settings` | object \| null |
+| `organization_id` | string |
+| `record_type` | enum: messaging_profile |
+| `redaction_enabled` | boolean |
+| `redaction_level` | integer |
+| `resource_group_id` | string \| null |
+| `smart_encoding` | boolean |
+| `updated_at` | date-time |
+| `url_shortener_settings` | object \| null |
+| `v1_secret` | string |
+| `webhook_api_version` | enum: 1, 2, 2010-04-01 |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+| `whitelisted_destinations` | array[string] |
+
+**Returned by:** List Auto-Response Settings, Create auto-response setting, Get Auto-Response Setting, Update Auto-Response Setting
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `id` | string |
+| `keywords` | array[string] |
+| `op` | enum: start, stop, info |
+| `resp_text` | string |
+| `updated_at` | date-time |
+
+## Optional Parameters
+
+### Create an alphanumeric sender ID — `client.alphanumericSenderIDs.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `usLongCodeFallback` | string | A US long code number to use as fallback when sending to US destinations. |
+
+### Send a message — `client.messages.send()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using an alphanumeric sender ID — `client.messages.sendWithAlphanumericSender()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `webhookUrl` | string (URL) | Callback URL for delivery status updates. |
+| `webhookFailoverUrl` | string (URL) | Failover callback URL for delivery status updates. |
+| `useProfileWebhooks` | boolean | If true, use the messaging profile's webhook settings. |
+
+### Send a group MMS message — `client.messages.sendGroupMms()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+
+### Send a long code message — `client.messages.sendLongCode()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using number pool — `client.messages.sendNumberPool()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Schedule a message — `client.messages.schedule()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+
+### Send a short code message — `client.messages.sendShortCode()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `mediaUrls` | array[string] | A list of media URLs. |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a WhatsApp message — `client.messages.sendWhatsapp()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
+| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
+
+### Update a messaging hosted number — `client.messagingHostedNumbers.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `messagingProfileId` | string (UUID) | Configure the messaging profile this phone number is assigned to:
+
+* Omit thi... |
+| `messagingProduct` | string | Configure the messaging product for this number:
+
+* Omit this field or set it... |
+| `tags` | array[string] | Tags to set on this phone number. |
+
+### Create auto-response setting — `client.messagingProfiles.autorespConfigs.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `respText` | string |  |
+
+### Update Auto-Response Setting — `client.messagingProfiles.autorespConfigs.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `respText` | string |  |
+
+## Webhook Payload Fields
+
+### `deliveryUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.sent, message.finalized | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: outbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | uuid | The id of the organization the messaging profile belongs to. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Subject of multimedia message |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | ISO 8601 formatted date indicating when the message was sent. |
+| `data.payload.completed_at` | date-time | ISO 8601 formatted date indicating when the message was finalized. |
+| `data.payload.valid_until` | date-time | Message must be out of the queue by this time or else it will be discarded and marked as 'sending_failed'. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+| `data.payload.smart_encoding_applied` | boolean | Indicates whether smart encoding was applied to this message. |
+| `data.payload.wait_seconds` | float | Seconds the message is queued due to rate limiting before being sent to the carrier. |
+| `meta.attempt` | integer | Number of attempts to deliver the webhook event. |
+| `meta.delivered_to` | url | The webhook URL the event was delivered to. |
+
+### `inboundMessage`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.received | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: inbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Message subject. |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | Not used for inbound messages. |
+| `data.payload.completed_at` | date-time | Not used for inbound messages. |
+| `data.payload.valid_until` | date-time | Not used for inbound messages. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+
+### `replacedLinkClick`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | string | Identifies the type of the resource. |
+| `data.url` | string | The original link that was sent in the message. |
+| `data.to` | string | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or short code). |
+| `data.message_id` | uuid | The message ID associated with the clicked link. |
+| `data.time_clicked` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+
+### Field Type Notes
+
+- `from` in responses/webhooks: object with sub-fields `phone_number` (string), `carrier` (string), `line_type` (string)
+- `to` in responses/webhooks: array of objects, each with `phone_number` (string), `carrier` (string), `line_type` (string), `status` (string)
+- `cost`: object with `amount` (string, decimal), `currency` (string, e.g., 'USD')

--- a/skills/telnyx-twilio-migration/sdk-reference/javascript/numbers.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/javascript/numbers.md
@@ -57,7 +57,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -368,7 +368,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -418,3 +418,433 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Numbers (JavaScript) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Advanced Orders, Create Advanced Order, Update Advanced Order, Get Advanced Order
+
+| Field | Type |
+|-------|------|
+| `area_code` | string |
+| `comments` | string |
+| `country_code` | string |
+| `customer_reference` | string |
+| `features` | array[object] |
+| `id` | uuid |
+| `orders` | array[string] |
+| `phone_number_type` | object |
+| `quantity` | integer |
+| `requirement_group_id` | uuid |
+| `status` | object |
+
+**Returned by:** List available phone number blocks
+
+| Field | Type |
+|-------|------|
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `range` | integer |
+| `record_type` | enum: available_phone_number_block |
+| `region_information` | array[object] |
+
+**Returned by:** List available phone numbers
+
+| Field | Type |
+|-------|------|
+| `best_effort` | boolean |
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `quickship` | boolean |
+| `record_type` | enum: available_phone_number |
+| `region_information` | array[object] |
+| `reservable` | boolean |
+| `vanity_format` | string |
+
+**Returned by:** Retrieve all comments
+
+| Field | Type |
+|-------|------|
+| `body` | string |
+| `comment_record_id` | uuid |
+| `comment_record_type` | enum: sub_number_order, requirement_group |
+| `commenter` | string |
+| `commenter_type` | enum: admin, user |
+| `created_at` | date-time |
+| `id` | uuid |
+| `read_at` | date-time |
+| `updated_at` | date-time |
+
+**Returned by:** Create a comment, Retrieve a comment, Mark a comment as read, Get country coverage
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Get coverage for a specific country
+
+| Field | Type |
+|-------|------|
+| `code` | string |
+| `features` | array[string] |
+| `international_sms` | boolean |
+| `inventory_coverage` | boolean |
+| `local` | object |
+| `mobile` | object |
+| `national` | object |
+| `numbers` | boolean |
+| `p2p` | boolean |
+| `phone_number_type` | array[string] |
+| `quickship` | boolean |
+| `region` | string \| null |
+| `reservable` | boolean |
+| `shared_cost` | object |
+| `toll_free` | object |
+
+**Returned by:** List customer service records, Create a customer service record, Get a customer service record
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `error_message` | string \| null |
+| `id` | uuid |
+| `phone_number` | string |
+| `record_type` | string |
+| `result` | object \| null |
+| `status` | enum: pending, completed, failed |
+| `updated_at` | date-time |
+| `webhook_url` | string |
+
+**Returned by:** Verify CSR phone number coverage
+
+| Field | Type |
+|-------|------|
+| `additional_data_required` | array[string] |
+| `has_csr_coverage` | boolean |
+| `phone_number` | string |
+| `reason` | string |
+| `record_type` | string |
+
+**Returned by:** List inexplicit number orders, Create an inexplicit number order, Retrieve an inexplicit number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `ordering_groups` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Create an inventory coverage request
+
+| Field | Type |
+|-------|------|
+| `administrative_area` | string |
+| `advance_requirements` | boolean |
+| `count` | integer |
+| `coverage_type` | enum: number, block |
+| `group` | string |
+| `group_type` | string |
+| `number_range` | integer |
+| `number_type` | enum: did, toll-free |
+| `phone_number_type` | enum: local, toll_free, national, landline, shared_cost, mobile |
+| `record_type` | string |
+
+**Returned by:** List mobile network operators
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `id` | uuid |
+| `mcc` | string |
+| `mnc` | string |
+| `name` | string |
+| `network_preferences_enabled` | boolean |
+| `record_type` | string |
+| `tadig` | string |
+
+**Returned by:** List network coverage locations
+
+| Field | Type |
+|-------|------|
+| `available_services` | array[object] |
+| `location` | object |
+| `record_type` | string |
+
+**Returned by:** List number block orders, Create a number block order, Retrieve a number block order
+
+| Field | Type |
+|-------|------|
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers_count` | integer |
+| `range` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `starting_number` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve a list of phone numbers associated to orders, Retrieve a single phone number within a number order., Update requirements for a single phone number within a number order.
+
+| Field | Type |
+|-------|------|
+| `bundle_id` | uuid |
+| `country_code` | string |
+| `deadline` | date-time |
+| `id` | uuid |
+| `is_block_number` | boolean |
+| `locality` | string |
+| `order_request_id` | uuid |
+| `phone_number` | string |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `requirements_status` | enum: pending, approved, cancelled, deleted, requirement-info-exception, requirement-info-pending, requirement-info-under-review |
+| `status` | enum: pending, success, failure |
+| `sub_number_order_id` | uuid |
+
+**Returned by:** List number orders, Create a number order, Retrieve a number order, Update a number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers` | array[object] |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `sub_number_orders_ids` | array[string] |
+| `updated_at` | date-time |
+
+**Returned by:** List number reservations, Create a number reservation, Retrieve a number reservation, Extend a number reservation
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `errors` | string |
+| `id` | uuid |
+| `phone_numbers` | array[object] |
+| `record_type` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve the features for a list of numbers
+
+| Field | Type |
+|-------|------|
+| `features` | array[string] |
+| `phone_number` | string |
+
+**Returned by:** Lists the phone number blocks jobs, Deletes all numbers associated with a phone number block, Retrieves a phone number blocks job
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `etc` | date-time |
+| `failed_operations` | array[object] |
+| `id` | uuid |
+| `record_type` | string |
+| `status` | enum: pending, in_progress, completed, failed |
+| `successful_operations` | array[object] |
+| `type` | enum: delete_phone_number_block |
+| `updated_at` | string |
+
+**Returned by:** List sub number orders, Retrieve a sub number order, Update a sub number order's requirements, Cancel a sub number order
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `is_block_sub_number_order` | boolean |
+| `order_request_id` | uuid |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+**Returned by:** Create a sub number orders report, Retrieve a sub number orders report
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `filters` | object |
+| `id` | uuid |
+| `order_type` | string |
+| `status` | enum: pending, success, failed, expired |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+## Optional Parameters
+
+### Create Advanced Order — `client.advancedOrders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `countryCode` | string (ISO 3166-1 alpha-2) |  |
+| `comments` | string |  |
+| `quantity` | integer |  |
+| `areaCode` | string |  |
+| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `features` | array[object] |  |
+| `customerReference` | string |  |
+| `requirementGroupId` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Update Advanced Order — `client.advancedOrders.updateRequirementGroup()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `countryCode` | string (ISO 3166-1 alpha-2) |  |
+| `comments` | string |  |
+| `quantity` | integer |  |
+| `areaCode` | string |  |
+| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `features` | array[object] |  |
+| `customerReference` | string |  |
+| `requirementGroupId` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Create a comment — `client.comments.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `body` | string |  |
+| `commenter` | string |  |
+| `commenterType` | enum (admin, user) |  |
+| `commentRecordType` | enum (sub_number_order, requirement_group) |  |
+| `commentRecordId` | string (UUID) |  |
+| `readAt` | string (date-time) | An ISO 8901 datetime string for when the comment was read. |
+| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the comment was created. |
+| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the comment was updated. |
+
+### Create an inexplicit number order — `client.inexplicitNumberOrders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `connectionId` | string (UUID) | Connection id to apply to phone numbers that are purchased |
+| `messagingProfileId` | string (UUID) | Messaging profile id to apply to phone numbers that are purchased |
+| `customerReference` | string | Reference label for the customer |
+| `billingGroupId` | string (UUID) | Billing group id to apply to phone numbers that are purchased |
+
+### Create a number block order — `client.numberBlockOrders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `recordType` | string |  |
+| `phoneNumbersCount` | integer | The count of phone numbers in the number order. |
+| `connectionId` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messagingProfileId` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `status` | enum (pending, success, failure) | The status of the order. |
+| `customerReference` | string | A customer reference string for customer look ups. |
+| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the number order was created. |
+| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the number order was updated. |
+| `requirementsMet` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `errors` | string | Errors the reservation could happen upon |
+
+### Update requirements for a single phone number within a number order. — `client.numberOrderPhoneNumbers.updateRequirements()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatoryRequirements` | array[object] |  |
+
+### Create a number order — `client.numberOrders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `phoneNumbers` | array[object] |  |
+| `connectionId` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messagingProfileId` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `billingGroupId` | string (UUID) | Identifies the billing group associated with the phone number. |
+| `customerReference` | string | A customer reference string for customer look ups. |
+
+### Update a number order — `client.numberOrders.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatoryRequirements` | array[object] |  |
+| `customerReference` | string | A customer reference string for customer look ups. |
+
+### Create a number reservation — `client.numberReservations.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `recordType` | string |  |
+| `phoneNumbers` | array[object] |  |
+| `status` | enum (pending, success, failure) | The status of the entire reservation. |
+| `customerReference` | string | A customer reference string for customer look ups. |
+| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the numbers reservation was created. |
+| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the number reservation was updated. |
+
+### Update a sub number order's requirements — `client.subNumberOrders.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatoryRequirements` | array[object] |  |
+
+### Create a sub number orders report — `client.subNumberOrdersReport.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `status` | enum (pending, success, failure) | Filter by order status |
+| `countryCode` | string (ISO 3166-1 alpha-2) | Filter by country code |
+| `createdAtGt` | string (date-time) | Filter for orders created after this date |
+| `createdAtLt` | string (date-time) | Filter for orders created before this date |
+| `orderRequestId` | string (UUID) | Filter by specific order request ID |
+| `customerReference` | string | Filter by customer reference |
+
+## Webhook Payload Fields
+
+### `numberOrderStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.event_type` | string | The type of event being sent |
+| `data.id` | uuid | Unique identifier for the event |
+| `data.occurred_at` | date-time | ISO 8601 timestamp of when the event occurred |
+| `data.payload.id` | uuid |  |
+| `data.payload.record_type` | string |  |
+| `data.payload.phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `data.payload.connection_id` | string | Identifies the connection associated with this phone number. |
+| `data.payload.messaging_profile_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.billing_group_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.phone_numbers` | array[object] |  |
+| `data.payload.sub_number_orders_ids` | array[string] |  |
+| `data.payload.status` | enum: pending, success, failure | The status of the order. |
+| `data.payload.customer_reference` | string | A customer reference string for customer look ups. |
+| `data.payload.created_at` | date-time | An ISO 8901 datetime string denoting when the number order was created. |
+| `data.payload.updated_at` | date-time | An ISO 8901 datetime string for when the number order was updated. |
+| `data.payload.requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `data.record_type` | string | Type of record |
+| `meta.attempt` | integer | Webhook delivery attempt number |
+| `meta.delivered_to` | uri | URL where the webhook was delivered |

--- a/skills/telnyx-twilio-migration/sdk-reference/javascript/voice.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/javascript/voice.md
@@ -30,7 +30,7 @@ try {
   const response = await client.calls.dial({
     connection_id: '7267xxxxxxxxxxxxxx',
     from: '+18005550101',
-    to: '+18005550100',
+    to: '+18005550100;secure=srtp',
   });
 } catch (err) {
   if (err instanceof Telnyx.APIConnectionError) {
@@ -67,8 +67,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -86,13 +86,13 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in the API Details section below |
+| ... | | | +56 optional params in the API Details section below |
 
 ```javascript
 const response = await client.calls.dial({
   connection_id: '7267xxxxxxxxxxxxxx',
   from: '+18005550101',
-  to: '+18005550100',
+  to: '+18005550100;secure=srtp',
 });
 
 console.log(response.data);
@@ -118,7 +118,7 @@ Primary inbound call-control command.
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in the API Details section below |
+| ... | | | +29 optional params in the API Details section below |
 
 ```javascript
 const response = await client.calls.actions.answer('v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ');
@@ -143,11 +143,11 @@ Common post-answer control path with downstream webhook implications.
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in the API Details section below |
+| ... | | | +35 optional params in the API Details section below |
 
 ```javascript
 const response = await client.calls.actions.transfer('call_control_id', {
-  to: '+18005550100',
+  to: '+18005550100;secure=srtp',
 });
 
 console.log(response.data);
@@ -223,7 +223,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
 | `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -393,7 +393,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -413,3 +413,427 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Voice (JavaScript) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List call control applications, Create a call control application, Retrieve a call control application, Update a call control application, Delete a call control application
+
+| Field | Type |
+|-------|------|
+| `active` | boolean |
+| `anchorsite_override` | enum: Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, Chennai, IN, Amsterdam, Netherlands, Toronto, Canada, Sydney, Australia |
+| `application_name` | string |
+| `call_cost_in_webhooks` | boolean |
+| `created_at` | string |
+| `dtmf_type` | enum: RFC 2833, Inband, SIP INFO |
+| `first_command_timeout` | boolean |
+| `first_command_timeout_secs` | integer |
+| `id` | string |
+| `inbound` | object |
+| `outbound` | object |
+| `record_type` | enum: call_control_application |
+| `redact_dtmf_debug_logging` | boolean |
+| `tags` | array[string] |
+| `updated_at` | string |
+| `webhook_api_version` | enum: 1, 2 |
+| `webhook_event_failover_url` | url |
+| `webhook_event_url` | url |
+| `webhook_timeout_secs` | integer \| null |
+
+**Returned by:** Dial
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `recording_id` | uuid |
+| `start_time` | string |
+
+**Returned by:** Retrieve a call status
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `start_time` | string |
+
+**Returned by:** Answer call
+
+| Field | Type |
+|-------|------|
+| `recording_id` | uuid |
+| `result` | string |
+
+**Returned by:** Bridge calls, Hangup call, SIP Refer a call, Reject a call, Send SIP info, Transfer call
+
+| Field | Type |
+|-------|------|
+| `result` | string |
+
+**Returned by:** List all active calls for given connection
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `record_type` | enum: call |
+
+## Optional Parameters
+
+### Create a call control application — `client.callControlApplications.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `active` | boolean | Specifies whether the connection can be used. |
+| `anchorsiteOverride` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmfType` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `firstCommandTimeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `firstCommandTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `inbound` | object |  |
+| `outbound` | object |  |
+| `webhookApiVersion` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhookEventFailoverUrl` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhookTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `callCostInWebhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `redactDtmfDebugLogging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Update a call control application — `client.callControlApplications.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `callCostInWebhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `active` | boolean | Specifies whether the connection can be used. |
+| `anchorsiteOverride` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmfType` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `firstCommandTimeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `firstCommandTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `tags` | array[string] | Tags assigned to the Call Control Application. |
+| `inbound` | object |  |
+| `outbound` | object |  |
+| `webhookApiVersion` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhookEventFailoverUrl` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhookTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `redactDtmfDebugLogging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Dial — `client.calls.dial()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `audioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
+| `mediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
+| `preferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
+| `conferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
+| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `linkTo` | string | Use another call's control id for sharing the same call session id |
+| `bridgeIntent` | boolean | Indicates the intent to bridge this call with the call specified in link_to. |
+| `bridgeOnAnswer` | boolean | Whether to automatically bridge answered call to the call specified in link_to. |
+| `preventDoubleBridge` | boolean | Prevents bridging and hangs up the call if the target is already bridged. |
+| `parkAfterUnbridge` | string | If supplied with the value `self`, the current leg will be parked after unbri... |
+| `mediaEncryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the call. |
+| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
+| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
+| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE request. |
+| `sipTransportProtocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `streamUrl` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `streamTrack` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `streamCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `streamBidirectionalMode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `streamBidirectionalCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `streamBidirectionalTargetLegs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `streamBidirectionalSamplingRate` | enum (8000, 16000, 22050, 24000, 48000) | Audio sampling rate. |
+| `streamEstablishBeforeCallOriginate` | boolean | Establish websocket connection before dialing the destination. |
+| `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhookUrls` | object | A map of event types to webhook URLs. |
+| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `superviseCallControlId` | string (UUID) | The call leg which will be supervised by the new call. |
+| `supervisorRole` | enum (barge, whisper, monitor) | The role of the supervisor call. |
+| `enableDialogflow` | boolean | Enables Dialogflow for the current call. |
+| `dialogflowConfig` | object |  |
+| `transcription` | boolean | Enable transcription upon call answer. |
+| `transcriptionConfig` | object |  |
+| `sipRegion` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `streamAuthToken` | string | An authentication token to be sent as part of the WebSocket connection when u... |
+
+### Answer call — `client.calls.actions.answer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE response. |
+| `preferredCodecs` | enum (G722,PCMU,PCMA,G729,OPUS,VP8,H264) | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE response. |
+| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `streamUrl` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `streamTrack` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `streamCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `streamBidirectionalMode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `streamBidirectionalCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `streamBidirectionalTargetLegs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `transcription` | boolean | Enable transcription upon call answer. |
+| `transcriptionConfig` | object |  |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `webhookUrls` | object | A map of event types to webhook URLs. |
+| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
+
+### Bridge calls — `client.calls.actions.bridge()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `queue` | string | The name of the queue you want to bridge with, can't be used together with ca... |
+| `videoRoomId` | string (UUID) | The ID of the video room you want to bridge with, can't be used together with... |
+| `videoRoomContext` | string | The additional parameter that will be passed to the video conference. |
+| `preventDoubleBridge` | boolean | When set to `true`, it prevents bridging if the target call is already bridge... |
+| `parkAfterUnbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `playRingtone` | boolean | Specifies whether to play a ringtone if the call you want to bridge with has ... |
+| `ringtone` | enum (at, au, be, bg, br, ...) | Specifies which country ringtone to play when `play_ringtone` is set to `true`. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `muteDtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `holdAfterUnbridge` | boolean | Specifies behavior after the bridge ends. |
+
+### Hangup call — `client.calls.actions.hangup()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `customHeaders` | array[object] | Custom headers to be added to the SIP BYE message. |
+
+### SIP Refer a call — `client.calls.actions.refer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid execution of duplicate commands. |
+| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
+| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
+| `sipHeaders` | array[object] | SIP headers to be added to the request. |
+
+### Reject a call — `client.calls.actions.reject()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Send SIP info — `client.calls.actions.sendSipInfo()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Transfer call — `client.calls.actions.transfer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
+| `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `audioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
+| `earlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
+| `mediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
+| `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `parkAfterUnbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `clientState` | string | Use this field to add state to every subsequent webhook. |
+| `targetLegClientState` | string | Use this field to add state to every subsequent webhook for the new leg. |
+| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `mediaEncryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the new call leg. |
+| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
+| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
+| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE. |
+| `sipTransportProtocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `muteDtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `sipRegion` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `preferredCodecs` | string | The list of comma-separated codecs in order of preference to be used during t... |
+| `webhookUrls` | object | A map of event types to webhook URLs. |
+| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+
+## Webhook Payload Fields
+
+### `callAnswered`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.answered | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: answered | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### `callBridged`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.bridged | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+
+### `callHangup`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.hangup | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: hangup | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+| `data.payload.hangup_cause` | enum: call_rejected, normal_clearing, originator_cancel, timeout, time_limit, user_busy, not_found, no_answer, unspecified | The reason the call was ended (`call_rejected`, `normal_clearing`, `originator_cancel`, `timeout`, `time_limit`, `use... |
+| `data.payload.hangup_source` | enum: caller, callee, unknown | The party who ended the call (`callee`, `caller`, `unknown`). |
+| `data.payload.sip_hangup_cause` | string | The reason the call was ended (SIP response code). |
+| `data.payload.call_quality_stats` | object \| null | Call quality statistics aggregated from the CHANNEL_HANGUP_COMPLETE event. |
+
+### `callInitiated`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.initiated | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
+| `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.custom_headers` | array[object] | Custom headers from sip invite |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.shaken_stir_attestation` | string | SHAKEN/STIR attestation level. |
+| `data.payload.shaken_stir_validated` | boolean | Whether attestation was successfully validated or not. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.caller_id_name` | string | Caller id. |
+| `data.payload.call_screening_result` | string | Call screening result. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.direction` | enum: incoming, outgoing | Whether the call is `incoming` or `outgoing`. |
+| `data.payload.state` | enum: parked, bridging | State received from a command. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### Field Type Notes
+
+- `from` in webhook payloads: string (E.164 phone number)
+- `to` in webhook payloads: string (E.164 phone number)
+- The return value of `client.webhooks.unwrap()` is a parsed event object — access fields via `event.data.event_type`, `event.data.payload.call_control_id`, etc.

--- a/skills/telnyx-twilio-migration/sdk-reference/python/10dlc.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/python/10dlc.md
@@ -67,8 +67,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -209,7 +209,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `description` | string | Description of the event. |
 | `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -371,7 +371,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -411,3 +411,471 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# 10DLC (Python) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Brands, List Campaigns, List shared partner campaigns, List Shared Campaigns, List phone number campaigns
+
+| Field | Type |
+|-------|------|
+| `page` | integer |
+| `records` | array[object] |
+| `totalRecords` | integer |
+
+**Returned by:** Create Brand, Update Brand, Revet Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Get Brand Feedback By Id
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `category` | array[object] |
+
+**Returned by:** Get Brand SMS OTP Status, Get Brand SMS OTP Status by Brand ID
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `deliveryStatus` | string |
+| `deliveryStatusDate` | date-time |
+| `deliveryStatusDetails` | string |
+| `mobilePhone` | string |
+| `referenceId` | string |
+| `requestDate` | date-time |
+| `verifyDate` | date-time |
+
+**Returned by:** Get Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `assignedCampaignsCount` | number |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Order Brand External Vetting, Import External Vetting Record
+
+| Field | Type |
+|-------|------|
+| `createDate` | string |
+| `evpId` | string |
+| `vettedDate` | string |
+| `vettingClass` | string |
+| `vettingId` | string |
+| `vettingScore` | integer |
+| `vettingToken` | string |
+
+**Returned by:** Trigger Brand SMS OTP
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `referenceId` | string |
+
+**Returned by:** Get Campaign Cost
+
+| Field | Type |
+|-------|------|
+| `campaignUsecase` | string |
+| `description` | string |
+| `monthlyCost` | string |
+| `upFrontCost` | string |
+
+**Returned by:** Get campaign, Update campaign, Submit Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `autoRenewal` | boolean |
+| `billedDate` | string |
+| `brandDisplayName` | string |
+| `brandId` | string |
+| `campaignId` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createDate` | string |
+| `cspId` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isTMobileNumberPoolingEnabled` | boolean |
+| `isTMobileRegistered` | boolean |
+| `isTMobileSuspended` | boolean |
+| `messageFlow` | string |
+| `mock` | boolean |
+| `nextRenewalOrExpirationDate` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `referenceId` | string |
+| `resellerId` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `status` | string |
+| `subUsecases` | array[string] |
+| `submissionStatus` | enum: CREATED, FAILED, PENDING |
+| `subscriberHelp` | boolean |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `usecase` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Deactivate campaign
+
+| Field | Type |
+|-------|------|
+| `message` | string |
+| `record_type` | string |
+| `time` | number |
+
+**Returned by:** Submit campaign appeal for manual review
+
+| Field | Type |
+|-------|------|
+| `appealed_at` | date-time |
+
+**Returned by:** Get Campaign Mno Metadata
+
+| Field | Type |
+|-------|------|
+| `10999` | object |
+
+**Returned by:** Get Sharing Status
+
+| Field | Type |
+|-------|------|
+| `sharedByMe` | object |
+| `sharedWithMe` | object |
+
+**Returned by:** Qualify By Usecase
+
+| Field | Type |
+|-------|------|
+| `annualFee` | number |
+| `maxSubUsecases` | integer |
+| `minSubUsecases` | integer |
+| `mnoMetadata` | object |
+| `monthlyFee` | number |
+| `quarterlyFee` | number |
+| `usecase` | string |
+
+**Returned by:** Get Single Shared Campaign, Update Single Shared Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `assignedPhoneNumbersCount` | number |
+| `brandDisplayName` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createdAt` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isNumberPoolingEnabled` | boolean |
+| `messageFlow` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `subUsecases` | array[string] |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `updatedAt` | string |
+| `usecase` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Assign Messaging Profile To Campaign
+
+| Field | Type |
+|-------|------|
+| `campaignId` | string |
+| `messagingProfileId` | string |
+| `taskId` | string |
+| `tcrCampaignId` | string |
+
+**Returned by:** Get Assignment Task Status
+
+| Field | Type |
+|-------|------|
+| `createdAt` | date-time |
+| `status` | string |
+| `taskId` | string |
+| `updatedAt` | date-time |
+
+**Returned by:** Get Phone Number Status
+
+| Field | Type |
+|-------|------|
+| `records` | array[object] |
+
+**Returned by:** Create New Phone Number Campaign, Get Single Phone Number Campaign, Create New Phone Number Campaign, Delete Phone Number Campaign
+
+| Field | Type |
+|-------|------|
+| `assignmentStatus` | enum: FAILED_ASSIGNMENT, PENDING_ASSIGNMENT, ASSIGNED, PENDING_UNASSIGNMENT, FAILED_UNASSIGNMENT |
+| `brandId` | string |
+| `campaignId` | string |
+| `createdAt` | string |
+| `failureReasons` | string |
+| `phoneNumber` | string |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `telnyxCampaignId` | string |
+| `updatedAt` | string |
+
+## Optional Parameters
+
+### Create Brand — `client.messaging_10dlc.brand.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `company_name` | string | (Required for Non-profit/private/public) Legal company name. |
+| `first_name` | string | First name of business contact. |
+| `last_name` | string | Last name of business contact. |
+| `ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `phone` | string | Valid phone number in e.164 international format. |
+| `street` | string | Street number and name. |
+| `city` | string | City name |
+| `state` | string | State. |
+| `postal_code` | string | Postal codes. |
+| `stock_symbol` | string | (Required for public company) stock symbol. |
+| `stock_exchange` | object | (Required for public company) stock exchange. |
+| `ip_address` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `website` | string | Brand website URL. |
+| `is_reseller` | boolean |  |
+| `mock` | boolean | Mock brand for testing purposes. |
+| `mobile_phone` | string | Valid mobile phone number in e.164 international format. |
+| `business_contact_email` | string | Business contact email. |
+| `webhook_url` | string | Webhook URL for brand status updates. |
+| `webhook_failover_url` | string | Webhook failover URL for brand status updates. |
+
+### Update Brand — `client.messaging_10dlc.brand.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `company_name` | string | (Required for Non-profit/private/public) Legal company name. |
+| `first_name` | string | First name of business contact. |
+| `last_name` | string | Last name of business contact. |
+| `ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `phone` | string | Valid phone number in e.164 international format. |
+| `street` | string | Street number and name. |
+| `city` | string | City name |
+| `state` | string | State. |
+| `postal_code` | string | Postal codes. |
+| `stock_symbol` | string | (Required for public company) stock symbol. |
+| `stock_exchange` | object | (Required for public company) stock exchange. |
+| `ip_address` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `website` | string | Brand website URL. |
+| `alt_business_id_type` | enum (NONE, DUNS, GIIN, LEI) | An enumeration. |
+| `is_reseller` | boolean |  |
+| `identity_status` | enum (VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED) | The verification status of an active brand |
+| `business_contact_email` | string | Business contact email. |
+| `webhook_url` | string | Webhook URL for brand status updates. |
+| `webhook_failover_url` | string | Webhook failover URL for brand status updates. |
+| `alt_business_id` | string (UUID) | Alternate business identifier such as DUNS, LEI, or GIIN |
+
+### Import External Vetting Record — `client.messaging_10dlc.brand.external_vetting.imports()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `vetting_token` | string | Required by some providers for vetting record confirmation. |
+
+### Update campaign — `client.messaging_10dlc.campaign.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `reseller_id` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `sample1` | string | Message sample. |
+| `sample2` | string | Message sample. |
+| `sample3` | string | Message sample. |
+| `sample4` | string | Message sample. |
+| `sample5` | string | Message sample. |
+| `message_flow` | string | Message flow description. |
+| `help_message` | string | Help message of the campaign. |
+| `auto_renewal` | boolean | Help message of the campaign. |
+| `webhook_url` | string | Webhook to which campaign status updates are sent. |
+| `webhook_failover_url` | string | Webhook failover to which campaign status updates are sent. |
+
+### Submit Campaign — `client.messaging_10dlc.campaign_builder.submit()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `age_gated` | boolean | Age gated message content in campaign. |
+| `auto_renewal` | boolean | Campaign subscription auto-renewal option. |
+| `direct_lending` | boolean | Direct lending or loan arrangement |
+| `embedded_link` | boolean | Does message generated by the campaign include URL link in SMS? |
+| `embedded_phone` | boolean | Does message generated by the campaign include phone number in SMS? |
+| `help_keywords` | string | Subscriber help keywords. |
+| `help_message` | string | Help message of the campaign. |
+| `message_flow` | string | Message flow description. |
+| `mno_ids` | array[integer] | Submit campaign to given list of MNOs by MNO's network ID. |
+| `number_pool` | boolean | Does campaign utilize pool of phone numbers? |
+| `optin_keywords` | string | Subscriber opt-in keywords. |
+| `optin_message` | string | Subscriber opt-in message. |
+| `optout_keywords` | string | Subscriber opt-out keywords. |
+| `optout_message` | string | Subscriber opt-out message. |
+| `reference_id` | string (UUID) | Caller supplied campaign reference ID. |
+| `reseller_id` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `sample1` | string | Message sample. |
+| `sample2` | string | Message sample. |
+| `sample3` | string | Message sample. |
+| `sample4` | string | Message sample. |
+| `sample5` | string | Message sample. |
+| `sub_usecases` | array[string] | Campaign sub-usecases. |
+| `subscriber_help` | boolean | Does campaign responds to help keyword(s)? |
+| `subscriber_optin` | boolean | Does campaign require subscriber to opt-in before SMS is sent to subscriber? |
+| `subscriber_optout` | boolean | Does campaign support subscriber opt-out keyword(s)? |
+| `tag` | array[string] | Tags to be set on the Campaign. |
+| `terms_and_conditions` | boolean | Is terms and conditions accepted? |
+| `privacy_policy_link` | string | Link to the campaign's privacy policy. |
+| `terms_and_conditions_link` | string | Link to the campaign's terms and conditions. |
+| `embedded_link_sample` | string | Sample of an embedded link that will be sent to subscribers. |
+| `webhook_url` | string | Webhook to which campaign status updates are sent. |
+| `webhook_failover_url` | string | Failover webhook to which campaign status updates are sent. |
+
+### Update Single Shared Campaign — `client.messaging_10dlc.partner_campaigns.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `webhook_url` | string | Webhook to which campaign status updates are sent. |
+| `webhook_failover_url` | string | Webhook failover to which campaign status updates are sent. |
+
+### Assign Messaging Profile To Campaign — `client.messaging_10dlc.phone_number_assignment_by_profile.assign()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `tcr_campaign_id` | string (UUID) | The TCR ID of the shared campaign you want to link to the specified messaging... |
+| `campaign_id` | string (UUID) | The ID of the campaign you want to link to the specified messaging profile. |
+
+## Webhook Payload Fields
+
+### `campaignStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `brandId` | string | Brand ID associated with the campaign. |
+| `campaignId` | string | The ID of the campaign. |
+| `createDate` | string | Unix timestamp when campaign was created. |
+| `cspId` | string | Alphanumeric identifier of the CSP associated with this campaign. |
+| `isTMobileRegistered` | boolean | Indicates whether the campaign is registered with T-Mobile. |
+| `type` | enum: TELNYX_EVENT, REGISTRATION, MNO_REVIEW, TELNYX_REVIEW, NUMBER_POOL_PROVISIONED, NUMBER_POOL_DEPROVISIONED, TCR_EVENT, VERIFIED |  |
+| `description` | string | Description of the event. |
+| `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |

--- a/skills/telnyx-twilio-migration/sdk-reference/python/ai-assistants.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/python/ai-assistants.md
@@ -32,8 +32,8 @@ import telnyx
 try:
     assistant = client.ai.assistants.create(
         instructions="You are a helpful assistant.",
-        model="openai/gpt-4o",
         name="my-resource",
+        model="openai/gpt-4o",
     )
 except telnyx.APIConnectionError:
     print("Network error — check connectivity and retry")
@@ -61,7 +61,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -74,18 +74,17 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `description` | string | No |  |
-| `greeting` | string | No | Text that the assistant will use to start the conversation. |
-| ... | | | +11 optional params in the API Details section below |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in the API Details section below |
 
 ```python
 assistant = client.ai.assistants.create(
     instructions="You are a helpful assistant.",
-    model="openai/gpt-4o",
     name="my-resource",
+    model="openai/gpt-4o",
 )
 print(assistant.id)
 ```
@@ -197,7 +196,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### Update an assistant
 
@@ -208,10 +207,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistant_id` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +15 optional params in the API Details section below |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in the API Details section below |
 
 ```python
 assistant = client.ai.assistants.update(
@@ -226,7 +225,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### List assistants
 
@@ -248,7 +247,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Import assistants from external provider
 
@@ -279,7 +278,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Get All Tags
 
@@ -381,7 +380,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -394,8 +393,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
 | Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Get Canary Deploy | `client.ai.assistants.canary_deploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
-| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistant_id` |
-| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistant_id` |
+| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
 | Delete Canary Deploy | `client.ai.assistants.canary_deploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Assistant Sms Chat | `client.ai.assistants.send_sms()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from_`, `to`, `assistant_id` |
 | Clone Assistant | `client.ai.assistants.clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |
@@ -406,6 +405,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Add Assistant Tag | `client.ai.assistants.tags.add()` | `POST /ai/assistants/{assistant_id}/tags` | Create or provision an additional resource when the core tasks do not cover this flow. | `tag`, `assistant_id` |
 | Remove Assistant Tag | `client.ai.assistants.tags.remove()` | `DELETE /ai/assistants/{assistant_id}/tags/{tag}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `tag` |
 | Get assistant texml | `client.ai.assistants.get_texml()` | `GET /ai/assistants/{assistant_id}/texml` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Add Assistant Tool | `client.ai.assistants.tools.add()` | `PUT /ai/assistants/{assistant_id}/tools/{tool_id}` | Modify an existing resource without recreating it. | `assistant_id`, `tool_id` |
+| Remove Assistant Tool | `client.ai.assistants.tools.remove()` | `DELETE /ai/assistants/{assistant_id}/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `tool_id` |
 | Test Assistant Tool | `client.ai.assistants.tools.test()` | `POST /ai/assistants/{assistant_id}/tools/{tool_id}/test` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id`, `tool_id` |
 | Get all versions of an assistant | `client.ai.assistants.versions.list()` | `GET /ai/assistants/{assistant_id}/versions` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
 | Get a specific assistant version | `client.ai.assistants.versions.retrieve()` | `GET /ai/assistants/{assistant_id}/versions/{version_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id`, `version_id` |
@@ -417,7 +418,398 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get MCP Server | `client.ai.mcp_servers.retrieve()` | `GET /ai/mcp_servers/{mcp_server_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `mcp_server_id` |
 | Update MCP Server | `client.ai.mcp_servers.update()` | `PUT /ai/mcp_servers/{mcp_server_id}` | Modify an existing resource without recreating it. | `mcp_server_id` |
 | Delete MCP Server | `client.ai.mcp_servers.delete()` | `DELETE /ai/mcp_servers/{mcp_server_id}` | Remove, detach, or clean up an existing resource. | `mcp_server_id` |
+| List Tools | `client.ai.tools.list()` | `GET /ai/tools` | Inspect available resources or choose an existing resource before mutating it. | None |
+| Create Tool | `client.ai.tools.create()` | `POST /ai/tools` | Create or provision an additional resource when the core tasks do not cover this flow. | `type_`, `display_name` |
+| Get Tool | `client.ai.tools.retrieve()` | `GET /ai/tools/{tool_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `tool_id` |
+| Update Tool | `client.ai.tools.update()` | `PATCH /ai/tools/{tool_id}` | Modify an existing resource without recreating it. | `tool_id` |
+| Delete Tool | `client.ai.tools.delete()` | `DELETE /ai/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `tool_id` |
 
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# AI Assistants (Python) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+
+## Response Schemas
+
+**Returned by:** List assistants, Create an assistant, Import assistants from external provider, Get an assistant, Update an assistant, Clone Assistant, Get all versions of an assistant, Get a specific assistant version, Update a specific assistant version, Promote an assistant version to main
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
+| `dynamic_variables_webhook_url` | string |
+| `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
+| `greeting` | string |
+| `id` | string |
+| `import_metadata` | object |
+| `insight_settings` | object |
+| `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
+| `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
+| `messaging_settings` | object |
+| `model` | string |
+| `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
+| `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
+| `telephony_settings` | object |
+| `tools` | array[object] |
+| `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
+| `voice_settings` | object |
+| `widget_settings` | object |
+
+**Returned by:** Get All Tags, Add Assistant Tag, Remove Assistant Tag
+
+| Field | Type |
+|-------|------|
+| `tags` | array[string] |
+
+**Returned by:** List assistant tests with pagination, Create a new assistant test, Get assistant test by ID, Update an assistant test
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `destination` | string |
+| `instructions` | string |
+| `max_duration_seconds` | integer |
+| `name` | string |
+| `rubric` | array[object] |
+| `telnyx_conversation_channel` | object |
+| `test_id` | uuid |
+| `test_suite` | string |
+
+**Returned by:** Get all test suite names
+
+| Field | Type |
+|-------|------|
+| `data` | array[string] |
+
+**Returned by:** Get test suite run history, Get test run history for a specific test, Trigger a manual test run, Get specific test run details
+
+| Field | Type |
+|-------|------|
+| `completed_at` | date-time |
+| `conversation_id` | string |
+| `conversation_insights_id` | string |
+| `created_at` | date-time |
+| `detail_status` | array[object] |
+| `logs` | string |
+| `run_id` | uuid |
+| `status` | enum: pending, starting, running, passed, failed, error |
+| `test_id` | uuid |
+| `test_suite_run_id` | uuid |
+| `triggered_by` | string |
+| `updated_at` | date-time |
+
+**Returned by:** Delete an assistant
+
+| Field | Type |
+|-------|------|
+| `deleted` | boolean |
+| `id` | string |
+| `object` | string |
+
+**Returned by:** Get Canary Deploy, Create Canary Deploy, Update Canary Deploy
+
+| Field | Type |
+|-------|------|
+| `assistant_id` | string |
+| `created_at` | date-time |
+| `rules` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Assistant Chat (BETA)
+
+| Field | Type |
+|-------|------|
+| `content` | string |
+
+**Returned by:** Assistant Sms Chat
+
+| Field | Type |
+|-------|------|
+| `conversation_id` | string |
+
+**Returned by:** List scheduled events
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Test Assistant Tool
+
+| Field | Type |
+|-------|------|
+| `content_type` | string |
+| `request` | object |
+| `response` | string |
+| `status_code` | integer |
+| `success` | boolean |
+
+**Returned by:** Create MCP Server, Get MCP Server, Update MCP Server
+
+| Field | Type |
+|-------|------|
+| `allowed_tools` | array \| null |
+| `api_key_ref` | string \| null |
+| `created_at` | date-time |
+| `id` | string |
+| `name` | string |
+| `type` | string |
+| `url` | string |
+
+**Returned by:** List Tools, Create Tool, Get Tool, Update Tool
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `display_name` | string |
+| `id` | string |
+| `timeout_ms` | integer |
+| `tool_definition` | object |
+| `type` | string |
+
+## Optional Parameters
+
+### Create an assistant — `client.ai.assistants.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
+| `transcription` | object |  |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+
+### Import assistants from external provider — `client.ai.assistants.imports()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `import_ids` | array[string] | Optional list of assistant IDs to import from the external provider. |
+
+### Create a new assistant test — `client.ai.assistants.tests.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `description` | string | Optional detailed description of what this test evaluates and its purpose. |
+| `telnyx_conversation_channel` | object | The communication channel through which the test will be conducted. |
+| `max_duration_seconds` | integer | Maximum duration in seconds that the test conversation should run before timi... |
+| `test_suite` | string | Optional test suite name to group related tests together. |
+
+### Trigger test suite execution — `client.ai.assistants.tests.test_suites.runs.trigger()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `destination_version_id` | string (UUID) | Optional assistant version ID to use for all test runs in this suite. |
+
+### Update an assistant test — `client.ai.assistants.tests.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | Updated name for the assistant test. |
+| `description` | string | Updated description of the test's purpose and evaluation criteria. |
+| `telnyx_conversation_channel` | enum (phone_call, web_call, sms_chat, web_chat) |  |
+| `destination` | string | Updated target destination for test conversations. |
+| `max_duration_seconds` | integer | Updated maximum test duration in seconds. |
+| `test_suite` | string | Updated test suite assignment for better organization. |
+| `instructions` | string | Updated test scenario instructions and objectives. |
+| `rubric` | array[object] | Updated evaluation criteria for assessing assistant performance. |
+
+### Trigger a manual test run — `client.ai.assistants.tests.runs.trigger()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `destination_version_id` | string (UUID) | Optional assistant version ID to use for this test run. |
+
+### Update an assistant — `client.ai.assistants.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `instructions` | string | System instructions for the assistant. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
+| `transcription` | object |  |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+| `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai.assistants.canary_deploys.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai.assistants.canary_deploys.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Assistant Chat (BETA) — `client.ai.assistants.chat()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | The optional display name of the user sending the message |
+
+### Assistant Sms Chat — `client.ai.assistants.send_sms()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string |  |
+| `conversation_metadata` | object |  |
+| `should_create_conversation` | boolean |  |
+
+### Create a scheduled event — `client.ai.assistants.scheduled_events.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Required for sms scheduled events. |
+| `conversation_metadata` | object | Metadata associated with the conversation. |
+| `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
+
+### Test Assistant Tool — `client.ai.assistants.tools.test()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `arguments` | object | Key-value arguments to use for the webhook test |
+| `dynamic_variables` | object | Key-value dynamic variables to use for the webhook test |
+
+### Update a specific assistant version — `client.ai.assistants.versions.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `instructions` | string | System instructions for the assistant. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
+| `transcription` | object |  |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+
+### Create MCP Server — `client.ai.mcp_servers.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `api_key_ref` | string |  |
+| `allowed_tools` | array[string] |  |
+
+### Update MCP Server — `client.ai.mcp_servers.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `name` | string |  |
+| `type_` | string |  |
+| `url` | string (URL) |  |
+| `api_key_ref` | string |  |
+| `allowed_tools` | array[string] |  |
+| `created_at` | string (date-time) |  |
+
+### Create Tool — `client.ai.tools.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `function` | object |  |
+| `retrieval` | object |  |
+| `handoff` | object |  |
+| `invite` | object |  |
+| `webhook` | object |  |
+| `timeout_ms` | integer |  |
+
+### Update Tool — `client.ai.tools.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type_` | string |  |
+| `display_name` | string |  |
+| `function` | object |  |
+| `retrieval` | object |  |
+| `handoff` | object |  |
+| `invite` | object |  |
+| `webhook` | object |  |
+| `timeout_ms` | integer |  |

--- a/skills/telnyx-twilio-migration/sdk-reference/python/messaging.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/python/messaging.md
@@ -66,8 +66,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -191,7 +191,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.media` | array[object] |  |
 | `data.record_type` | enum: event | Identifies the type of the resource. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -372,6 +372,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsapp_message` | object | Yes |  |
 | `type_` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```python
 response = client.messages.send_whatsapp(
@@ -395,7 +396,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -429,3 +430,425 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Messaging (Python) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List alphanumeric sender IDs, Create an alphanumeric sender ID, Retrieve an alphanumeric sender ID, Delete an alphanumeric sender ID, List alphanumeric sender IDs for a messaging profile
+
+| Field | Type |
+|-------|------|
+| `alphanumeric_sender_id` | string |
+| `id` | uuid |
+| `messaging_profile_id` | uuid |
+| `organization_id` | string |
+| `record_type` | enum: alphanumeric_sender_id |
+| `us_long_code_fallback` | string |
+
+**Returned by:** Send a message, Send a message using an alphanumeric sender ID, Retrieve group MMS messages, Send a group MMS message, Send a long code message, Send a message using number pool, Schedule a message, Send a short code message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `wait_seconds` | float |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** Send a WhatsApp message
+
+| Field | Type |
+|-------|------|
+| `body` | object |
+| `direction` | string |
+| `encoding` | string |
+| `from` | object |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `organization_id` | string |
+| `received_at` | date-time |
+| `record_type` | string |
+| `to` | array[object] |
+| `type` | string |
+| `wait_seconds` | float |
+
+**Returned by:** Retrieve a message, Get detailed messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Cancel a scheduled message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** List messaging hosted numbers, Retrieve a messaging hosted number, Update a messaging hosted number
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `eligible_messaging_products` | array[string] |
+| `features` | object |
+| `health` | object |
+| `id` | string |
+| `messaging_product` | string |
+| `messaging_profile_id` | string \| null |
+| `organization_id` | string |
+| `phone_number` | string |
+| `record_type` | enum: messaging_phone_number, messaging_settings |
+| `tags` | array[string] |
+| `traffic_type` | string |
+| `type` | enum: long-code, toll-free, short-code, longcode, tollfree, shortcode |
+| `updated_at` | date-time |
+
+**Returned by:** List opt-outs
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `from` | string |
+| `keyword` | string \| null |
+| `messaging_profile_id` | string \| null |
+| `to` | string |
+
+**Returned by:** List high-level messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Regenerate messaging profile secret
+
+| Field | Type |
+|-------|------|
+| `ai_assistant_id` | string \| null |
+| `alpha_sender` | string \| null |
+| `created_at` | date-time |
+| `daily_spend_limit` | string |
+| `daily_spend_limit_enabled` | boolean |
+| `enabled` | boolean |
+| `health_webhook_url` | url |
+| `id` | uuid |
+| `mms_fall_back_to_sms` | boolean |
+| `mms_transcoding` | boolean |
+| `mobile_only` | boolean |
+| `name` | string |
+| `number_pool_settings` | object \| null |
+| `organization_id` | string |
+| `record_type` | enum: messaging_profile |
+| `redaction_enabled` | boolean |
+| `redaction_level` | integer |
+| `resource_group_id` | string \| null |
+| `smart_encoding` | boolean |
+| `updated_at` | date-time |
+| `url_shortener_settings` | object \| null |
+| `v1_secret` | string |
+| `webhook_api_version` | enum: 1, 2, 2010-04-01 |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+| `whitelisted_destinations` | array[string] |
+
+**Returned by:** List Auto-Response Settings, Create auto-response setting, Get Auto-Response Setting, Update Auto-Response Setting
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `id` | string |
+| `keywords` | array[string] |
+| `op` | enum: start, stop, info |
+| `resp_text` | string |
+| `updated_at` | date-time |
+
+## Optional Parameters
+
+### Create an alphanumeric sender ID — `client.alphanumeric_sender_ids.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `us_long_code_fallback` | string | A US long code number to use as fallback when sending to US destinations. |
+
+### Send a message — `client.messages.send()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from_` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type_` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using an alphanumeric sender ID — `client.messages.send_with_alphanumeric_sender()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `webhook_url` | string (URL) | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | If true, use the messaging profile's webhook settings. |
+
+### Send a group MMS message — `client.messages.send_group_mms()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+
+### Send a long code message — `client.messages.send_long_code()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type_` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using number pool — `client.messages.send_number_pool()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type_` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Schedule a message — `client.messages.schedule()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from_` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type_` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+
+### Send a short code message — `client.messages.send_short_code()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type_` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a WhatsApp message — `client.messages.send_whatsapp()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type_` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
+
+### Update a messaging hosted number — `client.messaging_hosted_numbers.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `messaging_profile_id` | string (UUID) | Configure the messaging profile this phone number is assigned to:
+
+* Omit thi... |
+| `messaging_product` | string | Configure the messaging product for this number:
+
+* Omit this field or set it... |
+| `tags` | array[string] | Tags to set on this phone number. |
+
+### Create auto-response setting — `client.messaging_profiles.autoresp_configs.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `resp_text` | string |  |
+
+### Update Auto-Response Setting — `client.messaging_profiles.autoresp_configs.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `resp_text` | string |  |
+
+## Webhook Payload Fields
+
+### `deliveryUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.sent, message.finalized | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: outbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | uuid | The id of the organization the messaging profile belongs to. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Subject of multimedia message |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | ISO 8601 formatted date indicating when the message was sent. |
+| `data.payload.completed_at` | date-time | ISO 8601 formatted date indicating when the message was finalized. |
+| `data.payload.valid_until` | date-time | Message must be out of the queue by this time or else it will be discarded and marked as 'sending_failed'. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+| `data.payload.smart_encoding_applied` | boolean | Indicates whether smart encoding was applied to this message. |
+| `data.payload.wait_seconds` | float | Seconds the message is queued due to rate limiting before being sent to the carrier. |
+| `meta.attempt` | integer | Number of attempts to deliver the webhook event. |
+| `meta.delivered_to` | url | The webhook URL the event was delivered to. |
+
+### `inboundMessage`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.received | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: inbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Message subject. |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | Not used for inbound messages. |
+| `data.payload.completed_at` | date-time | Not used for inbound messages. |
+| `data.payload.valid_until` | date-time | Not used for inbound messages. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+
+### `replacedLinkClick`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | string | Identifies the type of the resource. |
+| `data.url` | string | The original link that was sent in the message. |
+| `data.to` | string | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or short code). |
+| `data.message_id` | uuid | The message ID associated with the clicked link. |
+| `data.time_clicked` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+
+### Field Type Notes
+
+- `from` in responses/webhooks: object with sub-fields `phone_number` (string), `carrier` (string), `line_type` (string)
+- `to` in responses/webhooks: array of objects, each with `phone_number` (string), `carrier` (string), `line_type` (string), `status` (string)
+- `cost`: object with `amount` (string, decimal), `currency` (string, e.g., 'USD')

--- a/skills/telnyx-twilio-migration/sdk-reference/python/numbers.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/python/numbers.md
@@ -56,7 +56,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -362,7 +362,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -412,3 +412,433 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Numbers (Python) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Advanced Orders, Create Advanced Order, Update Advanced Order, Get Advanced Order
+
+| Field | Type |
+|-------|------|
+| `area_code` | string |
+| `comments` | string |
+| `country_code` | string |
+| `customer_reference` | string |
+| `features` | array[object] |
+| `id` | uuid |
+| `orders` | array[string] |
+| `phone_number_type` | object |
+| `quantity` | integer |
+| `requirement_group_id` | uuid |
+| `status` | object |
+
+**Returned by:** List available phone number blocks
+
+| Field | Type |
+|-------|------|
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `range` | integer |
+| `record_type` | enum: available_phone_number_block |
+| `region_information` | array[object] |
+
+**Returned by:** List available phone numbers
+
+| Field | Type |
+|-------|------|
+| `best_effort` | boolean |
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `quickship` | boolean |
+| `record_type` | enum: available_phone_number |
+| `region_information` | array[object] |
+| `reservable` | boolean |
+| `vanity_format` | string |
+
+**Returned by:** Retrieve all comments
+
+| Field | Type |
+|-------|------|
+| `body` | string |
+| `comment_record_id` | uuid |
+| `comment_record_type` | enum: sub_number_order, requirement_group |
+| `commenter` | string |
+| `commenter_type` | enum: admin, user |
+| `created_at` | date-time |
+| `id` | uuid |
+| `read_at` | date-time |
+| `updated_at` | date-time |
+
+**Returned by:** Create a comment, Retrieve a comment, Mark a comment as read, Get country coverage
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Get coverage for a specific country
+
+| Field | Type |
+|-------|------|
+| `code` | string |
+| `features` | array[string] |
+| `international_sms` | boolean |
+| `inventory_coverage` | boolean |
+| `local` | object |
+| `mobile` | object |
+| `national` | object |
+| `numbers` | boolean |
+| `p2p` | boolean |
+| `phone_number_type` | array[string] |
+| `quickship` | boolean |
+| `region` | string \| null |
+| `reservable` | boolean |
+| `shared_cost` | object |
+| `toll_free` | object |
+
+**Returned by:** List customer service records, Create a customer service record, Get a customer service record
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `error_message` | string \| null |
+| `id` | uuid |
+| `phone_number` | string |
+| `record_type` | string |
+| `result` | object \| null |
+| `status` | enum: pending, completed, failed |
+| `updated_at` | date-time |
+| `webhook_url` | string |
+
+**Returned by:** Verify CSR phone number coverage
+
+| Field | Type |
+|-------|------|
+| `additional_data_required` | array[string] |
+| `has_csr_coverage` | boolean |
+| `phone_number` | string |
+| `reason` | string |
+| `record_type` | string |
+
+**Returned by:** List inexplicit number orders, Create an inexplicit number order, Retrieve an inexplicit number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `ordering_groups` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Create an inventory coverage request
+
+| Field | Type |
+|-------|------|
+| `administrative_area` | string |
+| `advance_requirements` | boolean |
+| `count` | integer |
+| `coverage_type` | enum: number, block |
+| `group` | string |
+| `group_type` | string |
+| `number_range` | integer |
+| `number_type` | enum: did, toll-free |
+| `phone_number_type` | enum: local, toll_free, national, landline, shared_cost, mobile |
+| `record_type` | string |
+
+**Returned by:** List mobile network operators
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `id` | uuid |
+| `mcc` | string |
+| `mnc` | string |
+| `name` | string |
+| `network_preferences_enabled` | boolean |
+| `record_type` | string |
+| `tadig` | string |
+
+**Returned by:** List network coverage locations
+
+| Field | Type |
+|-------|------|
+| `available_services` | array[object] |
+| `location` | object |
+| `record_type` | string |
+
+**Returned by:** List number block orders, Create a number block order, Retrieve a number block order
+
+| Field | Type |
+|-------|------|
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers_count` | integer |
+| `range` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `starting_number` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve a list of phone numbers associated to orders, Retrieve a single phone number within a number order., Update requirements for a single phone number within a number order.
+
+| Field | Type |
+|-------|------|
+| `bundle_id` | uuid |
+| `country_code` | string |
+| `deadline` | date-time |
+| `id` | uuid |
+| `is_block_number` | boolean |
+| `locality` | string |
+| `order_request_id` | uuid |
+| `phone_number` | string |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `requirements_status` | enum: pending, approved, cancelled, deleted, requirement-info-exception, requirement-info-pending, requirement-info-under-review |
+| `status` | enum: pending, success, failure |
+| `sub_number_order_id` | uuid |
+
+**Returned by:** List number orders, Create a number order, Retrieve a number order, Update a number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers` | array[object] |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `sub_number_orders_ids` | array[string] |
+| `updated_at` | date-time |
+
+**Returned by:** List number reservations, Create a number reservation, Retrieve a number reservation, Extend a number reservation
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `errors` | string |
+| `id` | uuid |
+| `phone_numbers` | array[object] |
+| `record_type` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve the features for a list of numbers
+
+| Field | Type |
+|-------|------|
+| `features` | array[string] |
+| `phone_number` | string |
+
+**Returned by:** Lists the phone number blocks jobs, Deletes all numbers associated with a phone number block, Retrieves a phone number blocks job
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `etc` | date-time |
+| `failed_operations` | array[object] |
+| `id` | uuid |
+| `record_type` | string |
+| `status` | enum: pending, in_progress, completed, failed |
+| `successful_operations` | array[object] |
+| `type` | enum: delete_phone_number_block |
+| `updated_at` | string |
+
+**Returned by:** List sub number orders, Retrieve a sub number order, Update a sub number order's requirements, Cancel a sub number order
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `is_block_sub_number_order` | boolean |
+| `order_request_id` | uuid |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+**Returned by:** Create a sub number orders report, Retrieve a sub number orders report
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `filters` | object |
+| `id` | uuid |
+| `order_type` | string |
+| `status` | enum: pending, success, failed, expired |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+## Optional Parameters
+
+### Create Advanced Order — `client.advanced_orders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `country_code` | string (ISO 3166-1 alpha-2) |  |
+| `comments` | string |  |
+| `quantity` | integer |  |
+| `area_code` | string |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `features` | array[object] |  |
+| `customer_reference` | string |  |
+| `requirement_group_id` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Update Advanced Order — `client.advanced_orders.update_requirement_group()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `country_code` | string (ISO 3166-1 alpha-2) |  |
+| `comments` | string |  |
+| `quantity` | integer |  |
+| `area_code` | string |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `features` | array[object] |  |
+| `customer_reference` | string |  |
+| `requirement_group_id` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Create a comment — `client.comments.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `body` | string |  |
+| `commenter` | string |  |
+| `commenter_type` | enum (admin, user) |  |
+| `comment_record_type` | enum (sub_number_order, requirement_group) |  |
+| `comment_record_id` | string (UUID) |  |
+| `read_at` | string (date-time) | An ISO 8901 datetime string for when the comment was read. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the comment was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the comment was updated. |
+
+### Create an inexplicit number order — `client.inexplicit_number_orders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `connection_id` | string (UUID) | Connection id to apply to phone numbers that are purchased |
+| `messaging_profile_id` | string (UUID) | Messaging profile id to apply to phone numbers that are purchased |
+| `customer_reference` | string | Reference label for the customer |
+| `billing_group_id` | string (UUID) | Billing group id to apply to phone numbers that are purchased |
+
+### Create a number block order — `client.number_block_orders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `record_type` | string |  |
+| `phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `connection_id` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `status` | enum (pending, success, failure) | The status of the order. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the number order was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the number order was updated. |
+| `requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `errors` | string | Errors the reservation could happen upon |
+
+### Update requirements for a single phone number within a number order. — `client.number_order_phone_numbers.update_requirements()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatory_requirements` | array[object] |  |
+
+### Create a number order — `client.number_orders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `phone_numbers` | array[object] |  |
+| `connection_id` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `billing_group_id` | string (UUID) | Identifies the billing group associated with the phone number. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+
+### Update a number order — `client.number_orders.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatory_requirements` | array[object] |  |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+
+### Create a number reservation — `client.number_reservations.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `record_type` | string |  |
+| `phone_numbers` | array[object] |  |
+| `status` | enum (pending, success, failure) | The status of the entire reservation. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the numbers reservation was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the number reservation was updated. |
+
+### Update a sub number order's requirements — `client.sub_number_orders.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatory_requirements` | array[object] |  |
+
+### Create a sub number orders report — `client.sub_number_orders_report.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `status` | enum (pending, success, failure) | Filter by order status |
+| `country_code` | string (ISO 3166-1 alpha-2) | Filter by country code |
+| `created_at_gt` | string (date-time) | Filter for orders created after this date |
+| `created_at_lt` | string (date-time) | Filter for orders created before this date |
+| `order_request_id` | string (UUID) | Filter by specific order request ID |
+| `customer_reference` | string | Filter by customer reference |
+
+## Webhook Payload Fields
+
+### `numberOrderStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.event_type` | string | The type of event being sent |
+| `data.id` | uuid | Unique identifier for the event |
+| `data.occurred_at` | date-time | ISO 8601 timestamp of when the event occurred |
+| `data.payload.id` | uuid |  |
+| `data.payload.record_type` | string |  |
+| `data.payload.phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `data.payload.connection_id` | string | Identifies the connection associated with this phone number. |
+| `data.payload.messaging_profile_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.billing_group_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.phone_numbers` | array[object] |  |
+| `data.payload.sub_number_orders_ids` | array[string] |  |
+| `data.payload.status` | enum: pending, success, failure | The status of the order. |
+| `data.payload.customer_reference` | string | A customer reference string for customer look ups. |
+| `data.payload.created_at` | date-time | An ISO 8901 datetime string denoting when the number order was created. |
+| `data.payload.updated_at` | date-time | An ISO 8901 datetime string for when the number order was updated. |
+| `data.payload.requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `data.record_type` | string | Type of record |
+| `meta.attempt` | integer | Webhook delivery attempt number |
+| `meta.delivered_to` | uri | URL where the webhook was delivered |

--- a/skills/telnyx-twilio-migration/sdk-reference/python/voice.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/python/voice.md
@@ -33,7 +33,7 @@ try:
     response = client.calls.dial(
         connection_id="7267xxxxxxxxxxxxxx",
         from_="+18005550101",
-        to="+18005550100",
+        to="+18005550100;secure=srtp",
     )
 except telnyx.APIConnectionError:
     print("Network error — check connectivity and retry")
@@ -66,8 +66,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -85,13 +85,13 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in the API Details section below |
+| ... | | | +56 optional params in the API Details section below |
 
 ```python
 response = client.calls.dial(
     connection_id="7267xxxxxxxxxxxxxx",
     from_="+18005550101",
-    to="+18005550100",
+    to="+18005550100;secure=srtp",
 )
 print(response.data)
 ```
@@ -116,7 +116,7 @@ Primary inbound call-control command.
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in the API Details section below |
+| ... | | | +29 optional params in the API Details section below |
 
 ```python
 response = client.calls.actions.answer(
@@ -142,12 +142,12 @@ Common post-answer control path with downstream webhook implications.
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in the API Details section below |
+| ... | | | +35 optional params in the API Details section below |
 
 ```python
 response = client.calls.actions.transfer(
     call_control_id="550e8400-e29b-41d4-a716-446655440000",
-    to="+18005550100",
+    to="+18005550100;secure=srtp",
 )
 print(response.data)
 ```
@@ -221,7 +221,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
 | `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -393,7 +393,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -413,3 +413,427 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Voice (Python) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List call control applications, Create a call control application, Retrieve a call control application, Update a call control application, Delete a call control application
+
+| Field | Type |
+|-------|------|
+| `active` | boolean |
+| `anchorsite_override` | enum: Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, Chennai, IN, Amsterdam, Netherlands, Toronto, Canada, Sydney, Australia |
+| `application_name` | string |
+| `call_cost_in_webhooks` | boolean |
+| `created_at` | string |
+| `dtmf_type` | enum: RFC 2833, Inband, SIP INFO |
+| `first_command_timeout` | boolean |
+| `first_command_timeout_secs` | integer |
+| `id` | string |
+| `inbound` | object |
+| `outbound` | object |
+| `record_type` | enum: call_control_application |
+| `redact_dtmf_debug_logging` | boolean |
+| `tags` | array[string] |
+| `updated_at` | string |
+| `webhook_api_version` | enum: 1, 2 |
+| `webhook_event_failover_url` | url |
+| `webhook_event_url` | url |
+| `webhook_timeout_secs` | integer \| null |
+
+**Returned by:** Dial
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `recording_id` | uuid |
+| `start_time` | string |
+
+**Returned by:** Retrieve a call status
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `start_time` | string |
+
+**Returned by:** Answer call
+
+| Field | Type |
+|-------|------|
+| `recording_id` | uuid |
+| `result` | string |
+
+**Returned by:** Bridge calls, Hangup call, SIP Refer a call, Reject a call, Send SIP info, Transfer call
+
+| Field | Type |
+|-------|------|
+| `result` | string |
+
+**Returned by:** List all active calls for given connection
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `record_type` | enum: call |
+
+## Optional Parameters
+
+### Create a call control application — `client.call_control_applications.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `active` | boolean | Specifies whether the connection can be used. |
+| `anchorsite_override` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmf_type` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `first_command_timeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `first_command_timeout_secs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `inbound` | object |  |
+| `outbound` | object |  |
+| `webhook_api_version` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhook_event_failover_url` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhook_timeout_secs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `call_cost_in_webhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `redact_dtmf_debug_logging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Update a call control application — `client.call_control_applications.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `call_cost_in_webhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `active` | boolean | Specifies whether the connection can be used. |
+| `anchorsite_override` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmf_type` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `first_command_timeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `first_command_timeout_secs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `tags` | array[string] | Tags assigned to the Call Control Application. |
+| `inbound` | object |  |
+| `outbound` | object |  |
+| `webhook_api_version` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhook_event_failover_url` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhook_timeout_secs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `redact_dtmf_debug_logging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Dial — `client.calls.dial()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
+| `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
+| `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
+| `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `link_to` | string | Use another call's control id for sharing the same call session id |
+| `bridge_intent` | boolean | Indicates the intent to bridge this call with the call specified in link_to. |
+| `bridge_on_answer` | boolean | Whether to automatically bridge answered call to the call specified in link_to. |
+| `prevent_double_bridge` | boolean | Prevents bridging and hangs up the call if the target is already bridged. |
+| `park_after_unbridge` | string | If supplied with the value `self`, the current leg will be parked after unbri... |
+| `media_encryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the call. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE request. |
+| `sip_transport_protocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `stream_url` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `stream_track` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `stream_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `stream_bidirectional_mode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `stream_bidirectional_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `stream_bidirectional_target_legs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `stream_bidirectional_sampling_rate` | enum (8000, 16000, 22050, 24000, 48000) | Audio sampling rate. |
+| `stream_establish_before_call_originate` | boolean | Establish websocket connection before dialing the destination. |
+| `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `supervise_call_control_id` | string (UUID) | The call leg which will be supervised by the new call. |
+| `supervisor_role` | enum (barge, whisper, monitor) | The role of the supervisor call. |
+| `enable_dialogflow` | boolean | Enables Dialogflow for the current call. |
+| `dialogflow_config` | object |  |
+| `transcription` | boolean | Enable transcription upon call answer. |
+| `transcription_config` | object |  |
+| `sip_region` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `stream_auth_token` | string | An authentication token to be sent as part of the WebSocket connection when u... |
+
+### Answer call — `client.calls.actions.answer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE response. |
+| `preferred_codecs` | enum (G722,PCMU,PCMA,G729,OPUS,VP8,H264) | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE response. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `stream_url` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `stream_track` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `stream_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `stream_bidirectional_mode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `stream_bidirectional_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `stream_bidirectional_target_legs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `transcription` | boolean | Enable transcription upon call answer. |
+| `transcription_config` | object |  |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
+
+### Bridge calls — `client.calls.actions.bridge()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `queue` | string | The name of the queue you want to bridge with, can't be used together with ca... |
+| `video_room_id` | string (UUID) | The ID of the video room you want to bridge with, can't be used together with... |
+| `video_room_context` | string | The additional parameter that will be passed to the video conference. |
+| `prevent_double_bridge` | boolean | When set to `true`, it prevents bridging if the target call is already bridge... |
+| `park_after_unbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `play_ringtone` | boolean | Specifies whether to play a ringtone if the call you want to bridge with has ... |
+| `ringtone` | enum (at, au, be, bg, br, ...) | Specifies which country ringtone to play when `play_ringtone` is set to `true`. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `mute_dtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `hold_after_unbridge` | boolean | Specifies behavior after the bridge ends. |
+
+### Hangup call — `client.calls.actions.hangup()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP BYE message. |
+
+### SIP Refer a call — `client.calls.actions.refer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid execution of duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the request. |
+
+### Reject a call — `client.calls.actions.reject()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Send SIP info — `client.calls.actions.send_sip_info()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Transfer call — `client.calls.actions.transfer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from_` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
+| `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
+| `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
+| `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
+| `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `park_after_unbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `target_leg_client_state` | string | Use this field to add state to every subsequent webhook for the new leg. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `media_encryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the new call leg. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE. |
+| `sip_transport_protocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `mute_dtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `sip_region` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `preferred_codecs` | string | The list of comma-separated codecs in order of preference to be used during t... |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+
+## Webhook Payload Fields
+
+### `callAnswered`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.answered | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: answered | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### `callBridged`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.bridged | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+
+### `callHangup`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.hangup | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: hangup | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+| `data.payload.hangup_cause` | enum: call_rejected, normal_clearing, originator_cancel, timeout, time_limit, user_busy, not_found, no_answer, unspecified | The reason the call was ended (`call_rejected`, `normal_clearing`, `originator_cancel`, `timeout`, `time_limit`, `use... |
+| `data.payload.hangup_source` | enum: caller, callee, unknown | The party who ended the call (`callee`, `caller`, `unknown`). |
+| `data.payload.sip_hangup_cause` | string | The reason the call was ended (SIP response code). |
+| `data.payload.call_quality_stats` | object \| null | Call quality statistics aggregated from the CHANNEL_HANGUP_COMPLETE event. |
+
+### `callInitiated`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.initiated | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
+| `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.custom_headers` | array[object] | Custom headers from sip invite |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.shaken_stir_attestation` | string | SHAKEN/STIR attestation level. |
+| `data.payload.shaken_stir_validated` | boolean | Whether attestation was successfully validated or not. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.caller_id_name` | string | Caller id. |
+| `data.payload.call_screening_result` | string | Call screening result. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.direction` | enum: incoming, outgoing | Whether the call is `incoming` or `outgoing`. |
+| `data.payload.state` | enum: parked, bridging | State received from a command. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### Field Type Notes
+
+- `from` in webhook payloads: string (E.164 phone number)
+- `to` in webhook payloads: string (E.164 phone number)
+- The return value of `client.webhooks.unwrap()` is a parsed event object — access fields via `event.data.event_type`, `event.data.payload.call_control_id`, etc.

--- a/skills/telnyx-twilio-migration/sdk-reference/ruby/10dlc.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/ruby/10dlc.md
@@ -55,8 +55,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -203,7 +203,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `description` | string | Description of the event. |
 | `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -361,7 +361,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -401,3 +401,471 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# 10DLC (Ruby) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Brands, List Campaigns, List shared partner campaigns, List Shared Campaigns, List phone number campaigns
+
+| Field | Type |
+|-------|------|
+| `page` | integer |
+| `records` | array[object] |
+| `totalRecords` | integer |
+
+**Returned by:** Create Brand, Update Brand, Revet Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Get Brand Feedback By Id
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `category` | array[object] |
+
+**Returned by:** Get Brand SMS OTP Status, Get Brand SMS OTP Status by Brand ID
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `deliveryStatus` | string |
+| `deliveryStatusDate` | date-time |
+| `deliveryStatusDetails` | string |
+| `mobilePhone` | string |
+| `referenceId` | string |
+| `requestDate` | date-time |
+| `verifyDate` | date-time |
+
+**Returned by:** Get Brand
+
+| Field | Type |
+|-------|------|
+| `altBusinessId` | string |
+| `altBusinessIdType` | enum: NONE, DUNS, GIIN, LEI |
+| `assignedCampaignsCount` | number |
+| `brandId` | string |
+| `brandRelationship` | object |
+| `businessContactEmail` | string |
+| `city` | string |
+| `companyName` | string |
+| `country` | string |
+| `createdAt` | string |
+| `cspId` | string |
+| `displayName` | string |
+| `ein` | string |
+| `email` | string |
+| `entityType` | object |
+| `failureReasons` | string |
+| `firstName` | string |
+| `identityStatus` | enum: VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED |
+| `ipAddress` | string |
+| `isReseller` | boolean |
+| `lastName` | string |
+| `mobilePhone` | string |
+| `mock` | boolean |
+| `optionalAttributes` | object |
+| `phone` | string |
+| `postalCode` | string |
+| `referenceId` | string |
+| `state` | string |
+| `status` | enum: OK, REGISTRATION_PENDING, REGISTRATION_FAILED |
+| `stockExchange` | object |
+| `stockSymbol` | string |
+| `street` | string |
+| `tcrBrandId` | string |
+| `universalEin` | string |
+| `updatedAt` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+| `website` | string |
+
+**Returned by:** Order Brand External Vetting, Import External Vetting Record
+
+| Field | Type |
+|-------|------|
+| `createDate` | string |
+| `evpId` | string |
+| `vettedDate` | string |
+| `vettingClass` | string |
+| `vettingId` | string |
+| `vettingScore` | integer |
+| `vettingToken` | string |
+
+**Returned by:** Trigger Brand SMS OTP
+
+| Field | Type |
+|-------|------|
+| `brandId` | string |
+| `referenceId` | string |
+
+**Returned by:** Get Campaign Cost
+
+| Field | Type |
+|-------|------|
+| `campaignUsecase` | string |
+| `description` | string |
+| `monthlyCost` | string |
+| `upFrontCost` | string |
+
+**Returned by:** Get campaign, Update campaign, Submit Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `autoRenewal` | boolean |
+| `billedDate` | string |
+| `brandDisplayName` | string |
+| `brandId` | string |
+| `campaignId` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createDate` | string |
+| `cspId` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isTMobileNumberPoolingEnabled` | boolean |
+| `isTMobileRegistered` | boolean |
+| `isTMobileSuspended` | boolean |
+| `messageFlow` | string |
+| `mock` | boolean |
+| `nextRenewalOrExpirationDate` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `referenceId` | string |
+| `resellerId` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `status` | string |
+| `subUsecases` | array[string] |
+| `submissionStatus` | enum: CREATED, FAILED, PENDING |
+| `subscriberHelp` | boolean |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `usecase` | string |
+| `vertical` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Deactivate campaign
+
+| Field | Type |
+|-------|------|
+| `message` | string |
+| `record_type` | string |
+| `time` | number |
+
+**Returned by:** Submit campaign appeal for manual review
+
+| Field | Type |
+|-------|------|
+| `appealed_at` | date-time |
+
+**Returned by:** Get Campaign Mno Metadata
+
+| Field | Type |
+|-------|------|
+| `10999` | object |
+
+**Returned by:** Get Sharing Status
+
+| Field | Type |
+|-------|------|
+| `sharedByMe` | object |
+| `sharedWithMe` | object |
+
+**Returned by:** Qualify By Usecase
+
+| Field | Type |
+|-------|------|
+| `annualFee` | number |
+| `maxSubUsecases` | integer |
+| `minSubUsecases` | integer |
+| `mnoMetadata` | object |
+| `monthlyFee` | number |
+| `quarterlyFee` | number |
+| `usecase` | string |
+
+**Returned by:** Get Single Shared Campaign, Update Single Shared Campaign
+
+| Field | Type |
+|-------|------|
+| `ageGated` | boolean |
+| `assignedPhoneNumbersCount` | number |
+| `brandDisplayName` | string |
+| `campaignStatus` | enum: TCR_PENDING, TCR_SUSPENDED, TCR_EXPIRED, TCR_ACCEPTED, TCR_FAILED, TELNYX_ACCEPTED, TELNYX_FAILED, MNO_PENDING, MNO_ACCEPTED, MNO_REJECTED, MNO_PROVISIONED, MNO_PROVISIONING_FAILED |
+| `createdAt` | string |
+| `description` | string |
+| `directLending` | boolean |
+| `embeddedLink` | boolean |
+| `embeddedLinkSample` | string |
+| `embeddedPhone` | boolean |
+| `failureReasons` | string |
+| `helpKeywords` | string |
+| `helpMessage` | string |
+| `isNumberPoolingEnabled` | boolean |
+| `messageFlow` | string |
+| `numberPool` | boolean |
+| `optinKeywords` | string |
+| `optinMessage` | string |
+| `optoutKeywords` | string |
+| `optoutMessage` | string |
+| `privacyPolicyLink` | string |
+| `sample1` | string |
+| `sample2` | string |
+| `sample3` | string |
+| `sample4` | string |
+| `sample5` | string |
+| `subUsecases` | array[string] |
+| `subscriberOptin` | boolean |
+| `subscriberOptout` | boolean |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `termsAndConditions` | boolean |
+| `termsAndConditionsLink` | string |
+| `updatedAt` | string |
+| `usecase` | string |
+| `webhookFailoverURL` | string |
+| `webhookURL` | string |
+
+**Returned by:** Assign Messaging Profile To Campaign
+
+| Field | Type |
+|-------|------|
+| `campaignId` | string |
+| `messagingProfileId` | string |
+| `taskId` | string |
+| `tcrCampaignId` | string |
+
+**Returned by:** Get Assignment Task Status
+
+| Field | Type |
+|-------|------|
+| `createdAt` | date-time |
+| `status` | string |
+| `taskId` | string |
+| `updatedAt` | date-time |
+
+**Returned by:** Get Phone Number Status
+
+| Field | Type |
+|-------|------|
+| `records` | array[object] |
+
+**Returned by:** Create New Phone Number Campaign, Get Single Phone Number Campaign, Create New Phone Number Campaign, Delete Phone Number Campaign
+
+| Field | Type |
+|-------|------|
+| `assignmentStatus` | enum: FAILED_ASSIGNMENT, PENDING_ASSIGNMENT, ASSIGNED, PENDING_UNASSIGNMENT, FAILED_UNASSIGNMENT |
+| `brandId` | string |
+| `campaignId` | string |
+| `createdAt` | string |
+| `failureReasons` | string |
+| `phoneNumber` | string |
+| `tcrBrandId` | string |
+| `tcrCampaignId` | string |
+| `telnyxCampaignId` | string |
+| `updatedAt` | string |
+
+## Optional Parameters
+
+### Create Brand — `client.messaging_10dlc.brand.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `company_name` | string | (Required for Non-profit/private/public) Legal company name. |
+| `first_name` | string | First name of business contact. |
+| `last_name` | string | Last name of business contact. |
+| `ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `phone` | string | Valid phone number in e.164 international format. |
+| `street` | string | Street number and name. |
+| `city` | string | City name |
+| `state` | string | State. |
+| `postal_code` | string | Postal codes. |
+| `stock_symbol` | string | (Required for public company) stock symbol. |
+| `stock_exchange` | object | (Required for public company) stock exchange. |
+| `ip_address` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `website` | string | Brand website URL. |
+| `is_reseller` | boolean |  |
+| `mock` | boolean | Mock brand for testing purposes. |
+| `mobile_phone` | string | Valid mobile phone number in e.164 international format. |
+| `business_contact_email` | string | Business contact email. |
+| `webhook_url` | string | Webhook URL for brand status updates. |
+| `webhook_failover_url` | string | Webhook failover URL for brand status updates. |
+
+### Update Brand — `client.messaging_10dlc.brand.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `company_name` | string | (Required for Non-profit/private/public) Legal company name. |
+| `first_name` | string | First name of business contact. |
+| `last_name` | string | Last name of business contact. |
+| `ein` | string | (Required for Non-profit) Government assigned corporate tax ID. |
+| `phone` | string | Valid phone number in e.164 international format. |
+| `street` | string | Street number and name. |
+| `city` | string | City name |
+| `state` | string | State. |
+| `postal_code` | string | Postal codes. |
+| `stock_symbol` | string | (Required for public company) stock symbol. |
+| `stock_exchange` | object | (Required for public company) stock exchange. |
+| `ip_address` | string (IPv4/IPv6) | IP address of the browser requesting to create brand identity. |
+| `website` | string | Brand website URL. |
+| `alt_business_id_type` | enum (NONE, DUNS, GIIN, LEI) | An enumeration. |
+| `is_reseller` | boolean |  |
+| `identity_status` | enum (VERIFIED, UNVERIFIED, SELF_DECLARED, VETTED_VERIFIED) | The verification status of an active brand |
+| `business_contact_email` | string | Business contact email. |
+| `webhook_url` | string | Webhook URL for brand status updates. |
+| `webhook_failover_url` | string | Webhook failover URL for brand status updates. |
+| `alt_business_id` | string (UUID) | Alternate business identifier such as DUNS, LEI, or GIIN |
+
+### Import External Vetting Record — `client.messaging_10dlc.brand.external_vetting.imports()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `vetting_token` | string | Required by some providers for vetting record confirmation. |
+
+### Update campaign — `client.messaging_10dlc.campaign.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `reseller_id` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `sample1` | string | Message sample. |
+| `sample2` | string | Message sample. |
+| `sample3` | string | Message sample. |
+| `sample4` | string | Message sample. |
+| `sample5` | string | Message sample. |
+| `message_flow` | string | Message flow description. |
+| `help_message` | string | Help message of the campaign. |
+| `auto_renewal` | boolean | Help message of the campaign. |
+| `webhook_url` | string | Webhook to which campaign status updates are sent. |
+| `webhook_failover_url` | string | Webhook failover to which campaign status updates are sent. |
+
+### Submit Campaign — `client.messaging_10dlc.campaign_builder.submit()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `age_gated` | boolean | Age gated message content in campaign. |
+| `auto_renewal` | boolean | Campaign subscription auto-renewal option. |
+| `direct_lending` | boolean | Direct lending or loan arrangement |
+| `embedded_link` | boolean | Does message generated by the campaign include URL link in SMS? |
+| `embedded_phone` | boolean | Does message generated by the campaign include phone number in SMS? |
+| `help_keywords` | string | Subscriber help keywords. |
+| `help_message` | string | Help message of the campaign. |
+| `message_flow` | string | Message flow description. |
+| `mno_ids` | array[integer] | Submit campaign to given list of MNOs by MNO's network ID. |
+| `number_pool` | boolean | Does campaign utilize pool of phone numbers? |
+| `optin_keywords` | string | Subscriber opt-in keywords. |
+| `optin_message` | string | Subscriber opt-in message. |
+| `optout_keywords` | string | Subscriber opt-out keywords. |
+| `optout_message` | string | Subscriber opt-out message. |
+| `reference_id` | string (UUID) | Caller supplied campaign reference ID. |
+| `reseller_id` | string (UUID) | Alphanumeric identifier of the reseller that you want to associate with this ... |
+| `sample1` | string | Message sample. |
+| `sample2` | string | Message sample. |
+| `sample3` | string | Message sample. |
+| `sample4` | string | Message sample. |
+| `sample5` | string | Message sample. |
+| `sub_usecases` | array[string] | Campaign sub-usecases. |
+| `subscriber_help` | boolean | Does campaign responds to help keyword(s)? |
+| `subscriber_optin` | boolean | Does campaign require subscriber to opt-in before SMS is sent to subscriber? |
+| `subscriber_optout` | boolean | Does campaign support subscriber opt-out keyword(s)? |
+| `tag` | array[string] | Tags to be set on the Campaign. |
+| `terms_and_conditions` | boolean | Is terms and conditions accepted? |
+| `privacy_policy_link` | string | Link to the campaign's privacy policy. |
+| `terms_and_conditions_link` | string | Link to the campaign's terms and conditions. |
+| `embedded_link_sample` | string | Sample of an embedded link that will be sent to subscribers. |
+| `webhook_url` | string | Webhook to which campaign status updates are sent. |
+| `webhook_failover_url` | string | Failover webhook to which campaign status updates are sent. |
+
+### Update Single Shared Campaign — `client.messaging_10dlc.partner_campaigns.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `webhook_url` | string | Webhook to which campaign status updates are sent. |
+| `webhook_failover_url` | string | Webhook failover to which campaign status updates are sent. |
+
+### Assign Messaging Profile To Campaign — `client.messaging_10dlc.phone_number_assignment_by_profile.assign()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `tcr_campaign_id` | string (UUID) | The TCR ID of the shared campaign you want to link to the specified messaging... |
+| `campaign_id` | string (UUID) | The ID of the campaign you want to link to the specified messaging profile. |
+
+## Webhook Payload Fields
+
+### `campaignStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `brandId` | string | Brand ID associated with the campaign. |
+| `campaignId` | string | The ID of the campaign. |
+| `createDate` | string | Unix timestamp when campaign was created. |
+| `cspId` | string | Alphanumeric identifier of the CSP associated with this campaign. |
+| `isTMobileRegistered` | boolean | Indicates whether the campaign is registered with T-Mobile. |
+| `type` | enum: TELNYX_EVENT, REGISTRATION, MNO_REVIEW, TELNYX_REVIEW, NUMBER_POOL_PROVISIONED, NUMBER_POOL_DEPROVISIONED, TCR_EVENT, VERIFIED |  |
+| `description` | string | Description of the event. |
+| `status` | enum: ACCEPTED, REJECTED, DORMANT, success, failed | The status of the campaign. |

--- a/skills/telnyx-twilio-migration/sdk-reference/ruby/ai-assistants.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/ruby/ai-assistants.md
@@ -26,7 +26,7 @@ All API calls can fail with network errors, rate limits (429), validation errors
 or authentication errors (401). Always handle errors in production code:
 
 ```ruby
-assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", model: "openai/gpt-4o", name: "my-resource")
+assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", name: "my-resource", model: "openai/gpt-4o")
 puts(assistant)
 ```
 
@@ -44,7 +44,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -57,16 +57,14 @@ Assistant creation is the entrypoint for any AI assistant integration. Agents ne
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes |  |
-| `model` | string | Yes | ID of the model to use. |
 | `instructions` | string | Yes | System instructions for the assistant. |
-| `tools` | array[object] | No | The tools that the assistant can use. |
-| `description` | string | No |  |
-| `greeting` | string | No | Text that the assistant will use to start the conversation. |
-| ... | | | +11 optional params in the API Details section below |
+| `tags` | array[string] | No | Tags associated with the assistant. |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | No | Deprecated for new integrations. |
+| ... | | | +22 optional params in the API Details section below |
 
 ```ruby
-assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", model: "openai/gpt-4o", name: "my-resource")
-
+assistant = client.ai.assistants.create(instructions: "You are a helpful assistant.", name: "my-resource", model: "openai/gpt-4o")
 puts(assistant)
 ```
 
@@ -175,7 +173,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### Update an assistant
 
@@ -186,10 +184,10 @@ Create or provision an additional resource when the core tasks do not cover this
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `assistant_id` | string (UUID) | Yes |  |
+| `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
-| `model` | string | No | ID of the model to use. |
-| `instructions` | string | No | System instructions for the assistant. |
-| ... | | | +15 optional params in the API Details section below |
+| `model` | string | No | ID of the model to use when `external_llm` is not set. |
+| ... | | | +26 optional params in the API Details section below |
 
 ```ruby
 assistant = client.ai.assistants.update("550e8400-e29b-41d4-a716-446655440000")
@@ -203,7 +201,7 @@ Primary response fields:
 - `assistant.created_at`
 - `assistant.description`
 - `assistant.dynamic_variables`
-- `assistant.dynamic_variables_webhook_url`
+- `assistant.dynamic_variables_webhook_timeout_ms`
 
 ### List assistants
 
@@ -226,7 +224,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Import assistants from external provider
 
@@ -255,7 +253,7 @@ Primary item fields:
 - `created_at`
 - `description`
 - `dynamic_variables`
-- `dynamic_variables_webhook_url`
+- `dynamic_variables_webhook_timeout_ms`
 
 ### Get All Tags
 
@@ -357,7 +355,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -370,8 +368,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
 | Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Get Canary Deploy | `client.ai.assistants.canary_deploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
-| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `versions`, `assistant_id` |
-| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `versions`, `assistant_id` |
+| Create Canary Deploy | `client.ai.assistants.canary_deploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | `client.ai.assistants.canary_deploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
 | Delete Canary Deploy | `client.ai.assistants.canary_deploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
 | Assistant Sms Chat | `client.ai.assistants.send_sms()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistant_id` |
 | Clone Assistant | `client.ai.assistants.clone_()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |
@@ -382,6 +380,8 @@ Before using any operation below, read [the optional-parameters section](referen
 | Add Assistant Tag | `client.ai.assistants.tags.add()` | `POST /ai/assistants/{assistant_id}/tags` | Create or provision an additional resource when the core tasks do not cover this flow. | `tag`, `assistant_id` |
 | Remove Assistant Tag | `client.ai.assistants.tags.remove()` | `DELETE /ai/assistants/{assistant_id}/tags/{tag}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `tag` |
 | Get assistant texml | `client.ai.assistants.get_texml()` | `GET /ai/assistants/{assistant_id}/texml` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Add Assistant Tool | `client.ai.assistants.tools.add()` | `PUT /ai/assistants/{assistant_id}/tools/{tool_id}` | Modify an existing resource without recreating it. | `assistant_id`, `tool_id` |
+| Remove Assistant Tool | `client.ai.assistants.tools.remove()` | `DELETE /ai/assistants/{assistant_id}/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `tool_id` |
 | Test Assistant Tool | `client.ai.assistants.tools.test_()` | `POST /ai/assistants/{assistant_id}/tools/{tool_id}/test` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id`, `tool_id` |
 | Get all versions of an assistant | `client.ai.assistants.versions.list()` | `GET /ai/assistants/{assistant_id}/versions` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
 | Get a specific assistant version | `client.ai.assistants.versions.retrieve()` | `GET /ai/assistants/{assistant_id}/versions/{version_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id`, `version_id` |
@@ -393,7 +393,398 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get MCP Server | `client.ai.mcp_servers.retrieve()` | `GET /ai/mcp_servers/{mcp_server_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `mcp_server_id` |
 | Update MCP Server | `client.ai.mcp_servers.update()` | `PUT /ai/mcp_servers/{mcp_server_id}` | Modify an existing resource without recreating it. | `mcp_server_id` |
 | Delete MCP Server | `client.ai.mcp_servers.delete()` | `DELETE /ai/mcp_servers/{mcp_server_id}` | Remove, detach, or clean up an existing resource. | `mcp_server_id` |
+| List Tools | `client.ai.tools.list()` | `GET /ai/tools` | Inspect available resources or choose an existing resource before mutating it. | None |
+| Create Tool | `client.ai.tools.create()` | `POST /ai/tools` | Create or provision an additional resource when the core tasks do not cover this flow. | `type`, `display_name` |
+| Get Tool | `client.ai.tools.retrieve()` | `GET /ai/tools/{tool_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `tool_id` |
+| Update Tool | `client.ai.tools.update()` | `PATCH /ai/tools/{tool_id}` | Modify an existing resource without recreating it. | `tool_id` |
+| Delete Tool | `client.ai.tools.delete()` | `DELETE /ai/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `tool_id` |
 
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# AI Assistants (Ruby) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+
+## Response Schemas
+
+**Returned by:** List assistants, Create an assistant, Import assistants from external provider, Get an assistant, Update an assistant, Clone Assistant, Get all versions of an assistant, Get a specific assistant version, Update a specific assistant version, Promote an assistant version to main
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `dynamic_variables` | object |
+| `dynamic_variables_webhook_timeout_ms` | integer |
+| `dynamic_variables_webhook_url` | string |
+| `enabled_features` | array[object] |
+| `external_llm` | object |
+| `fallback_config` | object |
+| `greeting` | string |
+| `id` | string |
+| `import_metadata` | object |
+| `insight_settings` | object |
+| `instructions` | string |
+| `integrations` | array[object] |
+| `interruption_settings` | object |
+| `llm_api_key_ref` | string |
+| `mcp_servers` | array[object] |
+| `messaging_settings` | object |
+| `model` | string |
+| `name` | string |
+| `observability_settings` | object |
+| `post_conversation_settings` | object |
+| `privacy_settings` | object |
+| `related_mission_ids` | array[string] |
+| `tags` | array[string] |
+| `telephony_settings` | object |
+| `tools` | array[object] |
+| `transcription` | object |
+| `version_created_at` | date-time |
+| `version_id` | string |
+| `version_name` | string |
+| `voice_settings` | object |
+| `widget_settings` | object |
+
+**Returned by:** Get All Tags, Add Assistant Tag, Remove Assistant Tag
+
+| Field | Type |
+|-------|------|
+| `tags` | array[string] |
+
+**Returned by:** List assistant tests with pagination, Create a new assistant test, Get assistant test by ID, Update an assistant test
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `description` | string |
+| `destination` | string |
+| `instructions` | string |
+| `max_duration_seconds` | integer |
+| `name` | string |
+| `rubric` | array[object] |
+| `telnyx_conversation_channel` | object |
+| `test_id` | uuid |
+| `test_suite` | string |
+
+**Returned by:** Get all test suite names
+
+| Field | Type |
+|-------|------|
+| `data` | array[string] |
+
+**Returned by:** Get test suite run history, Get test run history for a specific test, Trigger a manual test run, Get specific test run details
+
+| Field | Type |
+|-------|------|
+| `completed_at` | date-time |
+| `conversation_id` | string |
+| `conversation_insights_id` | string |
+| `created_at` | date-time |
+| `detail_status` | array[object] |
+| `logs` | string |
+| `run_id` | uuid |
+| `status` | enum: pending, starting, running, passed, failed, error |
+| `test_id` | uuid |
+| `test_suite_run_id` | uuid |
+| `triggered_by` | string |
+| `updated_at` | date-time |
+
+**Returned by:** Delete an assistant
+
+| Field | Type |
+|-------|------|
+| `deleted` | boolean |
+| `id` | string |
+| `object` | string |
+
+**Returned by:** Get Canary Deploy, Create Canary Deploy, Update Canary Deploy
+
+| Field | Type |
+|-------|------|
+| `assistant_id` | string |
+| `created_at` | date-time |
+| `rules` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Assistant Chat (BETA)
+
+| Field | Type |
+|-------|------|
+| `content` | string |
+
+**Returned by:** Assistant Sms Chat
+
+| Field | Type |
+|-------|------|
+| `conversation_id` | string |
+
+**Returned by:** List scheduled events
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Test Assistant Tool
+
+| Field | Type |
+|-------|------|
+| `content_type` | string |
+| `request` | object |
+| `response` | string |
+| `status_code` | integer |
+| `success` | boolean |
+
+**Returned by:** Create MCP Server, Get MCP Server, Update MCP Server
+
+| Field | Type |
+|-------|------|
+| `allowed_tools` | array \| null |
+| `api_key_ref` | string \| null |
+| `created_at` | date-time |
+| `id` | string |
+| `name` | string |
+| `type` | string |
+| `url` | string |
+
+**Returned by:** List Tools, Create Tool, Get Tool, Update Tool
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `display_name` | string |
+| `id` | string |
+| `timeout_ms` | integer |
+| `tool_definition` | object |
+| `type` | string |
+
+## Optional Parameters
+
+### Create an assistant — `client.ai.assistants.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
+| `transcription` | object |  |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+
+### Import assistants from external provider — `client.ai.assistants.imports()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `import_ids` | array[string] | Optional list of assistant IDs to import from the external provider. |
+
+### Create a new assistant test — `client.ai.assistants.tests.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `description` | string | Optional detailed description of what this test evaluates and its purpose. |
+| `telnyx_conversation_channel` | object | The communication channel through which the test will be conducted. |
+| `max_duration_seconds` | integer | Maximum duration in seconds that the test conversation should run before timi... |
+| `test_suite` | string | Optional test suite name to group related tests together. |
+
+### Trigger test suite execution — `client.ai.assistants.tests.test_suites.runs.trigger()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `destination_version_id` | string (UUID) | Optional assistant version ID to use for all test runs in this suite. |
+
+### Update an assistant test — `client.ai.assistants.tests.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | Updated name for the assistant test. |
+| `description` | string | Updated description of the test's purpose and evaluation criteria. |
+| `telnyx_conversation_channel` | enum (phone_call, web_call, sms_chat, web_chat) |  |
+| `destination` | string | Updated target destination for test conversations. |
+| `max_duration_seconds` | integer | Updated maximum test duration in seconds. |
+| `test_suite` | string | Updated test suite assignment for better organization. |
+| `instructions` | string | Updated test scenario instructions and objectives. |
+| `rubric` | array[object] | Updated evaluation criteria for assessing assistant performance. |
+
+### Trigger a manual test run — `client.ai.assistants.tests.runs.trigger()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `destination_version_id` | string (UUID) | Optional assistant version ID to use for this test run. |
+
+### Update an assistant — `client.ai.assistants.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `instructions` | string | System instructions for the assistant. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
+| `transcription` | object |  |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+| `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
+
+### Create Canary Deploy — `client.ai.assistants.canary_deploys.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Update Canary Deploy — `client.ai.assistants.canary_deploys.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rules` | array[object] |  |
+
+### Assistant Chat (BETA) — `client.ai.assistants.chat()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | The optional display name of the user sending the message |
+
+### Assistant Sms Chat — `client.ai.assistants.send_sms()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string |  |
+| `conversation_metadata` | object |  |
+| `should_create_conversation` | boolean |  |
+
+### Create a scheduled event — `client.ai.assistants.scheduled_events.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Required for sms scheduled events. |
+| `conversation_metadata` | object | Metadata associated with the conversation. |
+| `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
+
+### Test Assistant Tool — `client.ai.assistants.tools.test_()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `arguments` | object | Key-value arguments to use for the webhook test |
+| `dynamic_variables` | object | Key-value dynamic variables to use for the webhook test |
+
+### Update a specific assistant version — `client.ai.assistants.versions.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string |  |
+| `model` | string | ID of the model to use when `external_llm` is not set. |
+| `instructions` | string | System instructions for the assistant. |
+| `tools` | array[object] | Deprecated for new integrations. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
+| `description` | string |  |
+| `greeting` | string | Text that the assistant will use to start the conversation. |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
+| `transcription` | object |  |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `integrations` | array[object] | Connected integrations attached to the assistant. |
+| `observability_settings` | object |  |
+| `tags` | array[string] | Tags associated with the assistant. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+
+### Create MCP Server — `client.ai.mcp_servers.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `api_key_ref` | string |  |
+| `allowed_tools` | array[string] |  |
+
+### Update MCP Server — `client.ai.mcp_servers.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `name` | string |  |
+| `type` | string |  |
+| `url` | string (URL) |  |
+| `api_key_ref` | string |  |
+| `allowed_tools` | array[string] |  |
+| `created_at` | string (date-time) |  |
+
+### Create Tool — `client.ai.tools.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `function` | object |  |
+| `retrieval` | object |  |
+| `handoff` | object |  |
+| `invite` | object |  |
+| `webhook` | object |  |
+| `timeout_ms` | integer |  |
+
+### Update Tool — `client.ai.tools.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type` | string |  |
+| `display_name` | string |  |
+| `function` | object |  |
+| `retrieval` | object |  |
+| `handoff` | object |  |
+| `invite` | object |  |
+| `webhook` | object |  |
+| `timeout_ms` | integer |  |

--- a/skills/telnyx-twilio-migration/sdk-reference/ruby/messaging.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/ruby/messaging.md
@@ -50,8 +50,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -175,7 +175,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.media` | array[object] |  |
 | `data.record_type` | enum: event | Identifies the type of the resource. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -340,6 +340,7 @@ Send WhatsApp traffic instead of SMS/MMS.
 | `whatsapp_message` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
 | `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```ruby
 response = client.messages.send_whatsapp(from: "+13125551234", to: "+13125551234", whatsapp_message: {})
@@ -360,7 +361,7 @@ Primary response fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -394,3 +395,425 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Messaging (Ruby) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List alphanumeric sender IDs, Create an alphanumeric sender ID, Retrieve an alphanumeric sender ID, Delete an alphanumeric sender ID, List alphanumeric sender IDs for a messaging profile
+
+| Field | Type |
+|-------|------|
+| `alphanumeric_sender_id` | string |
+| `id` | uuid |
+| `messaging_profile_id` | uuid |
+| `organization_id` | string |
+| `record_type` | enum: alphanumeric_sender_id |
+| `us_long_code_fallback` | string |
+
+**Returned by:** Send a message, Send a message using an alphanumeric sender ID, Retrieve group MMS messages, Send a group MMS message, Send a long code message, Send a message using number pool, Schedule a message, Send a short code message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `wait_seconds` | float |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** Send a WhatsApp message
+
+| Field | Type |
+|-------|------|
+| `body` | object |
+| `direction` | string |
+| `encoding` | string |
+| `from` | object |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `organization_id` | string |
+| `received_at` | date-time |
+| `record_type` | string |
+| `to` | array[object] |
+| `type` | string |
+| `wait_seconds` | float |
+
+**Returned by:** Retrieve a message, Get detailed messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Cancel a scheduled message
+
+| Field | Type |
+|-------|------|
+| `cc` | array[object] |
+| `completed_at` | date-time |
+| `cost` | object \| null |
+| `cost_breakdown` | object \| null |
+| `direction` | enum: outbound |
+| `encoding` | string |
+| `errors` | array[object] |
+| `from` | object |
+| `id` | uuid |
+| `media` | array[object] |
+| `messaging_profile_id` | string |
+| `num_chars` | integer |
+| `organization_id` | uuid |
+| `parts` | integer |
+| `received_at` | date-time |
+| `record_type` | enum: message |
+| `sent_at` | date-time |
+| `smart_encoding_applied` | boolean |
+| `subject` | string \| null |
+| `tags` | array[string] |
+| `tcr_campaign_billable` | boolean |
+| `tcr_campaign_id` | string \| null |
+| `tcr_campaign_registered` | string \| null |
+| `text` | string |
+| `to` | array[object] |
+| `type` | enum: SMS, MMS |
+| `valid_until` | date-time |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+
+**Returned by:** List messaging hosted numbers, Retrieve a messaging hosted number, Update a messaging hosted number
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `eligible_messaging_products` | array[string] |
+| `features` | object |
+| `health` | object |
+| `id` | string |
+| `messaging_product` | string |
+| `messaging_profile_id` | string \| null |
+| `organization_id` | string |
+| `phone_number` | string |
+| `record_type` | enum: messaging_phone_number, messaging_settings |
+| `tags` | array[string] |
+| `traffic_type` | string |
+| `type` | enum: long-code, toll-free, short-code, longcode, tollfree, shortcode |
+| `updated_at` | date-time |
+
+**Returned by:** List opt-outs
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `from` | string |
+| `keyword` | string \| null |
+| `messaging_profile_id` | string \| null |
+| `to` | string |
+
+**Returned by:** List high-level messaging profile metrics
+
+| Field | Type |
+|-------|------|
+| `data` | array[object] |
+| `meta` | object |
+
+**Returned by:** Regenerate messaging profile secret
+
+| Field | Type |
+|-------|------|
+| `ai_assistant_id` | string \| null |
+| `alpha_sender` | string \| null |
+| `created_at` | date-time |
+| `daily_spend_limit` | string |
+| `daily_spend_limit_enabled` | boolean |
+| `enabled` | boolean |
+| `health_webhook_url` | url |
+| `id` | uuid |
+| `mms_fall_back_to_sms` | boolean |
+| `mms_transcoding` | boolean |
+| `mobile_only` | boolean |
+| `name` | string |
+| `number_pool_settings` | object \| null |
+| `organization_id` | string |
+| `record_type` | enum: messaging_profile |
+| `redaction_enabled` | boolean |
+| `redaction_level` | integer |
+| `resource_group_id` | string \| null |
+| `smart_encoding` | boolean |
+| `updated_at` | date-time |
+| `url_shortener_settings` | object \| null |
+| `v1_secret` | string |
+| `webhook_api_version` | enum: 1, 2, 2010-04-01 |
+| `webhook_failover_url` | url |
+| `webhook_url` | url |
+| `whitelisted_destinations` | array[string] |
+
+**Returned by:** List Auto-Response Settings, Create auto-response setting, Get Auto-Response Setting, Update Auto-Response Setting
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `id` | string |
+| `keywords` | array[string] |
+| `op` | enum: start, stop, info |
+| `resp_text` | string |
+| `updated_at` | date-time |
+
+## Optional Parameters
+
+### Create an alphanumeric sender ID — `client.alphanumeric_sender_ids.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `us_long_code_fallback` | string | A US long code number to use as fallback when sending to US destinations. |
+
+### Send a message — `client.messages.send_()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using an alphanumeric sender ID — `client.messages.send_with_alphanumeric_sender()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `webhook_url` | string (URL) | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | If true, use the messaging profile's webhook settings. |
+
+### Send a group MMS message — `client.messages.send_group_mms()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+
+### Send a long code message — `client.messages.send_long_code()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a message using number pool — `client.messages.send_number_pool()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Schedule a message — `client.messages.schedule()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+
+### Send a short code message — `client.messages.send_short_code()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Message body (i.e., content) as a non-empty string. |
+| `subject` | string | Subject of multimedia message |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
+
+### Send a WhatsApp message — `client.messages.send_whatsapp()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
+
+### Update a messaging hosted number — `client.messaging_hosted_numbers.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `messaging_profile_id` | string (UUID) | Configure the messaging profile this phone number is assigned to:
+
+* Omit thi... |
+| `messaging_product` | string | Configure the messaging product for this number:
+
+* Omit this field or set it... |
+| `tags` | array[string] | Tags to set on this phone number. |
+
+### Create auto-response setting — `client.messaging_profiles.autoresp_configs.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `resp_text` | string |  |
+
+### Update Auto-Response Setting — `client.messaging_profiles.autoresp_configs.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `resp_text` | string |  |
+
+## Webhook Payload Fields
+
+### `deliveryUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.sent, message.finalized | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: outbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | uuid | The id of the organization the messaging profile belongs to. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Subject of multimedia message |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | ISO 8601 formatted date indicating when the message was sent. |
+| `data.payload.completed_at` | date-time | ISO 8601 formatted date indicating when the message was finalized. |
+| `data.payload.valid_until` | date-time | Message must be out of the queue by this time or else it will be discarded and marked as 'sending_failed'. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+| `data.payload.smart_encoding_applied` | boolean | Indicates whether smart encoding was applied to this message. |
+| `data.payload.wait_seconds` | float | Seconds the message is queued due to rate limiting before being sent to the carrier. |
+| `meta.attempt` | integer | Number of attempts to deliver the webhook event. |
+| `meta.delivered_to` | url | The webhook URL the event was delivered to. |
+
+### `inboundMessage`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.event_type` | enum: message.received | The type of event being delivered. |
+| `data.occurred_at` | date-time | ISO 8601 formatted date indicating when the resource was created. |
+| `data.payload.record_type` | enum: message | Identifies the type of the resource. |
+| `data.payload.direction` | enum: inbound | The direction of the message. |
+| `data.payload.id` | uuid | Identifies the type of resource. |
+| `data.payload.type` | enum: SMS, MMS | The type of message. |
+| `data.payload.messaging_profile_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.organization_id` | string | Unique identifier for a messaging profile. |
+| `data.payload.to` | array[object] |  |
+| `data.payload.cc` | array[object] |  |
+| `data.payload.text` | string | Message body (i.e., content) as a non-empty string. |
+| `data.payload.num_chars` | integer | The number of characters in the message text |
+| `data.payload.subject` | string \| null | Message subject. |
+| `data.payload.media` | array[object] |  |
+| `data.payload.webhook_url` | url | The URL where webhooks related to this message will be sent. |
+| `data.payload.webhook_failover_url` | url | The failover URL where webhooks related to this message will be sent if sending to the primary URL fails. |
+| `data.payload.encoding` | string | Encoding scheme used for the message body. |
+| `data.payload.parts` | integer | Number of parts into which the message's body must be split. |
+| `data.payload.tags` | array[string] | Tags associated with the resource. |
+| `data.payload.cost` | object \| null |  |
+| `data.payload.cost_breakdown` | object \| null | Detailed breakdown of the message cost components. |
+| `data.payload.tcr_campaign_id` | string \| null | The Campaign Registry (TCR) campaign ID associated with the message. |
+| `data.payload.tcr_campaign_billable` | boolean | Indicates whether the TCR campaign is billable. |
+| `data.payload.tcr_campaign_registered` | string \| null | The registration status of the TCR campaign. |
+| `data.payload.received_at` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+| `data.payload.sent_at` | date-time | Not used for inbound messages. |
+| `data.payload.completed_at` | date-time | Not used for inbound messages. |
+| `data.payload.valid_until` | date-time | Not used for inbound messages. |
+| `data.payload.errors` | array[object] | These errors may point at addressees when referring to unsuccessful/unconfirmed delivery statuses. |
+
+### `replacedLinkClick`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | string | Identifies the type of the resource. |
+| `data.url` | string | The original link that was sent in the message. |
+| `data.to` | string | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or short code). |
+| `data.message_id` | uuid | The message ID associated with the clicked link. |
+| `data.time_clicked` | date-time | ISO 8601 formatted date indicating when the message request was received. |
+
+### Field Type Notes
+
+- `from` in responses/webhooks: object with sub-fields `phone_number` (string), `carrier` (string), `line_type` (string)
+- `to` in responses/webhooks: array of objects, each with `phone_number` (string), `carrier` (string), `line_type` (string), `status` (string)
+- `cost`: object with `amount` (string, decimal), `currency` (string, e.g., 'USD')

--- a/skills/telnyx-twilio-migration/sdk-reference/ruby/numbers.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/ruby/numbers.md
@@ -44,7 +44,7 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
 
 ## Core Tasks
 
@@ -347,7 +347,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -397,3 +397,433 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Numbers (Ruby) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List Advanced Orders, Create Advanced Order, Update Advanced Order, Get Advanced Order
+
+| Field | Type |
+|-------|------|
+| `area_code` | string |
+| `comments` | string |
+| `country_code` | string |
+| `customer_reference` | string |
+| `features` | array[object] |
+| `id` | uuid |
+| `orders` | array[string] |
+| `phone_number_type` | object |
+| `quantity` | integer |
+| `requirement_group_id` | uuid |
+| `status` | object |
+
+**Returned by:** List available phone number blocks
+
+| Field | Type |
+|-------|------|
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `range` | integer |
+| `record_type` | enum: available_phone_number_block |
+| `region_information` | array[object] |
+
+**Returned by:** List available phone numbers
+
+| Field | Type |
+|-------|------|
+| `best_effort` | boolean |
+| `cost_information` | object |
+| `features` | array[object] |
+| `phone_number` | string |
+| `quickship` | boolean |
+| `record_type` | enum: available_phone_number |
+| `region_information` | array[object] |
+| `reservable` | boolean |
+| `vanity_format` | string |
+
+**Returned by:** Retrieve all comments
+
+| Field | Type |
+|-------|------|
+| `body` | string |
+| `comment_record_id` | uuid |
+| `comment_record_type` | enum: sub_number_order, requirement_group |
+| `commenter` | string |
+| `commenter_type` | enum: admin, user |
+| `created_at` | date-time |
+| `id` | uuid |
+| `read_at` | date-time |
+| `updated_at` | date-time |
+
+**Returned by:** Create a comment, Retrieve a comment, Mark a comment as read, Get country coverage
+
+| Field | Type |
+|-------|------|
+| `data` | object |
+
+**Returned by:** Get coverage for a specific country
+
+| Field | Type |
+|-------|------|
+| `code` | string |
+| `features` | array[string] |
+| `international_sms` | boolean |
+| `inventory_coverage` | boolean |
+| `local` | object |
+| `mobile` | object |
+| `national` | object |
+| `numbers` | boolean |
+| `p2p` | boolean |
+| `phone_number_type` | array[string] |
+| `quickship` | boolean |
+| `region` | string \| null |
+| `reservable` | boolean |
+| `shared_cost` | object |
+| `toll_free` | object |
+
+**Returned by:** List customer service records, Create a customer service record, Get a customer service record
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `error_message` | string \| null |
+| `id` | uuid |
+| `phone_number` | string |
+| `record_type` | string |
+| `result` | object \| null |
+| `status` | enum: pending, completed, failed |
+| `updated_at` | date-time |
+| `webhook_url` | string |
+
+**Returned by:** Verify CSR phone number coverage
+
+| Field | Type |
+|-------|------|
+| `additional_data_required` | array[string] |
+| `has_csr_coverage` | boolean |
+| `phone_number` | string |
+| `reason` | string |
+| `record_type` | string |
+
+**Returned by:** List inexplicit number orders, Create an inexplicit number order, Retrieve an inexplicit number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | string |
+| `messaging_profile_id` | string |
+| `ordering_groups` | array[object] |
+| `updated_at` | date-time |
+
+**Returned by:** Create an inventory coverage request
+
+| Field | Type |
+|-------|------|
+| `administrative_area` | string |
+| `advance_requirements` | boolean |
+| `count` | integer |
+| `coverage_type` | enum: number, block |
+| `group` | string |
+| `group_type` | string |
+| `number_range` | integer |
+| `number_type` | enum: did, toll-free |
+| `phone_number_type` | enum: local, toll_free, national, landline, shared_cost, mobile |
+| `record_type` | string |
+
+**Returned by:** List mobile network operators
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `id` | uuid |
+| `mcc` | string |
+| `mnc` | string |
+| `name` | string |
+| `network_preferences_enabled` | boolean |
+| `record_type` | string |
+| `tadig` | string |
+
+**Returned by:** List network coverage locations
+
+| Field | Type |
+|-------|------|
+| `available_services` | array[object] |
+| `location` | object |
+| `record_type` | string |
+
+**Returned by:** List number block orders, Create a number block order, Retrieve a number block order
+
+| Field | Type |
+|-------|------|
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers_count` | integer |
+| `range` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `starting_number` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve a list of phone numbers associated to orders, Retrieve a single phone number within a number order., Update requirements for a single phone number within a number order.
+
+| Field | Type |
+|-------|------|
+| `bundle_id` | uuid |
+| `country_code` | string |
+| `deadline` | date-time |
+| `id` | uuid |
+| `is_block_number` | boolean |
+| `locality` | string |
+| `order_request_id` | uuid |
+| `phone_number` | string |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `requirements_status` | enum: pending, approved, cancelled, deleted, requirement-info-exception, requirement-info-pending, requirement-info-under-review |
+| `status` | enum: pending, success, failure |
+| `sub_number_order_id` | uuid |
+
+**Returned by:** List number orders, Create a number order, Retrieve a number order, Update a number order
+
+| Field | Type |
+|-------|------|
+| `billing_group_id` | string |
+| `connection_id` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `messaging_profile_id` | string |
+| `phone_numbers` | array[object] |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `sub_number_orders_ids` | array[string] |
+| `updated_at` | date-time |
+
+**Returned by:** List number reservations, Create a number reservation, Retrieve a number reservation, Extend a number reservation
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `errors` | string |
+| `id` | uuid |
+| `phone_numbers` | array[object] |
+| `record_type` | string |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+
+**Returned by:** Retrieve the features for a list of numbers
+
+| Field | Type |
+|-------|------|
+| `features` | array[string] |
+| `phone_number` | string |
+
+**Returned by:** Lists the phone number blocks jobs, Deletes all numbers associated with a phone number block, Retrieves a phone number blocks job
+
+| Field | Type |
+|-------|------|
+| `created_at` | string |
+| `etc` | date-time |
+| `failed_operations` | array[object] |
+| `id` | uuid |
+| `record_type` | string |
+| `status` | enum: pending, in_progress, completed, failed |
+| `successful_operations` | array[object] |
+| `type` | enum: delete_phone_number_block |
+| `updated_at` | string |
+
+**Returned by:** List sub number orders, Retrieve a sub number order, Update a sub number order's requirements, Cancel a sub number order
+
+| Field | Type |
+|-------|------|
+| `country_code` | string |
+| `created_at` | date-time |
+| `customer_reference` | string |
+| `id` | uuid |
+| `is_block_sub_number_order` | boolean |
+| `order_request_id` | uuid |
+| `phone_number_type` | enum: local, toll_free, mobile, national, shared_cost, landline |
+| `phone_numbers_count` | integer |
+| `record_type` | string |
+| `regulatory_requirements` | array[object] |
+| `requirements_met` | boolean |
+| `status` | enum: pending, success, failure |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+**Returned by:** Create a sub number orders report, Retrieve a sub number orders report
+
+| Field | Type |
+|-------|------|
+| `created_at` | date-time |
+| `filters` | object |
+| `id` | uuid |
+| `order_type` | string |
+| `status` | enum: pending, success, failed, expired |
+| `updated_at` | date-time |
+| `user_id` | uuid |
+
+## Optional Parameters
+
+### Create Advanced Order — `client.advanced_orders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `country_code` | string (ISO 3166-1 alpha-2) |  |
+| `comments` | string |  |
+| `quantity` | integer |  |
+| `area_code` | string |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `features` | array[object] |  |
+| `customer_reference` | string |  |
+| `requirement_group_id` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Update Advanced Order — `client.advanced_orders.update_requirement_group()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `country_code` | string (ISO 3166-1 alpha-2) |  |
+| `comments` | string |  |
+| `quantity` | integer |  |
+| `area_code` | string |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `features` | array[object] |  |
+| `customer_reference` | string |  |
+| `requirement_group_id` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+
+### Create a comment — `client.comments.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `body` | string |  |
+| `commenter` | string |  |
+| `commenter_type` | enum (admin, user) |  |
+| `comment_record_type` | enum (sub_number_order, requirement_group) |  |
+| `comment_record_id` | string (UUID) |  |
+| `read_at` | string (date-time) | An ISO 8901 datetime string for when the comment was read. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the comment was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the comment was updated. |
+
+### Create an inexplicit number order — `client.inexplicit_number_orders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `connection_id` | string (UUID) | Connection id to apply to phone numbers that are purchased |
+| `messaging_profile_id` | string (UUID) | Messaging profile id to apply to phone numbers that are purchased |
+| `customer_reference` | string | Reference label for the customer |
+| `billing_group_id` | string (UUID) | Billing group id to apply to phone numbers that are purchased |
+
+### Create a number block order — `client.number_block_orders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `record_type` | string |  |
+| `phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `connection_id` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `status` | enum (pending, success, failure) | The status of the order. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the number order was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the number order was updated. |
+| `requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `errors` | string | Errors the reservation could happen upon |
+
+### Update requirements for a single phone number within a number order. — `client.number_order_phone_numbers.update_requirements()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatory_requirements` | array[object] |  |
+
+### Create a number order — `client.number_orders.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `phone_numbers` | array[object] |  |
+| `connection_id` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `billing_group_id` | string (UUID) | Identifies the billing group associated with the phone number. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+
+### Update a number order — `client.number_orders.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatory_requirements` | array[object] |  |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+
+### Create a number reservation — `client.number_reservations.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | string (UUID) |  |
+| `record_type` | string |  |
+| `phone_numbers` | array[object] |  |
+| `status` | enum (pending, success, failure) | The status of the entire reservation. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the numbers reservation was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the number reservation was updated. |
+
+### Update a sub number order's requirements — `client.sub_number_orders.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `regulatory_requirements` | array[object] |  |
+
+### Create a sub number orders report — `client.sub_number_orders_report.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `status` | enum (pending, success, failure) | Filter by order status |
+| `country_code` | string (ISO 3166-1 alpha-2) | Filter by country code |
+| `created_at_gt` | string (date-time) | Filter for orders created after this date |
+| `created_at_lt` | string (date-time) | Filter for orders created before this date |
+| `order_request_id` | string (UUID) | Filter by specific order request ID |
+| `customer_reference` | string | Filter by customer reference |
+
+## Webhook Payload Fields
+
+### `numberOrderStatusUpdate`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.event_type` | string | The type of event being sent |
+| `data.id` | uuid | Unique identifier for the event |
+| `data.occurred_at` | date-time | ISO 8601 timestamp of when the event occurred |
+| `data.payload.id` | uuid |  |
+| `data.payload.record_type` | string |  |
+| `data.payload.phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `data.payload.connection_id` | string | Identifies the connection associated with this phone number. |
+| `data.payload.messaging_profile_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.billing_group_id` | string | Identifies the messaging profile associated with the phone number. |
+| `data.payload.phone_numbers` | array[object] |  |
+| `data.payload.sub_number_orders_ids` | array[string] |  |
+| `data.payload.status` | enum: pending, success, failure | The status of the order. |
+| `data.payload.customer_reference` | string | A customer reference string for customer look ups. |
+| `data.payload.created_at` | date-time | An ISO 8901 datetime string denoting when the number order was created. |
+| `data.payload.updated_at` | date-time | An ISO 8901 datetime string for when the number order was updated. |
+| `data.payload.requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `data.record_type` | string | Type of record |
+| `meta.attempt` | integer | Webhook delivery attempt number |
+| `meta.delivered_to` | uri | URL where the webhook was delivered |

--- a/skills/telnyx-twilio-migration/sdk-reference/ruby/voice.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/ruby/voice.md
@@ -29,7 +29,7 @@ or authentication errors (401). Always handle errors in production code:
 response = client.calls.dial(
   connection_id: "7267xxxxxxxxxxxxxx",
   from: "+18005550101",
-  to: "+18005550100"
+  to: "+18005550100;secure=srtp"
 )
 puts(response)
 ```
@@ -54,8 +54,8 @@ Common error codes: `401` invalid API key, `403` insufficient permissions,
 Do not invent Telnyx parameters, enums, response fields, or webhook fields.
 
 - If the parameter, enum, or response field you need is not shown inline in this skill, read the API Details section below before writing code.
-- Before using any operation in `## Additional Operations`, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas).
-- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](references/api-details.md#webhook-payload-fields).
+- Before using any operation in `## Additional Operations`, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas).
+- Before reading or matching webhook fields beyond the inline examples, read [the webhook payload reference](#webhook-payload-fields).
 
 ## Core Tasks
 
@@ -73,13 +73,13 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in the API Details section below |
+| ... | | | +56 optional params in the API Details section below |
 
 ```ruby
 response = client.calls.dial(
   connection_id: "7267xxxxxxxxxxxxxx",
   from: "+18005550101",
-  to: "+18005550100"
+  to: "+18005550100;secure=srtp"
 )
 
 puts(response)
@@ -105,7 +105,7 @@ Primary inbound call-control command.
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in the API Details section below |
+| ... | | | +29 optional params in the API Details section below |
 
 ```ruby
 response = client.calls.actions.answer("v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ")
@@ -130,10 +130,13 @@ Common post-answer control path with downstream webhook implications.
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in the API Details section below |
+| ... | | | +35 optional params in the API Details section below |
 
 ```ruby
-response = client.calls.actions.transfer("call_control_id", to: "+18005550100")
+response = client.calls.actions.transfer(
+  "call_control_id",
+  to: "+18005550100;secure=srtp"
+)
 
 puts(response)
 ```
@@ -210,7 +213,7 @@ These webhook payload fields are inline because they are part of the primary int
 | `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
 | `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
 
-If you need webhook fields that are not listed inline here, read [the webhook payload reference](references/api-details.md#webhook-payload-fields) before writing the handler.
+If you need webhook fields that are not listed inline here, read [the webhook payload reference](#webhook-payload-fields) before writing the handler.
 
 ---
 
@@ -377,7 +380,7 @@ Primary item fields:
 ## Additional Operations
 
 Use the core tasks above first. The operations below are indexed here with exact SDK methods and required params; use the API Details section below for full optional params, response schemas, and lower-frequency webhook payloads.
-Before using any operation below, read [the optional-parameters section](references/api-details.md#optional-parameters) and [the response-schemas section](references/api-details.md#response-schemas) so you do not guess missing fields.
+Before using any operation below, read [the optional-parameters section](#optional-parameters) and [the response-schemas section](#response-schemas) so you do not guess missing fields.
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
@@ -397,3 +400,427 @@ Before using any operation below, read [the optional-parameters section](referen
 ---
 
 For exhaustive optional parameters, full response schemas, and complete webhook payloads, see the API Details section below.
+---
+
+# Voice (Ruby) — API Details
+
+## Table of Contents
+
+- [Response Schemas](#response-schemas)
+- [Optional Parameters](#optional-parameters)
+- [Webhook Payload Fields](#webhook-payload-fields)
+
+## Response Schemas
+
+**Returned by:** List call control applications, Create a call control application, Retrieve a call control application, Update a call control application, Delete a call control application
+
+| Field | Type |
+|-------|------|
+| `active` | boolean |
+| `anchorsite_override` | enum: Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, Chennai, IN, Amsterdam, Netherlands, Toronto, Canada, Sydney, Australia |
+| `application_name` | string |
+| `call_cost_in_webhooks` | boolean |
+| `created_at` | string |
+| `dtmf_type` | enum: RFC 2833, Inband, SIP INFO |
+| `first_command_timeout` | boolean |
+| `first_command_timeout_secs` | integer |
+| `id` | string |
+| `inbound` | object |
+| `outbound` | object |
+| `record_type` | enum: call_control_application |
+| `redact_dtmf_debug_logging` | boolean |
+| `tags` | array[string] |
+| `updated_at` | string |
+| `webhook_api_version` | enum: 1, 2 |
+| `webhook_event_failover_url` | url |
+| `webhook_event_url` | url |
+| `webhook_timeout_secs` | integer \| null |
+
+**Returned by:** Dial
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `recording_id` | uuid |
+| `start_time` | string |
+
+**Returned by:** Retrieve a call status
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `end_time` | string |
+| `is_alive` | boolean |
+| `record_type` | enum: call |
+| `start_time` | string |
+
+**Returned by:** Answer call
+
+| Field | Type |
+|-------|------|
+| `recording_id` | uuid |
+| `result` | string |
+
+**Returned by:** Bridge calls, Hangup call, SIP Refer a call, Reject a call, Send SIP info, Transfer call
+
+| Field | Type |
+|-------|------|
+| `result` | string |
+
+**Returned by:** List all active calls for given connection
+
+| Field | Type |
+|-------|------|
+| `call_control_id` | string |
+| `call_duration` | integer |
+| `call_leg_id` | string |
+| `call_session_id` | string |
+| `client_state` | string |
+| `record_type` | enum: call |
+
+## Optional Parameters
+
+### Create a call control application — `client.call_control_applications.create()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `active` | boolean | Specifies whether the connection can be used. |
+| `anchorsite_override` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmf_type` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `first_command_timeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `first_command_timeout_secs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `inbound` | object |  |
+| `outbound` | object |  |
+| `webhook_api_version` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhook_event_failover_url` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhook_timeout_secs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `call_cost_in_webhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `redact_dtmf_debug_logging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Update a call control application — `client.call_control_applications.update()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `call_cost_in_webhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `active` | boolean | Specifies whether the connection can be used. |
+| `anchorsite_override` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmf_type` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `first_command_timeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `first_command_timeout_secs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `tags` | array[string] | Tags assigned to the Call Control Application. |
+| `inbound` | object |  |
+| `outbound` | object |  |
+| `webhook_api_version` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhook_event_failover_url` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhook_timeout_secs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `redact_dtmf_debug_logging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+
+### Dial — `client.calls.dial()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
+| `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
+| `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
+| `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `link_to` | string | Use another call's control id for sharing the same call session id |
+| `bridge_intent` | boolean | Indicates the intent to bridge this call with the call specified in link_to. |
+| `bridge_on_answer` | boolean | Whether to automatically bridge answered call to the call specified in link_to. |
+| `prevent_double_bridge` | boolean | Prevents bridging and hangs up the call if the target is already bridged. |
+| `park_after_unbridge` | string | If supplied with the value `self`, the current leg will be parked after unbri... |
+| `media_encryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the call. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE request. |
+| `sip_transport_protocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `stream_url` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `stream_track` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `stream_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `stream_bidirectional_mode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `stream_bidirectional_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `stream_bidirectional_target_legs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `stream_bidirectional_sampling_rate` | enum (8000, 16000, 22050, 24000, 48000) | Audio sampling rate. |
+| `stream_establish_before_call_originate` | boolean | Establish websocket connection before dialing the destination. |
+| `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `supervise_call_control_id` | string (UUID) | The call leg which will be supervised by the new call. |
+| `supervisor_role` | enum (barge, whisper, monitor) | The role of the supervisor call. |
+| `enable_dialogflow` | boolean | Enables Dialogflow for the current call. |
+| `dialogflow_config` | object |  |
+| `transcription` | boolean | Enable transcription upon call answer. |
+| `transcription_config` | object |  |
+| `sip_region` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `stream_auth_token` | string | An authentication token to be sent as part of the WebSocket connection when u... |
+
+### Answer call — `client.calls.actions.answer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE response. |
+| `preferred_codecs` | enum (G722,PCMU,PCMA,G729,OPUS,VP8,H264) | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE response. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `stream_url` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `stream_track` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `stream_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `stream_bidirectional_mode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `stream_bidirectional_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `stream_bidirectional_target_legs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `transcription` | boolean | Enable transcription upon call answer. |
+| `transcription_config` | object |  |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
+
+### Bridge calls — `client.calls.actions.bridge()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `queue` | string | The name of the queue you want to bridge with, can't be used together with ca... |
+| `video_room_id` | string (UUID) | The ID of the video room you want to bridge with, can't be used together with... |
+| `video_room_context` | string | The additional parameter that will be passed to the video conference. |
+| `prevent_double_bridge` | boolean | When set to `true`, it prevents bridging if the target call is already bridge... |
+| `park_after_unbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `play_ringtone` | boolean | Specifies whether to play a ringtone if the call you want to bridge with has ... |
+| `ringtone` | enum (at, au, be, bg, br, ...) | Specifies which country ringtone to play when `play_ringtone` is set to `true`. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `mute_dtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `hold_after_unbridge` | boolean | Specifies behavior after the bridge ends. |
+
+### Hangup call — `client.calls.actions.hangup()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP BYE message. |
+
+### SIP Refer a call — `client.calls.actions.refer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid execution of duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the request. |
+
+### Reject a call — `client.calls.actions.reject()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Send SIP info — `client.calls.actions.send_sip_info()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+
+### Transfer call — `client.calls.actions.transfer()`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
+| `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
+| `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
+| `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
+| `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
+| `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `park_after_unbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `target_leg_client_state` | string | Use this field to add state to every subsequent webhook for the new leg. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `media_encryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the new call leg. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE. |
+| `sip_transport_protocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `mute_dtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `record` | enum (record-from-answer) | Start recording automatically after an event. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `sip_region` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `preferred_codecs` | string | The list of comma-separated codecs in order of preference to be used during t... |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+
+## Webhook Payload Fields
+
+### `callAnswered`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.answered | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: answered | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### `callBridged`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.bridged | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+
+### `callHangup`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.hangup | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.custom_headers` | array[object] | Custom headers set on answer command |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.state` | enum: hangup | State received from a command. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+| `data.payload.hangup_cause` | enum: call_rejected, normal_clearing, originator_cancel, timeout, time_limit, user_busy, not_found, no_answer, unspecified | The reason the call was ended (`call_rejected`, `normal_clearing`, `originator_cancel`, `timeout`, `time_limit`, `use... |
+| `data.payload.hangup_source` | enum: caller, callee, unknown | The party who ended the call (`callee`, `caller`, `unknown`). |
+| `data.payload.sip_hangup_cause` | string | The reason the call was ended (SIP response code). |
+| `data.payload.call_quality_stats` | object \| null | Call quality statistics aggregated from the CHANNEL_HANGUP_COMPLETE event. |
+
+### `callInitiated`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data.record_type` | enum: event | Identifies the type of the resource. |
+| `data.event_type` | enum: call.initiated | The type of event being delivered. |
+| `data.id` | uuid | Identifies the type of resource. |
+| `data.occurred_at` | date-time | ISO 8601 datetime of when the event occurred. |
+| `data.payload.call_control_id` | string | Call ID used to issue commands via Call Control API. |
+| `data.payload.connection_id` | string | Call Control App ID (formerly Telnyx connection ID) used in the call. |
+| `data.payload.connection_codecs` | string | The list of comma-separated codecs enabled for the connection. |
+| `data.payload.offered_codecs` | string | The list of comma-separated codecs offered by caller. |
+| `data.payload.call_leg_id` | string | ID that is unique to the call and can be used to correlate webhook events. |
+| `data.payload.custom_headers` | array[object] | Custom headers from sip invite |
+| `data.payload.sip_headers` | array[object] | User-to-User and Diversion headers from sip invite. |
+| `data.payload.shaken_stir_attestation` | string | SHAKEN/STIR attestation level. |
+| `data.payload.shaken_stir_validated` | boolean | Whether attestation was successfully validated or not. |
+| `data.payload.call_session_id` | string | ID that is unique to the call session and can be used to correlate webhook events. |
+| `data.payload.client_state` | string | State received from a command. |
+| `data.payload.caller_id_name` | string | Caller id. |
+| `data.payload.call_screening_result` | string | Call screening result. |
+| `data.payload.from` | string | Number or SIP URI placing the call. |
+| `data.payload.to` | string | Destination number or SIP URI of the call. |
+| `data.payload.direction` | enum: incoming, outgoing | Whether the call is `incoming` or `outgoing`. |
+| `data.payload.state` | enum: parked, bridging | State received from a command. |
+| `data.payload.start_time` | date-time | ISO 8601 datetime of when the call started. |
+| `data.payload.tags` | array[string] | Array of tags associated to number. |
+
+### Field Type Notes
+
+- `from` in webhook payloads: string (E.164 phone number)
+- `to` in webhook payloads: string (E.164 phone number)
+- The return value of `client.webhooks.unwrap()` is a parsed event object — access fields via `event.data.event_type`, `event.data.payload.call_control_id`, etc.

--- a/skills/telnyx-twilio-migration/sdk-reference/webrtc-client/android.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/webrtc-client/android.md
@@ -385,7 +385,7 @@ If using code obfuscation, add to `proguard-rules.pro`:
 
 <!-- BEGIN AUTO-GENERATED API REFERENCE -- do not edit below this line -->
 
-**[references/webrtc-server-api.md](references/webrtc-server-api.md) has the server-side WebRTC API — credential creation, token generation, and push notification setup. You MUST read it when setting up authentication or push notifications.**
+**[../curl/webrtc.md](../curl/webrtc.md) has the server-side WebRTC API — credential creation, token generation, and push notification setup. You MUST read it when setting up authentication or push notifications.**
 
 ## API Reference
 

--- a/skills/telnyx-twilio-migration/sdk-reference/webrtc-client/flutter.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/webrtc-client/flutter.md
@@ -493,7 +493,7 @@ final config = CredentialConfig(
 
 <!-- BEGIN AUTO-GENERATED API REFERENCE -- do not edit below this line -->
 
-**[references/webrtc-server-api.md](references/webrtc-server-api.md) has the server-side WebRTC API — credential creation, token generation, and push notification setup. You MUST read it when setting up authentication or push notifications.**
+**[../curl/webrtc.md](../curl/webrtc.md) has the server-side WebRTC API — credential creation, token generation, and push notification setup. You MUST read it when setting up authentication or push notifications.**
 
 ## API Reference
 

--- a/skills/telnyx-twilio-migration/sdk-reference/webrtc-client/ios.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/webrtc-client/ios.md
@@ -439,7 +439,7 @@ let txConfig = TxConfig(
 
 <!-- BEGIN AUTO-GENERATED API REFERENCE -- do not edit below this line -->
 
-**[references/webrtc-server-api.md](references/webrtc-server-api.md) has the server-side WebRTC API — credential creation, token generation, and push notification setup. You MUST read it when setting up authentication or push notifications.**
+**[../curl/webrtc.md](../curl/webrtc.md) has the server-side WebRTC API — credential creation, token generation, and push notification setup. You MUST read it when setting up authentication or push notifications.**
 
 ## API Reference
 

--- a/skills/telnyx-twilio-migration/sdk-reference/webrtc-client/javascript.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/webrtc-client/javascript.md
@@ -320,7 +320,7 @@ console.log('WebRTC supported:', webRTCInfo.supportWebRTC);
 
 <!-- BEGIN AUTO-GENERATED API REFERENCE -- do not edit below this line -->
 
-**[references/webrtc-server-api.md](references/webrtc-server-api.md) has the server-side WebRTC API — credential creation, token generation, and push notification setup. You MUST read it when setting up authentication or push notifications.**
+**[../curl/webrtc.md](../curl/webrtc.md) has the server-side WebRTC API — credential creation, token generation, and push notification setup. You MUST read it when setting up authentication or push notifications.**
 
 ## API Reference
 

--- a/skills/telnyx-twilio-migration/sdk-reference/webrtc-client/react-native.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/webrtc-client/react-native.md
@@ -307,7 +307,7 @@ await AsyncStorage.multiRemove([
 
 <!-- BEGIN AUTO-GENERATED API REFERENCE -- do not edit below this line -->
 
-**[references/webrtc-server-api.md](references/webrtc-server-api.md) has the server-side WebRTC API — credential creation, token generation, and push notification setup. You MUST read it when setting up authentication or push notifications.**
+**[../curl/webrtc.md](../curl/webrtc.md) has the server-side WebRTC API — credential creation, token generation, and push notification setup. You MUST read it when setting up authentication or push notifications.**
 
 ## API Reference
 

--- a/skills/telnyx-voice-curl/SKILL.md
+++ b/skills/telnyx-voice-curl/SKILL.md
@@ -86,7 +86,7 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +56 optional params in [references/api-details.md](references/api-details.md) |
 
 ```bash
 curl \
@@ -121,7 +121,7 @@ Primary inbound call-control command.
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +29 optional params in [references/api-details.md](references/api-details.md) |
 
 ```bash
 curl \
@@ -148,7 +148,7 @@ Common post-answer control path with downstream webhook implications.
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```bash
 curl \
@@ -156,7 +156,7 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-  "to": "+18005550100"
+  "to": "+18005550100;secure=srtp"
 }' \
   "https://api.telnyx.com/v2/calls/v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ/actions/transfer"
 ```

--- a/skills/telnyx-voice-curl/references/api-details.md
+++ b/skills/telnyx-voice-curl/references/api-details.md
@@ -128,14 +128,19 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
 | `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 | `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
 | `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +168,9 @@
 | `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
 | `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +192,8 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | Use this field to add state to every subsequent webhook. |
 | `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +223,7 @@
 | `webhook_urls` | object | A map of event types to webhook URLs. |
 | `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls
 
@@ -277,7 +288,9 @@
 |-----------|------|-------------|
 | `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/skills/telnyx-voice-go/SKILL.md
+++ b/skills/telnyx-voice-go/SKILL.md
@@ -52,7 +52,7 @@ response, err := client.Calls.Dial(context.Background(), telnyx.CallDialParams{
 		ConnectionID: "7267xxxxxxxxxxxxxx",
 		From:         "+18005550101",
 		To: telnyx.CallDialParamsToUnion{
-			OfString: telnyx.String("+18005550100"),
+			OfString: telnyx.String("+18005550100;secure=srtp"),
 		},
 	})
 if err != nil {
@@ -111,14 +111,14 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `TimeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `BillingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `ClientState` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +56 optional params in [references/api-details.md](references/api-details.md) |
 
 ```go
 	response, err := client.Calls.Dial(context.Background(), telnyx.CallDialParams{
 		ConnectionID: "7267xxxxxxxxxxxxxx",
 		From:         "+18005550101",
 		To: telnyx.CallDialParamsToUnion{
-			OfString: telnyx.String("+18005550100"),
+			OfString: telnyx.String("+18005550100;secure=srtp"),
 		},
 	})
 	if err != nil {
@@ -147,7 +147,7 @@ Primary inbound call-control command.
 | `BillingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `ClientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `WebhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +29 optional params in [references/api-details.md](references/api-details.md) |
 
 ```go
 	response, err := client.Calls.Actions.Answer(
@@ -178,14 +178,14 @@ Common post-answer control path with downstream webhook implications.
 | `TimeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `ClientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `WebhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```go
 	response, err := client.Calls.Actions.Transfer(
 		context.Background(),
 		"call_control_id",
 		telnyx.CallActionTransferParams{
-			To: "+18005550100",
+			To: "+18005550100;secure=srtp",
 		},
 	)
 	if err != nil {

--- a/skills/telnyx-voice-go/references/api-details.md
+++ b/skills/telnyx-voice-go/references/api-details.md
@@ -128,14 +128,19 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `Assistant` | object | AI Assistant configuration. |
+| `ConversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `FromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `Privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `AudioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `SendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
 | `MediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `PreferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `TimeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `TimeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `AnsweringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `AnsweringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `DeepfakeDetection` | object | Enables deepfake detection on the call. |
 | `ConferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
 | `CustomHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `BillingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +168,9 @@
 | `SendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
 | `WebhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `WebhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `WebhookUrls` | object | A map of event types to webhook URLs. |
+| `WebhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `WebhookRetriesPolicies` | object | A map of event types to retry policies. |
 | `Record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `RecordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `RecordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +192,8 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `Assistant` | object | AI Assistant configuration. |
+| `ConversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `BillingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `ClientState` | string | Use this field to add state to every subsequent webhook. |
 | `CommandId` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +223,7 @@
 | `WebhookUrls` | object | A map of event types to webhook URLs. |
 | `WebhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `WebhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `DeepfakeDetection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.Calls.Actions.Bridge()`
 
@@ -277,7 +288,9 @@
 |-----------|------|-------------|
 | `From` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `FromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `Privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `AudioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `SendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `EarlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `MediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `TimeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/skills/telnyx-voice-java/SKILL.md
+++ b/skills/telnyx-voice-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.36.0</version>
+    <version>6.58.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.36.0")
+implementation("com.telnyx.sdk:telnyx:6.58.0")
 ```
 
 ## Setup
@@ -51,7 +51,7 @@ import com.telnyx.sdk.models.calls.CallDialResponse;
 CallDialParams params = CallDialParams.builder()
     .connectionId("7267xxxxxxxxxxxxxx")
     .from("+18005550101")
-    .to("+18005550100")
+    .to("+18005550100;secure=srtp")
     .build();
 CallDialResponse response = client.calls().dial(params);
 ```
@@ -95,7 +95,7 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +56 optional params in [references/api-details.md](references/api-details.md) |
 
 ```java
 import com.telnyx.sdk.models.calls.CallDialParams;
@@ -104,7 +104,7 @@ import com.telnyx.sdk.models.calls.CallDialResponse;
 CallDialParams params = CallDialParams.builder()
     .connectionId("7267xxxxxxxxxxxxxx")
     .from("+18005550101")
-    .to("+18005550100")
+    .to("+18005550100;secure=srtp")
     .build();
 CallDialResponse response = client.calls().dial(params);
 ```
@@ -129,7 +129,7 @@ Primary inbound call-control command.
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +29 optional params in [references/api-details.md](references/api-details.md) |
 
 ```java
 import com.telnyx.sdk.models.calls.actions.ActionAnswerParams;
@@ -155,7 +155,7 @@ Common post-answer control path with downstream webhook implications.
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```java
 import com.telnyx.sdk.models.calls.actions.ActionTransferParams;
@@ -163,7 +163,7 @@ import com.telnyx.sdk.models.calls.actions.ActionTransferResponse;
 
 ActionTransferParams params = ActionTransferParams.builder()
     .callControlId("v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ")
-    .to("+18005550100")
+    .to("+18005550100;secure=srtp")
     .build();
 ActionTransferResponse response = client.calls().actions().transfer(params);
 ```

--- a/skills/telnyx-voice-java/references/api-details.md
+++ b/skills/telnyx-voice-java/references/api-details.md
@@ -128,14 +128,19 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
 | `mediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `preferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
 | `conferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
 | `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +168,9 @@
 | `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
 | `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhookUrls` | object | A map of event types to webhook URLs. |
+| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +192,8 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | Use this field to add state to every subsequent webhook. |
 | `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +223,7 @@
 | `webhookUrls` | object | A map of event types to webhook URLs. |
 | `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.calls().actions().bridge()`
 
@@ -277,7 +288,9 @@
 |-----------|------|-------------|
 | `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `earlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `mediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/skills/telnyx-voice-javascript/SKILL.md
+++ b/skills/telnyx-voice-javascript/SKILL.md
@@ -43,7 +43,7 @@ try {
   const response = await client.calls.dial({
     connection_id: '7267xxxxxxxxxxxxxx',
     from: '+18005550101',
-    to: '+18005550100',
+    to: '+18005550100;secure=srtp',
   });
 } catch (err) {
   if (err instanceof Telnyx.APIConnectionError) {
@@ -99,13 +99,13 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +56 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const response = await client.calls.dial({
   connection_id: '7267xxxxxxxxxxxxxx',
   from: '+18005550101',
-  to: '+18005550100',
+  to: '+18005550100;secure=srtp',
 });
 
 console.log(response.data);
@@ -131,7 +131,7 @@ Primary inbound call-control command.
 | `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +29 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const response = await client.calls.actions.answer('v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ');
@@ -156,11 +156,11 @@ Common post-answer control path with downstream webhook implications.
 | `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `clientState` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const response = await client.calls.actions.transfer('call_control_id', {
-  to: '+18005550100',
+  to: '+18005550100;secure=srtp',
 });
 
 console.log(response.data);

--- a/skills/telnyx-voice-javascript/references/api-details.md
+++ b/skills/telnyx-voice-javascript/references/api-details.md
@@ -128,14 +128,19 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
 | `mediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `preferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
 | `conferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
 | `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +168,9 @@
 | `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
 | `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhookUrls` | object | A map of event types to webhook URLs. |
+| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +192,8 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `clientState` | string | Use this field to add state to every subsequent webhook. |
 | `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +223,7 @@
 | `webhookUrls` | object | A map of event types to webhook URLs. |
 | `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `deepfakeDetection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.calls.actions.bridge()`
 
@@ -277,7 +288,9 @@
 |-----------|------|-------------|
 | `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `earlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `mediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/skills/telnyx-voice-python/SKILL.md
+++ b/skills/telnyx-voice-python/SKILL.md
@@ -46,7 +46,7 @@ try:
     response = client.calls.dial(
         connection_id="7267xxxxxxxxxxxxxx",
         from_="+18005550101",
-        to="+18005550100",
+        to="+18005550100;secure=srtp",
     )
 except telnyx.APIConnectionError:
     print("Network error — check connectivity and retry")
@@ -98,13 +98,13 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +56 optional params in [references/api-details.md](references/api-details.md) |
 
 ```python
 response = client.calls.dial(
     connection_id="7267xxxxxxxxxxxxxx",
     from_="+18005550101",
-    to="+18005550100",
+    to="+18005550100;secure=srtp",
 )
 print(response.data)
 ```
@@ -129,7 +129,7 @@ Primary inbound call-control command.
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +29 optional params in [references/api-details.md](references/api-details.md) |
 
 ```python
 response = client.calls.actions.answer(
@@ -155,12 +155,12 @@ Common post-answer control path with downstream webhook implications.
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```python
 response = client.calls.actions.transfer(
     call_control_id="550e8400-e29b-41d4-a716-446655440000",
-    to="+18005550100",
+    to="+18005550100;secure=srtp",
 )
 print(response.data)
 ```

--- a/skills/telnyx-voice-python/references/api-details.md
+++ b/skills/telnyx-voice-python/references/api-details.md
@@ -128,14 +128,19 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
 | `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 | `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
 | `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +168,9 @@
 | `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
 | `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +192,8 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | Use this field to add state to every subsequent webhook. |
 | `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +223,7 @@
 | `webhook_urls` | object | A map of event types to webhook URLs. |
 | `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.calls.actions.bridge()`
 
@@ -277,7 +288,9 @@
 |-----------|------|-------------|
 | `from_` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |

--- a/skills/telnyx-voice-ruby/SKILL.md
+++ b/skills/telnyx-voice-ruby/SKILL.md
@@ -42,7 +42,7 @@ or authentication errors (401). Always handle errors in production code:
 response = client.calls.dial(
   connection_id: "7267xxxxxxxxxxxxxx",
   from: "+18005550101",
-  to: "+18005550100"
+  to: "+18005550100;secure=srtp"
 )
 puts(response)
 ```
@@ -86,13 +86,13 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
-| ... | | | +48 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +56 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
 response = client.calls.dial(
   connection_id: "7267xxxxxxxxxxxxxx",
   from: "+18005550101",
-  to: "+18005550100"
+  to: "+18005550100;secure=srtp"
 )
 
 puts(response)
@@ -118,7 +118,7 @@ Primary inbound call-control command.
 | `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +26 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +29 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
 response = client.calls.actions.answer("v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ")
@@ -143,10 +143,13 @@ Common post-answer control path with downstream webhook implications.
 | `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
 | `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
-| ... | | | +33 optional params in [references/api-details.md](references/api-details.md) |
+| ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```ruby
-response = client.calls.actions.transfer("call_control_id", to: "+18005550100")
+response = client.calls.actions.transfer(
+  "call_control_id",
+  to: "+18005550100;secure=srtp"
+)
 
 puts(response)
 ```

--- a/skills/telnyx-voice-ruby/references/api-details.md
+++ b/skills/telnyx-voice-ruby/references/api-details.md
@@ -128,14 +128,19 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
 | `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
 | `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
 | `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
 | `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
 | `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 | `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
 | `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
@@ -163,6 +168,9 @@
 | `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
 | `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
 | `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
 | `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
 | `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
@@ -184,6 +192,8 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| `assistant` | object | AI Assistant configuration. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
 | `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
 | `client_state` | string | Use this field to add state to every subsequent webhook. |
 | `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
@@ -213,6 +223,7 @@
 | `webhook_urls` | object | A map of event types to webhook URLs. |
 | `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
 | `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.calls.actions.bridge()`
 
@@ -277,7 +288,9 @@
 |-----------|------|-------------|
 | `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
 | `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
 | `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
 | `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
 | `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
 | `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |


### PR DESCRIPTION
## Auto-generated Telnyx skills update

Fresh generated-output run after source PR https://github.com/team-telnyx/telnyx-ext-skills-generator/pull/81 merged.

This run required a follow-up SDK metadata refresh because upstream Python/Ruby SDK releases landed after PR #81:
- Source metadata PR: https://github.com/team-telnyx/telnyx-ext-skills-generator/pull/82
- Source generator commit used for this run: `a76f9dcc092397f807dde772e7c0d633018b3006`
- Downstream generated commit: `981c711d5dda4d4cff16a8efe32856a4cfe38b4d`
- Supersedes closed verification PR: https://github.com/team-telnyx/ai/pull/211

## Scope

- Profile: `northstar-v2`
- Products: `messaging`, `voice`, `10dlc`, `numbers`, `ai-assistants`
- Languages: `curl`, `go`, `java`, `javascript`, `python`, `ruby`
- Generated canonical skills copied: 30
- Manual/non-target skills preserved: 204
- Canonical skills total in `team-telnyx/ai`: 234
- Provider copies refreshed via `./scripts/sync-skills.sh`

## Managed embedded refs refreshed

- `skills/telnyx-twilio-migration/sdk-reference/{language}/{product}.md`: 30 scoped product/language refs refreshed.
- `skills/telnyx-webrtc-client-*/references/webrtc-server-api.md`: 5 server-side WebRTC API refs refreshed.
- `skills/telnyx-twilio-migration/sdk-reference/webrtc-client/*.md`: 5 WebRTC client migration refs refreshed with valid relative server API links.
- Claude/Cursor provider copies include the same refreshed managed refs.

## Validation

- `./sdk-extraction/run_all.sh` — passed
  - Python 4.143.0
  - JavaScript v6.70.0
  - Ruby 5.122.0
  - Go v4.71.0
  - Java 6.58.0
- `python3 -m pytest tests/test_northstar_v2.py tests/test_publish_ai.py -q` — 47 passed
- `./publish.sh --dry-run --scope-manifest scopes/northstar-v2-pilot.json ...` — passed
- Embedded link audit passed: no stale `references/api-details.md`, no malformed `the API Details section below#`, and no broken `references/webrtc-server-api.md` links under Twilio migration WebRTC client refs.
- `./publish.sh --scope-manifest scopes/northstar-v2-pilot.json ...` — passed and opened this PR.

## Notes

This PR is draft while source PR #82 is unmerged. It is a generated-output verification artifact, not something to merge independently before the metadata source lands.
