### PR TITLE
feat(opencode): add GLM-5.2 and MiniMax-M3-MXFP8 support with thinking variants

### DIFF
--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Added `zai-org/GLM-5.2` and `MiniMaxAI/MiniMax-M3-MXFP8` to the default enabled-models allowlist (now 5 models). Both are Telnyx-hosted text-generation models with 1M context windows, auto-registered from `GET https://api.telnyx.com/v2/ai/models`.
+- Updated `opencode auth login` model preset label from "Recommended 3" to "Recommended 5" and refreshed the hint text to list the new lineup.
+- Added thinking on/off variants for reasoning models. Thinking-capable models are registered with `reasoning: true` and two variants: `thinking` (default, `enable_thinking: true`) and `no-thinking` (`enable_thinking: false`). A `chat.message` + `chat.params` hook pair propagates the selected variant to the Telnyx API request body.
+- Added `THINKING_CAPABLE_MODELS` set to `models-config.ts` listing the 5 known reasoner model IDs. Non-reasoners are not sent `enable_thinking` (Telnyx API rejects it with error 10015).
+
+### Fixed
+
+- Fixed TUI `/telnyx` model toggle re-registering models with hardcoded `output: 16384` instead of the API's `max_output_length`. The TUI now honors the per-model output limit (e.g. 131072 for GLM-5.2), matching the server-side registration.
+- Removed unused `DEFAULT_ENABLED_MODELS` import from `tui.tsx`.
+
 ## [0.1.4] - 2026-05-19
 
 ### Fixed

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -23,12 +23,15 @@ opencode plugin -g @telnyx/opencode
 - reads the Telnyx API key from either `TELNYX_API_KEY` or OpenCode's stored `auth.json` credential
 - fetches available models from `https://api.telnyx.com/v2/ai/models` at startup
 - registers only Telnyx-hosted text models from the API response
-- enables these three recommended models by default:
+- enables these five recommended models by default:
   - `moonshotai/Kimi-K2.6`
+  - `zai-org/GLM-5.2`
   - `zai-org/GLM-5.1-FP8`
+  - `MiniMaxAI/MiniMax-M3-MXFP8`
   - `MiniMaxAI/MiniMax-M2.7`
 - persists the enabled-model allowlist in `~/.config/opencode/telnyx-models.json`
 - lets users enable additional Telnyx-hosted models through the `/telnyx` TUI command
+- registers thinking-capable models with `reasoning: true` and two variants: `thinking` (default, `enable_thinking: true`) and `no-thinking` (`enable_thinking: false`)
 - strips `maxOutputTokens` before requests so Telnyx accepts tool-enabled runs
 
 ## Authenticate
@@ -41,7 +44,7 @@ opencode auth login --provider telnyx --method "API Key"
 
 During login the plugin also asks which Telnyx model preset to enable:
 
-- **Recommended 3 (default)**
+- **Recommended 5 (default)**
 - **All hosted Telnyx models**
 - **Keep existing config**
 
@@ -63,6 +66,23 @@ opencode auth list
 opencode run --model 'telnyx/moonshotai/Kimi-K2.6' 'Say hello in one sentence.'
 ```
 
+## Thinking variants
+
+Telnyx-hosted reasoning models (all 5 default models) are registered with `reasoning: true` and two OpenCode variants:
+
+- `thinking` (default) — sends `enable_thinking: true` to the Telnyx API; reasoning content is surfaced in OpenCode
+- `no-thinking` — sends `enable_thinking: false`; skips the reasoning step for lower latency
+
+```bash
+# Thinking on (default)
+opencode run --model 'telnyx/zai-org/GLM-5.2' 'What is 2+2?'
+
+# Thinking off
+opencode run --model 'telnyx/zai-org/GLM-5.2' --variant no-thinking 'What is 2+2?'
+```
+
+Non-reasoning Telnyx models (e.g. Llama, Qwen) are registered without thinking config — the Telnyx API rejects `enable_thinking` for non-reasoner models (error 10015). Only models in the `THINKING_CAPABLE_MODELS` set get thinking variants.
+
 ## How auth works
 
 Auth precedence is:
@@ -79,7 +99,9 @@ At startup the plugin calls `GET https://api.telnyx.com/v2/ai/models` and regist
 Default allowlist:
 
 - `moonshotai/Kimi-K2.6`
+- `zai-org/GLM-5.2`
 - `zai-org/GLM-5.1-FP8`
+- `MiniMaxAI/MiniMax-M3-MXFP8`
 - `MiniMaxAI/MiniMax-M2.7`
 
 Allowlist file:
@@ -89,7 +111,9 @@ Allowlist file:
   "version": 1,
   "enabledModels": [
     "moonshotai/Kimi-K2.6",
+    "zai-org/GLM-5.2",
     "zai-org/GLM-5.1-FP8",
+    "MiniMaxAI/MiniMax-M3-MXFP8",
     "MiniMaxAI/MiniMax-M2.7"
   ]
 }
@@ -104,7 +128,7 @@ Path:
 
 The package also registers a `/telnyx` command (alias: `/telnyx-models`) that opens an interactive model manager in the OpenCode TUI.
 
-- the dialog starts from the default 3-model allowlist
+- the dialog starts from the default 5-model allowlist
 - selecting a model toggles it on or off
 - changes are persisted to `~/.config/opencode/telnyx-models.json`
 - updated provider model availability is applied without manually editing config files

--- a/plugins/opencode/src/index.ts
+++ b/plugins/opencode/src/index.ts
@@ -78,6 +78,12 @@ function modelConfig(model: JsonObject): [string, JsonObject] | undefined {
     base.variants = {
       thinking: { enable_thinking: true },
       "no-thinking": { enable_thinking: false },
+      max: { disabled: true },
+      high: { disabled: true },
+      medium: { disabled: true },
+      low: { disabled: true },
+      fast: { disabled: true },
+      none: { disabled: true },
     }
   }
 

--- a/plugins/opencode/src/index.ts
+++ b/plugins/opencode/src/index.ts
@@ -2,13 +2,15 @@ import { readFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
 import type { Plugin } from "@opencode-ai/plugin"
-import { DEFAULT_ENABLED_MODELS, loadEnabledModels, persistEnabledModels } from "./models-config"
+import { DEFAULT_ENABLED_MODELS, THINKING_CAPABLE_MODELS, loadEnabledModels, persistEnabledModels } from "./models-config"
 
 const PROVIDER_ID = "telnyx"
 const API_BASE = "https://api.telnyx.com/v2/ai"
 const OPENAI_BASE = `${API_BASE}/openai`
 const MODELS_URL = `${API_BASE}/models`
 const TEXT_TASKS = new Set(["text-generation", "text generation"])
+
+const sessionVariants = new Map<string, string>()
 
 type JsonObject = Record<string, unknown>
 
@@ -54,23 +56,32 @@ function modelConfig(model: JsonObject): [string, JsonObject] | undefined {
   const shortId = id.includes("/") ? id.split("/").pop() ?? id : id
   const vision = model.is_vision_supported === true
   const output = typeof model.max_output_length === "number" ? model.max_output_length : 16384
+  const thinking = THINKING_CAPABLE_MODELS.has(id)
 
-  return [
-    id,
-    {
-      name: shortId,
-      limit: { context, output },
-      ...(vision
-        ? {
-            attachment: true,
-            modalities: {
-              input: ["text", "image"],
-              output: ["text"],
-            },
-          }
-        : {}),
-    },
-  ]
+  const base: JsonObject = {
+    name: shortId,
+    limit: { context, output },
+    ...(vision
+      ? {
+          attachment: true,
+          modalities: {
+            input: ["text", "image"],
+            output: ["text"],
+          },
+        }
+      : {}),
+  }
+
+  if (thinking) {
+    base.reasoning = true
+    base.options = { enable_thinking: true }
+    base.variants = {
+      thinking: { enable_thinking: true },
+      "no-thinking": { enable_thinking: false },
+    }
+  }
+
+  return [id, base]
 }
 
 async function fetchModels(key: string | undefined, enabledModelIDs: readonly string[]): Promise<Record<string, JsonObject>> {
@@ -163,9 +174,9 @@ const TelnyxAuthPlugin: Plugin = async () => {
             message: "Which Telnyx models should be enabled?",
             options: [
               {
-                label: "Recommended 3 (default)",
+                label: "Recommended 5 (default)",
                 value: "recommended",
-                hint: "Kimi-K2.6, GLM-5.1-FP8, MiniMax-M2.7",
+                hint: "Kimi-K2.6, GLM-5.2, GLM-5.1-FP8, MiniMax-M3-MXFP8, MiniMax-M2.7",
               },
               {
                 label: "All hosted Telnyx models",
@@ -217,8 +228,23 @@ const TelnyxAuthPlugin: Plugin = async () => {
       }
     },
 
-    "chat.params": async (input: { model?: { providerID?: string } }, output: { maxOutputTokens?: number }) => {
-      if (input.model?.providerID === PROVIDER_ID) output.maxOutputTokens = undefined
+    "chat.message": async (input: { sessionID: string; model?: { providerID?: string }; variant?: string }) => {
+      if (input.model?.providerID !== PROVIDER_ID) return
+      if (input.variant) sessionVariants.set(input.sessionID, input.variant)
+      else sessionVariants.delete(input.sessionID)
+    },
+
+    "chat.params": async (
+      input: { model?: { providerID?: string; options?: { enable_thinking?: boolean } }; sessionID: string },
+      output: { maxOutputTokens?: number; options?: Record<string, unknown> },
+    ) => {
+      if (input.model?.providerID !== PROVIDER_ID) return
+      output.maxOutputTokens = undefined
+      const variant = sessionVariants.get(input.sessionID)
+      if (variant === "no-thinking") {
+        output.options ??= {}
+        output.options.enable_thinking = false
+      }
     },
   }
 }

--- a/plugins/opencode/src/models-config.ts
+++ b/plugins/opencode/src/models-config.ts
@@ -16,7 +16,25 @@ export const DEFAULT_ENABLED_MODELS = [
   "moonshotai/Kimi-K2.6",
   "zai-org/GLM-5.1-FP8",
   "MiniMaxAI/MiniMax-M2.7",
+  "zai-org/GLM-5.2",
+  "MiniMaxAI/MiniMax-M3-MXFP8",
 ] as const
+
+/**
+ * Telnyx-hosted model IDs known to support the `enable_thinking` request
+ * parameter (reasoning models). The Telnyx API rejects `enable_thinking`
+ * for non-reasoner models with error 10015, so this set must only contain
+ * confirmed reasoners. Verified via the Telnyx Chat Completions API.
+ *
+ * Extend this set as new reasoners are confirmed on the Telnyx platform.
+ */
+export const THINKING_CAPABLE_MODELS: ReadonlySet<string> = new Set([
+  "moonshotai/Kimi-K2.6",
+  "zai-org/GLM-5.1-FP8",
+  "MiniMaxAI/MiniMax-M2.7",
+  "zai-org/GLM-5.2",
+  "MiniMaxAI/MiniMax-M3-MXFP8",
+])
 
 function isObject(value: unknown): value is JsonObject {
   return typeof value === "object" && value !== null

--- a/plugins/opencode/src/tui.tsx
+++ b/plugins/opencode/src/tui.tsx
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
 import type { TuiPlugin, TuiPluginModule, TuiPluginApi } from "@opencode-ai/plugin/tui"
-import { DEFAULT_ENABLED_MODELS, loadEnabledModels, persistEnabledModels } from "./models-config"
+import { loadEnabledModels, persistEnabledModels, THINKING_CAPABLE_MODELS } from "./models-config"
 
 const PROVIDER_ID = "telnyx"
 const API_BASE = "https://api.telnyx.com/v2/ai"
@@ -42,7 +42,9 @@ function isTelnyxHostedModel(model: JsonObject): boolean {
   return typeof model.owned_by === "string" && model.owned_by.toLowerCase() === "telnyx"
 }
 
-function normalizeModel(model: JsonObject): { id: string; name: string; context: number; vision: boolean } | undefined {
+type HostedModel = { id: string; name: string; context: number; output: number; vision: boolean; thinking: boolean }
+
+function normalizeModel(model: JsonObject): HostedModel | undefined {
   const id = typeof model.id === "string" ? model.id : undefined
   const task = typeof model.task === "string" ? model.task : undefined
   const context = typeof model.context_length === "number" ? model.context_length : undefined
@@ -51,10 +53,12 @@ function normalizeModel(model: JsonObject): { id: string; name: string; context:
   if (!isTelnyxHostedModel(model)) return undefined
   const name = id.includes("/") ? id.split("/").pop() ?? id : id
   const vision = model.is_vision_supported === true
-  return { id, name, context, vision }
+  const output = typeof model.max_output_length === "number" ? model.max_output_length : 16384
+  const thinking = THINKING_CAPABLE_MODELS.has(id)
+  return { id, name, context, output, vision, thinking }
 }
 
-async function fetchHostedModels(key: string | undefined): Promise<Array<{ id: string; name: string; context: number; vision: boolean }>> {
+async function fetchHostedModels(key: string | undefined): Promise<HostedModel[]> {
   if (!key) return []
   try {
     const response = await fetch(MODELS_URL, {
@@ -76,17 +80,25 @@ async function fetchHostedModels(key: string | undefined): Promise<Array<{ id: s
   }
 }
 
-function providerModels(models: Array<{ id: string; name: string; context: number; vision: boolean }>, enabled: Set<string>) {
+function providerModels(models: HostedModel[], enabled: Set<string>) {
   return Object.fromEntries(
     models.flatMap((model) => {
       if (!enabled.has(model.id)) return []
       const entry: Record<string, unknown> = {
         name: model.name,
-        limit: { context: model.context, output: 16384 },
+        limit: { context: model.context, output: model.output },
       }
       if (model.vision) {
         entry.attachment = true
         entry.modalities = { input: ["text", "image"], output: ["text"] }
+      }
+      if (model.thinking) {
+        entry.reasoning = true
+        entry.options = { enable_thinking: true }
+        entry.variants = {
+          thinking: { enable_thinking: true },
+          "no-thinking": { enable_thinking: false },
+        }
       }
       return [[model.id, entry] as const]
     }),

--- a/plugins/opencode/src/tui.tsx
+++ b/plugins/opencode/src/tui.tsx
@@ -98,6 +98,12 @@ function providerModels(models: HostedModel[], enabled: Set<string>) {
         entry.variants = {
           thinking: { enable_thinking: true },
           "no-thinking": { enable_thinking: false },
+          max: { disabled: true },
+          high: { disabled: true },
+          medium: { disabled: true },
+          low: { disabled: true },
+          fast: { disabled: true },
+          none: { disabled: true },
         }
       }
       return [[model.id, entry] as const]


### PR DESCRIPTION
## What this does

Adds `zai-org/GLM-5.2` and `MiniMaxAI/MiniMax-M3-MXFP8` to the `@telnyx/opencode` plugin's default enabled-models allowlist (now 5 models), and adds thinking on/off variants for reasoning models via the Telnyx API's `enable_thinking` parameter.

## Changes

### New models (default allowlist: 3 → 5)
- `zai-org/GLM-5.2` — 1M context, 131072 max output tokens
- `MiniMaxAI/MiniMax-M3-MXFP8` — 1M context
- Existing 3 models retained: Kimi-K2.6, GLM-5.1-FP8, MiniMax-M2.7

### Thinking on/off variants
- Reasoning models registered with `reasoning: true` and two OpenCode variants:
  - `thinking` (default) — sends `enable_thinking: true`
  - `no-thinking` — sends `enable_thinking: false` (skips reasoning for lower latency)
- `chat.message` hook captures the selected variant per session; `chat.params` hook injects `enable_thinking: false` into the request body for `no-thinking` (since `chat.params` doesn't receive the variant directly)
- `sessionVariants` map is cleaned up when a session switches away from a thinking variant
- `THINKING_CAPABLE_MODELS` set gates which models get thinking config — non-reasoners are NOT sent `enable_thinking` (Telnyx API rejects it with error 10015)

### TUI output-limit bug fix
- Fixed `/telnyx` TUI model toggle re-registering models with hardcoded `output: 16384` instead of the API's `max_output_length`
- TUI now honors per-model output limit (e.g. 131072 for GLM-5.2), matching server-side registration

### Auth preset
- Updated `opencode auth login` model preset label from "Recommended 3" to "Recommended 5"

## Usage

```bash
# Thinking on (default)
opencode run --model 'telnyx/zai-org/GLM-5.2' 'What is 2+2?'

# Thinking off
opencode run --model 'telnyx/zai-org/GLM-5.2' --variant no-thinking 'What is 2+2?'
```

## Verification

- [x] `npm run typecheck` — exit 0, zero type errors
- [x] `npm run build` — dist/index.js + dist/tui.js produced
- [x] `bun --bun test test/models-config.test.ts` — 3/3 pass
- [x] Live smoke test (isolated env, `file://` plugin path, no npm publish):
  - `telnyx/zai-org/GLM-5.2` → returns response ✓
  - `telnyx/MiniMaxAI/MiniMax-M3-MXFP8` → returns response with `<mm:think>` reasoning block ✓
  - `telnyx/zai-org/GLM-5.2 --variant no-thinking` → returns response, `reasoning: 0` tokens ✓
  - `telnyx/moonshotai/Kimi-K2.6` → existing model still works (regression) ✓
  - Non-reasoner (Llama-3.3-70B) via plugin → no error 10015 (plugin correctly omits `enable_thinking`) ✓
- [x] 5-agent review (`/review-work`): all 5 PASS, no P0/P1 blocking issues

## Files changed

| File | Change |
|------|--------|
| `src/models-config.ts` | Added 2 new default models + `THINKING_CAPABLE_MODELS` set |
| `src/index.ts` | Thinking config in `modelConfig()`, `chat.message` + `chat.params` hooks for variant propagation, auth preset label update |
| `src/tui.tsx` | Fixed hardcoded `output: 16384` bug, added thinking config to `providerModels()` |
| `README.md` | Updated default allowlist (3→5), added thinking variants section, updated preset label |
| `CHANGELOG.md` | Added [Unreleased] entry |