### PR TITLE
chore(opencode): bump @telnyx/opencode to 0.1.5

### DIFF
--- a/plugins/opencode/CHANGELOG.md
+++ b/plugins/opencode/CHANGELOG.md
@@ -4,12 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.5] - 2026-06-25
+
 ### Added
 
 - Added `zai-org/GLM-5.2` and `MiniMaxAI/MiniMax-M3-MXFP8` to the default enabled-models allowlist (now 5 models). Both are Telnyx-hosted text-generation models with 1M context windows, auto-registered from `GET https://api.telnyx.com/v2/ai/models`.
 - Updated `opencode auth login` model preset label from "Recommended 3" to "Recommended 5" and refreshed the hint text to list the new lineup.
 - Added thinking on/off variants for reasoning models. Thinking-capable models are registered with `reasoning: true` and two variants: `thinking` (default, `enable_thinking: true`) and `no-thinking` (`enable_thinking: false`). A `chat.message` + `chat.params` hook pair propagates the selected variant to the Telnyx API request body.
 - Added `THINKING_CAPABLE_MODELS` set to `models-config.ts` listing the 5 known reasoner model IDs. Non-reasoners are not sent `enable_thinking` (Telnyx API rejects it with error 10015).
+- Disabled inherited OpenCode reasoning variants (`max`/`high`/`medium`/`low`/`fast`/`none`) for Telnyx reasoners so only the Telnyx-safe `thinking`/`no-thinking` variants are selectable.
 
 ### Fixed
 

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telnyx/opencode",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Telnyx auth and provider plugin for OpenCode",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Bump version for npm publish. Changes since 0.1.4 (from PR #244):

- Added `zai-org/GLM-5.2` and `MiniMaxAI/MiniMax-M3-MXFP8` to the default enabled-models allowlist (now 5 models)
- Added thinking on/off variants (`enable_thinking`) for reasoning models via `chat.message` + `chat.params` hooks
- Fixed TUI `/telnyx` output-limit bug (hardcoded `16384` → API `max_output_length`)
- Disabled inherited OpenCode reasoning variants (`max`/`high`/`medium`/`low`/`fast`/`none`) for Telnyx reasoners

This is a version bump only — no code changes beyond `package.json` version and the CHANGELOG date stamp. Required to trigger the npm publish workflow (0.1.4 is already published on npm).