### PR TITLE
feat(setup-10dlc): add compliance validation, opt-in methods, disclosure checks

### DIFF
--- a/cli/src/commands/setup-10dlc.ts
+++ b/cli/src/commands/setup-10dlc.ts
@@ -2,13 +2,75 @@
  * telnyx-agent setup-10dlc — Zero to compliant US A2P messaging in one command.
  *
  * Steps:
- * 1. Create a 10DLC brand (via telnyx CLI)
- * 2. Create a campaign (via telnyx CLI)
- * 3. Assign a phone number to the campaign (via telnyx CLI, optional)
+ * 1. Validate inputs (use-case enum, opt-in method, sample messages, disclosures)
+ * 2. Create a 10DLC brand (via telnyx CLI)
+ * 3. Create a campaign (via telnyx CLI) with generated compliant message_flow
+ * 4. Assign a phone number to the campaign (via telnyx CLI, optional)
+ *
+ * Compliance logic (use-case catalog, opt-in methods, required disclosures,
+ * sample-message validation, HELP/STOP/START defaults) adapted from the
+ * internal Minerva 10DLC campaign builder service.
  */
 
 import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
-import { printStep, printSuccess, printError, outputJson, type StepResult } from "../utils/output.ts";
+import { printStep, printSuccess, printError, printWarning, outputJson, type StepResult } from "../utils/output.ts";
+
+// ─── 10DLC domain constants ──────────────────────────────────────────────────
+
+/** Canonical TCR use cases (snake_case for Go CLI compatibility). */
+const VALID_USE_CASES = [
+  "2FA",
+  "ACCOUNT_NOTIFICATION",
+  "CUSTOMER_CARE",
+  "DELIVERY_NOTIFICATIONS",
+  "FRAUD_ALERT_MESSAGING",
+  "HIGHER_EDUCATION",
+  "LOW_VOLUME_MIXED",
+  "M2M",
+  "MARKETING",
+  "MIXED",
+  "POLLING_AND_VOTING",
+  "PUBLIC_SERVICE_ANNOUNCEMENT",
+  "SECURITY_ALERT",
+] as const;
+
+/** Human-readable labels for display + error messages. */
+const USE_CASE_LABELS: Record<string, string> = {
+  "2FA": "2FA",
+  ACCOUNT_NOTIFICATION: "Account Notification",
+  CUSTOMER_CARE: "Customer Care",
+  DELIVERY_NOTIFICATIONS: "Delivery Notifications",
+  FRAUD_ALERT_MESSAGING: "Fraud Alert Messaging",
+  HIGHER_EDUCATION: "Higher Education",
+  LOW_VOLUME_MIXED: "Low Volume Mixed",
+  M2M: "Machine-to-Machine (M2M)",
+  MARKETING: "Marketing",
+  MIXED: "Mixed",
+  POLLING_AND_VOTING: "Polling and Voting",
+  PUBLIC_SERVICE_ANNOUNCEMENT: "Public Service Announcement",
+  SECURITY_ALERT: "Security Alert",
+};
+
+/** Use cases that require two sample messages. */
+const USE_CASES_NEEDING_TWO_SAMPLES = new Set(["MARKETING", "MIXED", "LOW_VOLUME_MIXED", "POLLING_AND_VOTING"]);
+
+/** Opt-in methods. */
+const VALID_OPT_IN_METHODS = ["web", "verbal", "paper", "inbound"] as const;
+
+/** Terms that will cause TCR rejection — must not appear in sample messages. */
+const PROHIBITED_TERMS = ["guaranteed", "winner", "you have been selected", "act now", "limited time"];
+
+/** Canonical compliant disclosure sentence. */
+const CANONICAL_DISCLOSURES =
+  "Message frequency may vary. Message and data rates may apply. Reply STOP to opt out, HELP for help. We will not share your mobile information with third parties for marketing purposes.";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface ValidationIssue {
+  severity: "blocking" | "warning";
+  field: string;
+  message: string;
+}
 
 interface Setup10dlcResult {
   brand_id: string;
@@ -17,11 +79,116 @@ interface Setup10dlcResult {
   campaign_id: string;
   campaign_status: string;
   usecase: string;
+  opt_in_method: string;
+  message_flow: string;
+  help_message: string;
+  stop_message: string;
+  start_message: string;
   assigned_number?: string;
+  warnings: string[];
   note: string;
   ready: boolean;
   steps: StepResult[];
 }
+
+// ─── Compliance helpers ──────────────────────────────────────────────────────
+
+/** Generate the message_flow based on opt-in method + brand + optional website. */
+function buildMessageFlow(method: string, brand: string, website?: string): string {
+  const disclosures = CANONICAL_DISCLOSURES;
+  switch (method) {
+    case "verbal":
+      return `Consumers opt in by verbally providing consent over the phone. Our staff reads a script explaining that by providing their phone number, they agree to receive SMS messages from ${brand}. ${disclosures}`;
+    case "paper":
+      return `Consumers opt in by filling out a paper form that includes an SMS opt-in checkbox. The form states: By providing your phone number and checking this box, you agree to receive SMS messages from ${brand}. ${disclosures}`;
+    case "inbound":
+      return `Consumers opt in by texting a keyword to our number. The keyword is displayed on our website and marketing materials. Upon texting the keyword, the consumer receives a confirmation message from ${brand}. ${disclosures}`;
+    case "web":
+    default:
+      return `Consumers opt in by submitting the web form located at ${website ?? "[your opt-in URL]"}. The form includes clear SMS consent language: By submitting this form, you agree to receive SMS messages from ${brand}. ${disclosures}`;
+  }
+}
+
+/** Lint a message_flow for required 10DLC disclosures. Returns blocking issues. */
+function lintMessageFlow(flow: string): ValidationIssue[] {
+  const lower = flow.toLowerCase();
+  const issues: ValidationIssue[] = [];
+
+  const checks: Array<[string, string[], string]> = [
+    ["opt-in path", ["opt in", "opt-in", "subscribe", "consent", "agree"], "missing_opt_in_path"],
+    ["STOP instruction", ["stop"], "missing_stop"],
+    ["HELP instruction", ["help"], "missing_help"],
+    ["message frequency", ["frequency", "may vary"], "missing_frequency"],
+    ["message & data rates", ["data rates", "msg & data", "message and data"], "missing_rates"],
+  ];
+
+  for (const [label, needles] of checks) {
+    if (!needles.some((n) => lower.includes(n))) {
+      issues.push({ severity: "blocking", field: "message_flow", message: `Message flow missing required disclosure: ${label}` });
+    }
+  }
+
+  // No-sharing requires all three phrases.
+  const hasNoSharing =
+    lower.includes("will not share") &&
+    lower.includes("mobile information") &&
+    lower.includes("third parties");
+  if (!hasNoSharing) {
+    issues.push({
+      severity: "blocking",
+      field: "message_flow",
+      message: "Message flow missing mobile no-sharing disclosure (must include 'will not share', 'mobile information', and 'third parties')",
+    });
+  }
+
+  return issues;
+}
+
+/** Validate a sample message. Returns blocking + warning issues. */
+function validateSampleMessage(msg: string, brand: string, label: string): ValidationIssue[] {
+  const lower = msg.toLowerCase();
+  const issues: ValidationIssue[] = [];
+
+  // Blocking: prohibited terms
+  for (const term of PROHIBITED_TERMS) {
+    if (lower.includes(term)) {
+      issues.push({ severity: "blocking", field: label, message: `Prohibited term '${term}' in ${label}` });
+    }
+  }
+
+  // Warning: placeholder text
+  if (/\[.*?\]|<.*?>/.test(msg) || /\bsample_text\b|\bplaceholder\b/i.test(msg)) {
+    issues.push({ severity: "warning", field: label, message: `${label} contains placeholder text — replace with real message content` });
+  }
+
+  // Warning: brand name should appear
+  if (brand.toLowerCase() && !lower.includes(brand.toLowerCase())) {
+    issues.push({ severity: "warning", field: label, message: `${label} should include the brand name '${brand}'` });
+  }
+
+  // Warning: STOP opt-out
+  if (!lower.includes("stop")) {
+    issues.push({ severity: "warning", field: label, message: `${label} missing STOP opt-out instruction` });
+  }
+
+  // Warning: 160-char SMS limit
+  if (msg.length > 160) {
+    issues.push({ severity: "warning", field: label, message: `${label} is ${msg.length} characters — exceeds 160-char SMS limit` });
+  }
+
+  return issues;
+}
+
+/** Generate default HELP/STOP/START auto-response messages. */
+function buildHelpStopStart(brand: string, email: string, phone: string) {
+  return {
+    helpMessage: `${brand} Support: For help, reply HELP or contact us at ${email} or ${phone}. Msg & data rates may apply. Reply STOP to unsubscribe.`,
+    stopMessage: `You have been unsubscribed from ${brand} messages. No further messages will be sent. Reply START to resubscribe.`,
+    startMessage: `${brand}: You have resubscribed to receive SMS messages. Msg frequency may vary. Msg & data rates may apply. Reply STOP to unsubscribe, HELP for help.`,
+  };
+}
+
+// ─── Command ─────────────────────────────────────────────────────────────────
 
 export async function setup10dlcCommand(flags: Record<string, string | boolean>): Promise<void> {
   const jsonOutput = flags.json === true;
@@ -33,10 +200,27 @@ export async function setup10dlcCommand(flags: Record<string, string | boolean>)
     process.exit(1);
   }
 
+  // ── Validate use case ──
+  const usecase = (flags.usecase as string) || "CUSTOMER_CARE";
+  if (!VALID_USE_CASES.includes(usecase as (typeof VALID_USE_CASES)[number])) {
+    printError(
+      `Invalid use case '${usecase}'. Valid values: ${VALID_USE_CASES.map((u) => USE_CASE_LABELS[u]).join(", ")}`,
+    );
+    process.exit(1);
+  }
+
+  // ── Validate opt-in method ──
+  const optInMethod = (flags["opt-in-method"] as string) || "web";
+  if (!VALID_OPT_IN_METHODS.includes(optInMethod as (typeof VALID_OPT_IN_METHODS)[number])) {
+    printError(`Invalid opt-in method '${optInMethod}'. Valid values: ${VALID_OPT_IN_METHODS.join(", ")}`);
+    process.exit(1);
+  }
+
   const phoneNumberId = (flags["phone-number-id"] as string) || "";
   const totalSteps = phoneNumberId ? 3 : 2;
   const steps: StepResult[] = [];
   const startTime = Date.now();
+  const warnings: string[] = [];
 
   let brandId = "";
   let brandName = "";
@@ -44,13 +228,62 @@ export async function setup10dlcCommand(flags: Record<string, string | boolean>)
   let campaignId = "";
   let campaignStatus = "";
   let assignedNumber: string | undefined;
-  const usecase = (flags.usecase as string) || "CUSTOMER_CARE";
 
   try {
     const ts = new Date().toISOString().slice(0, 19).replace("T", " ");
     brandName = (flags["brand-name"] as string) || `Agent Brand - ${ts}`;
+    const companyName = (flags["company-name"] as string) || "";
     const vertical = (flags.vertical as string) || "TECHNOLOGY";
+    const website = (flags.website as string) || "";
+
+    if (optInMethod === "web" && !website) {
+      warnings.push("--website not provided; web opt-in message_flow will contain a placeholder URL");
+    }
+
     if (!jsonOutput) console.log("\n🚀 Setting up 10DLC A2P Messaging...\n");
+
+    // ── Pre-submission compliance validation ──
+    const messageFlow = (flags["message-flow"] as string) || buildMessageFlow(optInMethod, brandName, website);
+    const flowIssues = lintMessageFlow(messageFlow);
+    const blockingFlowIssues = flowIssues.filter((i) => i.severity === "blocking");
+    if (blockingFlowIssues.length > 0) {
+      printError("Message flow failed compliance validation (blocking issues):");
+      for (const issue of blockingFlowIssues) {
+        console.error(`  • ${issue.message}`);
+      }
+      process.exit(1);
+    }
+    flowIssues.filter((i) => i.severity === "warning").forEach((i) => warnings.push(i.message));
+
+    // ── Validate sample messages ──
+    const sample1 = (flags["sample-message"] as string) || "Your verification code is {code}. Reply STOP to opt out.";
+    const needsTwoSamples = USE_CASES_NEEDING_TWO_SAMPLES.has(usecase);
+    const sample2Default = `${brandName}: You are now subscribed to receive SMS messages. Msg frequency may vary. Msg & data rates may apply. Reply STOP to unsubscribe, HELP for help.`;
+    const sample2 = (flags["sample-message-2"] as string) || (needsTwoSamples ? sample2Default : "");
+
+    const sampleIssues = validateSampleMessage(sample1, brandName, "sample_message");
+    if (sample2) sampleIssues.push(...validateSampleMessage(sample2, brandName, "sample_message_2"));
+
+    const blockingSamples = sampleIssues.filter((i) => i.severity === "blocking");
+    if (blockingSamples.length > 0) {
+      printError("Sample message validation failed (blocking issues):");
+      for (const issue of blockingSamples) {
+        console.error(`  • ${issue.message}`);
+      }
+      process.exit(1);
+    }
+    sampleIssues.filter((i) => i.severity === "warning").forEach((i) => warnings.push(i.message));
+
+    // ── Generate HELP/STOP/START defaults ──
+    const { helpMessage, stopMessage, startMessage } = buildHelpStopStart(brandName, email, phone);
+    const helpMsg = (flags["help-message"] as string) || helpMessage;
+    const stopMsg = (flags["stop-message"] as string) || stopMessage;
+    const startMsg = (flags["start-message"] as string) || startMessage;
+
+    // Print warnings before proceeding
+    if (!jsonOutput) {
+      for (const w of warnings) printWarning(w);
+    }
 
     // Step 1: Create 10DLC brand via CLI
     const step1Start = Date.now();
@@ -64,6 +297,7 @@ export async function setup10dlcCommand(flags: Record<string, string | boolean>)
         "--sole-prop",
         "--country", "US",
       ];
+      if (companyName) brandArgs.push("--company-name", companyName);
       const brandRes = await telnyxCli(brandArgs);
       const brandData = brandRes.data as Record<string, unknown>;
       brandId = String(brandData.id);
@@ -77,7 +311,6 @@ export async function setup10dlcCommand(flags: Record<string, string | boolean>)
 
     // Step 2: Create campaign via CLI
     const description = (flags.description as string) || "Agent-provisioned campaign for customer communications";
-    const sampleMessage = (flags["sample-message"] as string) || "Your verification code is {code}. Reply STOP to opt out.";
     const step2Start = Date.now();
     try {
       const campaignArgs = [
@@ -85,14 +318,15 @@ export async function setup10dlcCommand(flags: Record<string, string | boolean>)
         "--brand-id", brandId,
         "--usecase", usecase,
         "--description", description,
-        "--sample1", sampleMessage,
-        "--message-flow", "Customers opt in via our website by providing their phone number.",
+        "--sample1", sample1,
+        "--message-flow", messageFlow,
       ];
+      if (sample2) campaignArgs.push("--sample2", sample2);
       const campaignRes = await telnyxCli(campaignArgs);
       const campaignData = campaignRes.data as Record<string, unknown>;
       campaignId = String(campaignData.id);
       campaignStatus = String(campaignData.status ?? "PENDING");
-      steps.push({ step: 2, name: "Create campaign", status: "completed", resourceId: campaignId, detail: usecase, elapsedMs: Date.now() - step2Start });
+      steps.push({ step: 2, name: "Create campaign", status: "completed", resourceId: campaignId, detail: USE_CASE_LABELS[usecase] ?? usecase, elapsedMs: Date.now() - step2Start });
     } catch (err) {
       steps.push({ step: 2, name: "Create campaign", status: "failed", detail: errorMsg(err), elapsedMs: Date.now() - step2Start });
       throw err;
@@ -127,7 +361,13 @@ export async function setup10dlcCommand(flags: Record<string, string | boolean>)
       campaign_id: campaignId,
       campaign_status: campaignStatus,
       usecase,
+      opt_in_method: optInMethod,
+      message_flow: messageFlow,
+      help_message: helpMsg,
+      stop_message: stopMsg,
+      start_message: startMsg,
       assigned_number: assignedNumber,
+      warnings,
       note,
       ready: true,
       steps,
@@ -136,13 +376,14 @@ export async function setup10dlcCommand(flags: Record<string, string | boolean>)
     if (jsonOutput) {
       outputJson(result);
     } else {
-      const details: Record<string, string> = {
+      const details: Record<string, string | number | boolean> = {
         "Brand ID": brandId,
         "Brand Name": brandName,
         "Brand Status": brandStatus,
         "Campaign ID": campaignId,
         "Campaign Status": campaignStatus,
-        "Use Case": usecase,
+        "Use Case": USE_CASE_LABELS[usecase] ?? usecase,
+        "Opt-In Method": optInMethod,
       };
       if (assignedNumber) details["Assigned Number"] = assignedNumber;
       details["Ready"] = "✓";
@@ -155,6 +396,7 @@ export async function setup10dlcCommand(flags: Record<string, string | boolean>)
       brand_id: brandId || null,
       campaign_id: campaignId || null,
       ready: false,
+      warnings,
       steps,
       error: errorMsg(err),
       elapsed_ms: Date.now() - startTime,

--- a/cli/src/commands/setup-10dlc.ts
+++ b/cli/src/commands/setup-10dlc.ts
@@ -156,8 +156,8 @@ function validateSampleMessage(msg: string, brand: string, label: string): Valid
     }
   }
 
-  // Warning: placeholder text
-  if (/\[.*?\]|<.*?>/.test(msg) || /\bsample_text\b|\bplaceholder\b/i.test(msg)) {
+  // Warning: placeholder text (uses negated character classes to avoid ReDoS)
+  if (/\[[^\]]*\]|<[^>]*>/.test(msg) || /\bsample_text\b|\bplaceholder\b/i.test(msg)) {
     issues.push({ severity: "warning", field: label, message: `${label} contains placeholder text — replace with real message content` });
   }
 

--- a/cli/src/commands/setup-10dlc.ts
+++ b/cli/src/commands/setup-10dlc.ts
@@ -144,6 +144,19 @@ function lintMessageFlow(flow: string): ValidationIssue[] {
   return issues;
 }
 
+/** Detect placeholder patterns ([...], <...>, sample_text, placeholder) using linear string ops. */
+function hasPlaceholderPattern(msg: string): boolean {
+  // [..] bracket placeholder
+  const bracketOpen = msg.indexOf("[");
+  if (bracketOpen !== -1 && msg.indexOf("]", bracketOpen) !== -1) return true;
+  // <..> angle placeholder
+  const angleOpen = msg.indexOf("<");
+  if (angleOpen !== -1 && msg.indexOf(">", angleOpen) !== -1) return true;
+  // Explicit placeholder words
+  const lower = msg.toLowerCase();
+  return lower.includes("sample_text") || lower.includes("placeholder");
+}
+
 /** Validate a sample message. Returns blocking + warning issues. */
 function validateSampleMessage(msg: string, brand: string, label: string): ValidationIssue[] {
   const lower = msg.toLowerCase();
@@ -156,8 +169,8 @@ function validateSampleMessage(msg: string, brand: string, label: string): Valid
     }
   }
 
-  // Warning: placeholder text (uses negated character classes to avoid ReDoS)
-  if (/\[[^\]]*\]|<[^>]*>/.test(msg) || /\bsample_text\b|\bplaceholder\b/i.test(msg)) {
+  // Warning: placeholder text (string-based checks to avoid ReDoS — no regex on uncontrolled input)
+  if (hasPlaceholderPattern(msg)) {
     issues.push({ severity: "warning", field: label, message: `${label} contains placeholder text — replace with real message content` });
   }
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -53,11 +53,22 @@ Setup-specific Flags:
   --phone           Contact phone for brand (setup-10dlc, required)
   --email           Contact email for brand (setup-10dlc, required)
   --brand-name      Brand display name (setup-10dlc)
-  --company-name    Company name (setup-10dlc)
+  --company-name    Company name passed to brand create (setup-10dlc)
   --vertical        Business vertical (setup-10dlc, default: TECHNOLOGY)
   --usecase         Campaign use case (setup-10dlc, default: CUSTOMER_CARE)
+                    Valid: 2FA, ACCOUNT_NOTIFICATION, CUSTOMER_CARE, DELIVERY_NOTIFICATIONS,
+                    FRAUD_ALERT_MESSAGING, HIGHER_EDUCATION, LOW_VOLUME_MIXED, M2M,
+                    MARKETING, MIXED, POLLING_AND_VOTING, PUBLIC_SERVICE_ANNOUNCEMENT, SECURITY_ALERT
+  --opt-in-method   How consumers opt in (setup-10dlc, default: web)
+                    Valid: web, verbal, paper, inbound
+  --website         Opt-in website URL (setup-10dlc, recommended for --opt-in-method web)
   --description     Campaign description (setup-10dlc)
-  --sample-message  Sample message text (setup-10dlc)
+  --sample-message  First sample message text (setup-10dlc)
+  --sample-message-2 Second sample message (setup-10dlc, required for Marketing/Mixed/Low Volume Mixed/Polling)
+  --message-flow     Custom message flow (setup-10dlc, default: generated from --opt-in-method)
+  --help-message    HELP auto-response text (setup-10dlc, default: generated)
+  --stop-message    STOP auto-response text (setup-10dlc, default: generated)
+  --start-message   START auto-response text (setup-10dlc, default: generated)
   --phone-number-id Assign existing number to campaign (setup-10dlc)
   --phone-numbers   Comma-separated E.164 numbers to port (setup-porting, required)
   --customer-name   Customer name on the losing carrier account (setup-porting)


### PR DESCRIPTION
## Summary

The `setup-10dlc` command was bare-bones — it accepted any string for `--usecase`, hardcoded a single website opt-in message flow regardless of use case, provided only one sample message, and did no compliance validation before submitting to TCR. This PR ports compliance logic from the internal [Minerva 10DLC campaign builder](https://github.com/team-telnyx/infra-svc-minerva-mcp) service.

## What changed

### Use-case enum validation
- `--usecase` now validated against the 13 canonical TCR use cases (was: any string forwarded to the API)
- Invalid values exit(1) with a list of valid options

### Opt-in method + per-method message flow
- New `--opt-in-method` flag: `web` (default), `verbal`, `paper`, `inbound`
- Message flow is now **generated per opt-in method** (was: hardcoded website narrative)
- Each template includes all required disclosures (opt-in path, STOP, HELP, frequency, data rates, no-sharing)
- New `--website` flag for web opt-in URL substitution

### Required-disclosure lint (pre-submission)
- Before creating the campaign, the message flow is checked for 6 required disclosures:
  - Opt-in path (opt in/opt-in/subscribe/consent/agree)
  - STOP instruction
  - HELP instruction
  - Message frequency (frequency/may vary)
  - Message & data rates (data rates/msg & data/message and data)
  - Mobile no-sharing (requires all three: "will not share" + "mobile information" + "third parties")
- Missing disclosures are **blocking** — the command exits before submitting to TCR

### Sample-message validation
- **Blocking**: prohibited terms (guaranteed, winner, "you have been selected", "act now", "limited time")
- **Warnings**: placeholder text (`[...]`, `<...>`, SAMPLE_TEXT), missing brand name, missing STOP, >160 chars
- New `--sample-message-2` flag for use cases requiring two samples (Marketing, Mixed, Low Volume Mixed, Polling and Voting)

### HELP/STOP/START auto-response messages
- Generated defaults with brand name, contact info, and opt-out instructions
- Override flags: `--help-message`, `--stop-message`, `--start-message`

### Blocking vs warning severity
- Output now distinguishes blocking issues (exit 1) from warnings (proceed with notice)
- Warnings collected and surfaced in both JSON and human-readable output

### Other fixes
- `--company-name` is now consumed (was documented in help but never read — dead flag)
- New flags documented in help text with valid values listed
- Canonical disclosure sentence: *"Message frequency may vary. Message and data rates may apply. Reply STOP to opt out, HELP for help. We will not share your mobile information with third parties for marketing purposes."*

## What did NOT change
- The brand → campaign → assign-number write path is unchanged
- `--sole-prop` still hardcoded (standard business registration is a separate future task)
- No approval polling added (brand vetting sequencing is a separate decision)
- No number purchase/lease — only assignment of existing numbers

## Source
Compliance rules (use-case catalog, opt-in method templates, disclosure lint, sample validation, HELP/STOP/START defaults) adapted from `infra-svc-minerva-mcp` — the internal Telnyx-hosted Minerva 10DLC campaign builder service.

## Testing
- `npx tsc --noEmit` — passes clean
- `npm test` (19 tests) — all pass
- `npx tsx --test tests/integration-ci.test.ts` (15 tests, includes setup-10dlc error case) — all pass