### PR TITLE
feat: Add SMS action commands to agent CLI

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "tsx bin/telnyx-agent.ts",
-    "test": "tsx --test tests/integration.test.ts tests/telnyx-cli-flags.test.ts tests/edge-handoff.test.ts tests/tts.test.ts tests/whatsapp.test.ts",
+    "test": "tsx --test tests/integration.test.ts tests/telnyx-cli-flags.test.ts tests/edge-handoff.test.ts tests/tts.test.ts tests/whatsapp.test.ts tests/sms.test.ts",
     "typecheck": "tsc --noEmit",
     "postinstall": "tsx scripts/postinstall.ts",
     "build": "npm run typecheck"

--- a/cli/src/commands/capabilities.ts
+++ b/cli/src/commands/capabilities.ts
@@ -12,7 +12,7 @@ interface Capability {
 
 const CAPABILITIES: Record<string, Capability[]> = {
   "📱 Messaging": [
-    { name: "SMS / MMS", description: "Send and receive text and multimedia messages", actions: ["send_sms", "list_messaging_profiles", "create_messaging_profile"] },
+    { name: "SMS / MMS", description: "Send, schedule, and manage text and multimedia messages", actions: ["send_sms", "send_mms", "schedule_sms", "check_sms_status", "cancel_scheduled_sms", "list_messaging_profiles", "create_messaging_profile"] },
   ],
   "📞 Voice": [
     { name: "Call Control", description: "Make and manage voice calls via SIP connections", actions: ["make_call", "list_connections"] },
@@ -70,6 +70,9 @@ const CAPABILITIES: Record<string, Capability[]> = {
 
 const COMPOSITE_COMMANDS = [
   { name: "telnyx-agent setup-sms", description: "Zero to SMS: creates messaging profile, buys number, assigns it" },
+  { name: "telnyx-agent send-sms", description: "Send an SMS or MMS message (pass --media-url to send MMS)" },
+  { name: "telnyx-agent schedule-sms", description: "Schedule an SMS for future delivery at a given ISO 8601 time" },
+  { name: "telnyx-agent sms-status", description: "Check SMS delivery status, or cancel a scheduled message with --cancel" },
   { name: "telnyx-agent setup-voice", description: "Zero to voice: creates SIP connection, buys number, assigns it" },
   { name: "telnyx-agent setup-iot", description: "Zero to IoT: lists SIMs, creates group, activates SIM" },
   { name: "telnyx-agent setup-ai", description: "Zero to AI assistant: creates assistant, buys number, wires them together" },

--- a/cli/src/commands/capabilities.ts
+++ b/cli/src/commands/capabilities.ts
@@ -12,7 +12,7 @@ interface Capability {
 
 const CAPABILITIES: Record<string, Capability[]> = {
   "📱 Messaging": [
-    { name: "SMS / MMS", description: "Send, schedule, and manage text and multimedia messages", actions: ["send_sms", "send_mms", "schedule_sms", "check_sms_status", "cancel_scheduled_sms", "list_messaging_profiles", "create_messaging_profile"] },
+    { name: "SMS / MMS", description: "Send, schedule, and manage text and multimedia messages", actions: ["send_sms", "send_mms", "send_group_mms", "schedule_sms", "check_sms_status", "cancel_scheduled_sms", "list_messaging_profiles", "create_messaging_profile"] },
   ],
   "📞 Voice": [
     { name: "Call Control", description: "Make and manage voice calls via SIP connections", actions: ["make_call", "list_connections"] },
@@ -71,6 +71,7 @@ const CAPABILITIES: Record<string, Capability[]> = {
 const COMPOSITE_COMMANDS = [
   { name: "telnyx-agent setup-sms", description: "Zero to SMS: creates messaging profile, buys number, assigns it" },
   { name: "telnyx-agent send-sms", description: "Send an SMS or MMS message (pass --media-url to send MMS)" },
+  { name: "telnyx-agent send-group-mms", description: "Send a group MMS to multiple recipients (--to comma-separated E.164 numbers)" },
   { name: "telnyx-agent schedule-sms", description: "Schedule an SMS for future delivery at a given ISO 8601 time" },
   { name: "telnyx-agent sms-status", description: "Check SMS delivery status, or cancel a scheduled message with --cancel" },
   { name: "telnyx-agent setup-voice", description: "Zero to voice: creates SIP connection, buys number, assigns it" },

--- a/cli/src/commands/schedule-sms.ts
+++ b/cli/src/commands/schedule-sms.ts
@@ -6,6 +6,7 @@
 
 import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
 import { printSuccess, printError, outputJson } from "../utils/output.ts";
+import { deriveMessageStatus } from "../utils/message-status.ts";
 
 interface ScheduleSmsResult {
   message_id: string;
@@ -56,7 +57,8 @@ export async function scheduleSmsCommand(flags: Record<string, string | boolean>
     const res = await telnyxCli(args);
     const data = (res?.data ?? res) as Record<string, unknown>;
     const messageId = String(data.id ?? data.message_id ?? "");
-    const status = String(data.status ?? data.delivery_status ?? "scheduled");
+    // Delivery state lives on each recipient (data.to[].status), not top-level.
+    const status = deriveMessageStatus(data, "scheduled");
 
     const result: ScheduleSmsResult = {
       message_id: messageId,

--- a/cli/src/commands/schedule-sms.ts
+++ b/cli/src/commands/schedule-sms.ts
@@ -1,0 +1,95 @@
+/**
+ * telnyx-agent schedule-sms — Schedule an SMS for later delivery.
+ *
+ * Shells out to the Go telnyx CLI `messages schedule` subcommand.
+ */
+
+import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
+import { printSuccess, printError, outputJson } from "../utils/output.ts";
+
+interface ScheduleSmsResult {
+  message_id: string;
+  status: string;
+  from: string;
+  to: string;
+  send_at: string;
+  scheduled: boolean;
+}
+
+export async function scheduleSmsCommand(flags: Record<string, string | boolean>): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const from = flags["from"] as string | undefined;
+  const to = flags["to"] as string | undefined;
+  const text = flags["text"] as string | undefined;
+  const sendAt = flags["send-at"] as string | undefined;
+  const messagingProfileId = flags["messaging-profile-id"] as string | undefined;
+  const mediaUrl = flags["media-url"] as string | undefined;
+
+  if (!from) {
+    printError("--from is required (E.164 format, e.g., +13125550000)");
+    process.exit(1);
+  }
+  if (!to) {
+    printError("--to is required (E.164 format, e.g., +13125550001)");
+    process.exit(1);
+  }
+  if (!text) {
+    printError("--text is required");
+    process.exit(1);
+  }
+  if (!sendAt) {
+    printError("--send-at is required (ISO 8601 datetime, e.g., 2024-12-31T00:00:00Z)");
+    process.exit(1);
+  }
+
+  const args: string[] = [
+    "messages", "schedule",
+    "--from", from,
+    "--to", to,
+    "--text", text,
+    "--send-at", sendAt,
+  ];
+  if (messagingProfileId) args.push("--messaging-profile-id", messagingProfileId);
+  if (mediaUrl) args.push("--media-url", mediaUrl);
+
+  try {
+    const res = await telnyxCli(args);
+    const data = (res?.data ?? res) as Record<string, unknown>;
+    const messageId = String(data.id ?? data.message_id ?? "");
+    const status = String(data.status ?? data.delivery_status ?? "scheduled");
+
+    const result: ScheduleSmsResult = {
+      message_id: messageId,
+      status,
+      from,
+      to,
+      send_at: sendAt,
+      scheduled: true,
+    };
+
+    if (jsonOutput) {
+      outputJson(result);
+    } else {
+      printSuccess("SMS scheduled!", {
+        "Message ID": messageId,
+        Status: status,
+        From: from,
+        To: to,
+        "Send At": sendAt,
+      });
+    }
+  } catch (err) {
+    if (jsonOutput) {
+      outputJson({ error: errorMsg(err) });
+    } else {
+      printError(errorMsg(err));
+    }
+    process.exit(1);
+  }
+}
+
+function errorMsg(err: unknown): string {
+  if (err instanceof TelnyxCLIError) return err.stderr || err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/cli/src/commands/send-group-mms.ts
+++ b/cli/src/commands/send-group-mms.ts
@@ -1,0 +1,89 @@
+/**
+ * telnyx-agent send-group-mms — Send a group MMS message.
+ *
+ * Shells out to the Go telnyx CLI `messages send-group-mms` subcommand.
+ * `--to` accepts a comma-separated list of E.164 recipients.
+ */
+
+import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
+import { printSuccess, printError, outputJson } from "../utils/output.ts";
+
+interface SendGroupMmsResult {
+  message_id: string;
+  status: string;
+  type: string;
+  from: string;
+  to: string[];
+}
+
+export async function sendGroupMmsCommand(flags: Record<string, string | boolean>): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const from = flags["from"] as string | undefined;
+  const to = flags["to"] as string | undefined;
+  const text = flags["text"] as string | undefined;
+  const mediaUrl = flags["media-url"] as string | undefined;
+  const messagingProfileId = flags["messaging-profile-id"] as string | undefined;
+
+  if (!from) {
+    printError("--from is required (E.164 format, e.g., +131****0000)");
+    process.exit(1);
+  }
+  if (!to) {
+    printError("--to is required (comma-separated E.164 numbers, e.g., +131****0001,+131****0002)");
+    process.exit(1);
+  }
+
+  // Group MMS always goes through the group-MMS subcommand (type is MMS).
+  const type = "MMS";
+
+  const args: string[] = [
+    "messages", "send-group-mms",
+    "--from", from,
+    "--to", to,
+  ];
+  if (text) args.push("--text", text);
+  if (mediaUrl) args.push("--media-url", mediaUrl);
+  if (messagingProfileId) args.push("--messaging-profile-id", messagingProfileId);
+
+  try {
+    const res = await telnyxCli(args);
+    const data = (res?.data ?? res) as Record<string, unknown>;
+    const messageId = String(data.id ?? data.message_id ?? "");
+    const status = String(data.status ?? data.delivery_status ?? "submitted");
+
+    const recipients = to.split(",").map((n) => n.trim()).filter(Boolean);
+
+    const result: SendGroupMmsResult = {
+      message_id: messageId,
+      status,
+      type,
+      from,
+      to: recipients,
+    };
+
+    if (jsonOutput) {
+      outputJson(result);
+    } else {
+      printSuccess("Group MMS sent!", {
+        "Message ID": messageId,
+        Status: status,
+        Type: type,
+        From: from,
+        To: recipients.join(", "),
+      });
+    }
+  } catch (err) {
+    if (jsonOutput) {
+      outputJson({ error: errorMsg(err) });
+    } else {
+      printError(errorMsg(err));
+    }
+    process.exit(1);
+  }
+}
+
+function errorMsg(err: unknown): string {
+  if (err instanceof TelnyxCLIError) return err.stderr || err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/cli/src/commands/send-group-mms.ts
+++ b/cli/src/commands/send-group-mms.ts
@@ -7,6 +7,7 @@
 
 import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
 import { printSuccess, printError, outputJson } from "../utils/output.ts";
+import { deriveMessageStatus } from "../utils/message-status.ts";
 
 interface SendGroupMmsResult {
   message_id: string;
@@ -22,7 +23,6 @@ export async function sendGroupMmsCommand(flags: Record<string, string | boolean
   const to = flags["to"] as string | undefined;
   const text = flags["text"] as string | undefined;
   const mediaUrl = flags["media-url"] as string | undefined;
-  const messagingProfileId = flags["messaging-profile-id"] as string | undefined;
 
   if (!from) {
     printError("--from is required (E.164 format, e.g., +131****0000)");
@@ -30,6 +30,13 @@ export async function sendGroupMmsCommand(flags: Record<string, string | boolean
   }
   if (!to) {
     printError("--to is required (comma-separated E.164 numbers, e.g., +131****0001,+131****0002)");
+    process.exit(1);
+  }
+  if (flags["messaging-profile-id"]) {
+    // The group-MMS API schema does not accept messaging_profile_id, so the
+    // generated Go CLI subcommand has no such flag. Fail fast instead of
+    // forwarding a flag the CLI would reject.
+    printError("--messaging-profile-id is not supported for group MMS (the sending number's profile is used)");
     process.exit(1);
   }
 
@@ -43,13 +50,15 @@ export async function sendGroupMmsCommand(flags: Record<string, string | boolean
   ];
   if (text) args.push("--text", text);
   if (mediaUrl) args.push("--media-url", mediaUrl);
-  if (messagingProfileId) args.push("--messaging-profile-id", messagingProfileId);
+  // Note: the group-MMS API (and thus the generated Go CLI subcommand) does not
+  // accept messaging_profile_id, so no --messaging-profile-id passthrough here.
 
   try {
     const res = await telnyxCli(args);
     const data = (res?.data ?? res) as Record<string, unknown>;
     const messageId = String(data.id ?? data.message_id ?? "");
-    const status = String(data.status ?? data.delivery_status ?? "submitted");
+    // Delivery state lives on each recipient (data.to[].status), not top-level.
+    const status = deriveMessageStatus(data, "queued");
 
     const recipients = to.split(",").map((n) => n.trim()).filter(Boolean);
 

--- a/cli/src/commands/send-group-mms.ts
+++ b/cli/src/commands/send-group-mms.ts
@@ -43,11 +43,18 @@ export async function sendGroupMmsCommand(flags: Record<string, string | boolean
   // Group MMS always goes through the group-MMS subcommand (type is MMS).
   const type = "MMS";
 
+  // The Go CLI expects `--to` repeated once per recipient, not a single
+  // comma-separated string, so split the user-facing list and push a `--to`
+  // flag per recipient.
+  const recipients = to.split(",").map((n) => n.trim()).filter(Boolean);
+
   const args: string[] = [
     "messages", "send-group-mms",
     "--from", from,
-    "--to", to,
   ];
+  for (const recipient of recipients) {
+    args.push("--to", recipient);
+  }
   if (text) args.push("--text", text);
   if (mediaUrl) args.push("--media-url", mediaUrl);
   // Note: the group-MMS API (and thus the generated Go CLI subcommand) does not
@@ -59,8 +66,6 @@ export async function sendGroupMmsCommand(flags: Record<string, string | boolean
     const messageId = String(data.id ?? data.message_id ?? "");
     // Delivery state lives on each recipient (data.to[].status), not top-level.
     const status = deriveMessageStatus(data, "queued");
-
-    const recipients = to.split(",").map((n) => n.trim()).filter(Boolean);
 
     const result: SendGroupMmsResult = {
       message_id: messageId,

--- a/cli/src/commands/send-group-mms.ts
+++ b/cli/src/commands/send-group-mms.ts
@@ -22,7 +22,7 @@ export async function sendGroupMmsCommand(flags: Record<string, string | boolean
   const from = flags["from"] as string | undefined;
   const to = flags["to"] as string | undefined;
   const text = flags["text"] as string | undefined;
-  const mediaUrl = flags["media-url"] as string | undefined;
+  const mediaUrls = flags["media-url"] as string | string[] | undefined;
 
   if (!from) {
     printError("--from is required (E.164 format, e.g., +131****0000)");
@@ -56,7 +56,12 @@ export async function sendGroupMmsCommand(flags: Record<string, string | boolean
     args.push("--to", recipient);
   }
   if (text) args.push("--text", text);
-  if (mediaUrl) args.push("--media-url", mediaUrl);
+  // The Go CLI treats --media-url as a repeatable array flag, so push
+  // one --media-url per URL (matches the API's media_urls[] body field).
+  const mediaUrlList = Array.isArray(mediaUrls) ? mediaUrls : (mediaUrls ? [mediaUrls] : []);
+  for (const url of mediaUrlList) {
+    args.push("--media-url", url);
+  }
   // Note: the group-MMS API (and thus the generated Go CLI subcommand) does not
   // accept messaging_profile_id, so no --messaging-profile-id passthrough here.
 

--- a/cli/src/commands/send-sms.ts
+++ b/cli/src/commands/send-sms.ts
@@ -35,8 +35,10 @@ export async function sendSmsCommand(flags: Record<string, string | boolean>): P
     printError("--to is required (E.164 format, e.g., +13125550001)");
     process.exit(1);
   }
-  if (!text) {
-    printError("--text is required (pass --media-url for an MMS with media)");
+  // --text is required for a plain SMS, but the Telnyx API supports
+  // media-only MMS, so only require text when no --media-url is provided.
+  if (!text && !mediaUrl) {
+    printError("--text is required (or pass --media-url for a media-only MMS)");
     process.exit(1);
   }
 
@@ -47,9 +49,9 @@ export async function sendSmsCommand(flags: Record<string, string | boolean>): P
     "messages", "send",
     "--from", from,
     "--to", to,
-    "--text", text,
     "--type", type,
   ];
+  if (text) args.push("--text", text);
   if (mediaUrl) args.push("--media-url", mediaUrl);
   if (messagingProfileId) args.push("--messaging-profile-id", messagingProfileId);
   if (webhookUrl) args.push("--webhook-url", webhookUrl);

--- a/cli/src/commands/send-sms.ts
+++ b/cli/src/commands/send-sms.ts
@@ -1,0 +1,96 @@
+/**
+ * telnyx-agent send-sms — Send an SMS or MMS message.
+ *
+ * Shells out to the Go telnyx CLI `messages send` subcommand.
+ * Pass --media-url to send an MMS (sets --type MMS automatically).
+ */
+
+import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
+import { printSuccess, printError, outputJson } from "../utils/output.ts";
+
+interface SendSmsResult {
+  message_id: string;
+  status: string;
+  type: string;
+  from: string;
+  to: string;
+}
+
+export async function sendSmsCommand(flags: Record<string, string | boolean>): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const from = flags["from"] as string | undefined;
+  const to = flags["to"] as string | undefined;
+  const text = flags["text"] as string | undefined;
+  const mediaUrl = flags["media-url"] as string | undefined;
+  const messagingProfileId = flags["messaging-profile-id"] as string | undefined;
+  const webhookUrl = flags["webhook-url"] as string | undefined;
+  const subject = flags["subject"] as string | undefined;
+
+  if (!from) {
+    printError("--from is required (E.164 format, e.g., +13125550000)");
+    process.exit(1);
+  }
+  if (!to) {
+    printError("--to is required (E.164 format, e.g., +13125550001)");
+    process.exit(1);
+  }
+  if (!text) {
+    printError("--text is required (pass --media-url for an MMS with media)");
+    process.exit(1);
+  }
+
+  // media-url upgrades the send to MMS
+  const type = mediaUrl ? "MMS" : "SMS";
+
+  const args: string[] = [
+    "messages", "send",
+    "--from", from,
+    "--to", to,
+    "--text", text,
+    "--type", type,
+  ];
+  if (mediaUrl) args.push("--media-url", mediaUrl);
+  if (messagingProfileId) args.push("--messaging-profile-id", messagingProfileId);
+  if (webhookUrl) args.push("--webhook-url", webhookUrl);
+  if (subject) args.push("--subject", subject);
+
+  try {
+    const res = await telnyxCli(args);
+    const data = (res?.data ?? res) as Record<string, unknown>;
+    const messageId = String(data.id ?? data.message_id ?? "");
+    const status = String(data.status ?? data.delivery_status ?? "submitted");
+
+    const result: SendSmsResult = {
+      message_id: messageId,
+      status,
+      type,
+      from,
+      to,
+    };
+
+    if (jsonOutput) {
+      outputJson(result);
+    } else {
+      printSuccess(`${type} sent!`, {
+        "Message ID": messageId,
+        Status: status,
+        Type: type,
+        From: from,
+        To: to,
+      });
+    }
+  } catch (err) {
+    if (jsonOutput) {
+      outputJson({ error: errorMsg(err) });
+    } else {
+      printError(errorMsg(err));
+    }
+    process.exit(1);
+  }
+}
+
+function errorMsg(err: unknown): string {
+  if (err instanceof TelnyxCLIError) return err.stderr || err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/cli/src/commands/send-sms.ts
+++ b/cli/src/commands/send-sms.ts
@@ -7,6 +7,7 @@
 
 import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
 import { printSuccess, printError, outputJson } from "../utils/output.ts";
+import { deriveMessageStatus } from "../utils/message-status.ts";
 
 interface SendSmsResult {
   message_id: string;
@@ -58,7 +59,8 @@ export async function sendSmsCommand(flags: Record<string, string | boolean>): P
     const res = await telnyxCli(args);
     const data = (res?.data ?? res) as Record<string, unknown>;
     const messageId = String(data.id ?? data.message_id ?? "");
-    const status = String(data.status ?? data.delivery_status ?? "submitted");
+    // Delivery state lives on each recipient (data.to[].status), not top-level.
+    const status = deriveMessageStatus(data, "queued");
 
     const result: SendSmsResult = {
       message_id: messageId,

--- a/cli/src/commands/sms-status.ts
+++ b/cli/src/commands/sms-status.ts
@@ -7,6 +7,7 @@
 
 import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
 import { printSuccess, printError, outputJson } from "../utils/output.ts";
+import { deriveMessageStatus } from "../utils/message-status.ts";
 
 interface SmsStatusResult {
   message_id: string;
@@ -29,7 +30,8 @@ export async function smsStatusCommand(flags: Record<string, string | boolean>):
       const res = await telnyxCli(["messages", "cancel-scheduled", "--id", id]);
       const data = (res?.data ?? res) as Record<string, unknown>;
       const messageId = String(data.id ?? id);
-      const status = String(data.status ?? data.delivery_status ?? "cancelled");
+      // Delivery state lives on each recipient (data.to[].status), not top-level.
+      const status = deriveMessageStatus(data, "cancelled");
 
       const result: SmsStatusResult = {
         message_id: messageId,
@@ -51,7 +53,8 @@ export async function smsStatusCommand(flags: Record<string, string | boolean>):
     const res = await telnyxCli(["messages", "retrieve", "--id", id]);
     const data = (res?.data ?? res) as Record<string, unknown>;
     const messageId = String(data.id ?? id);
-    const status = String(data.status ?? data.delivery_status ?? "unknown");
+    // Delivery state lives on each recipient (data.to[].status), not top-level.
+    const status = deriveMessageStatus(data, "unknown");
 
     const result: SmsStatusResult = {
       message_id: messageId,

--- a/cli/src/commands/sms-status.ts
+++ b/cli/src/commands/sms-status.ts
@@ -1,0 +1,83 @@
+/**
+ * telnyx-agent sms-status — Check SMS delivery status or cancel a scheduled message.
+ *
+ * Default: retrieve message status via `messages retrieve`.
+ * With --cancel: cancel a scheduled message via `messages cancel-scheduled`.
+ */
+
+import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
+import { printSuccess, printError, outputJson } from "../utils/output.ts";
+
+interface SmsStatusResult {
+  message_id: string;
+  status: string;
+  cancelled?: boolean;
+}
+
+export async function smsStatusCommand(flags: Record<string, string | boolean>): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const id = flags["id"] as string | undefined;
+  const cancel = flags.cancel === true;
+
+  if (!id) {
+    printError("--id is required (message ID)");
+    process.exit(1);
+  }
+
+  try {
+    if (cancel) {
+      const res = await telnyxCli(["messages", "cancel-scheduled", "--id", id]);
+      const data = (res?.data ?? res) as Record<string, unknown>;
+      const messageId = String(data.id ?? id);
+      const status = String(data.status ?? data.delivery_status ?? "cancelled");
+
+      const result: SmsStatusResult = {
+        message_id: messageId,
+        status,
+        cancelled: true,
+      };
+
+      if (jsonOutput) {
+        outputJson(result);
+      } else {
+        printSuccess("Scheduled message cancelled!", {
+          "Message ID": messageId,
+          Status: status,
+        });
+      }
+      return;
+    }
+
+    const res = await telnyxCli(["messages", "retrieve", "--id", id]);
+    const data = (res?.data ?? res) as Record<string, unknown>;
+    const messageId = String(data.id ?? id);
+    const status = String(data.status ?? data.delivery_status ?? "unknown");
+
+    const result: SmsStatusResult = {
+      message_id: messageId,
+      status,
+    };
+
+    if (jsonOutput) {
+      outputJson(result);
+    } else {
+      printSuccess("SMS status retrieved!", {
+        "Message ID": messageId,
+        Status: status,
+      });
+    }
+  } catch (err) {
+    if (jsonOutput) {
+      outputJson({ error: errorMsg(err) });
+    } else {
+      printError(errorMsg(err));
+    }
+    process.exit(1);
+  }
+}
+
+function errorMsg(err: unknown): string {
+  if (err instanceof TelnyxCLIError) return err.stderr || err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -117,7 +117,7 @@ SMS Action Flags:
   --to <e164,...>        Comma-separated recipients, E.164 (send-group-mms — required)
   --text <msg>           Message text (send-sms, schedule-sms — required; send-group-mms — optional)
   --media-url <url>      Media URL; sends MMS instead of SMS (send-sms, schedule-sms, send-group-mms)
-  --messaging-profile-id <id> Messaging profile to use (send-sms, send-group-mms, schedule-sms)
+  --messaging-profile-id <id> Messaging profile to use (send-sms, schedule-sms; not supported by group MMS)
   --webhook-url <url>    Webhook for delivery status updates (send-sms)
   --subject <text>       MMS subject line (send-sms)
   --send-at <iso8601>    Send time, ISO 8601 (schedule-sms — required, e.g., 2024-12-31T00:00:00Z)

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -22,6 +22,7 @@ import { setupWhatsappCommand } from "./commands/setup-whatsapp.ts";
 import { whatsappSendCommand } from "./commands/whatsapp-send.ts";
 import { whatsappTemplatesCommand } from "./commands/whatsapp-templates.ts";
 import { sendSmsCommand } from "./commands/send-sms.ts";
+import { sendGroupMmsCommand } from "./commands/send-group-mms.ts";
 import { scheduleSmsCommand } from "./commands/schedule-sms.ts";
 import { smsStatusCommand } from "./commands/sms-status.ts";
 import { parseFlags } from "./utils/output.ts";
@@ -53,6 +54,7 @@ Commands:
   whatsapp-send     Send a WhatsApp message (text or template)
   whatsapp-templates List or create WhatsApp message templates
   send-sms          Send an SMS or MMS message (--media-url sends MMS)
+  send-group-mms    Send a group MMS to multiple recipients (--to comma-separated)
   schedule-sms      Schedule an SMS for future delivery (--send-at ISO 8601)
   sms-status        Check SMS delivery status, or cancel a scheduled message (--cancel)
 
@@ -110,11 +112,12 @@ TTS-voices Flags:
   --provider        Filter voices by provider: telnyx, aws, azure, elevenlabs, minimax, resemble, rime, xai (optional)
   --api-key <key>   Provider API key forwarded to the Go CLI for provider-backed voice lists (e.g., elevenlabs, resemble)
 SMS Action Flags:
-  --from <e164>          Sender number, E.164 (send-sms, schedule-sms — required)
+  --from <e164>          Sender number, E.164 (send-sms, send-group-mms, schedule-sms — required)
   --to <e164>            Recipient number, E.164 (send-sms, schedule-sms — required)
-  --text <msg>           Message text (send-sms, schedule-sms — required)
-  --media-url <url>      Media URL; sends MMS instead of SMS (send-sms, schedule-sms)
-  --messaging-profile-id <id> Messaging profile to use (send-sms, schedule-sms)
+  --to <e164,...>        Comma-separated recipients, E.164 (send-group-mms — required)
+  --text <msg>           Message text (send-sms, schedule-sms — required; send-group-mms — optional)
+  --media-url <url>      Media URL; sends MMS instead of SMS (send-sms, schedule-sms, send-group-mms)
+  --messaging-profile-id <id> Messaging profile to use (send-sms, send-group-mms, schedule-sms)
   --webhook-url <url>    Webhook for delivery status updates (send-sms)
   --subject <text>       MMS subject line (send-sms)
   --send-at <iso8601>    Send time, ISO 8601 (schedule-sms — required, e.g., 2024-12-31T00:00:00Z)
@@ -168,6 +171,8 @@ Examples:
   telnyx-agent whatsapp-templates --waba-id <id> --create --name promo --category MARKETING --component '[]'
   telnyx-agent send-sms --from +131****0000 --to +131****0001 --text "Hello!"
   telnyx-agent send-sms --from +131****0000 --to +131****0001 --text "See this" --media-url https://example.com/img.png --subject "Photo"
+  telnyx-agent send-group-mms --from +131****0000 --to +131****0001,+131****0002,+131****0003 --text "Group hi!"
+  telnyx-agent send-group-mms --from +131****0000 --to +131****0001,+131****0002 --media-url https://example.com/cat.png
   telnyx-agent schedule-sms --from +131****0000 --to +131****0001 --text "Later" --send-at 2024-12-31T00:00:00Z
   telnyx-agent sms-status --id 3fa85f64-5717-4562-b3fc-2c963f66afa6
   telnyx-agent sms-status --id 3fa85f64-5717-4562-b3fc-2c963f66afa6 --cancel
@@ -194,6 +199,7 @@ const COMMANDS: Record<string, (flags: Record<string, string | boolean>) => Prom
   "whatsapp-send": whatsappSendCommand,
   "whatsapp-templates": whatsappTemplatesCommand,
   "send-sms": sendSmsCommand,
+  "send-group-mms": sendGroupMmsCommand,
   "schedule-sms": scheduleSmsCommand,
   "sms-status": smsStatusCommand,
 };

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -21,6 +21,9 @@ import { ttsVoicesCommand } from "./commands/tts-voices.ts";
 import { setupWhatsappCommand } from "./commands/setup-whatsapp.ts";
 import { whatsappSendCommand } from "./commands/whatsapp-send.ts";
 import { whatsappTemplatesCommand } from "./commands/whatsapp-templates.ts";
+import { sendSmsCommand } from "./commands/send-sms.ts";
+import { scheduleSmsCommand } from "./commands/schedule-sms.ts";
+import { smsStatusCommand } from "./commands/sms-status.ts";
 import { parseFlags } from "./utils/output.ts";
 
 const HELP = `
@@ -49,6 +52,9 @@ Commands:
   setup-whatsapp    Zero to WhatsApp: list WABA, buy number, verify, set profile
   whatsapp-send     Send a WhatsApp message (text or template)
   whatsapp-templates List or create WhatsApp message templates
+  send-sms          Send an SMS or MMS message (--media-url sends MMS)
+  schedule-sms      Schedule an SMS for future delivery (--send-at ISO 8601)
+  sms-status        Check SMS delivery status, or cancel a scheduled message (--cancel)
 
 Global Flags:
   --json            Output structured JSON instead of human-readable text
@@ -103,6 +109,17 @@ TTS Flags:
 TTS-voices Flags:
   --provider        Filter voices by provider: telnyx, aws, azure, elevenlabs, minimax, resemble, rime, xai (optional)
   --api-key <key>   Provider API key forwarded to the Go CLI for provider-backed voice lists (e.g., elevenlabs, resemble)
+SMS Action Flags:
+  --from <e164>          Sender number, E.164 (send-sms, schedule-sms — required)
+  --to <e164>            Recipient number, E.164 (send-sms, schedule-sms — required)
+  --text <msg>           Message text (send-sms, schedule-sms — required)
+  --media-url <url>      Media URL; sends MMS instead of SMS (send-sms, schedule-sms)
+  --messaging-profile-id <id> Messaging profile to use (send-sms, schedule-sms)
+  --webhook-url <url>    Webhook for delivery status updates (send-sms)
+  --subject <text>       MMS subject line (send-sms)
+  --send-at <iso8601>    Send time, ISO 8601 (schedule-sms — required, e.g., 2024-12-31T00:00:00Z)
+  --id <message-id>      Message ID (sms-status — required)
+  --cancel               Cancel a scheduled message instead of retrieving status (sms-status)
 
 WhatsApp Flags:
   --waba-id <id>    WhatsApp Business Account id (setup-whatsapp, whatsapp-templates)
@@ -149,6 +166,11 @@ Examples:
   telnyx-agent whatsapp-send --from +155****1111 --to +155****2222 --template-name order_ready
   telnyx-agent whatsapp-templates --waba-id <id> --json
   telnyx-agent whatsapp-templates --waba-id <id> --create --name promo --category MARKETING --component '[]'
+  telnyx-agent send-sms --from +131****0000 --to +131****0001 --text "Hello!"
+  telnyx-agent send-sms --from +131****0000 --to +131****0001 --text "See this" --media-url https://example.com/img.png --subject "Photo"
+  telnyx-agent schedule-sms --from +131****0000 --to +131****0001 --text "Later" --send-at 2024-12-31T00:00:00Z
+  telnyx-agent sms-status --id 3fa85f64-5717-4562-b3fc-2c963f66afa6
+  telnyx-agent sms-status --id 3fa85f64-5717-4562-b3fc-2c963f66afa6 --cancel
 `;
 
 const COMMANDS: Record<string, (flags: Record<string, string | boolean>) => Promise<void>> = {
@@ -171,6 +193,9 @@ const COMMANDS: Record<string, (flags: Record<string, string | boolean>) => Prom
   "setup-whatsapp": setupWhatsappCommand,
   "whatsapp-send": whatsappSendCommand,
   "whatsapp-templates": whatsappTemplatesCommand,
+  "send-sms": sendSmsCommand,
+  "schedule-sms": scheduleSmsCommand,
+  "sms-status": smsStatusCommand,
 };
 
 export async function run(argv: string[]): Promise<void> {

--- a/cli/src/utils/message-status.ts
+++ b/cli/src/utils/message-status.ts
@@ -1,0 +1,48 @@
+/**
+ * Message status helpers — derive delivery state from Telnyx message resources.
+ *
+ * The Messages API reports delivery state per recipient (`data.to[].status`),
+ * not as a top-level `status` field (see the OutboundMessagePayload schema:
+ * `to` is an array of { phone_number, carrier, line_type, status }).
+ */
+
+export interface RecipientStatus {
+  phone_number: string;
+  status: string;
+}
+
+/** Extract per-recipient { phone_number, status } entries from a message resource. */
+export function recipientStatuses(data: Record<string, unknown>): RecipientStatus[] {
+  const to = data.to;
+  if (!Array.isArray(to)) return [];
+  const out: RecipientStatus[] = [];
+  for (const entry of to) {
+    if (entry && typeof entry === "object") {
+      const rec = entry as Record<string, unknown>;
+      out.push({
+        phone_number: String(rec.phone_number ?? ""),
+        status: String(rec.status ?? ""),
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Derive a single status string for a message resource.
+ * Prefers recipient status(es) from `data.to[].status`; falls back to a
+ * top-level `status`/`delivery_status` if present (defensive), then `fallback`.
+ * Multiple distinct recipient statuses are joined with ", ".
+ */
+export function deriveMessageStatus(data: Record<string, unknown>, fallback: string): string {
+  const statuses = recipientStatuses(data)
+    .map((r) => r.status)
+    .filter((s) => s.length > 0);
+  if (statuses.length > 0) {
+    const unique = [...new Set(statuses)];
+    return unique.join(", ");
+  }
+  if (typeof data.status === "string" && data.status) return data.status;
+  if (typeof data.delivery_status === "string" && data.delivery_status) return data.delivery_status;
+  return fallback;
+}

--- a/cli/tests/sms.test.ts
+++ b/cli/tests/sms.test.ts
@@ -34,14 +34,16 @@ fs.appendFileSync(process.env.TELNYX_FAKE_ARGS_LOG, JSON.stringify(args) + "\\n"
 const command = args.filter((a) => a !== "--format" && a !== "json");
 function flag(f) { const i = command.indexOf(f); return i >= 0 ? command[i + 1] : null; }
 
+// Realistic Telnyx message resources: delivery state is reported per
+// recipient in data.to[].status — there is NO top-level status field.
 if (command[0] === "messages" && command[1] === "send") {
-  console.log(JSON.stringify({ data: { id: "msg-123", status: "queued", type: flag("--type"), from: flag("--from"), to: flag("--to") } }));
+  console.log(JSON.stringify({ data: { id: "msg-123", record_type: "message", type: flag("--type"), from: { phone_number: flag("--from"), carrier: "", line_type: "" }, to: [{ phone_number: flag("--to"), status: "queued", carrier: "", line_type: "" }] } }));
 } else if (command[0] === "messages" && command[1] === "schedule") {
-  console.log(JSON.stringify({ data: { id: "sched-456", status: "scheduled", send_at: flag("--send-at") } }));
+  console.log(JSON.stringify({ data: { id: "sched-456", record_type: "message", from: { phone_number: flag("--from") }, to: [{ phone_number: flag("--to"), status: "scheduled" }], send_at: flag("--send-at") } }));
 } else if (command[0] === "messages" && command[1] === "retrieve") {
-  console.log(JSON.stringify({ data: { id: flag("--id"), status: "delivered", direction: "outbound" } }));
+  console.log(JSON.stringify({ data: { id: flag("--id"), record_type: "message", direction: "outbound", to: [{ phone_number: "+13125550001", status: "delivered" }] } }));
 } else if (command[0] === "messages" && command[1] === "cancel-scheduled") {
-  console.log(JSON.stringify({ data: { id: flag("--id"), status: "cancelled" } }));
+  console.log(JSON.stringify({ data: { id: flag("--id"), record_type: "message", to: [{ phone_number: "+13125550001", status: "cancelled" }] } }));
 } else {
   console.log(JSON.stringify({ data: {} }));
 }
@@ -225,6 +227,33 @@ describe("SMS action commands", () => {
       !calls.some((a) => a.slice(0, 2).join(" ") === "messages retrieve"),
       "should not call retrieve",
     );
+  });
+
+  it("derives status from recipient entries (data.to[].status)", async () => {
+    const { deriveMessageStatus, recipientStatuses } = await import("../src/utils/message-status.ts");
+
+    // Real send/retrieve responses carry status per recipient, not top-level.
+    assert.equal(
+      deriveMessageStatus({ to: [{ phone_number: "+1", status: "queued" }] }, "submitted"),
+      "queued",
+    );
+    // Multiple distinct recipient statuses are all surfaced.
+    assert.equal(
+      deriveMessageStatus(
+        { to: [{ phone_number: "+1", status: "delivered" }, { phone_number: "+2", status: "sending_failed" }] },
+        "unknown",
+      ),
+      "delivered, sending_failed",
+    );
+    // Defensive: top-level status honored if recipients carry none.
+    assert.equal(deriveMessageStatus({ status: "cancelled", to: [] }, "unknown"), "cancelled");
+    // Fallback only when the response has no status information at all.
+    assert.equal(deriveMessageStatus({}, "unknown"), "unknown");
+
+    assert.deepEqual(recipientStatuses({ to: [{ phone_number: "+1", status: "queued" }] }), [
+      { phone_number: "+1", status: "queued" },
+    ]);
+    assert.deepEqual(recipientStatuses({ to: "not-an-array" }), []);
   });
 
   it("help text includes SMS commands", () => {

--- a/cli/tests/sms.test.ts
+++ b/cli/tests/sms.test.ts
@@ -33,13 +33,14 @@ fs.appendFileSync(process.env.TELNYX_FAKE_ARGS_LOG, JSON.stringify(args) + "\\n"
 
 const command = args.filter((a) => a !== "--format" && a !== "json");
 function flag(f) { const i = command.indexOf(f); return i >= 0 ? command[i + 1] : null; }
+function flags(f) { const out = []; for (let i = 0; i < command.length; i++) { if (command[i] === f && i + 1 < command.length) out.push(command[i + 1]); } return out; }
 
 // Realistic Telnyx message resources: delivery state is reported per
 // recipient in data.to[].status — there is NO top-level status field.
 if (command[0] === "messages" && command[1] === "send") {
   console.log(JSON.stringify({ data: { id: "msg-123", record_type: "message", type: flag("--type"), from: { phone_number: flag("--from"), carrier: "", line_type: "" }, to: [{ phone_number: flag("--to"), status: "queued", carrier: "", line_type: "" }] } }));
 } else if (command[0] === "messages" && command[1] === "send-group-mms") {
-  const recipients = (flag("--to") || "").split(",").map((p) => ({ phone_number: p, status: "queued", carrier: "", line_type: "" }));
+  const recipients = flags("--to").map((p) => ({ phone_number: p, status: "queued", carrier: "", line_type: "" }));
   console.log(JSON.stringify({ data: { id: "grp-789", record_type: "message", type: "MMS", from: { phone_number: flag("--from") }, to: recipients } }));
 } else if (command[0] === "messages" && command[1] === "schedule") {
   console.log(JSON.stringify({ data: { id: "sched-456", record_type: "message", from: { phone_number: flag("--from") }, to: [{ phone_number: flag("--to"), status: "scheduled" }], send_at: flag("--send-at") } }));
@@ -202,7 +203,16 @@ describe("SMS action commands", () => {
     const groupCall = calls.find((a) => a.slice(0, 2).join(" ") === "messages send-group-mms");
     assert.ok(groupCall, "should call messages send-group-mms");
     assertFlagValue(groupCall, "--from", "+131****0000");
-    assertFlagValue(groupCall, "--to", "+131****0001,+131****0002,+131****0003");
+    // Recipients are expanded into repeated --to flags, one per recipient.
+    const toIndices = groupCall
+      .map((a, i) => (a === "--to" ? i : -1))
+      .filter((i) => i >= 0);
+    assert.equal(toIndices.length, 3, "should push --to once per recipient");
+    assert.deepEqual(
+      toIndices.map((i) => groupCall[i + 1]),
+      ["+131****0001", "+131****0002", "+131****0003"],
+      "each --to should carry a single recipient (not a comma-separated list)",
+    );
     assertFlagValue(groupCall, "--text", "Group hi!");
     assert.ok(!groupCall.includes("--media-url"), "should not include --media-url when not provided");
   });

--- a/cli/tests/sms.test.ts
+++ b/cli/tests/sms.test.ts
@@ -8,7 +8,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, chmodSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -39,7 +39,8 @@ function flag(f) { const i = command.indexOf(f); return i >= 0 ? command[i + 1] 
 if (command[0] === "messages" && command[1] === "send") {
   console.log(JSON.stringify({ data: { id: "msg-123", record_type: "message", type: flag("--type"), from: { phone_number: flag("--from"), carrier: "", line_type: "" }, to: [{ phone_number: flag("--to"), status: "queued", carrier: "", line_type: "" }] } }));
 } else if (command[0] === "messages" && command[1] === "send-group-mms") {
-  console.log(JSON.stringify({ data: { id: "grp-789", record_type: "message", type: "MMS", from: { phone_number: flag("--from"), carrier: "", line_type: "" }, to: [{ phone_number: flag("--to"), status: "queued", carrier: "", line_type: "" }] } }));
+  const recipients = (flag("--to") || "").split(",").map((p) => ({ phone_number: p, status: "queued", carrier: "", line_type: "" }));
+  console.log(JSON.stringify({ data: { id: "grp-789", record_type: "message", type: "MMS", from: { phone_number: flag("--from") }, to: recipients } }));
 } else if (command[0] === "messages" && command[1] === "schedule") {
   console.log(JSON.stringify({ data: { id: "sched-456", record_type: "message", from: { phone_number: flag("--from") }, to: [{ phone_number: flag("--to"), status: "scheduled" }], send_at: flag("--send-at") } }));
 } else if (command[0] === "messages" && command[1] === "retrieve") {
@@ -66,6 +67,7 @@ if (command[0] === "messages" && command[1] === "send") {
 }
 
 function readLoggedArgs(logPath: string): string[][] {
+  if (!existsSync(logPath)) return [];
   return readFileSync(logPath, "utf8")
     .trim()
     .split("\n")
@@ -227,6 +229,29 @@ describe("SMS action commands", () => {
     assert.ok(groupCall, "should call messages send-group-mms");
     assertFlagValue(groupCall, "--media-url", "https://example.com/cat.png");
     assert.ok(!groupCall.includes("--text"), "should not include --text when not provided");
+  });
+
+  it("send-group-mms rejects --messaging-profile-id (not in the group MMS schema)", () => {
+    const fake = setupFakeTelnyx();
+
+    runAgentExpectingFailure(
+      [
+        "send-group-mms",
+        "--from", "+131****0000",
+        "--to", "+131****0001,+131****0002",
+        "--text", "hi",
+        "--messaging-profile-id", "prof-1",
+        "--json",
+      ],
+      fake.env,
+      /--messaging-profile-id is not supported for group MMS/,
+    );
+
+    const calls = readLoggedArgs(fake.logPath);
+    assert.ok(
+      !calls.some((a) => a.slice(0, 2).join(" ") === "messages send-group-mms"),
+      "should not invoke the Go CLI when an unsupported flag is passed",
+    );
   });
 
   it("send-group-mms fails without --from", () => {

--- a/cli/tests/sms.test.ts
+++ b/cli/tests/sms.test.ts
@@ -38,6 +38,8 @@ function flag(f) { const i = command.indexOf(f); return i >= 0 ? command[i + 1] 
 // recipient in data.to[].status — there is NO top-level status field.
 if (command[0] === "messages" && command[1] === "send") {
   console.log(JSON.stringify({ data: { id: "msg-123", record_type: "message", type: flag("--type"), from: { phone_number: flag("--from"), carrier: "", line_type: "" }, to: [{ phone_number: flag("--to"), status: "queued", carrier: "", line_type: "" }] } }));
+} else if (command[0] === "messages" && command[1] === "send-group-mms") {
+  console.log(JSON.stringify({ data: { id: "grp-789", record_type: "message", type: "MMS", from: { phone_number: flag("--from"), carrier: "", line_type: "" }, to: [{ phone_number: flag("--to"), status: "queued", carrier: "", line_type: "" }] } }));
 } else if (command[0] === "messages" && command[1] === "schedule") {
   console.log(JSON.stringify({ data: { id: "sched-456", record_type: "message", from: { phone_number: flag("--from") }, to: [{ phone_number: flag("--to"), status: "scheduled" }], send_at: flag("--send-at") } }));
 } else if (command[0] === "messages" && command[1] === "retrieve") {
@@ -78,6 +80,20 @@ function runAgent(args: string[], env: NodeJS.ProcessEnv): string {
     env,
     timeout: 30000,
   });
+}
+
+function runAgentExpectingFailure(args: string[], env: NodeJS.ProcessEnv, expected: RegExp): void {
+  try {
+    runAgent(args, env);
+    assert.fail("expected command to fail (non-zero exit), but it succeeded");
+  } catch (err: any) {
+    assert.ok(
+      err && err.status !== undefined && err.status !== 0,
+      `expected non-zero exit, got ${err?.status}`,
+    );
+    const output = `${err.stderr ?? ""}${err.stdout ?? ""}`;
+    assert.match(output, expected);
+  }
 }
 
 function assertFlagValue(args: string[], flag: string, value: string): void {
@@ -158,6 +174,79 @@ describe("SMS action commands", () => {
     assertFlagValue(sendCall, "--messaging-profile-id", "prof-1");
     assertFlagValue(sendCall, "--webhook-url", "https://example.com/wh");
     assertFlagValue(sendCall, "--subject", "Sub");
+  });
+
+  it("send-group-mms constructs messages send-group-mms args with --from, --to, --text", () => {
+    const fake = setupFakeTelnyx();
+
+    const out = runAgent(
+      [
+        "send-group-mms",
+        "--from", "+131****0000",
+        "--to", "+131****0001,+131****0002,+131****0003",
+        "--text", "Group hi!",
+        "--json",
+      ],
+      fake.env,
+    );
+
+    const data = JSON.parse(out);
+    assert.equal(data.message_id, "grp-789");
+    assert.equal(data.status, "queued");
+    assert.equal(data.type, "MMS");
+    assert.deepEqual(data.to, ["+131****0001", "+131****0002", "+131****0003"]);
+
+    const calls = readLoggedArgs(fake.logPath);
+    const groupCall = calls.find((a) => a.slice(0, 2).join(" ") === "messages send-group-mms");
+    assert.ok(groupCall, "should call messages send-group-mms");
+    assertFlagValue(groupCall, "--from", "+131****0000");
+    assertFlagValue(groupCall, "--to", "+131****0001,+131****0002,+131****0003");
+    assertFlagValue(groupCall, "--text", "Group hi!");
+    assert.ok(!groupCall.includes("--media-url"), "should not include --media-url when not provided");
+  });
+
+  it("send-group-mms with --media-url passes the flag through", () => {
+    const fake = setupFakeTelnyx();
+
+    const out = runAgent(
+      [
+        "send-group-mms",
+        "--from", "+131****0000",
+        "--to", "+131****0001,+131****0002",
+        "--media-url", "https://example.com/cat.png",
+        "--json",
+      ],
+      fake.env,
+    );
+
+    const data = JSON.parse(out);
+    assert.equal(data.type, "MMS");
+
+    const calls = readLoggedArgs(fake.logPath);
+    const groupCall = calls.find((a) => a.slice(0, 2).join(" ") === "messages send-group-mms");
+    assert.ok(groupCall, "should call messages send-group-mms");
+    assertFlagValue(groupCall, "--media-url", "https://example.com/cat.png");
+    assert.ok(!groupCall.includes("--text"), "should not include --text when not provided");
+  });
+
+  it("send-group-mms fails without --from", () => {
+    const fake = setupFakeTelnyx();
+
+    runAgentExpectingFailure(
+      ["send-group-mms", "--to", "+131****0001,+131****0002", "--text", "hi", "--json"],
+      fake.env,
+      /--from is required/,
+    );
+  });
+
+  it("send-group-mms fails without --to", () => {
+    const fake = setupFakeTelnyx();
+
+    runAgentExpectingFailure(
+      ["send-group-mms", "--from", "+131****0000", "--text", "hi", "--json"],
+      fake.env,
+      /--to is required/,
+    );
   });
 
   it("schedule-sms passes --send-at to messages schedule", () => {
@@ -263,6 +352,7 @@ describe("SMS action commands", () => {
       timeout: 30000,
     });
     assert.match(out, /send-sms/);
+    assert.match(out, /send-group-mms/);
     assert.match(out, /schedule-sms/);
     assert.match(out, /sms-status/);
   });

--- a/cli/tests/sms.test.ts
+++ b/cli/tests/sms.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Tests for SMS action commands (send-sms, schedule-sms, sms-status).
+ *
+ * Uses a fake `telnyx` binary (same pattern as telnyx-cli-flags.test.ts) that
+ * logs the Go CLI args it receives and returns canned JSON for the
+ * `messages send|schedule|retrieve|cancel-scheduled` subcommands.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliRoot = join(__dirname, "..");
+const cliBin = join(cliRoot, "bin", "telnyx-agent.ts");
+
+function setupFakeTelnyx(): { fakeTelnyx: string; logPath: string; env: NodeJS.ProcessEnv } {
+  const tempDir = mkdtempSync(join(tmpdir(), "telnyx-agent-sms-"));
+  const binDir = join(tempDir, "bin");
+  const logPath = join(tempDir, "args.jsonl");
+  mkdirSync(binDir, { recursive: true });
+
+  const fakeTelnyx = join(binDir, "telnyx");
+  writeFileSync(
+    fakeTelnyx,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.TELNYX_FAKE_ARGS_LOG, JSON.stringify(args) + "\\n");
+
+const command = args.filter((a) => a !== "--format" && a !== "json");
+function flag(f) { const i = command.indexOf(f); return i >= 0 ? command[i + 1] : null; }
+
+if (command[0] === "messages" && command[1] === "send") {
+  console.log(JSON.stringify({ data: { id: "msg-123", status: "queued", type: flag("--type"), from: flag("--from"), to: flag("--to") } }));
+} else if (command[0] === "messages" && command[1] === "schedule") {
+  console.log(JSON.stringify({ data: { id: "sched-456", status: "scheduled", send_at: flag("--send-at") } }));
+} else if (command[0] === "messages" && command[1] === "retrieve") {
+  console.log(JSON.stringify({ data: { id: flag("--id"), status: "delivered", direction: "outbound" } }));
+} else if (command[0] === "messages" && command[1] === "cancel-scheduled") {
+  console.log(JSON.stringify({ data: { id: flag("--id"), status: "cancelled" } }));
+} else {
+  console.log(JSON.stringify({ data: {} }));
+}
+`,
+  );
+  chmodSync(fakeTelnyx, 0o755);
+
+  return {
+    fakeTelnyx,
+    logPath,
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH}`,
+      TELNYX_CLI_PATH: fakeTelnyx,
+      TELNYX_FAKE_ARGS_LOG: logPath,
+    },
+  };
+}
+
+function readLoggedArgs(logPath: string): string[][] {
+  return readFileSync(logPath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function runAgent(args: string[], env: NodeJS.ProcessEnv): string {
+  return execFileSync("npx", ["tsx", cliBin, ...args], {
+    cwd: cliRoot,
+    encoding: "utf8",
+    env,
+    timeout: 30000,
+  });
+}
+
+function assertFlagValue(args: string[], flag: string, value: string): void {
+  const index = args.indexOf(flag);
+  assert.notEqual(index, -1, `expected ${flag} in ${args.join(" ")}`);
+  assert.equal(args[index + 1], value, `expected ${flag} ${value} in ${args.join(" ")}`);
+}
+
+describe("SMS action commands", () => {
+  it("send-sms constructs messages send args with --type SMS", () => {
+    const fake = setupFakeTelnyx();
+
+    const out = runAgent(
+      ["send-sms", "--from", "+13125550000", "--to", "+13125550001", "--text", "Hello!", "--json"],
+      fake.env,
+    );
+
+    const data = JSON.parse(out);
+    assert.equal(data.message_id, "msg-123");
+    assert.equal(data.status, "queued");
+    assert.equal(data.type, "SMS");
+
+    const calls = readLoggedArgs(fake.logPath);
+    const sendCall = calls.find((a) => a.slice(0, 2).join(" ") === "messages send");
+    assert.ok(sendCall, "should call messages send");
+    assertFlagValue(sendCall, "--from", "+13125550000");
+    assertFlagValue(sendCall, "--to", "+13125550001");
+    assertFlagValue(sendCall, "--text", "Hello!");
+    assertFlagValue(sendCall, "--type", "SMS");
+    assert.ok(!sendCall.includes("--media-url"), "SMS should not include --media-url");
+  });
+
+  it("send-sms with --media-url sends MMS (--type MMS)", () => {
+    const fake = setupFakeTelnyx();
+
+    const out = runAgent(
+      [
+        "send-sms",
+        "--from", "+13125550000",
+        "--to", "+13125550001",
+        "--text", "see this",
+        "--media-url", "https://example.com/img.png",
+        "--json",
+      ],
+      fake.env,
+    );
+
+    const data = JSON.parse(out);
+    assert.equal(data.type, "MMS");
+
+    const calls = readLoggedArgs(fake.logPath);
+    const sendCall = calls.find((a) => a.slice(0, 2).join(" ") === "messages send");
+    assert.ok(sendCall, "should call messages send");
+    assertFlagValue(sendCall, "--type", "MMS");
+    assertFlagValue(sendCall, "--media-url", "https://example.com/img.png");
+  });
+
+  it("send-sms passes optional flags through to the Go CLI", () => {
+    const fake = setupFakeTelnyx();
+
+    runAgent(
+      [
+        "send-sms",
+        "--from", "+13125550000",
+        "--to", "+13125550001",
+        "--text", "hi",
+        "--messaging-profile-id", "prof-1",
+        "--webhook-url", "https://example.com/wh",
+        "--subject", "Sub",
+        "--json",
+      ],
+      fake.env,
+    );
+
+    const calls = readLoggedArgs(fake.logPath);
+    const sendCall = calls.find((a) => a.slice(0, 2).join(" ") === "messages send");
+    assert.ok(sendCall);
+    assertFlagValue(sendCall, "--messaging-profile-id", "prof-1");
+    assertFlagValue(sendCall, "--webhook-url", "https://example.com/wh");
+    assertFlagValue(sendCall, "--subject", "Sub");
+  });
+
+  it("schedule-sms passes --send-at to messages schedule", () => {
+    const fake = setupFakeTelnyx();
+
+    const out = runAgent(
+      [
+        "schedule-sms",
+        "--from", "+13125550000",
+        "--to", "+13125550001",
+        "--text", "later",
+        "--send-at", "2024-12-31T00:00:00Z",
+        "--json",
+      ],
+      fake.env,
+    );
+
+    const data = JSON.parse(out);
+    assert.equal(data.message_id, "sched-456");
+    assert.equal(data.status, "scheduled");
+    assert.equal(data.send_at, "2024-12-31T00:00:00Z");
+
+    const calls = readLoggedArgs(fake.logPath);
+    const schedCall = calls.find((a) => a.slice(0, 2).join(" ") === "messages schedule");
+    assert.ok(schedCall, "should call messages schedule");
+    assertFlagValue(schedCall, "--from", "+13125550000");
+    assertFlagValue(schedCall, "--to", "+13125550001");
+    assertFlagValue(schedCall, "--text", "later");
+    assertFlagValue(schedCall, "--send-at", "2024-12-31T00:00:00Z");
+    assert.ok(!schedCall.includes("--type"), "schedule should not include --type");
+  });
+
+  it("sms-status retrieve calls messages retrieve", () => {
+    const fake = setupFakeTelnyx();
+
+    const out = runAgent(["sms-status", "--id", "msg-123", "--json"], fake.env);
+
+    const data = JSON.parse(out);
+    assert.equal(data.message_id, "msg-123");
+    assert.equal(data.status, "delivered");
+
+    const calls = readLoggedArgs(fake.logPath);
+    const retrieveCall = calls.find((a) => a.slice(0, 2).join(" ") === "messages retrieve");
+    assert.ok(retrieveCall, "should call messages retrieve");
+    assertFlagValue(retrieveCall, "--id", "msg-123");
+    assert.ok(
+      !calls.some((a) => a.slice(0, 2).join(" ") === "messages cancel-scheduled"),
+      "should not call cancel-scheduled",
+    );
+  });
+
+  it("sms-status --cancel calls messages cancel-scheduled", () => {
+    const fake = setupFakeTelnyx();
+
+    const out = runAgent(["sms-status", "--id", "sched-456", "--cancel", "--json"], fake.env);
+
+    const data = JSON.parse(out);
+    assert.equal(data.message_id, "sched-456");
+    assert.equal(data.status, "cancelled");
+    assert.equal(data.cancelled, true);
+
+    const calls = readLoggedArgs(fake.logPath);
+    const cancelCall = calls.find((a) => a.slice(0, 2).join(" ") === "messages cancel-scheduled");
+    assert.ok(cancelCall, "should call messages cancel-scheduled");
+    assertFlagValue(cancelCall, "--id", "sched-456");
+    assert.ok(
+      !calls.some((a) => a.slice(0, 2).join(" ") === "messages retrieve"),
+      "should not call retrieve",
+    );
+  });
+
+  it("help text includes SMS commands", () => {
+    const out = execFileSync("npx", ["tsx", cliBin, "help"], {
+      cwd: cliRoot,
+      encoding: "utf8",
+      timeout: 30000,
+    });
+    assert.match(out, /send-sms/);
+    assert.match(out, /schedule-sms/);
+    assert.match(out, /sms-status/);
+  });
+});


### PR DESCRIPTION
## Summary\n\nAdds SMS action commands to the agent CLI \u2014 previously only  (composite setup) existed with no way to actually send messages.\n\n### New Commands\n\n**** \u2014 Send an SMS or MMS message:\n- Auto-detects SMS vs MMS based on  flag\n- Extracts actual delivery status from API response\n\n**** \u2014 Schedule an SMS for later delivery:\n- Requires  (ISO 8601 datetime)\n\n**** \u2014 Check message delivery status or cancel scheduled messages:\n-  flag to cancel a scheduled message\n\n### Files Changed\n-  (new)\n-  (new)\n-  (new)\n-  \u2014 register 3 commands, help text, examples\n-  \u2014 update Messaging capabilities\n-  \u2014 7 mock-binary tests (all passing)\n\n### Test Results\n