### PR TITLE
AIF-156: Add OpenRouter provider readiness packet

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -93,6 +93,9 @@ jobs:
       - name: Guide structural tests
         run: npx tsx --test tests/guides.test.ts
 
+      - name: OpenRouter readiness packet tests
+        run: npx tsx --test tests/openrouter-readiness.test.ts
+
   api-readonly:
     name: API Read-Only Tests
     runs-on: ubuntu-latest
@@ -200,5 +203,4 @@ jobs:
         continue-on-error: true
         working-directory: cli
         run: RUN_WRITE_TESTS=true npx tsx tests/integration-ci-write.test.ts
-
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This repo is the one-stop shop for AI Agents and AI-first developers building wi
 - [Telnyx Plugins](#plugins) - Install the Telnyx plugin for Claude Code, Cursor, or Gemini CLI to give your coding assistant Telnyx MCP server access and Telnyx Agent Skills.
 
 - [Agent Toolkit](#agent-toolkit) - integrate Telnyx APIs with popular agent frameworks including OpenAI's Agent SDK, LangChain, CrewAI, and Vercel's AI SDK through function calling — available in [Python](#python) and [TypeScript](#typescript).
+
+- [Inference Integrations](#inference-integrations) - provider-readiness packets and model-backend integrations for LLM ecosystems such as OpenRouter.
   
 - [Agent Skills](#agent-skills) - give AI coding assistants accurate, up-to-date context about Telnyx APIs and SDKs.
   
@@ -156,6 +158,14 @@ const tools = toolkit.getLangChainTools();
 
 Works with LangChain and Vercel's AI SDK. See [TypeScript docs](/tools/typescript) for full usage.
  for the full list of commands and options.
+
+## Inference Integrations
+
+Provider-readiness packets and model-backend integrations for AI inference ecosystems live in [`inference/`](/inference).
+
+Current entries:
+
+- [OpenRouter readiness packet](/inference/openrouter) - onboarding packet, draft model manifest, and validation script for listing Telnyx as an OpenRouter provider.
 
 ## Agent Skills
 

--- a/inference/README.md
+++ b/inference/README.md
@@ -2,8 +2,12 @@
 
 Telnyx-as-LLM-backend integrations for AI application frameworks.
 
-Each subdirectory provides a provider/adapter that lets a framework route inference calls to Telnyx-hosted models. Planned entries include Vercel AI SDK, LangChain (Py + JS), LlamaIndex (Py + JS), LiteLLM, Haystack, Semantic Kernel, AutoGen, Dify, and Flowise.
+Each subdirectory provides a provider/adapter that lets a framework route inference calls to Telnyx-hosted models. Planned entries include Vercel AI SDK, LangChain (Py + JS), LlamaIndex (Py + JS), LiteLLM, Haystack, Semantic Kernel, AutoGen, Dify, Flowise, and OpenRouter.
 
 This directory is named `inference/` rather than `providers/` to avoid collision with the existing top-level `providers/` (which currently holds coding-assistant configs and will be consolidated under `plugins/` in a follow-up step).
 
 See the repo root `README.md` for the full architecture.
+
+## Current integration packets
+
+- [`openrouter/`](./openrouter/) - OpenRouter provider-onboarding readiness packet, model manifest draft, and validation script.

--- a/inference/openrouter/README.md
+++ b/inference/openrouter/README.md
@@ -1,0 +1,112 @@
+# Telnyx on OpenRouter
+
+This directory tracks the readiness packet for listing Telnyx as a model provider on OpenRouter.
+
+OpenRouter provider onboarding is application-based, not a normal upstream pull request. The current public provider guide asks providers to expose an OpenAI-compatible chat endpoint, a provider model-list endpoint with OpenRouter-specific metadata, automated payment or invoicing, privacy and data-retention terms, and enough uptime/performance quality for OpenRouter routing.
+
+Do not submit the OpenRouter provider application until the business and product fields in [`provider-application.md`](./provider-application.md) are confirmed.
+
+## Current status
+
+- Linear: `AIF-156`
+- Owner branch: `ifthikar/aif-156-list-telnyx-as-a-provider-on-openrouter`
+- OpenRouter public providers API currently has no `telnyx` provider entry.
+- Telnyx has the required OpenAI-compatible chat surface.
+- The remaining work is provider-onboarding readiness: model metadata, pricing, capacity, datacenter, billing, and data-retention details.
+
+## OpenRouter requirements
+
+Reference: <https://openrouter.ai/docs/guides/community/for-providers>
+
+OpenRouter expects:
+
+- A provider application submission.
+- A list-models endpoint that returns all models OpenRouter should serve.
+- Model metadata including:
+  - `id`
+  - `hugging_face_id` when applicable
+  - `name`
+  - `created`
+  - `input_modalities`
+  - `output_modalities`
+  - `quantization`
+  - `context_length`
+  - `max_output_length`
+  - token pricing in USD strings
+  - supported sampling parameters
+  - supported features
+  - optional launch/capacity fields such as `is_ready`, `discount_to_user`, and `capacity_tpm`
+  - datacenter country codes
+- Automatic payment, top-up, or invoicing.
+- Uptime, latency, throughput, streaming, and tool-call reliability suitable for routed production traffic.
+
+## Telnyx endpoints
+
+Telnyx Inference exposes an OpenAI-compatible base URL:
+
+```text
+https://api.telnyx.com/v2/ai/openai
+```
+
+Relevant endpoints:
+
+```text
+GET  /v2/ai/openai/models
+POST /v2/ai/openai/chat/completions
+```
+
+References:
+
+- Telnyx OpenAI-compatible chat completions: <https://developers.telnyx.com/api-reference/openai-chat/create-a-chat-completion-openai-compatible>
+- Telnyx OpenAI-compatible models endpoint: <https://developers.telnyx.com/api-reference/openai-chat/get-available-models-openai-compatible>
+- Telnyx available model list: <https://developers.telnyx.com/docs/inference/models>
+
+## Files
+
+- [`provider-application.md`](./provider-application.md) - Copy-ready application packet with confirmed fields and open blockers.
+- [`models.example.json`](./models.example.json) - OpenRouter-shaped draft manifest based on current public Telnyx model docs. It intentionally contains `TODO_` placeholders and is not ready to serve as a production endpoint.
+- [`validate-openrouter-readiness.mjs`](./validate-openrouter-readiness.mjs) - Local validation script for static manifest shape and live Telnyx endpoint behavior.
+
+## Validation
+
+Static validation does not require credentials:
+
+```bash
+node inference/openrouter/validate-openrouter-readiness.mjs
+```
+
+Live validation is opt-in:
+
+```bash
+export TELNYX_API_KEY=KEY...
+node inference/openrouter/validate-openrouter-readiness.mjs --live
+```
+
+Optional model override:
+
+```bash
+TELNYX_OPENROUTER_TEST_MODEL="moonshotai/Kimi-K2.6" \
+TELNYX_API_KEY=KEY... \
+node inference/openrouter/validate-openrouter-readiness.mjs --live
+```
+
+The live check exercises:
+
+1. `GET /v2/ai/openai/models`
+2. non-streaming chat completion
+3. streaming chat completion
+4. invalid-model error behavior
+
+## Readiness checklist
+
+- [x] Confirm Telnyx has an OpenAI-compatible chat endpoint.
+- [x] Confirm Telnyx has a discoverable models endpoint.
+- [x] Draft OpenRouter-shaped model metadata.
+- [ ] Replace placeholder pricing with product-approved USD-per-token values.
+- [ ] Confirm max output length per model.
+- [ ] Confirm supported sampling parameters per model.
+- [ ] Confirm tool-calling, JSON mode, structured output, and reasoning support per model.
+- [ ] Confirm production datacenter country codes and capacity TPM per model.
+- [ ] Confirm automated payment, invoicing, or OpenRouter billing arrangement.
+- [ ] Confirm privacy and data-retention terms for routed OpenRouter traffic.
+- [ ] Submit OpenRouter provider application after the items above are confirmed.

--- a/inference/openrouter/models.example.json
+++ b/inference/openrouter/models.example.json
@@ -1,0 +1,170 @@
+{
+  "_warning": "Draft only. Do not expose this as a production OpenRouter model-list endpoint until TODO fields are replaced with product-approved values.",
+  "_source_docs": [
+    "https://developers.telnyx.com/docs/inference/models",
+    "https://developers.telnyx.com/api-reference/openai-chat/get-available-models-openai-compatible",
+    "https://openrouter.ai/docs/guides/community/for-providers"
+  ],
+  "data": [
+    {
+      "id": "moonshotai/Kimi-K2.6",
+      "hugging_face_id": "moonshotai/Kimi-K2.6",
+      "name": "Moonshot AI: Kimi K2.6",
+      "created": 0,
+      "input_modalities": ["text"],
+      "output_modalities": ["text"],
+      "quantization": "TODO_CONFIRM_QUANTIZATION",
+      "context_length": 262144,
+      "max_output_length": null,
+      "pricing": {
+        "prompt": "TODO_CONFIRM_USD_PER_INPUT_TOKEN",
+        "completion": "TODO_CONFIRM_USD_PER_OUTPUT_TOKEN",
+        "request": "0",
+        "image": "0",
+        "input_cache_read": "TODO_CONFIRM_USD_PER_CACHED_INPUT_TOKEN"
+      },
+      "supported_sampling_parameters": [
+        "temperature",
+        "top_p",
+        "frequency_penalty",
+        "presence_penalty",
+        "stop",
+        "max_tokens"
+      ],
+      "supported_features": ["reasoning"],
+      "description": "Highest-intelligence Telnyx-hosted open-source chat model; recommended by current Telnyx model docs.",
+      "is_ready": false,
+      "is_free": false,
+      "discount_to_user": 0,
+      "capacity_tpm": null,
+      "openrouter": {
+        "slug": "moonshotai/kimi-k2.6"
+      },
+      "datacenters": [
+        {
+          "country_code": "TODO_CONFIRM_ISO_3166_ALPHA_2"
+        }
+      ]
+    },
+    {
+      "id": "zai-org/GLM-5.2",
+      "hugging_face_id": "zai-org/GLM-5.2",
+      "name": "Z.ai: GLM 5.2",
+      "created": 0,
+      "input_modalities": ["text"],
+      "output_modalities": ["text"],
+      "quantization": "TODO_CONFIRM_QUANTIZATION",
+      "context_length": 1000000,
+      "max_output_length": null,
+      "pricing": {
+        "prompt": "TODO_CONFIRM_USD_PER_INPUT_TOKEN",
+        "completion": "TODO_CONFIRM_USD_PER_OUTPUT_TOKEN",
+        "request": "0",
+        "image": "0",
+        "input_cache_read": "TODO_CONFIRM_USD_PER_CACHED_INPUT_TOKEN"
+      },
+      "supported_sampling_parameters": [
+        "temperature",
+        "top_p",
+        "frequency_penalty",
+        "presence_penalty",
+        "stop",
+        "max_tokens"
+      ],
+      "supported_features": ["reasoning"],
+      "description": "Telnyx-hosted long-context model for coding and reasoning.",
+      "is_ready": false,
+      "is_free": false,
+      "discount_to_user": 0,
+      "capacity_tpm": null,
+      "openrouter": {
+        "slug": "zai-org/glm-5.2"
+      },
+      "datacenters": [
+        {
+          "country_code": "TODO_CONFIRM_ISO_3166_ALPHA_2"
+        }
+      ]
+    },
+    {
+      "id": "zai-org/GLM-5.1-FP8",
+      "hugging_face_id": "zai-org/GLM-5.1-FP8",
+      "name": "Z.ai: GLM 5.1 FP8",
+      "created": 0,
+      "input_modalities": ["text"],
+      "output_modalities": ["text"],
+      "quantization": "fp8",
+      "context_length": 202000,
+      "max_output_length": null,
+      "pricing": {
+        "prompt": "TODO_CONFIRM_USD_PER_INPUT_TOKEN",
+        "completion": "TODO_CONFIRM_USD_PER_OUTPUT_TOKEN",
+        "request": "0",
+        "image": "0",
+        "input_cache_read": "TODO_CONFIRM_USD_PER_CACHED_INPUT_TOKEN"
+      },
+      "supported_sampling_parameters": [
+        "temperature",
+        "top_p",
+        "frequency_penalty",
+        "presence_penalty",
+        "stop",
+        "max_tokens"
+      ],
+      "supported_features": ["tools", "reasoning"],
+      "description": "Efficient Telnyx-hosted reasoning model with function-calling suitability per current model docs.",
+      "is_ready": false,
+      "is_free": false,
+      "discount_to_user": 0,
+      "capacity_tpm": null,
+      "openrouter": {
+        "slug": "zai-org/glm-5.1-fp8"
+      },
+      "datacenters": [
+        {
+          "country_code": "TODO_CONFIRM_ISO_3166_ALPHA_2"
+        }
+      ]
+    },
+    {
+      "id": "MiniMaxAI/MiniMax-M3-MXFP8",
+      "hugging_face_id": "MiniMaxAI/MiniMax-M3-MXFP8",
+      "name": "MiniMax AI: MiniMax M3 MXFP8",
+      "created": 0,
+      "input_modalities": ["text"],
+      "output_modalities": ["text"],
+      "quantization": "TODO_CONFIRM_QUANTIZATION",
+      "context_length": 1000000,
+      "max_output_length": null,
+      "pricing": {
+        "prompt": "TODO_CONFIRM_USD_PER_INPUT_TOKEN",
+        "completion": "TODO_CONFIRM_USD_PER_OUTPUT_TOKEN",
+        "request": "0",
+        "image": "0",
+        "input_cache_read": "TODO_CONFIRM_USD_PER_CACHED_INPUT_TOKEN"
+      },
+      "supported_sampling_parameters": [
+        "temperature",
+        "top_p",
+        "frequency_penalty",
+        "presence_penalty",
+        "stop",
+        "max_tokens"
+      ],
+      "supported_features": [],
+      "description": "Cost-efficient Telnyx-hosted high-intelligence chat model.",
+      "is_ready": false,
+      "is_free": false,
+      "discount_to_user": 0,
+      "capacity_tpm": null,
+      "openrouter": {
+        "slug": "minimaxai/minimax-m3-mxfp8"
+      },
+      "datacenters": [
+        {
+          "country_code": "TODO_CONFIRM_ISO_3166_ALPHA_2"
+        }
+      ]
+    }
+  ]
+}

--- a/inference/openrouter/provider-application.md
+++ b/inference/openrouter/provider-application.md
@@ -1,0 +1,133 @@
+# OpenRouter Provider Application Packet
+
+This packet prepares the Telnyx provider application for OpenRouter. It should be reviewed by Product, Billing/Finance, Legal, and the AI platform owner before the external OpenRouter form is submitted.
+
+OpenRouter provider application: <https://openrouter.ai/providers/apply>
+
+OpenRouter provider technical guide: <https://openrouter.ai/docs/guides/community/for-providers>
+
+## Provider summary
+
+Provider name: Telnyx
+
+Provider website: <https://telnyx.com>
+
+Provider type: OpenAI-compatible model inference provider
+
+Primary API base URL:
+
+```text
+https://api.telnyx.com/v2/ai/openai
+```
+
+Primary chat endpoint:
+
+```text
+POST https://api.telnyx.com/v2/ai/openai/chat/completions
+```
+
+Primary model-list endpoint:
+
+```text
+GET https://api.telnyx.com/v2/ai/openai/models
+```
+
+Authentication:
+
+```text
+Authorization: Bearer <TELNYX_API_KEY>
+```
+
+## Current model candidates
+
+Based on current public Telnyx model docs:
+
+| Model ID | Context | Notes |
+| --- | ---: | --- |
+| `moonshotai/Kimi-K2.6` | 256K | Recommended high-intelligence chat model |
+| `zai-org/GLM-5.2` | 1M | Coding, reasoning, long-context model |
+| `zai-org/GLM-5.1-FP8` | 202K | Efficient reasoning and function calling |
+| `MiniMaxAI/MiniMax-M3-MXFP8` | 1M | Cost-efficient high-intelligence model |
+| `thenlper/gte-large` | n/a | 1024-dimensional text embedding model |
+
+The OpenRouter first submission should likely start with chat models only. Embeddings can be added after confirming OpenRouter wants Telnyx embeddings in the same provider listing.
+
+## Confirmed technical fit
+
+- Telnyx exposes OpenAI-compatible chat completions.
+- Telnyx exposes an OpenAI-compatible models endpoint.
+- Model IDs follow the `{organization}/{model_name}` pattern.
+- Telnyx model metadata includes context length, task, regions, and pricing metadata in the Telnyx API schema.
+
+## Open questions before external submission
+
+These are blockers for a production OpenRouter provider submission.
+
+### Model metadata
+
+- Confirm exact model set for launch.
+- Confirm launch names and OpenRouter slugs.
+- Confirm max output tokens per model.
+- Confirm supported sampling parameters per model.
+- Confirm supported feature flags per model:
+  - tools
+  - JSON mode
+  - structured outputs
+  - logprobs
+  - reasoning
+- Confirm whether Kimi thinking should be disabled by default for OpenRouter voice/latency-sensitive traffic.
+- Confirm whether embeddings should be included in the initial provider listing.
+
+### Pricing and billing
+
+- Confirm per-token USD pricing that OpenRouter should display.
+- Confirm whether pricing should be flat or tiered by context length.
+- Confirm whether Telnyx wants a launch discount.
+- Confirm whether OpenRouter will pay through auto top-up or invoicing.
+- Confirm finance contact and billing owner.
+
+### Capacity and operations
+
+- Confirm per-model `capacity_tpm`.
+- Confirm production datacenter country codes.
+- Confirm rate limit policy and preferred 429 behavior.
+- Confirm status page or escalation contact for provider incidents.
+- Confirm whether OpenRouter should receive any provider-specific timeout guidance.
+
+### Privacy and data retention
+
+- Confirm public privacy-policy URL for OpenRouter-routed inference.
+- Confirm whether prompts/completions are stored.
+- Confirm retention period for logs, prompts, completions, and metadata.
+- Confirm whether OpenRouter traffic may be used for model training, evaluation, or debugging.
+- Confirm whether zero-data-retention routing is supported.
+
+## Draft external response
+
+Use this only after the open questions above are closed.
+
+```text
+Telnyx provides OpenAI-compatible LLM inference through Telnyx-hosted GPU infrastructure. Our API base URL is https://api.telnyx.com/v2/ai/openai, with chat completions available at /chat/completions and model discovery available at /models.
+
+Initial launch models:
+- moonshotai/Kimi-K2.6
+- zai-org/GLM-5.2
+- zai-org/GLM-5.1-FP8
+- MiniMaxAI/MiniMax-M3-MXFP8
+
+Authentication uses bearer tokens via Authorization: Bearer <TELNYX_API_KEY>.
+
+We can provide OpenRouter-specific model metadata, pricing, regions, and capacity once the provider account is created.
+```
+
+## Internal next steps
+
+1. Run live validation with a Telnyx API key:
+
+   ```bash
+   TELNYX_API_KEY=KEY... node inference/openrouter/validate-openrouter-readiness.mjs --live
+   ```
+
+2. Replace all `TODO_` fields in [`models.example.json`](./models.example.json).
+3. Decide whether Telnyx needs a dedicated OpenRouter-facing model metadata endpoint or whether OpenRouter can transform `GET /v2/ai/openai/models`.
+4. Submit the OpenRouter provider application only after Product/Billing/Legal approve the packet.

--- a/inference/openrouter/validate-openrouter-readiness.mjs
+++ b/inference/openrouter/validate-openrouter-readiness.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const manifestPath = join(__dirname, "models.example.json");
+const live = process.argv.includes("--live");
+const apiKey = process.env.TELNYX_API_KEY;
+const baseUrl = process.env.TELNYX_OPENROUTER_BASE_URL ?? "https://api.telnyx.com/v2/ai/openai";
+const testModel = process.env.TELNYX_OPENROUTER_TEST_MODEL ?? "moonshotai/Kimi-K2.6";
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function assertString(value, field) {
+  assert(typeof value === "string" && value.length > 0, `${field} must be a non-empty string`);
+}
+
+function assertStringArray(value, field) {
+  assert(Array.isArray(value) && value.length > 0, `${field} must be a non-empty array`);
+  for (const item of value) assertString(item, field);
+}
+
+function assertPricing(pricing, modelId) {
+  assert(pricing && typeof pricing === "object", `${modelId}.pricing must be an object`);
+  for (const key of ["prompt", "completion", "request", "image", "input_cache_read"]) {
+    assertString(pricing[key], `${modelId}.pricing.${key}`);
+  }
+}
+
+async function loadManifest() {
+  const raw = await readFile(manifestPath, "utf8");
+  return JSON.parse(raw);
+}
+
+async function validateStaticManifest() {
+  const manifest = await loadManifest();
+  assert(Array.isArray(manifest.data), "models.example.json must contain a data array");
+  assert(manifest.data.length >= 4, "models.example.json should include the initial chat model candidates");
+
+  for (const model of manifest.data) {
+    assertString(model.id, "model.id");
+    assertString(model.name, `${model.id}.name`);
+    assertStringArray(model.input_modalities, `${model.id}.input_modalities`);
+    assertStringArray(model.output_modalities, `${model.id}.output_modalities`);
+    assert(Number.isInteger(model.context_length) && model.context_length > 0, `${model.id}.context_length must be a positive integer`);
+    assert("max_output_length" in model, `${model.id}.max_output_length must be present`);
+    assertPricing(model.pricing, model.id);
+    assertStringArray(model.supported_sampling_parameters, `${model.id}.supported_sampling_parameters`);
+    assert(Array.isArray(model.supported_features), `${model.id}.supported_features must be an array`);
+    assert(model.is_ready === false, `${model.id}.is_ready must stay false until product fields are confirmed`);
+    assert(model.openrouter && typeof model.openrouter.slug === "string", `${model.id}.openrouter.slug is required`);
+    assert(Array.isArray(model.datacenters) && model.datacenters.length > 0, `${model.id}.datacenters is required`);
+  }
+
+  const todoCount = JSON.stringify(manifest).match(/TODO_/g)?.length ?? 0;
+  assert(todoCount > 0, "draft manifest should keep TODO placeholders until product-approved metadata is available");
+
+  console.log(`Static manifest check passed for ${manifest.data.length} model candidates (${todoCount} TODO placeholders remain).`);
+}
+
+async function fetchJson(url, options = {}) {
+  const response = await fetch(url, options);
+  const text = await response.text();
+  let body;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = text;
+  }
+  return { response, body };
+}
+
+async function validateModelsEndpoint() {
+  const { response, body } = await fetchJson(`${baseUrl}/models`, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+
+  assert(response.ok, `GET /models failed with ${response.status}: ${JSON.stringify(body).slice(0, 500)}`);
+  assert(body && Array.isArray(body.data), "GET /models response must include a data array");
+  assert(body.data.length > 0, "GET /models returned no models");
+
+  const ids = body.data.map((model) => model.id).filter(Boolean);
+  console.log(`Live models check passed. Returned ${ids.length} model IDs.`);
+  console.log(`Sample models: ${ids.slice(0, 5).join(", ")}`);
+}
+
+async function validateChatCompletion() {
+  const { response, body } = await fetchJson(`${baseUrl}/chat/completions`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: testModel,
+      messages: [{ role: "user", content: "Reply with the word ready." }],
+      max_tokens: 16,
+    }),
+  });
+
+  assert(response.ok, `chat completion failed with ${response.status}: ${JSON.stringify(body).slice(0, 500)}`);
+  assert(body && Array.isArray(body.choices) && body.choices.length > 0, "chat completion response must include choices");
+  if (!body.usage) {
+    console.warn("Warning: chat completion response did not include usage; OpenRouter may require usage accounting.");
+  }
+  console.log(`Live chat completion check passed with model ${testModel}.`);
+}
+
+async function validateStreamingChatCompletion() {
+  const response = await fetch(`${baseUrl}/chat/completions`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: testModel,
+      messages: [{ role: "user", content: "Reply with a short sentence." }],
+      max_tokens: 24,
+      stream: true,
+    }),
+  });
+
+  assert(response.ok, `streaming chat failed with ${response.status}: ${await response.text()}`);
+  const text = await response.text();
+  assert(text.includes("data:"), "streaming response should contain SSE data lines");
+  assert(text.includes("[DONE]") || text.trim().length > 0, "streaming response should include content or a done marker");
+  console.log("Live streaming chat check passed.");
+}
+
+async function validateInvalidModelError() {
+  const { response } = await fetchJson(`${baseUrl}/chat/completions`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "telnyx-openrouter/nonexistent-model",
+      messages: [{ role: "user", content: "This should fail." }],
+      max_tokens: 8,
+    }),
+  });
+
+  assert(response.status >= 400 && response.status < 500, `invalid model should return a 4xx user/provider error, got ${response.status}`);
+  console.log(`Invalid-model error behavior check passed with HTTP ${response.status}.`);
+}
+
+async function main() {
+  await validateStaticManifest();
+
+  if (!live) {
+    console.log("Live checks skipped. Pass --live with TELNYX_API_KEY to validate Telnyx endpoints.");
+    return;
+  }
+
+  assert(apiKey, "TELNYX_API_KEY is required for --live checks");
+  await validateModelsEndpoint();
+  await validateChatCompletion();
+  await validateStreamingChatCompletion();
+  await validateInvalidModelError();
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Telnyx AI skills monorepo — SDKs, CLI, guides, and agent skills",
   "scripts": {
     "test:guides": "npx tsx --test tests/guides.test.ts",
-    "test:guides-api": "npx tsx --test tests/guides-api.test.ts"
+    "test:guides-api": "npx tsx --test tests/guides-api.test.ts",
+    "test:openrouter-readiness": "npx tsx --test tests/openrouter-readiness.test.ts"
   },
   "devDependencies": {
     "tsx": "^4.19.0"

--- a/tests/openrouter-readiness.test.ts
+++ b/tests/openrouter-readiness.test.ts
@@ -1,0 +1,60 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = typeof import.meta.dirname === "string"
+  ? import.meta.dirname
+  : dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..");
+const OPENROUTER_DIR = join(ROOT, "inference", "openrouter");
+const MANIFEST_PATH = join(OPENROUTER_DIR, "models.example.json");
+
+const requiredFiles = [
+  "README.md",
+  "provider-application.md",
+  "models.example.json",
+  "validate-openrouter-readiness.mjs",
+];
+
+describe("OpenRouter readiness packet", () => {
+  it("includes the expected packet files", () => {
+    for (const file of requiredFiles) {
+      assert.ok(existsSync(join(OPENROUTER_DIR, file)), `${file} is missing`);
+    }
+  });
+
+  it("documents the external application gate", () => {
+    const readme = readFileSync(join(OPENROUTER_DIR, "README.md"), "utf8");
+    assert.match(readme, /Do not submit the OpenRouter provider application/i);
+    assert.match(readme, /privacy and data-retention/i);
+    assert.match(readme, /pricing/i);
+    assert.match(readme, /capacity/i);
+  });
+
+  it("keeps the model manifest marked as draft until product fields are confirmed", () => {
+    const manifest = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
+    assert.ok(Array.isArray(manifest.data));
+    assert.ok(manifest.data.length >= 4);
+
+    const serialized = JSON.stringify(manifest);
+    assert.match(serialized, /TODO_/);
+
+    for (const model of manifest.data) {
+      assert.equal(model.is_ready, false, `${model.id} must stay hidden until ready`);
+      assert.ok(model.id);
+      assert.ok(model.name);
+      assert.ok(Number.isInteger(model.context_length));
+      assert.ok(model.pricing);
+      assert.equal(typeof model.pricing.prompt, "string");
+      assert.equal(typeof model.pricing.completion, "string");
+      assert.ok(Array.isArray(model.input_modalities));
+      assert.ok(Array.isArray(model.output_modalities));
+      assert.ok(Array.isArray(model.supported_sampling_parameters));
+      assert.ok(Array.isArray(model.supported_features));
+      assert.ok(model.openrouter?.slug);
+      assert.ok(Array.isArray(model.datacenters));
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add an `inference/openrouter/` readiness packet for listing Telnyx as an OpenRouter provider.
- Document the OpenRouter provider onboarding path, Telnyx OpenAI-compatible endpoints, and the remaining product/business blockers before submitting the external application.
- Add an OpenRouter-shaped draft model manifest with explicit `TODO_` placeholders so it cannot be mistaken for a production endpoint.
- Add a credential-gated validation script plus a root `node:test` structural test wired into CI.

## Why this shape

OpenRouter provider onboarding is application-based rather than a normal upstream code PR. This PR prepares the internal packet we need before submission: model metadata, validation commands, current endpoint fit, and unresolved pricing/billing/privacy/capacity fields.

## Tests

- `node inference/openrouter/validate-openrouter-readiness.mjs`
- `npm run test:openrouter-readiness`
- `npm run test:guides`
- `git diff --check`

Live validation was not run locally because `TELNYX_API_KEY` is not set in this shell. It can be run with:

```bash
TELNYX_API_KEY=KEY... node inference/openrouter/validate-openrouter-readiness.mjs --live
```

## Remaining blockers before external OpenRouter submission

- Confirm launch model set.
- Confirm USD-per-token pricing and any tiering/discounts.
- Confirm max output tokens, supported params, and supported features per model.
- Confirm production datacenter country codes and capacity TPM.
- Confirm OpenRouter payment/invoicing path.
- Confirm privacy/data-retention terms for OpenRouter-routed inference.

Linear: AIF-156
