### PR TITLE
feat: add compose studio and scribe workspace navigation

### DIFF
--- a/apps/link-desktop/src/renderer/styles.css
+++ b/apps/link-desktop/src/renderer/styles.css
@@ -117,8 +117,17 @@ button {
 .desktop.terminalOpen .mainPane,
 .desktop.terminalOpen .appSurface,
 .desktop.terminalOpen .pageSurface,
+.desktop.terminalOpen .assistantPanel,
 .desktop.terminalOpen .pageSectionShell {
   min-height: 0;
+}
+
+.desktop.terminalOpen .workspace,
+.desktop.terminalOpen .rail,
+.desktop.terminalOpen .sidebar,
+.desktop.terminalOpen .assistantPanel,
+.desktop.terminalOpen .pageSectionShell {
+  overflow: hidden;
 }
 
 .desktop[data-theme="dark"] {
@@ -136,6 +145,8 @@ button {
   --toggle-off-border: #4b4742;
   --toggle-off-thumb: #d7d0c8;
   --shadow: 0 20px 60px rgba(0, 0, 0, 0.34);
+  color: var(--text);
+  background: var(--bg);
 }
 
 .desktop[data-theme="dark"] * {
@@ -189,6 +200,31 @@ button {
 .titleBarAction:hover {
   color: var(--text);
   background: transparent;
+}
+
+.titleBarAction:disabled {
+  cursor: default;
+  opacity: 0.65;
+}
+
+.updateTitleBarAction {
+  color: var(--accent);
+}
+
+.updateTitleBarAction.downloaded {
+  color: #087443;
+}
+
+.updateTitleBarAction.error {
+  color: #a33a2c;
+}
+
+.desktop[data-theme="dark"] .updateTitleBarAction.downloaded {
+  color: #63d59a;
+}
+
+.desktop[data-theme="dark"] .updateTitleBarAction.error {
+  color: #ff8a78;
 }
 
 .codexTitleBarIcon {
@@ -302,11 +338,21 @@ button {
 }
 
 .desktop[data-theme="dark"] .railButton:hover,
-.desktop[data-theme="dark"] .railButton.selected,
-.desktop[data-theme="dark"] .avatar:hover,
-.desktop[data-theme="dark"] .avatar.selected {
+.desktop[data-theme="dark"] .railButton.selected {
   color: var(--text);
   background: #2d2b28;
+}
+
+.desktop[data-theme="dark"] .avatar {
+  color: var(--text);
+  background: #2d2b28;
+}
+
+.desktop[data-theme="dark"] .avatar:hover,
+.desktop[data-theme="dark"] .avatar:focus-visible,
+.desktop[data-theme="dark"] .avatar.selected {
+  color: #22211f;
+  background: #f7f6f4;
 }
 
 .desktop[data-theme="dark"] .assistantRailButton:hover {
@@ -682,7 +728,7 @@ button {
 
 .desktop[data-theme="dark"] .assistantPanel .button.primary,
 .desktop[data-theme="dark"] .button.primary {
-  color: var(--accent-ink);
+  color: #f7fff9;
   background: var(--accent);
   border-color: var(--accent);
 }
@@ -949,6 +995,10 @@ button {
   .railSecondaryGroup {
     margin-top: 0;
   }
+}
+
+.desktop.terminalOpen .railSecondaryGroup {
+  margin-top: 0;
 }
 
 .accountMenuWrap {
@@ -3973,7 +4023,7 @@ button {
   gap: 14px;
 }
 
-.telnyxSetupHero,
+.telnyxSetupConnectCard,
 .telnyxSetupCredentialCard {
   border: 1px solid var(--border);
   border-radius: 8px;
@@ -3985,6 +4035,15 @@ button {
   grid-template-columns: 52px minmax(0, 1fr) auto;
   align-items: center;
   gap: 14px;
+  padding: 18px;
+}
+
+.telnyxSetupConnectCard {
+  display: grid;
+  overflow: hidden;
+}
+
+.telnyxSetupConnectCard .telnyxSetupHero {
   padding: 18px;
 }
 
@@ -4012,23 +4071,52 @@ button {
   line-height: 1.4;
 }
 
-.telnyxSetupGrid {
+.telnyxSetupStatusList {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 10px;
-}
-
-.telnyxSetupGrid > div {
-  display: grid;
-  gap: 6px;
-  min-width: 0;
-  padding: 14px;
-  border: 1px solid var(--border-soft);
+  gap: 0;
+  overflow: hidden;
+  border: 1px solid var(--border);
   border-radius: 8px;
   background: var(--surface);
 }
 
-.telnyxSetupGrid strong {
+.telnyxSetupCombinedHeader {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 16px;
+  padding: 16px;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.telnyxSetupCombinedHeader h3 {
+  margin: 0;
+  color: var(--text);
+  font-size: 17px;
+}
+
+.telnyxSetupCombinedHeader p {
+  margin: 5px 0 0;
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.telnyxSetupStatusRow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 16px;
+  min-width: 0;
+  padding: 14px 16px;
+}
+
+.telnyxSetupStatusRow + .telnyxSetupStatusRow {
+  border-top: 1px solid var(--border-soft);
+}
+
+.telnyxSetupStatusRow strong {
+  display: block;
   color: var(--text-muted);
   font-size: 12px;
   font-weight: 820;
@@ -4036,18 +4124,36 @@ button {
   text-transform: uppercase;
 }
 
-.telnyxSetupGrid span {
+.telnyxSetupStatusRow p {
+  margin: 5px 0 0;
   color: var(--text);
-  font-size: 16px;
-  font-weight: 820;
+  font-size: 14px;
+  line-height: 1.35;
 }
 
 .telnyxSetupAlert {
   margin: 0;
 }
 
+.telnyxSetupFinishButton {
+  white-space: nowrap;
+}
+
 .sessionsSetupAlert {
   grid-template-columns: 36px minmax(0, 1fr);
+}
+
+.telnyxSetupCredentialInline {
+  display: grid;
+  gap: 12px;
+  padding: 16px 18px 18px;
+  border-top: 1px solid var(--border-soft);
+  background: color-mix(in srgb, var(--surface-raised) 70%, transparent);
+}
+
+.telnyxSetupCredentialInline .credentialList,
+.telnyxSetupCredentialInline .credentialCard {
+  margin: 0;
 }
 
 .telnyxSetupCredentialCard {
@@ -4061,14 +4167,53 @@ button {
   margin: 0;
 }
 
+.sessionsSetupCombined .credentialFlatGroup {
+  min-width: 0;
+}
+
+.sessionsSetupCombined .credentialFieldsFlat {
+  display: grid;
+  gap: 0;
+}
+
+.sessionsSetupCombined .credentialFieldsFlat .credentialRow {
+  padding: 14px 16px;
+  border-top: 0;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.sessionsSetupCombined .credentialFieldsFlat .credentialRow:last-child {
+  border-bottom: 1px solid var(--border-soft);
+}
+
 @media (max-width: 900px) {
-  .telnyxSetupHero,
-  .telnyxSetupGrid {
+  .telnyxSetupHero {
     grid-template-columns: 1fr;
   }
 
   .telnyxSetupHero {
     align-items: start;
+  }
+
+  .telnyxSetupStatusRow,
+  .telnyxSetupCombinedHeader {
+    grid-template-columns: 1fr;
+    align-items: start;
+    gap: 10px;
+  }
+
+  .telnyxSetupStatusRow .badge,
+  .telnyxSetupCombinedHeader .badge,
+  .telnyxSetupFinishButton {
+    justify-self: start;
+  }
+
+  .sessionsSetupCombined .credentialFieldsFlat .credentialRow {
+    grid-template-columns: 1fr;
+  }
+
+  .sessionsSetupCombined .credentialFieldsFlat .credentialRow .button {
+    justify-self: start;
   }
 }
 
@@ -5485,6 +5630,14 @@ button {
   background: var(--surface);
 }
 
+.artifactImagePreview {
+  display: block;
+  max-width: min(100%, 1280px);
+  height: auto;
+  margin: 0 auto;
+  padding: 18px;
+}
+
 .artifactDocument pre {
   margin: 0;
   padding: 22px;
@@ -5657,9 +5810,11 @@ body.assistantPanelResizing {
 }
 
 .terminalDock {
+  position: relative;
+  z-index: 80;
   display: grid;
   grid-row: 3;
-  grid-template-rows: 40px minmax(0, 1fr) 38px;
+  grid-template-rows: 40px minmax(0, 1fr) auto;
   min-height: 0;
   border-top: 1px solid var(--border);
   color: #f4f1ec;
@@ -5674,6 +5829,105 @@ body.assistantPanelResizing {
   min-width: 0;
   padding: 0 12px;
   border-bottom: 1px solid #2d2b28;
+}
+
+.terminalDockHeaderLeft {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.terminalDockBrand {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  gap: 8px;
+  height: 28px;
+  padding: 0 10px;
+  border-radius: 8px;
+  color: #f4f1ec;
+  background: #242321;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.terminalDockBrandIcon {
+  display: grid;
+  place-items: center;
+  width: 18px;
+  height: 18px;
+  color: #00d4a2;
+}
+
+.terminalDockBrand strong {
+  font-size: 12px;
+  font-weight: 780;
+  white-space: nowrap;
+}
+
+.terminalDockInfo {
+  position: relative;
+  display: inline-grid;
+  place-items: center;
+  width: 18px;
+  height: 18px;
+  margin-right: -4px;
+  border: 1px solid #4a4641;
+  border-radius: 999px;
+  color: #c7c0b8;
+  background: transparent;
+  font: 700 11px/1 Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  text-transform: none;
+}
+
+.terminalDockInfo::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 9px);
+  left: 50%;
+  z-index: 2;
+  display: none;
+  width: min(300px, 52vw);
+  padding: 7px 9px;
+  transform: translateX(-50%);
+  border: 1px solid #3a3835;
+  border-radius: 7px;
+  color: #f4f1ec;
+  background: #242321;
+  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.38);
+  font: 650 11px/1.35 Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  text-align: left;
+  white-space: normal;
+}
+
+.terminalDockInfo::before {
+  content: "";
+  position: absolute;
+  bottom: calc(100% + 4px);
+  left: 50%;
+  display: none;
+  width: 8px;
+  height: 8px;
+  transform: translateX(-50%) rotate(45deg);
+  border-right: 1px solid #3a3835;
+  border-bottom: 1px solid #3a3835;
+  background: #242321;
+}
+
+.terminalDockInfo:hover,
+.terminalDockInfo:focus-visible {
+  color: #f4f1ec;
+  border-color: #6b655e;
+  background: #2d2b28;
+  outline: none;
+}
+
+.terminalDockInfo:hover::after,
+.terminalDockInfo:hover::before,
+.terminalDockInfo:focus-visible::after,
+.terminalDockInfo:focus-visible::before {
+  display: block;
 }
 
 .terminalDockTabs {
@@ -5781,9 +6035,10 @@ body.assistantPanelResizing {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
   align-items: center;
-  gap: 8px;
+  gap: 10px;
   min-width: 0;
-  padding: 0 16px;
+  min-height: 44px;
+  padding: 6px 16px;
   border-top: 1px solid #2d2b28;
   color: #d7d0c8;
   background: #151515;
@@ -5804,6 +6059,12 @@ body.assistantPanelResizing {
 
 .terminalCommandRow input::placeholder {
   color: #706b65;
+}
+
+@media (max-width: 860px) {
+  .terminalDockBrand strong {
+    display: none;
+  }
 }
 
 .assistantChatFrame {
@@ -8204,7 +8465,7 @@ body.assistantPanelResizing {
 }
 
 .desktop[data-theme="dark"] .assistantPanel .button.primary {
-  color: #001a14;
+  color: #f7fff9;
   background: var(--accent);
   border-color: var(--accent);
 }
@@ -13935,6 +14196,19 @@ body.assistantPanelResizing {
   }
 }
 
+@container (max-width: 760px) {
+  .phoneSetupAlert {
+    grid-template-columns: 36px minmax(0, 1fr);
+    align-items: start;
+    gap: 12px;
+  }
+
+  .phoneSetupAlert .runtimeSettingsButton {
+    grid-column: 2;
+    justify-self: start;
+  }
+}
+
 @media (max-width: 520px) {
   .phoneSetupAlert {
     grid-template-columns: 36px minmax(0, 1fr);
@@ -14511,6 +14785,269 @@ body.assistantPanelResizing {
   scroll-padding-bottom: var(--app-bottom-inset);
 }
 
+.agentsView .pageHeader {
+  position: relative;
+  z-index: 2;
+}
+
+.agentsView .agentControls {
+  position: relative;
+  z-index: 1;
+}
+
+.agentConnectionMeta {
+  display: block;
+  min-width: 0;
+  margin-top: 3px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 650;
+  line-height: 1.25;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.remotePairingWizard {
+  display: grid;
+  align-content: start;
+  gap: 16px;
+  width: min(860px, 100%);
+  margin: 0 auto;
+  padding-bottom: 28px;
+}
+
+.remotePairingHero {
+  display: grid;
+  grid-template-columns: 56px minmax(0, 1fr);
+  align-items: start;
+  gap: 14px;
+  padding: 18px 0 4px;
+}
+
+.remotePairingIcon {
+  display: grid;
+  place-items: center;
+  width: 56px;
+  height: 56px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: #006f59;
+  background: rgba(0, 227, 170, 0.12);
+}
+
+.remotePairingHero h2 {
+  margin: 0 0 8px;
+  color: var(--text);
+  font-size: 26px;
+  line-height: 1.1;
+  letter-spacing: 0;
+}
+
+.remotePairingHero p {
+  max-width: 680px;
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.remotePairingSteps {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.remotePairingSteps span {
+  display: flex;
+  align-items: center;
+  min-height: 32px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text-muted);
+  background: var(--surface);
+  font-size: 12px;
+  font-weight: 760;
+}
+
+.remotePairingSteps span.complete {
+  color: #005c49;
+  border-color: rgba(0, 143, 114, 0.38);
+  background: rgba(0, 227, 170, 0.1);
+}
+
+.remotePairingForm {
+  display: grid;
+  gap: 14px;
+}
+
+.remoteRuntimeChoice {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.remoteRuntimeChoice button {
+  display: grid;
+  grid-template-columns: 22px minmax(0, 1fr);
+  grid-template-areas:
+    "icon title"
+    "icon body";
+  align-items: start;
+  gap: 3px 10px;
+  min-height: 86px;
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  background: var(--surface);
+  text-align: left;
+}
+
+.remoteRuntimeChoice button svg {
+  grid-area: icon;
+  margin-top: 1px;
+  color: var(--text-muted);
+}
+
+.remoteRuntimeChoice button strong {
+  grid-area: title;
+  min-width: 0;
+  font-size: 15px;
+  line-height: 1.2;
+}
+
+.remoteRuntimeChoice button span {
+  grid-area: body;
+  min-width: 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.3;
+}
+
+.remoteRuntimeChoice button.selected {
+  border-color: rgba(0, 143, 114, 0.45);
+  background: rgba(0, 227, 170, 0.1);
+}
+
+.remotePairingGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.remotePairingWideField textarea {
+  min-height: 116px;
+  resize: vertical;
+}
+
+.connectionChecklist {
+  display: grid;
+  gap: 8px;
+}
+
+.compactConnectionChecklist {
+  margin-bottom: 12px;
+}
+
+.connectionChecklistItem {
+  display: grid;
+  grid-template-columns: 20px minmax(0, 1fr);
+  align-items: start;
+  gap: 9px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.connectionChecklistItem svg {
+  margin-top: 1px;
+  color: #008f72;
+}
+
+.connectionChecklistItem div {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.connectionChecklistItem strong {
+  min-width: 0;
+  color: var(--text);
+  font-size: 12px;
+  line-height: 1.25;
+}
+
+.connectionChecklistItem span {
+  min-width: 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.remotePairingReview,
+.remoteAgentConnectionPanel {
+  display: grid;
+  gap: 12px;
+}
+
+.remotePairingPaired {
+  display: grid;
+  grid-template-columns: 46px minmax(0, 1fr);
+  gap: 12px;
+  align-items: start;
+  padding: 16px;
+  border: 1px solid rgba(0, 143, 114, 0.32);
+  border-radius: 8px;
+  background: rgba(0, 227, 170, 0.08);
+}
+
+.remotePairingPaired h3 {
+  margin: 0 0 4px;
+  font-size: 16px;
+  line-height: 1.25;
+}
+
+.remotePairingPaired p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.remotePairingPaired .directoryActionPanel {
+  grid-column: 2;
+  margin-top: 4px;
+}
+
+.remotePairingActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+@media (max-width: 760px) {
+  .remotePairingHero,
+  .remotePairingGrid,
+  .remoteRuntimeChoice,
+  .remotePairingSteps {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .remotePairingActions,
+  .remotePairingPaired .directoryActionPanel {
+    justify-content: stretch;
+  }
+
+  .remotePairingActions > .button,
+  .remotePairingPaired .directoryActionPanel > .button {
+    flex: 1 1 auto;
+  }
+}
+
 .wikiHubView .pageSectionShellSingle .wikiHubContent {
   display: flex;
   flex: 1 1 auto;
@@ -14666,6 +15203,513 @@ body.assistantPanelResizing {
 
 .wikiWorkspaceDraftRow > span {
   min-width: 0;
+}
+
+.composeStudioShell {
+  display: grid;
+  align-content: start;
+  gap: 14px;
+  width: 100%;
+  min-width: 0;
+}
+
+.composeStudioTabs {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  overflow-x: auto;
+}
+
+.composeStudioTabs button {
+  flex: 0 0 auto;
+  height: 34px;
+  padding: 0 12px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  color: var(--text-muted);
+  background: transparent;
+  font-size: 13px;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.composeStudioTabs button:hover {
+  color: var(--text);
+  background: var(--surface-muted);
+}
+
+.composeStudioTabs button.selected {
+  color: var(--text);
+  border-color: var(--border-soft);
+  background: var(--surface-soft);
+}
+
+.composePromptPanel,
+.composeStudioSection,
+.composeDesignCard,
+.composeSystemRow,
+.composeExampleCard {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.composePromptPanel {
+  display: grid;
+  gap: 12px;
+  padding: 14px;
+}
+
+.composePromptHeader {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.composePromptIcon,
+.composeProjectIcon,
+.composeSystemIcon,
+.composeSystemCreateCard > span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.composePromptHeader > div {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.composePromptHeader strong,
+.composeStudioSectionHeader strong {
+  font-size: 15px;
+  font-weight: 850;
+}
+
+.composePromptHeader span,
+.composeStudioSectionHeader span {
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.composePromptField {
+  width: 100%;
+  min-height: 112px;
+  resize: vertical;
+  padding: 12px;
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+  color: var(--text);
+  background: var(--surface-raised);
+  font: inherit;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.composePromptField:focus {
+  outline: 2px solid color-mix(in srgb, var(--accent) 28%, transparent);
+  outline-offset: 2px;
+}
+
+.composePromptActions,
+.composeStudioSectionHeader,
+.composeSystemActions,
+.composeDesignCard header,
+.composeDesignCard .directoryRowActions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.composePromptActions {
+  justify-content: flex-end;
+}
+
+.composeStudioStats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.composeStudioStats > div {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+  background: var(--surface-raised);
+}
+
+.composeStudioStats strong {
+  font-size: 18px;
+  font-weight: 900;
+}
+
+.composeStudioStats span {
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 750;
+}
+
+.composeStudioStack,
+.composeStudioSection {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+}
+
+.composeStudioSection {
+  padding: 14px;
+}
+
+.composeProjectTable,
+.composeStudioSection .wikiWorkspaceDraftTable {
+  border-radius: 8px;
+}
+
+.composeProjectTable .chatResultRows,
+.composeStudioSection .wikiWorkspaceDraftTable .chatResultRows {
+  max-height: none;
+}
+
+.chatSessionRows:not(.bulkEditing) .composeProjectRow,
+.composeProjectRow {
+  grid-template-columns: minmax(260px, 1.4fr) minmax(150px, 0.7fr) minmax(110px, 0.5fr) minmax(88px, 0.35fr) var(--table-action-column-width);
+}
+
+.composeProjectNameCell {
+  gap: 10px;
+}
+
+.composeProjectIcon {
+  flex: 0 0 auto;
+  width: 30px;
+  height: 30px;
+}
+
+.composeProjectNameCell small {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  color: var(--text-muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.composeDesignGrid,
+.composeExampleGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 12px;
+  min-width: 0;
+}
+
+.composeDesignCard {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+  padding: 14px;
+}
+
+.composeDesignCard header > div {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.composeDesignCard header strong,
+.composeSystemSummary strong {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  font-size: 15px;
+  font-weight: 850;
+}
+
+.composeDesignCard header span,
+.composeDesignCard p,
+.composeSystemSummary small,
+.composeSystemSummary p {
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.45;
+}
+
+.composeDesignCard p,
+.composeSystemSummary p {
+  margin: 0;
+}
+
+.composeDesignCardMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.composeDesignCardMeta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 750;
+}
+
+.composeSystemCreateGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.composeSystemCreateCard {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 3px 12px;
+  align-items: center;
+  min-width: 0;
+  min-height: 92px;
+  padding: 12px;
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+  color: var(--text);
+  background: var(--surface-raised);
+  text-align: left;
+}
+
+.composeSystemCreateCard:hover {
+  border-color: color-mix(in srgb, var(--accent) 32%, var(--border));
+  background: color-mix(in srgb, var(--accent-soft) 24%, var(--surface-raised));
+}
+
+.composeSystemCreateCard > span {
+  grid-row: span 2;
+}
+
+.composeSystemCreateCard strong {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  font-size: 14px;
+  font-weight: 850;
+}
+
+.composeSystemCreateCard em {
+  padding: 2px 6px;
+  border-radius: 999px;
+  color: #315a2f;
+  background: #dff2d6;
+  font-size: 10px;
+  font-style: normal;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.composeSystemCreateCard small {
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.composeSystemList {
+  display: grid;
+  gap: 10px;
+}
+
+.composeSystemRow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  min-width: 0;
+  padding: 12px;
+}
+
+.composeSystemSummary {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 10px;
+  min-width: 0;
+}
+
+.composeSystemSummary > div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.composeSystemActions {
+  justify-content: flex-end;
+}
+
+.composeExampleCard {
+  display: grid;
+  grid-template-columns: minmax(150px, 0.85fr) minmax(0, 1fr);
+  min-width: 0;
+  overflow: hidden;
+}
+
+.composeExamplePreview {
+  position: relative;
+  min-height: 260px;
+  background:
+    linear-gradient(135deg, color-mix(in srgb, var(--compose-accent, var(--accent)) 16%, transparent), transparent 42%),
+    var(--surface-raised);
+  border-right: 1px solid var(--border-soft);
+}
+
+.composeExamplePreview span {
+  position: absolute;
+  display: block;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--compose-accent, var(--accent)) 44%, var(--surface));
+}
+
+.composePreviewRail {
+  top: 18px;
+  bottom: 18px;
+  left: 18px;
+  width: 34px;
+  opacity: 0.45;
+}
+
+.composePreviewHeader {
+  top: 20px;
+  left: 66px;
+  right: 20px;
+  height: 34px;
+  opacity: 0.36;
+}
+
+.composePreviewMain {
+  left: 66px;
+  right: 70px;
+  bottom: 24px;
+  height: 132px;
+  opacity: 0.26;
+}
+
+.composePreviewSide {
+  right: 20px;
+  bottom: 24px;
+  width: 38px;
+  height: 132px;
+  opacity: 0.34;
+}
+
+.composePreviewLine {
+  left: 80px;
+  right: 84px;
+  height: 8px;
+  opacity: 0.5;
+}
+
+.composePreviewLine.one {
+  top: 78px;
+}
+
+.composePreviewLine.two {
+  top: 100px;
+  right: 118px;
+}
+
+.composePreviewLine.three {
+  top: 122px;
+  right: 102px;
+}
+
+.composePreviewDot {
+  width: 18px;
+  height: 18px;
+  opacity: 0.7;
+}
+
+.composePreviewDot.one {
+  right: 31px;
+  top: 81px;
+}
+
+.composePreviewDot.two {
+  right: 31px;
+  top: 112px;
+}
+
+.composeExamplePreview.console .composePreviewMain {
+  height: 160px;
+}
+
+.composeExamplePreview.flow .composePreviewMain {
+  right: 20px;
+  height: 92px;
+}
+
+.composeExamplePreview.board .composePreviewMain {
+  display: grid;
+}
+
+.composeExampleBody {
+  display: grid;
+  align-content: start;
+  gap: 12px;
+  min-width: 0;
+  padding: 16px;
+}
+
+.composeExampleBody h3 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 900;
+}
+
+.composeExampleBody p,
+.composeExampleBody blockquote {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.45;
+}
+
+.composeExampleBody blockquote {
+  padding-left: 12px;
+  border-left: 3px solid var(--compose-accent, var(--accent));
+  font-style: italic;
+}
+
+.composeExampleTags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.composeExampleTags span {
+  padding: 4px 8px;
+  border-radius: 999px;
+  color: var(--text-muted);
+  background: var(--surface-muted);
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.composeStudioEmpty {
+  grid-column: 1 / -1;
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+  background: var(--surface-raised);
 }
 
 .wikiWorkspaceEditorSurface {
@@ -15022,6 +16066,45 @@ body.assistantPanelResizing {
   .wikiWorkspacePrimaryActions {
     width: 100%;
     justify-content: flex-start;
+  }
+
+  .composeExampleCard {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .composeExamplePreview {
+    min-height: 220px;
+    border-right: 0;
+    border-bottom: 1px solid var(--border-soft);
+  }
+}
+
+@media (max-width: 820px) {
+  .composeStudioStats,
+  .composeSystemCreateGrid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .composeSystemRow {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .composeSystemActions,
+  .composePromptActions {
+    justify-content: flex-start;
+  }
+
+  .chatSessionRows:not(.bulkEditing) .composeProjectRow,
+  .composeProjectRow {
+    grid-template-columns: minmax(0, 1fr) minmax(86px, auto) var(--table-action-column-width);
+  }
+
+  .composeProjectRow > span:nth-child(2) {
+    display: none;
+  }
+
+  .composeProjectRow > span:nth-child(4) {
+    display: none;
   }
 }
 
@@ -15984,6 +17067,105 @@ body.assistantPanelResizing {
 .scribesView .pageSectionSidebar button.selected {
   background: var(--surface);
   box-shadow: none;
+}
+
+.desktop[data-theme="dark"] .settingsView .pageSectionSidebar,
+.desktop[data-theme="dark"] .phoneView .pageSectionSidebar,
+.desktop[data-theme="dark"] .driveView .pageSectionSidebar,
+.desktop[data-theme="dark"] .wikiHubView .pageSectionSidebar,
+.desktop[data-theme="dark"] .skillsView .pageSectionSidebar,
+.desktop[data-theme="dark"] .agentsView .pageSectionSidebar,
+.desktop[data-theme="dark"] .scribesView .pageSectionSidebar {
+  background: #1b1a19;
+}
+
+.desktop[data-theme="dark"] .settingsView .pageSectionSidebarHeading,
+.desktop[data-theme="dark"] .phoneView .pageSectionSidebarHeading,
+.desktop[data-theme="dark"] .driveView .pageSectionSidebarHeading,
+.desktop[data-theme="dark"] .wikiHubView .pageSectionSidebarHeading,
+.desktop[data-theme="dark"] .skillsView .pageSectionSidebarHeading,
+.desktop[data-theme="dark"] .agentsView .pageSectionSidebarHeading,
+.desktop[data-theme="dark"] .scribesView .pageSectionSidebarHeading {
+  border-color: var(--border);
+  background: #1b1a19;
+}
+
+.desktop[data-theme="dark"] .pageSectionSidebarHeadingInner {
+  color: var(--text);
+  background: #2d2b28;
+  box-shadow: inset 0 0 0 1px var(--border);
+}
+
+.desktop[data-theme="dark"] .settingsView .pageSectionSidebarGroupTitle,
+.desktop[data-theme="dark"] .phoneView .pageSectionSidebarGroupTitle,
+.desktop[data-theme="dark"] .driveView .pageSectionSidebarGroupTitle,
+.desktop[data-theme="dark"] .wikiHubView .pageSectionSidebarGroupTitle,
+.desktop[data-theme="dark"] .skillsView .pageSectionSidebarGroupTitle,
+.desktop[data-theme="dark"] .agentsView .pageSectionSidebarGroupTitle,
+.desktop[data-theme="dark"] .scribesView .pageSectionSidebarGroupTitle {
+  color: var(--text-muted);
+  background: #242321;
+}
+
+.desktop[data-theme="dark"] .settingsView .pageSectionSidebar button.selected,
+.desktop[data-theme="dark"] .phoneView .pageSectionSidebar button.selected,
+.desktop[data-theme="dark"] .driveView .pageSectionSidebar button.selected,
+.desktop[data-theme="dark"] .wikiHubView .pageSectionSidebar button.selected,
+.desktop[data-theme="dark"] .skillsView .pageSectionSidebar button.selected,
+.desktop[data-theme="dark"] .agentsView .pageSectionSidebar button.selected,
+.desktop[data-theme="dark"] .scribesView .pageSectionSidebar button.selected {
+  color: var(--text);
+  background: #2d2b28;
+  box-shadow: none;
+}
+
+.desktop[data-theme="dark"] .pageSectionSidebar button:hover,
+.desktop[data-theme="dark"] .pageSectionSidebar button:focus-visible {
+  color: var(--text);
+  background: #282623;
+}
+
+[data-theme="dark"] .button.primary,
+[data-theme="dark"] .button.secondary.active,
+[data-theme="dark"] .runtimeSettingsButton,
+[data-theme="dark"] .assistantPanel .button.primary,
+[data-theme="dark"] .onboardingHeroStepComplete.checked {
+  color: #f7fff9;
+}
+
+[data-theme="dark"] .button.primary svg,
+[data-theme="dark"] .button.secondary.active svg,
+[data-theme="dark"] .runtimeSettingsButton svg,
+[data-theme="dark"] .assistantPanel .button.primary svg,
+[data-theme="dark"] .onboardingHeroStepComplete.checked svg {
+  color: currentColor;
+}
+
+[data-theme="dark"] .pageSectionSidebar {
+  border-color: var(--border);
+  background: #1b1a19;
+}
+
+[data-theme="dark"] .pageSectionSidebarHeading {
+  border-color: var(--border);
+  background: #1b1a19;
+}
+
+[data-theme="dark"] .pageSectionSidebarHeadingInner {
+  color: var(--text);
+  background: #2d2b28;
+  box-shadow: inset 0 0 0 1px var(--border);
+}
+
+[data-theme="dark"] .pageSectionSidebarGroupTitle {
+  color: var(--text-muted);
+  border-color: var(--border);
+  background: #242321;
+}
+
+[data-theme="dark"] .pageSectionSidebar button.selected {
+  color: var(--text);
+  background: #2d2b28;
 }
 
 .settingsSectionMain {
@@ -21052,66 +22234,6 @@ body.assistantPanelResizing {
   justify-content: flex-end;
 }
 
-.publisherStatus {
-  display: grid;
-  grid-template-columns: 34px minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 10px;
-  margin-bottom: 12px;
-  padding: 10px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--surface);
-}
-
-.publisherStatus.ready {
-  border-color: rgba(0, 227, 170, 0.35);
-  background: rgba(0, 227, 170, 0.08);
-}
-
-.publisherStatus.warning {
-  border-color: rgba(182, 123, 28, 0.34);
-  background: rgba(182, 123, 28, 0.10);
-}
-
-.publisherStatus.danger {
-  border-color: rgba(208, 74, 74, 0.34);
-  background: rgba(208, 74, 74, 0.08);
-}
-
-.publisherStatusIcon {
-  display: grid;
-  place-items: center;
-  width: 34px;
-  height: 34px;
-  border-radius: 8px;
-  color: var(--text);
-  background: var(--surface-raised);
-}
-
-.publisherStatusBody {
-  display: grid;
-  gap: 3px;
-  min-width: 0;
-}
-
-.publisherStatusBody strong {
-  font-size: 13px;
-}
-
-.publisherStatusBody span,
-.publisherStatusBody small {
-  color: var(--text-muted);
-  font-size: 12px;
-  line-height: 1.35;
-  white-space: normal;
-}
-
-.publisherStatus .button {
-  align-self: center;
-  white-space: nowrap;
-}
-
 .marketplaceCard {
   display: grid;
   gap: 12px;
@@ -21347,6 +22469,246 @@ body.assistantPanelResizing {
 .designSection {
   display: grid;
   gap: 12px;
+}
+
+.cloudLinkDocs {
+  display: grid;
+  grid-template-columns: minmax(150px, 0.24fr) minmax(0, 1fr);
+  align-items: start;
+  gap: 14px;
+  width: 100%;
+}
+
+.cloudLinkDocsIndex {
+  position: sticky;
+  top: 14px;
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface-raised);
+}
+
+.cloudLinkDocsIndex strong {
+  margin-bottom: 6px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 820;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.cloudLinkDocsIndex a {
+  min-width: 0;
+  padding: 8px 10px;
+  border-radius: 7px;
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.cloudLinkDocsIndex a:hover {
+  background: var(--surface-soft);
+}
+
+.cloudLinkDocsMain {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+}
+
+.cloudLinkDocsUtility {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) auto minmax(240px, auto);
+  align-items: center;
+  gap: 10px;
+  min-height: 0;
+}
+
+.cloudLinkDocsSearch {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  min-height: 40px;
+  padding: 0 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.cloudLinkDocsSearch svg {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+}
+
+.cloudLinkDocsSearch input {
+  min-width: 0;
+  width: 100%;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+}
+
+.cloudLinkDocsToggle {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  min-height: 40px;
+  padding: 7px 9px 7px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.cloudLinkDocsToggle span {
+  display: grid;
+  gap: 1px;
+  min-width: 0;
+}
+
+.cloudLinkDocsToggle strong,
+.cloudLinkDocsToggle small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cloudLinkDocsToggle small {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.cloudLinkDocsToggle input {
+  appearance: none;
+  position: relative;
+  width: 38px;
+  height: 22px;
+  border: 1px solid var(--toggle-off-border);
+  border-radius: 999px;
+  background: var(--toggle-off-bg);
+  box-shadow: inset 0 1px 2px rgba(31, 30, 28, 0.08);
+  cursor: pointer;
+}
+
+.cloudLinkDocsToggle input::before {
+  content: "";
+  display: block;
+  width: 18px;
+  height: 18px;
+  margin: 1px;
+  border-radius: 50%;
+  background: var(--toggle-off-thumb);
+  box-shadow: 0 1px 3px rgba(27, 27, 26, 0.18);
+  transition: transform 140ms ease;
+}
+
+.cloudLinkDocsToggle input:checked {
+  border-color: var(--accent);
+  background: var(--accent);
+  box-shadow: none;
+}
+
+.cloudLinkDocsToggle input:checked::before {
+  background: #ffffff;
+  transform: translateX(16px);
+}
+
+.cloudLinkDocsIntro {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 12px;
+  min-height: 0;
+}
+
+.cloudLinkDocsIntro h2,
+.cloudLinkDocsSection h2 {
+  margin: 0 0 6px;
+  color: var(--text);
+  font-size: 20px;
+  line-height: 1.15;
+}
+
+.cloudLinkDocsSection {
+  min-height: 0;
+  scroll-margin-top: 14px;
+}
+
+.cloudLinkDocsSection header {
+  margin-bottom: 14px;
+}
+
+.cloudLinkDocsSectionGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.cloudLinkDocsSectionGrid > div {
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+  background: var(--surface-soft);
+}
+
+.cloudLinkDocsSectionGrid h3 {
+  margin: 0 0 8px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 820;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.cloudLinkDocsSectionGrid ul {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding-left: 18px;
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.cloudLinkDocsSectionGrid p {
+  margin: 0;
+}
+
+@media (max-width: 900px) {
+  .cloudLinkDocs {
+    grid-template-columns: 1fr;
+  }
+
+  .cloudLinkDocsIndex {
+    position: static;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  }
+
+  .cloudLinkDocsIndex strong {
+    grid-column: 1 / -1;
+  }
+
+  .cloudLinkDocsUtility {
+    grid-template-columns: 1fr;
+  }
+
+  .cloudLinkDocsUtility .button {
+    justify-content: center;
+    width: 100%;
+  }
+
+  .cloudLinkDocsIntro,
+  .cloudLinkDocsSectionGrid {
+    grid-template-columns: 1fr;
+  }
 }
 
 .designPanelHeader {
@@ -22573,10 +23935,10 @@ body.assistantPanelResizing {
 
 .modelCenterHeader {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   gap: 16px;
-  margin-bottom: 22px;
+  margin-bottom: 14px;
 }
 
 .modelCenterEyebrow {
@@ -22602,9 +23964,13 @@ body.assistantPanelResizing {
   margin-bottom: 0;
 }
 
+.modelCenterRouteSetupAlert + .modelCenterShortcutsPage {
+  margin-top: 14px;
+}
+
 .modelCenterStack {
   display: grid;
-  gap: 18px;
+  gap: 14px;
 }
 
 .modelCenterGrid {
@@ -22675,6 +24041,24 @@ body.assistantPanelResizing {
   justify-content: space-between;
   gap: 16px;
   margin-bottom: 16px;
+}
+
+.modelCenterCatalogCard .modelCenterCardHeader {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: start;
+}
+
+.modelCenterCatalogCard .modelCenterCardHeader h3 {
+  line-height: 1.15;
+}
+
+.modelCenterCatalogCard .modelCenterCardHeader p {
+  max-width: 720px;
+}
+
+.modelCenterCatalogCard .modelCenterCatalogList {
+  min-width: 0;
 }
 
 .modelCenterCardHeader h3 {
@@ -22801,6 +24185,38 @@ body.assistantPanelResizing {
   margin: 0 0 16px;
 }
 
+.modelCenterEngineList {
+  display: grid;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.modelCenterEnginePanel {
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+  border: 1px solid var(--border-soft);
+  border-radius: 14px;
+  background: var(--surface);
+}
+
+.modelCenterEngineHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.modelCenterEngineHeader h3,
+.modelCenterEngineHeader p {
+  margin: 0;
+}
+
+.modelCenterEngineHeader p {
+  margin-top: 5px;
+  color: var(--text-dim);
+}
+
 .modelCenterToggleRow {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
@@ -22835,6 +24251,52 @@ body.assistantPanelResizing {
   height: 24px;
 }
 
+.modelCenterSettingRow {
+  display: grid;
+  grid-template-columns: minmax(0, 0.44fr) minmax(260px, 0.56fr);
+  align-items: center;
+  gap: 14px;
+  margin-top: 16px;
+  padding: 14px 16px;
+  border: 1px solid var(--border-soft);
+  border-radius: 14px;
+  background: var(--surface);
+}
+
+.modelCenterSettingRow strong,
+.modelCenterSettingRow small {
+  display: block;
+}
+
+.modelCenterSettingRow small {
+  margin-top: 4px;
+  color: var(--text-dim);
+}
+
+.modelCenterSettingControls {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.modelCenterSettingControls select {
+  min-width: 0;
+  min-height: 42px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface-raised);
+  color: var(--text);
+  font: inherit;
+  padding: 0 12px;
+}
+
+.modelCenterSettingControlsCompact {
+  grid-template-columns: repeat(2, max-content);
+  justify-content: end;
+}
+
 .modelCenterInlineActions,
 .modelCenterHeaderActions,
 .modelCenterCatalogActions {
@@ -22852,6 +24314,144 @@ body.assistantPanelResizing {
 
 .modelCenterDiagnosticActions .button {
   justify-content: center;
+}
+
+.modelCenterApiIntroCompact {
+  min-height: 0;
+}
+
+.modelCenterApiIntroCompact h2,
+.modelCenterApiIntroCompact p {
+  margin: 0;
+}
+
+.modelCenterApiIntroCompact p {
+  margin-top: 6px;
+}
+
+.modelCenterApiHeader {
+  align-items: center;
+}
+
+.modelCenterApiSetupAlert,
+.modelCenterDiagnosticNotice {
+  margin: 0 0 14px;
+}
+
+.modelCenterApiNoActionAlert {
+  grid-template-columns: 36px minmax(0, 1fr);
+}
+
+.modelCenterApiFormGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.modelCenterApiFormGrid .wide {
+  grid-column: 1 / -1;
+}
+
+.modelCenterApiFormGrid .modelCenterField {
+  margin-bottom: 0;
+}
+
+.modelCenterApiUrlRow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 14px;
+  margin-top: 14px;
+  padding: 14px 16px;
+  border: 1px solid var(--border-soft);
+  border-radius: 14px;
+  background: var(--surface);
+}
+
+.modelCenterApiUrlRow strong,
+.modelCenterApiUrlRow code {
+  display: block;
+}
+
+.modelCenterApiUrlRow strong {
+  margin-bottom: 4px;
+  color: var(--text-dim);
+  font-size: 12px;
+  font-weight: 760;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.modelCenterApiUrlRow code {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--text);
+  font-family: inherit;
+}
+
+.modelCenterApiActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 16px;
+}
+
+.modelCenterVpnCallout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 18px;
+}
+
+.modelCenterVpnCopy {
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1fr);
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.modelCenterVpnCopy h3,
+.modelCenterVpnCopy p {
+  margin: 0;
+}
+
+.modelCenterVpnCopy p {
+  margin-top: 5px;
+  color: var(--text-dim);
+}
+
+.modelCenterVpnActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.modelCenterRoleAccessSummary {
+  margin: -4px 0 12px;
+  color: var(--text-dim);
+  font-size: 13px;
+}
+
+.modelCenterRoleAccessList {
+  margin-bottom: 18px;
+}
+
+.modelCenterBrowserAccessRow {
+  margin-bottom: 0;
+}
+
+.modelCenterDiagnosticHint {
+  margin: 10px 0 0;
+  color: var(--text-dim);
+  font-size: 13px;
+}
+
+.modelCenterDiagnosticNotice {
+  margin-top: 12px;
+  margin-bottom: 0;
 }
 
 .modelCenterPrimaryActions {
@@ -22891,6 +24491,14 @@ body.assistantPanelResizing {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 12px;
+}
+
+.modelCenterRoleMetaGrid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.modelCenterAssignedModelField {
+  margin-bottom: 18px;
 }
 
 .modelCenterStatusGrid {
@@ -22941,7 +24549,23 @@ body.assistantPanelResizing {
   align-items: center;
   justify-content: flex-end;
   gap: 12px;
+  padding-top: 20px;
   margin-bottom: 18px;
+}
+
+.modelCenterShortcutSystem {
+  display: grid;
+  gap: 0;
+  margin: 0 0 20px;
+  border-top: 1px solid var(--border-soft);
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.modelCenterShortcutsCard {
+  overflow: hidden;
+  padding-top: 0;
+  color: var(--text);
+  background: var(--surface-raised);
 }
 
 .modelCenterShortcutComposer {
@@ -22954,6 +24578,10 @@ body.assistantPanelResizing {
   border: 1px solid var(--border-soft);
   border-radius: 14px;
   background: var(--surface);
+}
+
+.modelCenterShortcutsCard > .modelCenterShortcutComposer:first-child {
+  margin-top: 20px;
 }
 
 .modelCenterShortcutCapture.capturing {
@@ -22982,18 +24610,22 @@ body.assistantPanelResizing {
   justify-content: flex-start;
   min-width: 0;
   min-height: var(--top-control-height);
-  margin: 0 0 4px;
-  padding: 0;
-  border-top: 1px solid var(--border);
-  border-bottom: 1px solid var(--border);
+  margin: 0 -20px 4px;
+  padding: 0 20px;
+  border-top: 1px solid var(--border-soft);
+  border-bottom: 1px solid var(--border-soft);
   color: var(--text-muted);
-  background: #f1efeb;
+  background: var(--surface-soft);
   font-size: 10px;
   font-weight: 820;
   letter-spacing: 0.08em;
   line-height: 1.1;
   text-align: left;
   text-transform: uppercase;
+}
+
+.modelCenterShortcutGroup:first-child .modelCenterShortcutSectionLabel {
+  border-top: 0;
 }
 
 .modelCenterShortcutList.compact {
@@ -23074,16 +24706,255 @@ body.assistantPanelResizing {
   white-space: nowrap;
 }
 
+.modelCenterRouteSections {
+  display: grid;
+  gap: 18px;
+}
+
+.modelCenterRouteSection {
+  display: grid;
+  gap: 10px;
+}
+
+.modelCenterRouteSectionHeader {
+  display: grid;
+  gap: 2px;
+}
+
+.modelCenterRouteSectionHeader h4,
+.modelCenterRouteSectionHeader p {
+  margin: 0;
+}
+
+.modelCenterRouteSectionHeader h4 {
+  font-size: 16px;
+}
+
+.modelCenterRouteSectionHeader p {
+  color: var(--text-muted);
+}
+
+.modelCenterRouteTable {
+  display: grid;
+  overflow: hidden;
+  border: 1px solid var(--border-soft);
+  border-radius: 12px;
+  background: var(--surface);
+}
+
+.modelCenterRouteTableHeader {
+  min-height: 42px;
+  color: var(--text-muted);
+  background: #f1efeb;
+  font-size: 11px;
+  font-weight: 820;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.modelCenterRoleTableRow,
+.modelCenterAvailableRouteRow {
+  display: grid;
+  align-items: center;
+  gap: 14px;
+  min-width: 0;
+  padding: 11px 14px;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.modelCenterRoleTableRow {
+  grid-template-columns: minmax(150px, 1.1fr) minmax(160px, 1.3fr) minmax(95px, 0.7fr) minmax(95px, 0.7fr) minmax(190px, 1fr);
+}
+
+.modelCenterAvailableRouteRow {
+  grid-template-columns: minmax(190px, 1.25fr) minmax(105px, 0.75fr) minmax(150px, 1fr) minmax(110px, 0.75fr) minmax(100px, 0.7fr) 58px;
+}
+
+.modelCenterRoleTableRow:last-child,
+.modelCenterAvailableRoute:last-child .modelCenterAvailableRouteRow {
+  border-bottom: 0;
+}
+
+.modelCenterRoleTableRow > span,
+.modelCenterAvailableRouteRow > span {
+  min-width: 0;
+}
+
+.modelCenterRoleTableRow strong,
+.modelCenterAvailableRouteRow strong,
+.modelCenterRoleTableRow small,
+.modelCenterAvailableRouteRow small {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.modelCenterRoleTableRow small,
+.modelCenterAvailableRouteRow small {
+  color: var(--text-muted);
+}
+
+.modelCenterCompactSelect {
+  width: 100%;
+  min-width: 0;
+  min-height: 36px;
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  color: var(--text);
+  background: var(--surface);
+  font: inherit;
+  padding: 0 10px;
+}
+
+.modelCenterAvailableRoute {
+  display: block;
+}
+
+.modelCenterAvailableRoute > summary {
+  list-style: none;
+  cursor: pointer;
+}
+
+.modelCenterAvailableRoute > summary::-webkit-details-marker {
+  display: none;
+}
+
+.modelCenterRouteActionCell {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.modelCenterRouteActionMenu {
+  position: relative;
+}
+
+.modelCenterRouteActionMenu > summary {
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--border-soft);
+  border-radius: 9px;
+  color: var(--text-muted);
+  background: var(--surface-soft);
+  list-style: none;
+  cursor: pointer;
+}
+
+.modelCenterRouteActionMenu > summary::-webkit-details-marker {
+  display: none;
+}
+
+.modelCenterRouteActionMenu > summary:hover,
+.modelCenterRouteActionMenu > summary:focus-visible {
+  color: var(--text);
+  background: var(--surface);
+  outline: none;
+}
+
+.modelCenterRouteActionMenuPanel {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 12;
+  display: grid;
+  min-width: 210px;
+  padding: 6px;
+  border: 1px solid var(--border-soft);
+  border-radius: 10px;
+  background: var(--surface);
+  box-shadow: 0 16px 40px rgba(31, 30, 28, 0.14);
+}
+
+.modelCenterRouteActionMenuPanel button,
+.modelCenterRouteActionMenuPanel span {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  min-height: 34px;
+  padding: 0 10px;
+  border-radius: 8px;
+  color: var(--text);
+  background: transparent;
+  font: inherit;
+  font-weight: 720;
+  text-align: left;
+}
+
+.modelCenterRouteActionMenuPanel button:hover,
+.modelCenterRouteActionMenuPanel button:focus-visible {
+  background: var(--surface-soft);
+  outline: none;
+}
+
+.modelCenterRouteActionMenuPanel button:disabled {
+  color: var(--text-muted);
+  cursor: default;
+}
+
+.modelCenterRouteExpandIcon {
+  color: var(--text-muted);
+  transition: transform 160ms ease;
+}
+
+.modelCenterAvailableRoute[open] .modelCenterRouteExpandIcon {
+  transform: rotate(180deg);
+}
+
+.modelCenterRouteDetails {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  padding: 0 14px 14px;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.modelCenterRouteDetails > div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid var(--border-soft);
+  border-radius: 10px;
+  background: var(--surface-soft);
+}
+
+.modelCenterRouteDetails strong {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 820;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.modelCenterRouteDetails code,
+.modelCenterRouteDetails span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--text);
+}
+
 .modelCenterShortcutRow.compact {
   border: 0;
   border-bottom: 1px solid var(--border-soft);
   border-radius: 0;
   background: transparent;
+  color: var(--text);
   padding: 14px 0;
+}
+
+.modelCenterShortcutRow.compact strong {
+  color: var(--text);
 }
 
 .modelCenterShortcutList.compact .modelCenterShortcutRow:last-child {
   border-bottom: 0;
+  padding-bottom: 6px;
 }
 
 .modelCenterShortcutRowActions {
@@ -23203,6 +25074,71 @@ body.assistantPanelResizing {
   box-shadow: inset 0 -1px 0 color-mix(in srgb, var(--border) 55%, transparent);
 }
 
+.desktop[data-theme="dark"] .modelCenterShortcutsCard {
+  color: var(--text);
+  background: var(--surface-raised);
+  border-color: var(--border);
+}
+
+.desktop[data-theme="dark"] .modelCenterCard,
+.desktop[data-theme="dark"] .modelCenterHero,
+.desktop[data-theme="dark"] .modelCenterEmptyState,
+.desktop[data-theme="dark"] .modelCenterRouteRow,
+.desktop[data-theme="dark"] .modelCenterTableRow,
+.desktop[data-theme="dark"] .modelCenterCatalogRow,
+.desktop[data-theme="dark"] .modelCenterProviderModelRow {
+  color: var(--text);
+  background: var(--surface-raised);
+  border-color: var(--border);
+}
+
+.desktop[data-theme="dark"] .modelCenterTableRow,
+.desktop[data-theme="dark"] .modelCenterCatalogRow,
+.desktop[data-theme="dark"] .modelCenterProviderModelRow {
+  background: var(--surface);
+  border-color: var(--border-soft);
+}
+
+.desktop[data-theme="dark"] .modelCenterCardHeader h3,
+.desktop[data-theme="dark"] .modelCenterEmptyState strong,
+.desktop[data-theme="dark"] .modelCenterTableRow strong,
+.desktop[data-theme="dark"] .modelCenterCatalogRow strong,
+.desktop[data-theme="dark"] .modelCenterProviderModelRow strong,
+.desktop[data-theme="dark"] .modelCenterRouteRow strong {
+  color: var(--text);
+}
+
+.desktop[data-theme="dark"] .modelCenterCardHeader p,
+.desktop[data-theme="dark"] .modelCenterEmptyState p,
+.desktop[data-theme="dark"] .modelCenterTableRow small,
+.desktop[data-theme="dark"] .modelCenterCatalogRow small,
+.desktop[data-theme="dark"] .modelCenterProviderModelRow small,
+.desktop[data-theme="dark"] .modelCenterRouteRow small {
+  color: var(--text-muted);
+}
+
+.desktop[data-theme="dark"] .modelCenterShortcutSectionLabel {
+  color: var(--text-muted);
+  background: var(--surface-soft);
+  border-color: var(--border);
+}
+
+.desktop[data-theme="dark"] .modelCenterShortcutRow.compact {
+  color: var(--text);
+  border-color: var(--border-soft);
+}
+
+.desktop[data-theme="dark"] .modelCenterShortcutRow.compact strong {
+  color: var(--text);
+}
+
+.desktop[data-theme="dark"] .modelCenterShortcutKeys kbd,
+.desktop[data-theme="dark"] .modelCenterShortcutSelect select {
+  color: var(--text);
+  background: var(--surface-soft);
+  border-color: var(--border);
+}
+
 .modelCenterRouteMeta {
   display: flex;
   align-items: center;
@@ -23219,46 +25155,68 @@ body.assistantPanelResizing {
   align-self: stretch;
   width: 100%;
   min-height: 34px;
-  margin-bottom: 14px;
+  margin-bottom: 0;
 }
 
-.modelCenterImportRow {
+.modelCenterDesignTabs + .modelCenterStack,
+.modelCenterDesignTabs + .modelCenterCard {
+  margin-top: -2px;
+}
+
+.modelCenterToolbarGroup {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) minmax(0, 1fr);
-  align-items: center;
-  gap: 12px;
-  margin: 0 0 16px;
-  padding: 12px;
-  border: 1px solid var(--border-soft);
-  border-radius: 14px;
-  background: var(--surface-soft);
+  gap: 10px;
+  margin-top: -2px;
 }
 
-.modelCenterImportLabel {
+.modelCenterSearchToolbar {
+  width: 100%;
+}
+
+.modelCenterFilterBar {
+  margin-top: 0;
+}
+
+.modelCenterInstallPanel {
+  border-color: rgba(14, 212, 162, 0.34);
+  background: rgba(14, 212, 162, 0.06);
+}
+
+.modelCenterInstallGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) max-content;
+  gap: 12px;
+}
+
+.modelCenterInstallField {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+}
+
+.modelCenterInstallField span {
   color: var(--text-dim);
   font-size: 12px;
   font-weight: 780;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  white-space: nowrap;
 }
 
-.modelCenterImportGroup {
-  display: grid;
-  grid-template-columns: minmax(160px, 1fr) auto;
-  gap: 8px;
+.modelCenterInstallField input {
   min-width: 0;
-}
-
-.modelCenterImportRow input {
-  min-width: 0;
-  min-height: 38px;
+  min-height: 42px;
   border: 1px solid var(--border);
   border-radius: 10px;
   background: var(--surface);
   color: var(--text);
   font: inherit;
   padding: 0 12px;
+}
+
+.modelCenterInstallAction {
+  align-self: end;
+  min-height: 42px;
+  white-space: nowrap;
 }
 
 .modelCenterCatalogSearch {
@@ -23420,11 +25378,7 @@ body.assistantPanelResizing {
     grid-template-columns: 1fr;
   }
 
-  .modelCenterImportRow {
-    grid-template-columns: 1fr;
-  }
-
-  .modelCenterImportGroup {
+  .modelCenterInstallGrid {
     grid-template-columns: 1fr;
   }
 
@@ -23456,17 +25410,41 @@ body.assistantPanelResizing {
 
   .modelCenterGrid.two,
   .modelCenterSplitFields,
+  .modelCenterApiFormGrid,
+  .modelCenterApiUrlRow,
+  .modelCenterVpnCallout,
   .modelCenterSetupSteps,
   .modelCenterDiagnosticActions,
+  .modelCenterSettingRow,
+  .modelCenterRoleMetaGrid,
   .modelCenterRouteRowActionable,
   .modelCenterRouteDefinitions > div,
-  .modelCenterCatalogNotice,
-  .modelCenterImportRow {
+  .modelCenterCatalogNotice {
+    grid-template-columns: 1fr;
+  }
+
+  .modelCenterSettingControls {
     grid-template-columns: 1fr;
   }
 
   .modelCenterRouteMeta,
-  .modelCenterRouteActions {
+  .modelCenterRouteActions,
+  .modelCenterApiActions,
+  .modelCenterVpnActions {
+    justify-content: flex-start;
+  }
+
+  .modelCenterRoleTableRow,
+  .modelCenterAvailableRouteRow,
+  .modelCenterRouteDetails {
+    grid-template-columns: 1fr;
+  }
+
+  .modelCenterRouteTableHeader {
+    display: none;
+  }
+
+  .modelCenterRouteActionCell {
     justify-content: flex-start;
   }
 }


### PR DESCRIPTION
Adds the Compose studio experience, updates Compose/Wiki icons and labels, keeps the Compose submenu available while state loads, and routes the assistant Scribe tab to the main Scribe workspace.\n\nVerification:\n- npm run build --prefix apps/link-desktop