### PR TITLE
fix: guard opencode against GLM-5.2 streamed tool-call corruption

### DIFF
--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -33,7 +33,7 @@ opencode plugin -g @telnyx/opencode
 - lets users enable additional Telnyx-hosted models through the `/telnyx` TUI command
 - registers thinking-capable models with `reasoning: true` and two variants: `thinking` (default, `enable_thinking: true`) and `no-thinking` (`enable_thinking: false`)
 - strips `maxOutputTokens` before requests so Telnyx accepts tool-enabled runs
-- excludes known-unsafe hosted models from plugin registration by default; currently `zai-org/GLM-5.2` is withheld because streamed tool-call arguments may be corrupted in OpenCode workflows
+- emits a runtime warning when using a model with a known compatibility issue (e.g. `zai-org/GLM-5.2` streamed tool-call corruption)
 
 ## Authenticate
 
@@ -125,12 +125,6 @@ Path:
 - `~/.config/opencode/telnyx-models.json`
 - override with `OPENCODE_TELNYX_MODELS_PATH`
 
-Known-unsafe models are still withheld from registration even if they appear in the saved allowlist. For internal validation only, set:
-
-```bash
-export OPENCODE_TELNYX_INCLUDE_UNSAFE_MODELS=1
-```
-
 ## TUI model manager
 
 The package also registers a `/telnyx` command (alias: `/telnyx-models`) that opens an interactive model manager in the OpenCode TUI.
@@ -204,9 +198,23 @@ or set `TELNYX_API_KEY` and retry.
 
 Some smaller models cannot fit OpenCode's full tool list and system prompt into their effective prompt budget. This is model-specific, not a plugin auth issue.
 
-### `zai-org/GLM-5.2` does not appear in `/telnyx`
+### Known issue: `zai-org/GLM-5.2` streamed tool-call arguments
 
-As of June 27, 2026, the plugin excludes `zai-org/GLM-5.2` by default because we have an open compatibility investigation for corrupted streamed tool-call arguments. Set `OPENCODE_TELNYX_INCLUDE_UNSAFE_MODELS=1` only if you are intentionally validating that failure mode.
+As of June 27, 2026, `zai-org/GLM-5.2` may produce corrupted tool-call arguments (duplicated or overlapped substrings) when used with streaming and tools in OpenCode workflows. The model remains registered and visible in `/telnyx` — plain chat and non-streaming usage are unaffected.
+
+When you start a session with a model that has a known issue, the plugin emits a warning to the OpenCode log:
+
+```
+[telnyx] ⚠ Known issue with zai-org/GLM-5.2: streamed tool-call arguments may be corrupted …
+```
+
+To suppress the warning, set:
+
+```bash
+export OPENCODE_TELNYX_INCLUDE_UNSAFE_MODELS=1
+```
+
+This also re-enables live probing of the model in `npm run test:live` (by default the harness skips models with known issues).
 
 ### How do I run the lightweight package tests?
 

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -33,6 +33,7 @@ opencode plugin -g @telnyx/opencode
 - lets users enable additional Telnyx-hosted models through the `/telnyx` TUI command
 - registers thinking-capable models with `reasoning: true` and two variants: `thinking` (default, `enable_thinking: true`) and `no-thinking` (`enable_thinking: false`)
 - strips `maxOutputTokens` before requests so Telnyx accepts tool-enabled runs
+- excludes known-unsafe hosted models from plugin registration by default; currently `zai-org/GLM-5.2` is withheld because streamed tool-call arguments may be corrupted in OpenCode workflows
 
 ## Authenticate
 
@@ -124,6 +125,12 @@ Path:
 - `~/.config/opencode/telnyx-models.json`
 - override with `OPENCODE_TELNYX_MODELS_PATH`
 
+Known-unsafe models are still withheld from registration even if they appear in the saved allowlist. For internal validation only, set:
+
+```bash
+export OPENCODE_TELNYX_INCLUDE_UNSAFE_MODELS=1
+```
+
 ## TUI model manager
 
 The package also registers a `/telnyx` command (alias: `/telnyx-models`) that opens an interactive model manager in the OpenCode TUI.
@@ -196,6 +203,10 @@ or set `TELNYX_API_KEY` and retry.
 ### A small-context model fails while larger models work
 
 Some smaller models cannot fit OpenCode's full tool list and system prompt into their effective prompt budget. This is model-specific, not a plugin auth issue.
+
+### `zai-org/GLM-5.2` does not appear in `/telnyx`
+
+As of June 27, 2026, the plugin excludes `zai-org/GLM-5.2` by default because we have an open compatibility investigation for corrupted streamed tool-call arguments. Set `OPENCODE_TELNYX_INCLUDE_UNSAFE_MODELS=1` only if you are intentionally validating that failure mode.
 
 ### `/telnyx` does not appear
 

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -169,7 +169,7 @@ The repo includes a live regression harness that:
 Create a `.env` file in `plugins/opencode/` or export `TELNYX_API_KEY`, then run:
 
 ```bash
-npm test
+npm run test:live
 ```
 
 Useful optional filters:
@@ -207,6 +207,16 @@ Some smaller models cannot fit OpenCode's full tool list and system prompt into 
 ### `zai-org/GLM-5.2` does not appear in `/telnyx`
 
 As of June 27, 2026, the plugin excludes `zai-org/GLM-5.2` by default because we have an open compatibility investigation for corrupted streamed tool-call arguments. Set `OPENCODE_TELNYX_INCLUDE_UNSAFE_MODELS=1` only if you are intentionally validating that failure mode.
+
+### How do I run the lightweight package tests?
+
+Run:
+
+```bash
+npm test
+```
+
+This runs the local unit tests directly from the TypeScript sources. The live Telnyx model probe remains available as `npm run test:live`.
 
 ### `/telnyx` does not appear
 

--- a/plugins/opencode/package.json
+++ b/plugins/opencode/package.json
@@ -25,7 +25,8 @@
     "build:tui": "bun scripts/build-tui.ts",
     "build:types": "tsup src/index.ts src/tui.tsx --dts-only --format esm --out-dir dist",
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "test": "node --test test/run.ts"
+    "test": "node --experimental-strip-types --test test/*.test.ts",
+    "test:live": "node --experimental-strip-types test/run.ts"
   },
   "dependencies": {
     "@opencode-ai/plugin": "^1.2.27"

--- a/plugins/opencode/src/index.ts
+++ b/plugins/opencode/src/index.ts
@@ -204,11 +204,14 @@ const TelnyxAuthPlugin: Plugin = async () => {
       }
 
       const modelId = input.model?.modelID ?? input.model?.id
-      if (modelId) {
-        const issue = knownUnsafeModelReason(modelId)
+      const rawModelId = modelId?.startsWith(`${PROVIDER_ID}/`)
+        ? modelId.slice(PROVIDER_ID.length + 1)
+        : modelId
+      if (rawModelId) {
+        const issue = knownUnsafeModelReason(rawModelId)
         if (issue) {
           console.warn(
-            `[telnyx] ⚠ Known issue with ${modelId}: ${issue}. ` +
+            `[telnyx] ⚠ Known issue with ${rawModelId}: ${issue}. ` +
             `If you encounter corrupted tool-call output while streaming, this is likely the cause.`,
           )
         }

--- a/plugins/opencode/src/index.ts
+++ b/plugins/opencode/src/index.ts
@@ -2,13 +2,13 @@ import { readFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
 import type { Plugin } from "@opencode-ai/plugin"
-import { DEFAULT_ENABLED_MODELS, THINKING_CAPABLE_MODELS, loadEnabledModels, persistEnabledModels } from "./models-config"
+import { DEFAULT_ENABLED_MODELS, loadEnabledModels, persistEnabledModels } from "./models-config"
+import { isTelnyxHostedModel, modelConfig } from "./model-filter"
 
 const PROVIDER_ID = "telnyx"
 const API_BASE = "https://api.telnyx.com/v2/ai"
 const OPENAI_BASE = `${API_BASE}/openai`
 const MODELS_URL = `${API_BASE}/models`
-const TEXT_TASKS = new Set(["text-generation", "text generation"])
 
 const sessionVariants = new Map<string, string>()
 
@@ -41,55 +41,6 @@ function apiKey(): string | undefined {
   return process.env.TELNYX_API_KEY ?? storedApiKey()
 }
 
-function isTelnyxHostedModel(model: JsonObject): boolean {
-  return typeof model.owned_by === "string" && model.owned_by.toLowerCase() === "telnyx"
-}
-
-function modelConfig(model: JsonObject): [string, JsonObject] | undefined {
-  const id = typeof model.id === "string" ? model.id : undefined
-  const task = typeof model.task === "string" ? model.task : undefined
-  const context = typeof model.context_length === "number" ? model.context_length : undefined
-  if (!id || !task || context === undefined) return undefined
-  if (!TEXT_TASKS.has(task)) return undefined
-  if (!isTelnyxHostedModel(model)) return undefined
-
-  const shortId = id.includes("/") ? id.split("/").pop() ?? id : id
-  const vision = model.is_vision_supported === true
-  const output = typeof model.max_output_length === "number" ? model.max_output_length : 16384
-  const thinking = THINKING_CAPABLE_MODELS.has(id)
-
-  const base: JsonObject = {
-    name: shortId,
-    limit: { context, output },
-    ...(vision
-      ? {
-          attachment: true,
-          modalities: {
-            input: ["text", "image"],
-            output: ["text"],
-          },
-        }
-      : {}),
-  }
-
-  if (thinking) {
-    base.reasoning = true
-    base.options = { enable_thinking: true }
-    base.variants = {
-      thinking: { enable_thinking: true },
-      "no-thinking": { enable_thinking: false },
-      max: { disabled: true },
-      high: { disabled: true },
-      medium: { disabled: true },
-      low: { disabled: true },
-      fast: { disabled: true },
-      none: { disabled: true },
-    }
-  }
-
-  return [id, base]
-}
-
 async function fetchModels(key: string | undefined, enabledModelIDs: readonly string[]): Promise<Record<string, JsonObject>> {
   if (!key) return {}
 
@@ -106,7 +57,7 @@ async function fetchModels(key: string | undefined, enabledModelIDs: readonly st
 
     for (const item of data) {
       if (!isObject(item)) continue
-      const parsed = modelConfig(item)
+      const parsed = modelConfig(item, process.env)
       if (!parsed) continue
       availableModels.set(parsed[0], parsed[1])
     }
@@ -136,7 +87,7 @@ async function fetchAllHostedModelIDs(key: string | undefined): Promise<string[]
 
     for (const item of data) {
       if (!isObject(item)) continue
-      const parsed = modelConfig(item)
+      const parsed = modelConfig(item, process.env)
       if (!parsed) continue
       modelIDs.push(parsed[0])
     }

--- a/plugins/opencode/src/index.ts
+++ b/plugins/opencode/src/index.ts
@@ -3,7 +3,7 @@ import { homedir } from "node:os"
 import { join } from "node:path"
 import type { Plugin } from "@opencode-ai/plugin"
 import { DEFAULT_ENABLED_MODELS, loadEnabledModels, persistEnabledModels } from "./models-config"
-import { isTelnyxHostedModel, modelConfig } from "./model-filter"
+import { isTelnyxHostedModel, modelConfig, knownUnsafeModelReason } from "./model-filter"
 
 const PROVIDER_ID = "telnyx"
 const API_BASE = "https://api.telnyx.com/v2/ai"
@@ -185,14 +185,14 @@ const TelnyxAuthPlugin: Plugin = async () => {
       }
     },
 
-    "chat.message": async (input: { sessionID: string; model?: { providerID?: string }; variant?: string }) => {
+    "chat.message": async (input: { sessionID: string; model?: { providerID?: string; modelID?: string }; variant?: string }) => {
       if (input.model?.providerID !== PROVIDER_ID) return
       if (input.variant) sessionVariants.set(input.sessionID, input.variant)
       else sessionVariants.delete(input.sessionID)
     },
 
     "chat.params": async (
-      input: { model?: { providerID?: string; options?: { enable_thinking?: boolean } }; sessionID: string },
+      input: { model?: { providerID?: string; modelID?: string; id?: string; options?: { enable_thinking?: boolean } }; sessionID: string },
       output: { maxOutputTokens?: number; options?: Record<string, unknown> },
     ) => {
       if (input.model?.providerID !== PROVIDER_ID) return
@@ -201,6 +201,17 @@ const TelnyxAuthPlugin: Plugin = async () => {
       if (variant === "no-thinking") {
         output.options ??= {}
         output.options.enable_thinking = false
+      }
+
+      const modelId = input.model?.modelID ?? input.model?.id
+      if (modelId) {
+        const issue = knownUnsafeModelReason(modelId)
+        if (issue) {
+          console.warn(
+            `[telnyx] ⚠ Known issue with ${modelId}: ${issue}. ` +
+            `If you encounter corrupted tool-call output while streaming, this is likely the cause.`,
+          )
+        }
       }
     },
   }

--- a/plugins/opencode/src/model-filter.ts
+++ b/plugins/opencode/src/model-filter.ts
@@ -1,3 +1,5 @@
+import { THINKING_CAPABLE_MODELS } from "./models-config.ts"
+
 const TEXT_TASKS = new Set(["text-generation", "text generation"])
 const UNSAFE_MODELS_ENV = "OPENCODE_TELNYX_INCLUDE_UNSAFE_MODELS"
 
@@ -50,23 +52,38 @@ export function modelConfig(
   const shortId = id.includes("/") ? id.split("/").pop() ?? id : id
   const vision = model.is_vision_supported === true
   const output = typeof model.max_output_length === "number" ? model.max_output_length : 16384
+  const thinking = THINKING_CAPABLE_MODELS.has(id)
 
-  return [
-    id,
-    {
-      name: shortId,
-      limit: { context, output },
-      ...(vision
-        ? {
-            attachment: true,
-            modalities: {
-              input: ["text", "image"],
-              output: ["text"],
-            },
-          }
-        : {}),
-    },
-  ]
+  const base: JsonObject = {
+    name: shortId,
+    limit: { context, output },
+    ...(vision
+      ? {
+          attachment: true,
+          modalities: {
+            input: ["text", "image"],
+            output: ["text"],
+          },
+        }
+      : {}),
+  }
+
+  if (thinking) {
+    base.reasoning = true
+    base.options = { enable_thinking: true }
+    base.variants = {
+      thinking: { enable_thinking: true },
+      "no-thinking": { enable_thinking: false },
+      max: { disabled: true },
+      high: { disabled: true },
+      medium: { disabled: true },
+      low: { disabled: true },
+      fast: { disabled: true },
+      none: { disabled: true },
+    }
+  }
+
+  return [id, base]
 }
 
 export function describeModelCompatibility(

--- a/plugins/opencode/src/model-filter.ts
+++ b/plugins/opencode/src/model-filter.ts
@@ -47,7 +47,6 @@ export function modelConfig(
   if (!id || !task || context === undefined) return undefined
   if (!TEXT_TASKS.has(task)) return undefined
   if (!isTelnyxHostedModel(model)) return undefined
-  if (knownUnsafeModelReason(id, env)) return undefined
 
   const shortId = id.includes("/") ? id.split("/").pop() ?? id : id
   const vision = model.is_vision_supported === true

--- a/plugins/opencode/src/model-filter.ts
+++ b/plugins/opencode/src/model-filter.ts
@@ -1,0 +1,82 @@
+const TEXT_TASKS = new Set(["text-generation", "text generation"])
+const UNSAFE_MODELS_ENV = "OPENCODE_TELNYX_INCLUDE_UNSAFE_MODELS"
+
+export type JsonObject = Record<string, unknown>
+
+const KNOWN_UNSAFE_MODEL_REASONS: Record<string, string> = {
+  "zai-org/GLM-5.2":
+    "streamed tool-call arguments may be corrupted by duplicated or overlapped substrings",
+}
+
+function isObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null
+}
+
+function isTruthy(value: string | undefined): boolean {
+  if (!value) return false
+  const normalized = value.trim().toLowerCase()
+  return normalized === "1" || normalized === "true" || normalized === "yes"
+}
+
+export function unsafeModelsOptInEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return isTruthy(env[UNSAFE_MODELS_ENV])
+}
+
+export function knownUnsafeModelReason(modelId: string, env: NodeJS.ProcessEnv = process.env): string | undefined {
+  if (unsafeModelsOptInEnabled(env)) return undefined
+  return KNOWN_UNSAFE_MODEL_REASONS[modelId]
+}
+
+export function unsafeModelsOverrideEnvVar(): string {
+  return UNSAFE_MODELS_ENV
+}
+
+export function isTelnyxHostedModel(model: JsonObject): boolean {
+  return typeof model.owned_by === "string" && model.owned_by.toLowerCase() === "telnyx"
+}
+
+export function modelConfig(
+  model: JsonObject,
+  env: NodeJS.ProcessEnv = process.env,
+): [string, JsonObject] | undefined {
+  const id = typeof model.id === "string" ? model.id : undefined
+  const task = typeof model.task === "string" ? model.task : undefined
+  const context = typeof model.context_length === "number" ? model.context_length : undefined
+  if (!id || !task || context === undefined) return undefined
+  if (!TEXT_TASKS.has(task)) return undefined
+  if (!isTelnyxHostedModel(model)) return undefined
+  if (knownUnsafeModelReason(id, env)) return undefined
+
+  const shortId = id.includes("/") ? id.split("/").pop() ?? id : id
+  const vision = model.is_vision_supported === true
+  const output = typeof model.max_output_length === "number" ? model.max_output_length : 16384
+
+  return [
+    id,
+    {
+      name: shortId,
+      limit: { context, output },
+      ...(vision
+        ? {
+            attachment: true,
+            modalities: {
+              input: ["text", "image"],
+              output: ["text"],
+            },
+          }
+        : {}),
+    },
+  ]
+}
+
+export function describeModelCompatibility(
+  model: unknown,
+  env: NodeJS.ProcessEnv = process.env,
+): { id: string; reason: string } | undefined {
+  if (!isObject(model)) return undefined
+  const id = typeof model.id === "string" ? model.id : undefined
+  if (!id) return undefined
+  const reason = knownUnsafeModelReason(id, env)
+  if (!reason) return undefined
+  return { id, reason }
+}

--- a/plugins/opencode/src/tui.tsx
+++ b/plugins/opencode/src/tui.tsx
@@ -3,7 +3,8 @@ import { readFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
 import type { TuiPlugin, TuiPluginModule, TuiPluginApi } from "@opencode-ai/plugin/tui"
-import { loadEnabledModels, persistEnabledModels, THINKING_CAPABLE_MODELS } from "./models-config"
+import { loadEnabledModels, persistEnabledModels, THINKING_CAPABLE_MODELS } from "./models-config.ts"
+import { knownUnsafeModelReason } from "./model-filter.ts"
 
 const PROVIDER_ID = "telnyx"
 const API_BASE = "https://api.telnyx.com/v2/ai"
@@ -51,6 +52,7 @@ function normalizeModel(model: JsonObject): HostedModel | undefined {
   if (!id || !task || context === undefined) return undefined
   if (!TEXT_TASKS.has(task)) return undefined
   if (!isTelnyxHostedModel(model)) return undefined
+  if (knownUnsafeModelReason(id)) return undefined
   const name = id.includes("/") ? id.split("/").pop() ?? id : id
   const vision = model.is_vision_supported === true
   const output = typeof model.max_output_length === "number" ? model.max_output_length : 16384
@@ -84,6 +86,7 @@ function providerModels(models: HostedModel[], enabled: Set<string>) {
   return Object.fromEntries(
     models.flatMap((model) => {
       if (!enabled.has(model.id)) return []
+      if (knownUnsafeModelReason(model.id)) return []
       const entry: Record<string, unknown> = {
         name: model.name,
         limit: { context: model.context, output: model.output },

--- a/plugins/opencode/src/tui.tsx
+++ b/plugins/opencode/src/tui.tsx
@@ -4,7 +4,6 @@ import { homedir } from "node:os"
 import { join } from "node:path"
 import type { TuiPlugin, TuiPluginModule, TuiPluginApi } from "@opencode-ai/plugin/tui"
 import { loadEnabledModels, persistEnabledModels, THINKING_CAPABLE_MODELS } from "./models-config.ts"
-import { knownUnsafeModelReason } from "./model-filter.ts"
 
 const PROVIDER_ID = "telnyx"
 const API_BASE = "https://api.telnyx.com/v2/ai"
@@ -52,7 +51,6 @@ function normalizeModel(model: JsonObject): HostedModel | undefined {
   if (!id || !task || context === undefined) return undefined
   if (!TEXT_TASKS.has(task)) return undefined
   if (!isTelnyxHostedModel(model)) return undefined
-  if (knownUnsafeModelReason(id)) return undefined
   const name = id.includes("/") ? id.split("/").pop() ?? id : id
   const vision = model.is_vision_supported === true
   const output = typeof model.max_output_length === "number" ? model.max_output_length : 16384
@@ -86,7 +84,6 @@ function providerModels(models: HostedModel[], enabled: Set<string>) {
   return Object.fromEntries(
     models.flatMap((model) => {
       if (!enabled.has(model.id)) return []
-      if (knownUnsafeModelReason(model.id)) return []
       const entry: Record<string, unknown> = {
         name: model.name,
         limit: { context: model.context, output: model.output },

--- a/plugins/opencode/test/model-filter.test.ts
+++ b/plugins/opencode/test/model-filter.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, it } from "node:test"
 import assert from "node:assert/strict"
-import { knownUnsafeModelReason, modelConfig, unsafeModelsOverrideEnvVar } from "../src/model-filter.js"
+import { knownUnsafeModelReason, modelConfig, unsafeModelsOverrideEnvVar } from "../src/model-filter.ts"
 
 describe("model-filter", () => {
   const envVar = unsafeModelsOverrideEnvVar()

--- a/plugins/opencode/test/model-filter.test.ts
+++ b/plugins/opencode/test/model-filter.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, it } from "node:test"
+import assert from "node:assert/strict"
+import { knownUnsafeModelReason, modelConfig, unsafeModelsOverrideEnvVar } from "../src/model-filter.js"
+
+describe("model-filter", () => {
+  const envVar = unsafeModelsOverrideEnvVar()
+  const originalUnsafeOverride = process.env[envVar]
+
+  afterEach(() => {
+    if (originalUnsafeOverride === undefined) delete process.env[envVar]
+    else process.env[envVar] = originalUnsafeOverride
+  })
+
+  it("filters GLM-5.2 by default because streamed tool-call arguments are known unsafe", () => {
+    const glmModel = {
+      id: "zai-org/GLM-5.2",
+      owned_by: "telnyx",
+      task: "text-generation",
+      context_length: 1_000_000,
+      max_output_length: 16_384,
+    }
+
+    const reason = knownUnsafeModelReason(glmModel.id)
+    assert.match(reason ?? "", /streamed tool-call arguments/i)
+    assert.equal(modelConfig(glmModel), undefined)
+  })
+
+  it("allows GLM-5.2 when the explicit unsafe-model override is enabled", () => {
+    process.env[envVar] = "1"
+    const glmModel = {
+      id: "zai-org/GLM-5.2",
+      owned_by: "telnyx",
+      task: "text-generation",
+      context_length: 1_000_000,
+      max_output_length: 16_384,
+    }
+
+    assert.equal(knownUnsafeModelReason(glmModel.id), undefined)
+    assert.deepEqual(modelConfig(glmModel), [
+      "zai-org/GLM-5.2",
+      {
+        name: "GLM-5.2",
+        limit: {
+          context: 1_000_000,
+          output: 16_384,
+        },
+      },
+    ])
+  })
+})

--- a/plugins/opencode/test/model-filter.test.ts
+++ b/plugins/opencode/test/model-filter.test.ts
@@ -11,7 +11,7 @@ describe("model-filter", () => {
     else process.env[envVar] = originalUnsafeOverride
   })
 
-  it("filters GLM-5.2 by default because streamed tool-call arguments are known unsafe", () => {
+  it("registers GLM-5.2 normally (it is not withheld from modelConfig)", () => {
     const glmModel = {
       id: "zai-org/GLM-5.2",
       owned_by: "telnyx",
@@ -20,22 +20,7 @@ describe("model-filter", () => {
       max_output_length: 16_384,
     }
 
-    const reason = knownUnsafeModelReason(glmModel.id)
-    assert.match(reason ?? "", /streamed tool-call arguments/i)
-    assert.equal(modelConfig(glmModel), undefined)
-  })
-
-  it("allows GLM-5.2 when the explicit unsafe-model override is enabled", () => {
-    process.env[envVar] = "1"
-    const glmModel = {
-      id: "zai-org/GLM-5.2",
-      owned_by: "telnyx",
-      task: "text-generation",
-      context_length: 1_000_000,
-      max_output_length: 16_384,
-    }
-
-    assert.equal(knownUnsafeModelReason(glmModel.id), undefined)
+    // modelConfig returns a full config — GLM-5.2 is registered and visible
     assert.deepEqual(modelConfig(glmModel), [
       "zai-org/GLM-5.2",
       {
@@ -58,5 +43,20 @@ describe("model-filter", () => {
         },
       },
     ])
+  })
+
+  it("reports the known streaming issue for GLM-5.2 (for runtime warnings)", () => {
+    const reason = knownUnsafeModelReason("zai-org/GLM-5.2")
+    assert.match(reason ?? "", /streamed tool-call arguments/i)
+  })
+
+  it("suppresses the known-issue warning when the opt-in env is set", () => {
+    process.env[envVar] = "1"
+    assert.equal(knownUnsafeModelReason("zai-org/GLM-5.2"), undefined)
+  })
+
+  it("returns undefined for models with no known issues", () => {
+    assert.equal(knownUnsafeModelReason("zai-org/GLM-5.1-FP8"), undefined)
+    assert.equal(knownUnsafeModelReason("moonshotai/Kimi-K2.6"), undefined)
   })
 })

--- a/plugins/opencode/test/model-filter.test.ts
+++ b/plugins/opencode/test/model-filter.test.ts
@@ -44,6 +44,18 @@ describe("model-filter", () => {
           context: 1_000_000,
           output: 16_384,
         },
+        reasoning: true,
+        options: { enable_thinking: true },
+        variants: {
+          thinking: { enable_thinking: true },
+          "no-thinking": { enable_thinking: false },
+          max: { disabled: true },
+          high: { disabled: true },
+          medium: { disabled: true },
+          low: { disabled: true },
+          fast: { disabled: true },
+          none: { disabled: true },
+        },
       },
     ])
   })

--- a/plugins/opencode/test/models-config.test.ts
+++ b/plugins/opencode/test/models-config.test.ts
@@ -8,7 +8,7 @@ import {
   MODELS_CONFIG_VERSION,
   loadEnabledModels,
   persistEnabledModels,
-} from "../src/models-config.js"
+} from "../src/models-config.ts"
 
 describe("models-config", () => {
   let originalModelsPath: string | undefined

--- a/plugins/opencode/test/run.ts
+++ b/plugins/opencode/test/run.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { spawnSync } from "node:child_process"
 import { dirname, join, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
+import { describeModelCompatibility, isTelnyxHostedModel, modelConfig, unsafeModelsOverrideEnvVar } from "../src/model-filter.js"
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT_DIR = resolve(__dirname, "..")
@@ -30,6 +31,7 @@ interface ModelDescriptor {
   organization: string | undefined
   recommendedForAssistants: boolean
   requiresExternalKey: boolean
+  knownIssue?: string
 }
 
 interface ProbeResult {
@@ -52,10 +54,6 @@ interface ModelResult {
 
 function isObject(value: unknown): value is JsonObject {
   return typeof value === "object" && value !== null
-}
-
-function isTelnyxHostedModel(model: JsonObject): boolean {
-  return typeof model.owned_by === "string" && model.owned_by.toLowerCase() === TELNYX_OWNER
 }
 
 function shouldIncludeExternalModels(): boolean {
@@ -172,6 +170,11 @@ async function fetchModels(apiKey: string): Promise<ModelDescriptor[]> {
     if (!id || !task) return []
     if (!TEXT_TASKS.has(task)) return []
 
+    const compatibility = describeModelCompatibility(item, process.env)
+    const hostedByTelnyx = isTelnyxHostedModel(item)
+    const supportedConfig = modelConfig(item, process.env)
+    if (hostedByTelnyx && !supportedConfig && !compatibility) return []
+
     return [{
       id,
       providerModel: `${PROVIDER_ID}/${id}`,
@@ -180,7 +183,8 @@ async function fetchModels(apiKey: string): Promise<ModelDescriptor[]> {
       ownedBy,
       organization,
       recommendedForAssistants,
-      requiresExternalKey: !isTelnyxHostedModel(item),
+      requiresExternalKey: !hostedByTelnyx,
+      knownIssue: compatibility?.reason,
     }]
   }).sort((left, right) => left.id.localeCompare(right.id))
 }
@@ -424,6 +428,19 @@ async function main(): Promise<void> {
       console.log(`Running probes for ${model.providerModel}...`)
       if (model.requiresExternalKey) {
         const note = `requires external provider key (${model.ownedBy ?? "unknown"}) via api_key_ref/api_key and is filtered from plugin registration`
+        results.push({
+          modelId: model.id,
+          providerModel: model.providerModel,
+          context: model.context,
+          vision: model.vision,
+          simple: skippedProbe("simple", note),
+          tool: skippedProbe("tool", note),
+        })
+        continue
+      }
+
+      if (model.knownIssue) {
+        const note = `known incompatibility: ${model.knownIssue}; set ${unsafeModelsOverrideEnvVar()}=1 to include for internal validation`
         results.push({
           modelId: model.id,
           providerModel: model.providerModel,

--- a/plugins/opencode/test/run.ts
+++ b/plugins/opencode/test/run.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { spawnSync } from "node:child_process"
 import { dirname, join, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
-import { describeModelCompatibility, isTelnyxHostedModel, modelConfig, unsafeModelsOverrideEnvVar } from "../src/model-filter.js"
+import { describeModelCompatibility, isTelnyxHostedModel, modelConfig, unsafeModelsOverrideEnvVar } from "../src/model-filter.ts"
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT_DIR = resolve(__dirname, "..")

--- a/plugins/opencode/tsconfig.json
+++ b/plugins/opencode/tsconfig.json
@@ -11,6 +11,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
     "jsx": "preserve",
     "types": ["node"]
   },


### PR DESCRIPTION
## What this does

Keeps `zai-org/GLM-5.2` registered and visible in OpenCode — it's our most popular model — while surfacing the known streaming tool-call corruption issue as a runtime warning instead of hiding the model entirely.

## Background

Issue #248 reports that GLM-5.2 produces corrupted tool-call arguments when used with streaming and tools in OpenCode. The concatenated `function.arguments` is valid JSON, but string values (especially file paths) contain duplicated/overlapped substrings (e.g. `worker.js` → `worker.jsrker.js`). This is a backend/model-level issue, not a client-side delta-assembly problem.

## Approach: warn, don't hide

Hiding GLM-5.2 entirely would block all usage to mitigate a subset of usage patterns (streaming + tool calls). Plain chat and non-streaming usage are unaffected. Instead this PR:

1. **Keeps GLM-5.2 registered** with full thinking variants — same as every other model
2. **Emits a runtime `console.warn`** in the `chat.params` hook when the selected model has a known issue
3. **Documents the known issue** in the README troubleshooting section
4. **Annotates the live regression harness** — models with known issues are skipped in `npm run test:live` unless the override is set

The `OPENCODE_TELNYX_INCLUDE_UNSAFE_MODELS=1` env var is repurposed: instead of being required to *use* GLM-5.2, it now *suppresses the warning* and re-enables live probing.

## Changes

- **`model-filter.ts`** (new) — centralizes `KNOWN_UNSAFE_MODEL_REASONS` map, `knownUnsafeModelReason()`, `isTelnyxHostedModel()`, and `modelConfig()` (moved from `index.ts` for testability). `modelConfig` does **not** filter known-unsafe models — it registers them normally.
- **`index.ts`** — imports from `model-filter.ts`, adds runtime warning in `chat.params` hook. Strips the `telnyx/` provider prefix from `model.id` before the known-issue lookup (OpenCode passes provider-qualified IDs).
- **`tui.tsx`** — imports updated, no filtering applied. GLM-5.2 appears in `/telnyx` and can be toggled freely.
- **`test/model-filter.test.ts`** (new) — 4 tests: GLM-5.2 passes through `modelConfig`, `knownUnsafeModelReason` returns the warning text, env override suppresses it, clean models return undefined.
- **`test/run.ts`** — annotates models with known issues, skips probe unless override is set.
- **`README.md`** — troubleshooting entry for the known streaming issue, env override docs.

## Client-side fix?

Investigated all available plugin hooks — no clean client-side fix exists:
- Can't force `stream: false` from `chat.params` (OpenCode controls `doStream` vs `doGenerate`)
- Can't disable tool-call capability per-model
- Can't reliably detect corrupted-but-valid JSON in `tool.execute.before` (duplicated substrings look intentional)
- The corruption is in the SSE delta fragments emitted by the backend, not client-side assembly

The real fix is backend-side (vLLM streaming path, or evaluating SGLang as the issue suggests).

## Verification
- `npm test` — 7/7 pass ✅
- `npm run typecheck` — pass ✅
- `npm run build:server` — pass ✅
- `npm run build:types` — pass ✅

Closes #248
