### PR TITLE
feat(cli): update Edge CLI wrapper for v0.2.3 (stateful actors, expired-token fix)

### DIFF
--- a/cli/src/commands/capabilities.ts
+++ b/cli/src/commands/capabilities.ts
@@ -44,6 +44,7 @@ const CAPABILITIES: Record<string, Capability[]> = {
     { name: "Edge Functions", description: "Pair Telnyx AI workflows with Telnyx Edge Compute. telnyx-agent now provides an executable handoff and prefers API-key auth for agent use when supported by telnyx-edge.", actions: ["see_guides_edge_compute"] },
     { name: "Deployment Handoff", description: "Use team-telnyx/ai for orchestration patterns and telnyx-edge for deploy, secrets, bindings, and lifecycle management.", actions: ["telnyx_edge_ship", "telnyx_edge_secrets", "telnyx_edge_bindings"] },
     { name: "Edge CLI Bridge", description: "Thin executable handoff from telnyx-agent into telnyx-edge for real MCP and webhook starting points.", actions: ["edge_doctor", "setup_edge_mcp", "setup_edge_webhook"] },
+    { name: "Stateful Actors", description: "Per-entity stateful workloads on Edge Compute (Beta). Single-threaded, per-name, persisted. No external database needed for carts, sessions, call legs, chat rooms.", actions: ["telnyx_edge_new_func_actor", "telnyx_edge_actors_list", "telnyx_edge_types"] },
   ],
   "📋 10DLC Compliance": [
     { name: "10DLC Registration", description: "Register brands and campaigns for US A2P messaging", actions: ["create_10dlc_brand", "create_10dlc_campaign", "assign_10dlc_number"] },

--- a/cli/src/commands/edge-doctor.ts
+++ b/cli/src/commands/edge-doctor.ts
@@ -7,7 +7,7 @@
  */
 
 import { outputJson, printError, printSuccess, printWarning } from "../utils/output.ts";
-import { getEdgeAuthStatus, getEdgeHelp, hasEdgeCli, supportsApiKeyAuth } from "../edge-cli.ts";
+import { getEdgeAuthStatus, getEdgeHelp, getEdgeVersion, hasEdgeCli, supportsApiKeyAuth, supportsStatefulActors } from "../edge-cli.ts";
 
 interface EdgeDoctorResult {
   ready: boolean;
@@ -16,6 +16,7 @@ interface EdgeDoctorResult {
   authenticated: boolean;
   auth_mode: "api_key" | "oauth" | "none" | "unknown";
   api_key_auth_supported: boolean;
+  stateful_actors_supported: boolean;
   checks: Array<{ name: string; ok: boolean; detail: string }>;
   next_steps: string[];
 }
@@ -29,11 +30,12 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
   let authenticated = false;
   let authMode: EdgeDoctorResult["auth_mode"] = "none";
   let apiKeyAuthSupported = false;
+  let statefulActorsSupported = false;
 
   try {
     const out = getEdgeHelp();
     installed = hasEdgeCli();
-    version = extractVersion(out) ?? "installed";
+    version = getEdgeVersion() ?? extractVersion(out) ?? "installed";
     checks.push({ name: "telnyx-edge installed", ok: true, detail: version });
   } catch (err: any) {
     const detail = err?.code === "ENOENT"
@@ -48,6 +50,15 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
       name: "API-key auth supported",
       ok: apiKeyAuthSupported,
       detail: apiKeyAuthSupported ? "auth api-key set is available" : "no auth api-key set support detected",
+    });
+
+    statefulActorsSupported = supportsStatefulActors();
+    checks.push({
+      name: "Stateful actors supported",
+      ok: statefulActorsSupported,
+      detail: statefulActorsSupported
+        ? "actors subcommand available (v0.2.3+)"
+        : "telnyx-edge actors not available — upgrade to v0.2.3+ for stateful actors",
     });
 
     try {
@@ -95,6 +106,9 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
       "Deploy with: telnyx-edge ship",
       "Then connect the exposed HTTP or MCP boundary back into your AI workflow.",
     ];
+    if (statefulActorsSupported) {
+      nextSteps.push("For stateful workloads (carts, sessions, call legs): telnyx-edge new-func --actor --language ts --name my-actor");
+    }
   }
 
   const result: EdgeDoctorResult = {
@@ -104,6 +118,7 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
     authenticated,
     auth_mode: authMode,
     api_key_auth_supported: apiKeyAuthSupported,
+    stateful_actors_supported: statefulActorsSupported,
     checks,
     next_steps: nextSteps,
   };

--- a/cli/src/commands/edge-doctor.ts
+++ b/cli/src/commands/edge-doctor.ts
@@ -57,8 +57,8 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
       name: "Stateful actors supported",
       ok: statefulActorsSupported,
       detail: statefulActorsSupported
-        ? "actors subcommand available (v0.2.3+)"
-        : "telnyx-edge actors not available — upgrade to v0.2.3+ for stateful actors",
+        ? "new-func --actor available (v0.2.3+)"
+        : "new-func --actor not available — upgrade to v0.2.3+ for stateful actors",
     });
 
     try {

--- a/cli/src/commands/setup-edge-mcp.ts
+++ b/cli/src/commands/setup-edge-mcp.ts
@@ -3,13 +3,14 @@
  */
 
 import { outputJson, printError, printSuccess, printWarning } from "../utils/output.ts";
-import { getEdgeAuthStatus, hasEdgeCli, supportsApiKeyAuth } from "../edge-cli.ts";
+import { getEdgeAuthStatus, hasEdgeCli, supportsApiKeyAuth, supportsStatefulActors } from "../edge-cli.ts";
 
 interface SetupEdgeMcpResult {
   ready: boolean;
   authenticated: boolean;
   auth_mode: "api_key" | "oauth" | "none" | "unknown";
   api_key_auth_supported: boolean;
+  stateful_actors_supported: boolean;
   example: string;
   auth_command: string;
   deploy_command: string;
@@ -25,17 +26,28 @@ export async function setupEdgeMcpCommand(flags: Record<string, string | boolean
 
   const hasEdge = hasEdgeCli();
   const apiKeyAuthSupported = hasEdge ? supportsApiKeyAuth() : false;
+  const statefulActorsSupported = hasEdge ? supportsStatefulActors() : false;
   const authStatus = hasEdge ? safeAuthStatus() : { authenticated: false, mode: "none" as const };
   const authCommand = apiKeyAuthSupported
     ? "telnyx-edge auth api-key set <your-api-key>"
     : "telnyx-edge auth login";
   const deployCommand = `telnyx-edge new-func --from-dir=${MCP_EXAMPLE} --name=${name} && cd ${name} && telnyx-edge ship`;
 
+  const notes = [
+    "team-telnyx/ai provides the integration pattern, not the Edge lifecycle.",
+    "Use telnyx-edge for auth, deploy, secrets, bindings, and lifecycle management.",
+    "After deploy, connect the exposed MCP or HTTP boundary back into your AI workflow.",
+  ];
+  if (statefulActorsSupported) {
+    notes.push("For stateful MCP/webhook scenarios (per-user sessions, connection state): consider telnyx-edge new-func --actor --language ts");
+  }
+
   const result: SetupEdgeMcpResult = {
     ready: hasEdge && authStatus.authenticated,
     authenticated: authStatus.authenticated,
     auth_mode: authStatus.mode,
     api_key_auth_supported: apiKeyAuthSupported,
+    stateful_actors_supported: statefulActorsSupported,
     example: MCP_EXAMPLE,
     auth_command: authCommand,
     deploy_command: deployCommand,
@@ -44,11 +56,7 @@ export async function setupEdgeMcpCommand(flags: Record<string, string | boolean
       `Authenticate with ${authCommand}`,
       "Use a real Edge Compute example as the starting point",
     ],
-    notes: [
-      "team-telnyx/ai provides the integration pattern, not the Edge lifecycle.",
-      "Use telnyx-edge for auth, deploy, secrets, bindings, and lifecycle management.",
-      "After deploy, connect the exposed MCP or HTTP boundary back into your AI workflow.",
-    ],
+    notes,
   };
 
   if (jsonOutput) {

--- a/cli/src/commands/setup-edge-webhook.ts
+++ b/cli/src/commands/setup-edge-webhook.ts
@@ -3,13 +3,14 @@
  */
 
 import { outputJson, printError, printSuccess, printWarning } from "../utils/output.ts";
-import { getEdgeAuthStatus, hasEdgeCli, supportsApiKeyAuth } from "../edge-cli.ts";
+import { getEdgeAuthStatus, hasEdgeCli, supportsApiKeyAuth, supportsStatefulActors } from "../edge-cli.ts";
 
 interface SetupEdgeWebhookResult {
   ready: boolean;
   authenticated: boolean;
   auth_mode: "api_key" | "oauth" | "none" | "unknown";
   api_key_auth_supported: boolean;
+  stateful_actors_supported: boolean;
   example: string;
   auth_command: string;
   deploy_command: string;
@@ -25,17 +26,28 @@ export async function setupEdgeWebhookCommand(flags: Record<string, string | boo
 
   const hasEdge = hasEdgeCli();
   const apiKeyAuthSupported = hasEdge ? supportsApiKeyAuth() : false;
+  const statefulActorsSupported = hasEdge ? supportsStatefulActors() : false;
   const authStatus = hasEdge ? safeAuthStatus() : { authenticated: false, mode: "none" as const };
   const authCommand = apiKeyAuthSupported
     ? "telnyx-edge auth api-key set <your-api-key>"
     : "telnyx-edge auth login";
   const deployCommand = `telnyx-edge new-func --from-dir=${WEBHOOK_EXAMPLE} --name=${name} && cd ${name} && telnyx-edge ship`;
 
+  const notes = [
+    "Use this when your AI workflow needs an HTTP ingress point at the edge.",
+    "The deployed function lifecycle is still owned by telnyx-edge.",
+    "After deploy, point your webhook-producing system at the Edge endpoint and let team-telnyx/ai handle orchestration guidance.",
+  ];
+  if (statefulActorsSupported) {
+    notes.push("For stateful MCP/webhook scenarios (per-user sessions, connection state): consider telnyx-edge new-func --actor --language ts");
+  }
+
   const result: SetupEdgeWebhookResult = {
     ready: hasEdge && authStatus.authenticated,
     authenticated: authStatus.authenticated,
     auth_mode: authStatus.mode,
     api_key_auth_supported: apiKeyAuthSupported,
+    stateful_actors_supported: statefulActorsSupported,
     example: WEBHOOK_EXAMPLE,
     auth_command: authCommand,
     deploy_command: deployCommand,
@@ -44,11 +56,7 @@ export async function setupEdgeWebhookCommand(flags: Record<string, string | boo
       `Authenticate with ${authCommand}`,
       "Start from the webhook receiver example",
     ],
-    notes: [
-      "Use this when your AI workflow needs an HTTP ingress point at the edge.",
-      "The deployed function lifecycle is still owned by telnyx-edge.",
-      "After deploy, point your webhook-producing system at the Edge endpoint and let team-telnyx/ai handle orchestration guidance.",
-    ],
+    notes,
   };
 
   if (jsonOutput) {

--- a/cli/src/edge-cli.ts
+++ b/cli/src/edge-cli.ts
@@ -26,6 +26,42 @@ export function getEdgeHelp(): string {
   return runEdge(["--help"]);
 }
 
+/**
+ * Resolve the installed telnyx-edge version.
+ *
+ * Prefers the first-class `--version` flag introduced in v0.2.3. If that is
+ * unavailable (older CLI), falls back to parsing `--help` output with the
+ * existing semver regex.
+ */
+export function getEdgeVersion(): string | null {
+  try {
+    const v = matchVersion(runEdge(["--version"]));
+    if (v) return v;
+  } catch {
+    // older CLI without --version — fall back to --help parsing below
+  }
+  try {
+    return matchVersion(runEdge(["--help"]));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Feature detection for Stateful Actors (Beta, telnyx-edge v0.2.3+).
+ *
+ * Probes whether the installed CLI exposes the `actors` subcommand rather than
+ * relying on version parsing, so canary/preview builds are detected too.
+ */
+export function supportsStatefulActors(): boolean {
+  try {
+    runEdge(["actors", "--help"]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export type EdgeAuthStatus = {
   authenticated: boolean;
   mode: "api_key" | "oauth" | "none" | "unknown";
@@ -39,7 +75,9 @@ export function getEdgeAuthStatus(): EdgeAuthStatus {
     !text.includes("authentication status: none") &&
     !text.includes("not authenticated") &&
     !text.includes("status: ❌") &&
-    !text.includes("status: x");
+    !text.includes("status: x") &&
+    !text.includes("token expired") &&
+    !text.includes("⚠️");
 
   let mode: EdgeAuthStatus["mode"] = "unknown";
   if (
@@ -73,4 +111,9 @@ export function supportsApiKeyAuth(): boolean {
   } catch {
     return false;
   }
+}
+
+function matchVersion(text: string): string | null {
+  const match = text.match(/v?\d+\.\d+\.\d+/);
+  return match?.[0] ?? null;
 }

--- a/cli/src/edge-cli.ts
+++ b/cli/src/edge-cli.ts
@@ -50,13 +50,17 @@ export function getEdgeVersion(): string | null {
 /**
  * Feature detection for Stateful Actors (Beta, telnyx-edge v0.2.3+).
  *
- * Probes whether the installed CLI exposes the `actors` subcommand rather than
- * relying on version parsing, so canary/preview builds are detected too.
+ * Checks whether `new-func` exposes the `--actor` flag — the documented
+ * quick-start workflow (`telnyx-edge new-func --actor --name=account`).
+ * This is the actual scaffolding capability the wrapper cares about, not
+ * the account-scoped `actors` management subcommand. An actor-capable CLI
+ * that lacks `actors --help` (e.g. a canary build or the minimal surface
+ * described in the published quick start) still reports true here.
  */
 export function supportsStatefulActors(): boolean {
   try {
-    runEdge(["actors", "--help"]);
-    return true;
+    const out = runEdge(["new-func", "--help"]);
+    return /--actor\b/i.test(out);
   } catch {
     return false;
   }

--- a/cli/tests/edge-handoff.test.ts
+++ b/cli/tests/edge-handoff.test.ts
@@ -22,8 +22,8 @@ if (args.includes('--version')) {
   console.log('telnyx-edge v0.2.3');
   process.exit(0);
 }
-if (args[0] === 'actors' && args.includes('--help')) {
-  console.log('Manage account-scoped StatefulActor types');
+if (args[0] === 'new-func' && args.includes('--help')) {
+  console.log(['Create a new edge computing function', '', 'Flags:', '      --actor             Scaffold a StatefulActor (telnyx.toml) project — TypeScript only', '      --from-dir string   Copy files from existing directory', '  -h, --help              help for new-func', '  -l, --language string   Language runtime (go, js, ts, python, quarkus)', '  -n, --name string       Name of the function to create'].join('\\n'));
   process.exit(0);
 }
 if (args[0] === 'auth' && args[1] === 'api-key' && args[2] === 'set' && args.includes('--help')) {

--- a/cli/tests/edge-handoff.test.ts
+++ b/cli/tests/edge-handoff.test.ts
@@ -9,7 +9,7 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CLI = join(__dirname, "..", "bin", "telnyx-agent.ts");
 
-function withFakeEdgeCli(mode: "none" | "oauth" | "api_key" = "api_key") {
+function withFakeEdgeCli(mode: "none" | "oauth" | "api_key" | "expired_oauth" = "api_key") {
   const tempDir = mkdtempSync(join(tmpdir(), "telnyx-edge-fake-"));
   const binDir = join(tempDir, "bin");
   mkdirSync(binDir, { recursive: true });
@@ -18,12 +18,20 @@ function withFakeEdgeCli(mode: "none" | "oauth" | "api_key" = "api_key") {
     fakeEdge,
     `#!/usr/bin/env node
 const args = process.argv.slice(2);
+if (args.includes('--version')) {
+  console.log('telnyx-edge v0.2.3');
+  process.exit(0);
+}
+if (args[0] === 'actors' && args.includes('--help')) {
+  console.log('Manage account-scoped StatefulActor types');
+  process.exit(0);
+}
 if (args[0] === 'auth' && args[1] === 'api-key' && args[2] === 'set' && args.includes('--help')) {
   console.log('Set API key for authentication. The API key must be provided as an argument.');
   process.exit(0);
 }
 if (args.includes('--help')) {
-  console.log(['telnyx-edge v0.1.0', 'Commands: auth login, auth api-key set, ship, list, secrets, bindings'].join('\\n'));
+  console.log(['Telnyx Edge CLI v0.2.3', '', 'Available Commands:', '  actors      Manage StatefulActor types', '  auth        Authentication commands', '  ship        Ship a function', '  list        List functions', '  secrets     Manage secrets', '  bindings    Manage bindings'].join('\\n'));
   process.exit(0);
 }
 if (args[0] === 'auth' && args[1] === 'status') {
@@ -31,8 +39,12 @@ if (args[0] === 'auth' && args[1] === 'status') {
     console.log(['API Endpoint: https://api.telnyx.com', '', 'Authentication Status: None', 'Status: ❌ Not authenticated', "Run 'telnyx-edge auth login' or 'telnyx-edge auth api-key set <api_key>' to authenticate"].join('\\n'));
     process.exit(0);
   }
+  if ('${mode}' === 'expired_oauth') {
+    console.log(['API Endpoint: https://api.telnyx.com', '', 'Authentication Status: OAuth 2.0', 'Token Type: Bearer', 'Scopes: admin', 'Expires: 2026-06-22 18:35:42 IST', 'Status: ⚠️ Token expired - run telnyx-edge auth login to refresh'].join('\\n'));
+    process.exit(0);
+  }
   if ('${mode}' === 'oauth') {
-    console.log(['API Endpoint: https://api.telnyx.com', '', 'Authentication Status: OAuth', 'Status: ✅ Authenticated'].join('\\n'));
+    console.log(['API Endpoint: https://api.telnyx.com', '', 'Authentication Status: OAuth 2.0', 'Token Type: Bearer', 'Scopes: admin', 'Expires: 2026-07-06 12:11:42 IST', 'Status: ✅ Authenticated'].join('\\n'));
     process.exit(0);
   }
   console.log(['API Endpoint: https://api.telnyx.com', '', 'Authentication Status: API Key', 'Status: ✅ Authenticated'].join('\\n'));
@@ -82,6 +94,17 @@ describe("CLI — Edge Compute handoff", () => {
     assert.ok(commands.some((c: string) => c.includes("setup-edge-webhook")));
   });
 
+  it("capabilities JSON includes stateful actors entry", () => {
+    const output = run(["capabilities", "--json"]);
+    const data = JSON.parse(output);
+    const category = Object.keys(data.api_capabilities || {}).find((k) => k.includes("Edge Compute"));
+    assert.ok(category);
+    const caps = data.api_capabilities[category] as Array<{ name: string; description: string }>;
+    const actorCap = caps.find((c) => c.name === "Stateful Actors");
+    assert.ok(actorCap, "Stateful Actors capability should be listed");
+    assert.ok(actorCap!.description.toLowerCase().includes("per-entity"));
+  });
+
   it("edge-doctor reports API-key auth support and readiness", () => {
     const fake = withFakeEdgeCli("api_key");
     const output = run(["edge-doctor", "--json"], fake.env);
@@ -91,6 +114,7 @@ describe("CLI — Edge Compute handoff", () => {
     assert.equal(data.authenticated, true);
     assert.equal(data.auth_mode, "api_key");
     assert.equal(data.api_key_auth_supported, true);
+    assert.equal(data.stateful_actors_supported, true);
     assert.ok(Array.isArray(data.next_steps));
   });
 
@@ -102,7 +126,30 @@ describe("CLI — Edge Compute handoff", () => {
     assert.equal(data.telnyx_edge_installed, true);
     assert.equal(data.authenticated, false);
     assert.equal(data.api_key_auth_supported, true);
+    assert.equal(data.stateful_actors_supported, true);
     assert.ok(data.next_steps.some((s: string) => s.includes("auth api-key set")));
+  });
+
+  it("edge-doctor detects expired OAuth token as not authenticated", () => {
+    const fake = withFakeEdgeCli("expired_oauth");
+    const output = run(["edge-doctor", "--json"], fake.env);
+    const data = JSON.parse(output);
+    assert.equal(data.ready, false);
+    assert.equal(data.telnyx_edge_installed, true);
+    assert.equal(data.authenticated, false, "expired token should not be authenticated");
+    assert.equal(data.auth_mode, "oauth");
+    assert.equal(data.stateful_actors_supported, true);
+  });
+
+  it("edge-doctor suggests stateful actors when supported and authenticated", () => {
+    const fake = withFakeEdgeCli("api_key");
+    const output = run(["edge-doctor", "--json"], fake.env);
+    const data = JSON.parse(output);
+    assert.equal(data.ready, true);
+    assert.ok(
+      data.next_steps.some((s: string) => s.includes("--actor")),
+      "next_steps should mention --actor when stateful actors are supported",
+    );
   });
 
   it("setup-edge-mcp returns API-key auth handoff when unauthenticated", () => {
@@ -111,6 +158,7 @@ describe("CLI — Edge Compute handoff", () => {
     const data = JSON.parse(output);
     assert.equal(data.ready, false);
     assert.equal(data.api_key_auth_supported, true);
+    assert.equal(data.stateful_actors_supported, true);
     assert.equal(data.auth_command, "telnyx-edge auth api-key set <your-api-key>");
     assert.equal(data.example, "examples/ts/mcp-server");
     assert.ok(data.deploy_command.includes("demo-mcp"));
@@ -122,7 +170,28 @@ describe("CLI — Edge Compute handoff", () => {
     const data = JSON.parse(output);
     assert.equal(data.ready, true);
     assert.equal(data.auth_mode, "api_key");
+    assert.equal(data.stateful_actors_supported, true);
     assert.equal(data.example, "examples/js/webhook-receiver");
     assert.ok(data.deploy_command.includes("demo-webhook"));
+  });
+
+  it("setup-edge-mcp notes mention stateful actors when supported", () => {
+    const fake = withFakeEdgeCli("api_key");
+    const output = run(["setup-edge-mcp", "--json"], fake.env);
+    const data = JSON.parse(output);
+    assert.ok(
+      data.notes.some((n: string) => n.includes("--actor")),
+      "notes should mention --actor when stateful actors are supported",
+    );
+  });
+
+  it("setup-edge-webhook notes mention stateful actors when supported", () => {
+    const fake = withFakeEdgeCli("api_key");
+    const output = run(["setup-edge-webhook", "--json"], fake.env);
+    const data = JSON.parse(output);
+    assert.ok(
+      data.notes.some((n: string) => n.includes("--actor")),
+      "notes should mention --actor when stateful actors are supported",
+    );
   });
 });


### PR DESCRIPTION
## What

Updates the Edge CLI wrapper in `cli/` to match `telnyx-edge` v0.2.3, which adds Stateful Actors (Beta) and several new lifecycle commands.

## Bug fix

**Expired OAuth tokens were reported as authenticated.** The `getEdgeAuthStatus()` parser checked for `"status: ❌"` and `"status: x"` to detect unauthenticated state, but v0.2.3 outputs `"Status: ⚠️ Token expired"` for expired tokens. This slipped through as `authenticated: true`. Now detects `"token expired"` and `"⚠️"` in the status text.

## New features

- **`getEdgeVersion()`** — uses `--version` flag (v0.2.3+) with `--help` regex fallback for older CLIs
- **`supportsStatefulActors()`** — feature detection via `telnyx-edge actors --help`
- **`edge-doctor`** — reports `stateful_actors_supported`, suggests `new-func --actor` in next steps
- **`setup-edge-mcp` / `setup-edge-webhook`** — include `stateful_actors_supported`, add actor note
- **`capabilities`** — new Stateful Actors entry under Edge Compute

## Tests

- Fake CLI updated to simulate v0.2.3
- New: expired OAuth token detected as not authenticated
- New: stateful_actors_supported reported correctly
- New: capabilities JSON includes Stateful Actors
- All 11 edge-handoff tests pass, typecheck clean

## Context

Stateful actor canary passed 2026-07-06. See telnyx-edge-deploy PR #17 for the v0.5 plan.