### PR TITLE
feat: Add Voice API action commands to agent CLI

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "tsx bin/telnyx-agent.ts",
-    "test": "tsx --test tests/integration.test.ts tests/telnyx-cli-flags.test.ts tests/edge-handoff.test.ts tests/tts.test.ts tests/whatsapp.test.ts tests/sms.test.ts",
+    "test": "tsx --test tests/edge-handoff.test.ts tests/integration.test.ts tests/sms.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
     "typecheck": "tsc --noEmit",
     "postinstall": "tsx scripts/postinstall.ts",
     "build": "npm run typecheck"

--- a/cli/src/commands/call-control.ts
+++ b/cli/src/commands/call-control.ts
@@ -61,109 +61,14 @@ export async function callControlCommand(flags: Record<string, string | boolean>
   const deepfakeDetection = flags["deepfake-detection"] === true;
   const record = flags.record === true;
   const webhookUrl = flags["webhook-url"] as string | undefined;
-  // --cause defaults to CALL_REJECTED, the generic rejection cause.
-  const cause = (typeof flags.cause === "string" ? flags.cause : undefined) ?? "CALL_REJECTED";
-
-  if (!action) {
-    printError(`--action is required. Valid actions: ${ACTIONS.join(", ")}`);
-    process.exit(1);
-  }
-  if (!ACTIONS.includes(action as Action)) {
-    printError(`Unknown --action: ${action}. Valid actions: ${ACTIONS.join(", ")}`);
-    process.exit(1);
-  }
-  const act = action as Action;
-
-  // Every action needs a call-control-id (bridge uses it as the first leg).
-  if (!callControlId) {
-    printError("--call-control-id is required");
-    process.exit(1);
-  }
-
-  // Action-specific flag validation
-  if (act === "transfer") {
-    if (!to) {
-      printError("--to is required for transfer (E.164 destination number)");
-      process.exit(1);
-    }
-    if (!E164_RE.test(to)) {
-      printError(`Invalid --to number: ${to}. Must be E.164 (e.g. +13125559999)`);
-      process.exit(1);
-    }
-  }
-  if (act === "dtmf" && !digits) {
-    printError("--digits is required for dtmf (e.g. 1234 or *,#)");
-    process.exit(1);
-  }
-  if (act === "speak" && !payload) {
-    printError("--payload is required for speak (text to synthesize)");
-    process.exit(1);
-  }
-  if (act === "bridge" && !callControlId2) {
-    printError("--call-control-id-2 is required for bridge (the second call to bridge with)");
-    process.exit(1);
-  }
-  if (act === "refer" && !sipAddress) {
-    printError("--sip-address is required for refer (e.g. sip:user@example.com)");
-    process.exit(1);
-  }
-  if (act === "reject" && !REJECT_CAUSES.includes(cause as (typeof REJECT_CAUSES)[number])) {
-    printError(`Invalid --cause: ${cause}. Must be one of: ${REJECT_CAUSES.join(", ")}`);
-    process.exit(1);
-  }
-  if (act === "start-recording") {
-    if (channels !== undefined && !["single", "dual"].includes(channels)) {
-      printError(`Invalid --channels: ${channels}. Must be 'single' or 'dual'`);
-      process.exit(1);
-    }
-    if (format !== undefined && !["mp3", "wav"].includes(format)) {
-      printError(`Invalid --format: ${format}. Must be 'mp3' or 'wav'`);
-      process.exit(1);
-    }
-  }
-  // gather accepts optional client-state/command-id; forward only if provided.
-  if (act === "start-playback" && !audioUrl) {
-    printError("--audio-url is required for start-playback (URL of audio to play)");
-    process.exit(1);
-  }
-  if (act === "enqueue" && !queueName) {
-    printError("--queue-name is required for enqueue");
-    process.exit(1);
-  }
-  if (act === "send-sip-info") {
-    if (!body) {
-      printError("--body is required for send-sip-info (SIP INFO body content)");
-      process.exit(1);
-    }
-    if (!contentType) {
-      printError("--content-type is required for send-sip-info (e.g. application/dtmf-relay)");
-      process.exit(1);
-    }
-  }
-  if (act === "update-client-state" && !clientState) {
-    printError("--client-state is required for update-client-state");
-    process.exit(1);
-  }
-  // start-forking requires either a target or both rx+tx (the Voice API
-  // rejects fork_start without a destination).
-  if (act === "start-forking" && !forkTarget && !(forkRx && forkTx)) {
-    printError("--fork-target (or both --fork-rx and --fork-tx) is required for start-forking");
-    process.exit(1);
-  }
-
-  const args = buildActionArgs(act, {
-    callControlId,
-    callControlId2,
-    to,
-    digits,
-    payload,
-    voice,
-    sipAddress,
-    channels,
-    format,
-    deepfakeDetection,
-    record,
-    webhookUrl,
+    audioUrl,
+    queueName,
+    body,
+    contentType,
+    clientState,
+    commandId,
+    forkRx,
+    forkTx,
     cause,
   });
 
@@ -214,60 +119,68 @@ function buildActionArgs(
     deepfakeDetection: boolean;
     record: boolean;
     webhookUrl?: string;
-    cause: string;
-  },
-): string[] {
-  switch (action) {
-    case "answer":
+    case "gather":
       return [
-        "calls:actions", "answer",
+        "calls:actions", "gather",
         "--call-control-id", opts.callControlId,
-        // deepfake_detection is an object in the Answer API; the Go CLI exposes it via inner flags.
-        ...(opts.deepfakeDetection ? ["--deepfake-detection.enabled"] : []),
-        // The Go CLI's --record flag takes the event to record from, not a boolean.
-        ...(opts.record ? ["--record", "record-from-answer"] : []),
-        ...(opts.webhookUrl ? ["--webhook-url", opts.webhookUrl] : []),
+        ...(opts.clientState ? ["--client-state", opts.clientState] : []),
+        ...(opts.commandId ? ["--command-id", opts.commandId] : []),
       ];
-    case "hangup":
-      return ["calls:actions", "hangup", "--call-control-id", opts.callControlId];
-    case "transfer":
-      return ["calls:actions", "transfer", "--call-control-id", opts.callControlId, "--to", opts.to!];
-    case "dtmf":
-      return ["calls:actions", "send-dtmf", "--call-control-id", opts.callControlId, "--digits", opts.digits!];
-    case "start-recording":
-      // The Go CLI treats --channels and --format as required for
-      // start-recording. Supply safe defaults (single/mp3) when the caller
-      // omits them so the command works out of the box instead of erroring.
+    case "stop-gather":
+      return ["calls:actions", "stop-gather", "--call-control-id", opts.callControlId];
+    case "start-playback":
       return [
-        "calls:actions", "start-recording",
+        "calls:actions", "start-playback",
         "--call-control-id", opts.callControlId,
-        "--channels", opts.channels ?? "single",
-        "--format", opts.format ?? "mp3",
+        "--audio-url", opts.audioUrl!,
       ];
-    case "stop-recording":
-      return ["calls:actions", "stop-recording", "--call-control-id", opts.callControlId];
-    case "start-noise-suppression":
-      return ["calls:actions", "start-noise-suppression", "--call-control-id", opts.callControlId];
-    case "stop-noise-suppression":
-      return ["calls:actions", "stop-noise-suppression", "--call-control-id", opts.callControlId];
-    case "speak":
+    case "stop-playback":
+      return ["calls:actions", "stop-playback", "--call-control-id", opts.callControlId];
+    case "start-transcription":
+      return ["calls:actions", "start-transcription", "--call-control-id", opts.callControlId];
+    case "stop-transcription":
+      return ["calls:actions", "stop-transcription", "--call-control-id", opts.callControlId];
+    case "pause-recording":
+      return ["calls:actions", "pause-recording", "--call-control-id", opts.callControlId];
+    case "resume-recording":
+      return ["calls:actions", "resume-recording", "--call-control-id", opts.callControlId];
+    case "start-forking": {
+      const forkArgs = ["calls:actions", "start-forking", "--call-control-id", opts.callControlId];
+      if (opts.forkRx) forkArgs.push("--rx", opts.forkRx);
+      if (opts.forkTx) forkArgs.push("--tx", opts.forkTx);
+      return forkArgs;
+    }
+    case "stop-forking":
+      return ["calls:actions", "stop-forking", "--call-control-id", opts.callControlId];
+    case "start-siprec":
+      return ["calls:actions", "start-siprec", "--call-control-id", opts.callControlId];
+    case "stop-siprec":
+      return ["calls:actions", "stop-siprec", "--call-control-id", opts.callControlId];
+    case "start-streaming":
+      return ["calls:actions", "start-streaming", "--call-control-id", opts.callControlId];
+    case "stop-streaming":
+      return ["calls:actions", "stop-streaming", "--call-control-id", opts.callControlId];
+    case "enqueue":
       return [
-        "calls:actions", "speak",
+        "calls:actions", "enqueue",
         "--call-control-id", opts.callControlId,
-        "--payload", opts.payload!,
-        "--voice", opts.voice,
+        "--queue-name", opts.queueName!,
       ];
-    case "bridge":
+    case "leave-queue":
+      return ["calls:actions", "leave-queue", "--call-control-id", opts.callControlId];
+    case "send-sip-info":
       return [
-        "calls:actions", "bridge",
-        "--call-control-id-to-bridge", opts.callControlId,
-        "--call-control-id-to-bridge-with", opts.callControlId2!,
+        "calls:actions", "send-sip-info",
+        "--call-control-id", opts.callControlId,
+        "--body", opts.body!,
+        "--content-type", opts.contentType!,
       ];
-    case "refer":
-      return ["calls:actions", "refer", "--call-control-id", opts.callControlId, "--sip-address", opts.sipAddress!];
-    case "reject":
-      // The Reject API requires a cause (CALL_REJECTED or USER_BUSY).
-      return ["calls:actions", "reject", "--call-control-id", opts.callControlId, "--cause", opts.cause];
+    case "update-client-state":
+      return [
+        "calls:actions", "update-client-state",
+        "--call-control-id", opts.callControlId,
+        "--client-state", opts.clientState!,
+      ];
   }
 }
 

--- a/cli/src/commands/call-control.ts
+++ b/cli/src/commands/call-control.ts
@@ -34,11 +34,11 @@ const ACTIONS = [
 ] as const;
 type Action = (typeof ACTIONS)[number];
 
-/** E.164: a leading '+' then 1-15 digits, country code must not start with 0. */
-const E164_RE = /^\+[1-9]\d{1,14}$/;
-
 /** Valid causes for the Reject API (required by POST /calls/{id}/actions/reject). */
 const REJECT_CAUSES = ["CALL_REJECTED", "USER_BUSY"] as const;
+
+/** E.164: a leading '+' then 1-15 digits, country code must not start with 0. */
+const E164_RE = /^\+[1-9]\d{1,14}$/;
 
 interface CallControlResult {
   action: string;
@@ -61,6 +61,121 @@ export async function callControlCommand(flags: Record<string, string | boolean>
   const deepfakeDetection = flags["deepfake-detection"] === true;
   const record = flags.record === true;
   const webhookUrl = flags["webhook-url"] as string | undefined;
+  // Flags for the advanced call-control actions.
+  const audioUrl = flags["audio-url"] as string | undefined;
+  const queueName = flags["queue-name"] as string | undefined;
+  const body = flags["body"] as string | undefined;
+  const contentType = flags["content-type"] as string | undefined;
+  const clientState = flags["client-state"] as string | undefined;
+  const commandId = flags["command-id"] as string | undefined;
+  // Flags for media forking (start-forking).
+  // The Go CLI supports --rx, --tx, and --stream-type.
+  const forkRx = flags["fork-rx"] as string | undefined;
+  const forkTx = flags["fork-tx"] as string | undefined;
+  const forkStreamType = flags["fork-stream-type"] as string | undefined;
+  // --cause defaults to CALL_REJECTED, the generic rejection cause.
+  const cause = (typeof flags.cause === "string" ? flags.cause : undefined) ?? "CALL_REJECTED";
+
+  if (!action) {
+    printError(`--action is required. Valid actions: ${ACTIONS.join(", ")}`);
+    process.exit(1);
+  }
+  if (!ACTIONS.includes(action as Action)) {
+    printError(`Unknown --action: ${action}. Valid actions: ${ACTIONS.join(", ")}`);
+    process.exit(1);
+  }
+  const act = action as Action;
+
+  // Every action needs a call-control-id (bridge uses it as the first leg).
+  if (!callControlId) {
+    printError("--call-control-id is required");
+    process.exit(1);
+  }
+
+  // Action-specific flag validation
+  if (act === "transfer") {
+    if (!to) {
+      printError("--to is required for transfer (E.164 destination number)");
+      process.exit(1);
+    }
+    if (!E164_RE.test(to)) {
+      printError(`Invalid --to number: ${to}. Must be E.164 (e.g. +13125559999)`);
+      process.exit(1);
+    }
+  }
+  if (act === "dtmf" && !digits) {
+    printError("--digits is required for dtmf (e.g. 1234 or *,#)");
+    process.exit(1);
+  }
+  if (act === "speak" && !payload) {
+    printError("--payload is required for speak (text to synthesize)");
+    process.exit(1);
+  }
+  if (act === "bridge" && !callControlId2) {
+    printError("--call-control-id-2 is required for bridge (the second call to bridge with)");
+    process.exit(1);
+  }
+  if (act === "refer" && !sipAddress) {
+    printError("--sip-address is required for refer (e.g. sip:user@example.com)");
+    process.exit(1);
+  }
+  if (act === "start-recording") {
+    if (channels !== undefined && !["single", "dual"].includes(channels)) {
+      printError(`Invalid --channels: ${channels}. Must be 'single' or 'dual'`);
+      process.exit(1);
+    }
+    if (format !== undefined && !["mp3", "wav"].includes(format)) {
+      printError(`Invalid --format: ${format}. Must be 'mp3' or 'wav'`);
+      process.exit(1);
+    }
+  }
+  // gather accepts optional client-state/command-id; forward only if provided.
+  if (act === "start-playback" && !audioUrl) {
+    printError("--audio-url is required for start-playback (URL of audio to play)");
+    process.exit(1);
+  }
+  if (act === "enqueue" && !queueName) {
+    printError("--queue-name is required for enqueue");
+    process.exit(1);
+  }
+  if (act === "send-sip-info") {
+    if (!body) {
+      printError("--body is required for send-sip-info (SIP INFO body content)");
+      process.exit(1);
+    }
+    if (!contentType) {
+      printError("--content-type is required for send-sip-info (e.g. application/dtmf-relay)");
+      process.exit(1);
+    }
+  }
+  if (act === "update-client-state" && !clientState) {
+    printError("--client-state is required for update-client-state");
+    process.exit(1);
+  }
+  // start-forking requires both rx+tx (the Voice API rejects fork_start
+  // without a destination, and the Go CLI only exposes --rx/--tx).
+  if (act === "start-forking" && !(forkRx && forkTx)) {
+    printError("--fork-rx and --fork-tx are both required for start-forking");
+    process.exit(1);
+  }
+  if (act === "reject" && !REJECT_CAUSES.includes(cause as (typeof REJECT_CAUSES)[number])) {
+    printError(`Invalid --cause: ${cause}. Must be one of: ${REJECT_CAUSES.join(", ")}`);
+    process.exit(1);
+  }
+
+  const args = buildActionArgs(act, {
+    callControlId,
+    callControlId2,
+    to,
+    digits,
+    payload,
+    voice,
+    sipAddress,
+    channels,
+    format,
+    deepfakeDetection,
+    record,
+    webhookUrl,
     audioUrl,
     queueName,
     body,
@@ -69,6 +184,7 @@ export async function callControlCommand(flags: Record<string, string | boolean>
     commandId,
     forkRx,
     forkTx,
+    forkStreamType,
     cause,
   });
 
@@ -119,6 +235,66 @@ function buildActionArgs(
     deepfakeDetection: boolean;
     record: boolean;
     webhookUrl?: string;
+    audioUrl?: string;
+    queueName?: string;
+    body?: string;
+    contentType?: string;
+    clientState?: string;
+    commandId?: string;
+    forkRx?: string;
+    forkTx?: string;
+    forkStreamType?: string;
+    cause: string;
+  },
+): string[] {
+  switch (action) {
+    case "answer":
+      return [
+        "calls:actions", "answer",
+        "--call-control-id", opts.callControlId,
+        // deepfake_detection is an object in the Answer API; the Go CLI exposes it via inner flags.
+        ...(opts.deepfakeDetection ? ["--deepfake-detection.enabled"] : []),
+        // The Go CLI's --record flag takes the event to record from, not a boolean.
+        ...(opts.record ? ["--record", "record-from-answer"] : []),
+        ...(opts.webhookUrl ? ["--webhook-url", opts.webhookUrl] : []),
+      ];
+    case "hangup":
+      return ["calls:actions", "hangup", "--call-control-id", opts.callControlId];
+    case "transfer":
+      return ["calls:actions", "transfer", "--call-control-id", opts.callControlId, "--to", opts.to!];
+    case "dtmf":
+      return ["calls:actions", "send-dtmf", "--call-control-id", opts.callControlId, "--digits", opts.digits!];
+    case "start-recording":
+      return [
+        "calls:actions", "start-recording",
+        "--call-control-id", opts.callControlId,
+        // Supply safe defaults — the Go CLI requires both channels and format.
+        ...(opts.channels ? ["--channels", opts.channels] : ["--channels", "single"]),
+        ...(opts.format ? ["--format", opts.format] : ["--format", "mp3"]),
+      ];
+    case "stop-recording":
+      return ["calls:actions", "stop-recording", "--call-control-id", opts.callControlId];
+    case "start-noise-suppression":
+      return ["calls:actions", "start-noise-suppression", "--call-control-id", opts.callControlId];
+    case "stop-noise-suppression":
+      return ["calls:actions", "stop-noise-suppression", "--call-control-id", opts.callControlId];
+    case "speak":
+      return [
+        "calls:actions", "speak",
+        "--call-control-id", opts.callControlId,
+        "--payload", opts.payload!,
+        "--voice", opts.voice,
+      ];
+    case "bridge":
+      return [
+        "calls:actions", "bridge",
+        "--call-control-id-to-bridge", opts.callControlId,
+        "--call-control-id-to-bridge-with", opts.callControlId2!,
+      ];
+    case "refer":
+      return ["calls:actions", "refer", "--call-control-id", opts.callControlId, "--sip-address", opts.sipAddress!];
+    case "reject":
+      return ["calls:actions", "reject", "--call-control-id", opts.callControlId, "--cause", opts.cause];
     case "gather":
       return [
         "calls:actions", "gather",
@@ -148,6 +324,7 @@ function buildActionArgs(
       const forkArgs = ["calls:actions", "start-forking", "--call-control-id", opts.callControlId];
       if (opts.forkRx) forkArgs.push("--rx", opts.forkRx);
       if (opts.forkTx) forkArgs.push("--tx", opts.forkTx);
+      if (opts.forkStreamType) forkArgs.push("--stream-type", opts.forkStreamType);
       return forkArgs;
     }
     case "stop-forking":

--- a/cli/src/commands/call-control.ts
+++ b/cli/src/commands/call-control.ts
@@ -61,7 +61,8 @@ export async function callControlCommand(flags: Record<string, string | boolean>
   // Flags for the advanced call-control actions.
   const audioUrl = flags["audio-url"] as string | undefined;
   const queueName = flags["queue-name"] as string | undefined;
-  const content = flags["content"] as string | undefined;
+  const body = flags["body"] as string | undefined;
+  const contentType = flags["content-type"] as string | undefined;
   const clientState = flags["client-state"] as string | undefined;
   const commandId = flags["command-id"] as string | undefined;
 
@@ -118,11 +119,7 @@ export async function callControlCommand(flags: Record<string, string | boolean>
       process.exit(1);
     }
   }
-  // gather requires client-state and command-id per the Call Control API.
-  if (act === "gather" && (!clientState || !commandId)) {
-    printError("--client-state and --command-id are required for gather");
-    process.exit(1);
-  }
+  // gather accepts optional client-state/command-id; forward only if provided.
   if (act === "start-playback" && !audioUrl) {
     printError("--audio-url is required for start-playback (URL of audio to play)");
     process.exit(1);
@@ -131,9 +128,15 @@ export async function callControlCommand(flags: Record<string, string | boolean>
     printError("--queue-name is required for enqueue");
     process.exit(1);
   }
-  if (act === "send-sip-info" && !content) {
-    printError("--content is required for send-sip-info (SIP INFO body content)");
-    process.exit(1);
+  if (act === "send-sip-info") {
+    if (!body) {
+      printError("--body is required for send-sip-info (SIP INFO body content)");
+      process.exit(1);
+    }
+    if (!contentType) {
+      printError("--content-type is required for send-sip-info (e.g. application/dtmf-relay)");
+      process.exit(1);
+    }
   }
   if (act === "update-client-state" && !clientState) {
     printError("--client-state is required for update-client-state");
@@ -155,7 +158,8 @@ export async function callControlCommand(flags: Record<string, string | boolean>
     webhookUrl,
     audioUrl,
     queueName,
-    content,
+    body,
+    contentType,
     clientState,
     commandId,
   });
@@ -209,7 +213,8 @@ function buildActionArgs(
     webhookUrl?: string;
     audioUrl?: string;
     queueName?: string;
-    content?: string;
+    body?: string;
+    contentType?: string;
     clientState?: string;
     commandId?: string;
   },
@@ -263,8 +268,8 @@ function buildActionArgs(
       return [
         "calls:actions", "gather",
         "--call-control-id", opts.callControlId,
-        "--client-state", opts.clientState!,
-        "--command-id", opts.commandId!,
+        ...(opts.clientState ? ["--client-state", opts.clientState] : []),
+        ...(opts.commandId ? ["--command-id", opts.commandId] : []),
       ];
     case "stop-gather":
       return ["calls:actions", "stop-gather", "--call-control-id", opts.callControlId];
@@ -308,7 +313,8 @@ function buildActionArgs(
       return [
         "calls:actions", "send-sip-info",
         "--call-control-id", opts.callControlId,
-        "--content", opts.content!,
+        "--body", opts.body!,
+        "--content-type", opts.contentType!,
       ];
     case "update-client-state":
       return [

--- a/cli/src/commands/call-control.ts
+++ b/cli/src/commands/call-control.ts
@@ -1,0 +1,219 @@
+/**
+ * telnyx-agent call-control — Call Control actions for an in-progress call.
+ *
+ * A single command with a `--action` flag dispatches to the Go CLI's
+ * `calls:actions <sub>` subcommands, so the command registry stays small while
+ * still exposing the full Call Control surface.
+ *
+ * Supported actions:
+ *   answer, hangup, transfer, dtmf, start-recording, stop-recording,
+ *   start-noise-suppression, stop-noise-suppression, speak, bridge, refer, reject
+ */
+
+import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
+import { printSuccess, printError, outputJson } from "../utils/output.ts";
+
+const ACTIONS = [
+  "answer", "hangup", "transfer", "dtmf",
+  "start-recording", "stop-recording",
+  "start-noise-suppression", "stop-noise-suppression",
+  "speak", "bridge", "refer", "reject",
+] as const;
+type Action = (typeof ACTIONS)[number];
+
+/** E.164: a leading '+' then 1-15 digits, country code must not start with 0. */
+const E164_RE = /^\+[1-9]\d{1,14}$/;
+
+interface CallControlResult {
+  action: string;
+  call_control_id: string | null;
+  result: unknown;
+}
+
+export async function callControlCommand(flags: Record<string, string | boolean>): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const action = flags.action as string | undefined;
+  const callControlId = flags["call-control-id"] as string | undefined;
+  const to = flags.to as string | undefined;
+  const digits = flags.digits as string | undefined;
+  const payload = flags.payload as string | undefined;
+  const voice = (flags.voice as string | undefined) || "female";
+  const callControlId2 = flags["call-control-id-2"] as string | undefined;
+  const sipAddress = flags["sip-address"] as string | undefined;
+  const channels = flags.channels as string | undefined;
+  const format = flags.format as string | undefined;
+  const deepfakeDetection = flags["deepfake-detection"] === true;
+  const record = flags.record === true;
+  const webhookUrl = flags["webhook-url"] as string | undefined;
+
+  if (!action) {
+    printError(`--action is required. Valid actions: ${ACTIONS.join(", ")}`);
+    process.exit(1);
+  }
+  if (!ACTIONS.includes(action as Action)) {
+    printError(`Unknown --action: ${action}. Valid actions: ${ACTIONS.join(", ")}`);
+    process.exit(1);
+  }
+  const act = action as Action;
+
+  // Every action needs a call-control-id (bridge uses it as the first leg).
+  if (!callControlId) {
+    printError("--call-control-id is required");
+    process.exit(1);
+  }
+
+  // Action-specific flag validation
+  if (act === "transfer") {
+    if (!to) {
+      printError("--to is required for transfer (E.164 destination number)");
+      process.exit(1);
+    }
+    if (!E164_RE.test(to)) {
+      printError(`Invalid --to number: ${to}. Must be E.164 (e.g. +13125559999)`);
+      process.exit(1);
+    }
+  }
+  if (act === "dtmf" && !digits) {
+    printError("--digits is required for dtmf (e.g. 1234 or *,#)");
+    process.exit(1);
+  }
+  if (act === "speak" && !payload) {
+    printError("--payload is required for speak (text to synthesize)");
+    process.exit(1);
+  }
+  if (act === "bridge" && !callControlId2) {
+    printError("--call-control-id-2 is required for bridge (the second call to bridge with)");
+    process.exit(1);
+  }
+  if (act === "refer" && !sipAddress) {
+    printError("--sip-address is required for refer (e.g. sip:user@example.com)");
+    process.exit(1);
+  }
+  if (act === "start-recording") {
+    if (channels !== undefined && !["single", "dual"].includes(channels)) {
+      printError(`Invalid --channels: ${channels}. Must be 'single' or 'dual'`);
+      process.exit(1);
+    }
+    if (format !== undefined && !["mp3", "wav"].includes(format)) {
+      printError(`Invalid --format: ${format}. Must be 'mp3' or 'wav'`);
+      process.exit(1);
+    }
+  }
+
+  const args = buildActionArgs(act, {
+    callControlId,
+    callControlId2,
+    to,
+    digits,
+    payload,
+    voice,
+    sipAddress,
+    channels,
+    format,
+    deepfakeDetection,
+    record,
+    webhookUrl,
+  });
+
+  try {
+    if (!jsonOutput) console.log(`\n📞 Call Control: ${act}...`);
+    const res = await telnyxCli(args);
+    const data = res?.data ?? res;
+
+    const result: CallControlResult = {
+      action: act,
+      call_control_id: callControlId,
+      result: data,
+    };
+
+    if (jsonOutput) {
+      outputJson(result);
+    } else {
+      const details: Record<string, string | number | boolean> = {
+        "Action": act,
+        "Call Control ID": callControlId,
+      };
+      if (act === "bridge") details["Bridged With"] = callControlId2 ?? "";
+      printSuccess(`Call Control '${act}' completed`, details);
+    }
+  } catch (err) {
+    const msg = errorMsg(err);
+    if (jsonOutput) {
+      outputJson({ error: msg });
+    } else {
+      printError(msg);
+    }
+    process.exit(1);
+  }
+}
+
+function buildActionArgs(
+  action: Action,
+  opts: {
+    callControlId: string;
+    callControlId2?: string;
+    to?: string;
+    digits?: string;
+    payload?: string;
+    voice: string;
+    sipAddress?: string;
+    channels?: string;
+    format?: string;
+    deepfakeDetection: boolean;
+    record: boolean;
+    webhookUrl?: string;
+  },
+): string[] {
+  switch (action) {
+    case "answer":
+      return [
+        "calls:actions", "answer",
+        "--call-control-id", opts.callControlId,
+        ...(opts.deepfakeDetection ? ["--deepfake-detection"] : []),
+        ...(opts.record ? ["--record"] : []),
+        ...(opts.webhookUrl ? ["--webhook-url", opts.webhookUrl] : []),
+      ];
+    case "hangup":
+      return ["calls:actions", "hangup", "--call-control-id", opts.callControlId];
+    case "transfer":
+      return ["calls:actions", "transfer", "--call-control-id", opts.callControlId, "--to", opts.to!];
+    case "dtmf":
+      return ["calls:actions", "send-dtmf", "--call-control-id", opts.callControlId, "--digits", opts.digits!];
+    case "start-recording":
+      return [
+        "calls:actions", "start-recording",
+        "--call-control-id", opts.callControlId,
+        ...(opts.channels ? ["--channels", opts.channels] : []),
+        ...(opts.format ? ["--format", opts.format] : []),
+      ];
+    case "stop-recording":
+      return ["calls:actions", "stop-recording", "--call-control-id", opts.callControlId];
+    case "start-noise-suppression":
+      return ["calls:actions", "start-noise-suppression", "--call-control-id", opts.callControlId];
+    case "stop-noise-suppression":
+      return ["calls:actions", "stop-noise-suppression", "--call-control-id", opts.callControlId];
+    case "speak":
+      return [
+        "calls:actions", "speak",
+        "--call-control-id", opts.callControlId,
+        "--payload", opts.payload!,
+        "--voice", opts.voice,
+      ];
+    case "bridge":
+      return [
+        "calls:actions", "bridge",
+        "--call-control-id-to-bridge", opts.callControlId,
+        "--call-control-id-to-bridge-with", opts.callControlId2!,
+      ];
+    case "refer":
+      return ["calls:actions", "refer", "--call-control-id", opts.callControlId, "--sip-address", opts.sipAddress!];
+    case "reject":
+      return ["calls:actions", "reject", "--call-control-id", opts.callControlId];
+  }
+}
+
+function errorMsg(err: unknown): string {
+  if (err instanceof TelnyxCLIError) return err.stderr || err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/cli/src/commands/call-control.ts
+++ b/cli/src/commands/call-control.ts
@@ -65,6 +65,10 @@ export async function callControlCommand(flags: Record<string, string | boolean>
   const contentType = flags["content-type"] as string | undefined;
   const clientState = flags["client-state"] as string | undefined;
   const commandId = flags["command-id"] as string | undefined;
+  // Flags for media forking (start-forking).
+  const forkTarget = flags["fork-target"] as string | undefined;
+  const forkRx = flags["fork-rx"] as string | undefined;
+  const forkTx = flags["fork-tx"] as string | undefined;
 
   if (!action) {
     printError(`--action is required. Valid actions: ${ACTIONS.join(", ")}`);
@@ -142,6 +146,12 @@ export async function callControlCommand(flags: Record<string, string | boolean>
     printError("--client-state is required for update-client-state");
     process.exit(1);
   }
+  // start-forking requires either a target or both rx+tx (the Voice API
+  // rejects fork_start without a destination).
+  if (act === "start-forking" && !forkTarget && !(forkRx && forkTx)) {
+    printError("--fork-target (or both --fork-rx and --fork-tx) is required for start-forking");
+    process.exit(1);
+  }
 
   const args = buildActionArgs(act, {
     callControlId,
@@ -162,6 +172,9 @@ export async function callControlCommand(flags: Record<string, string | boolean>
     contentType,
     clientState,
     commandId,
+    forkTarget,
+    forkRx,
+    forkTx,
   });
 
   try {
@@ -217,6 +230,9 @@ function buildActionArgs(
     contentType?: string;
     clientState?: string;
     commandId?: string;
+    forkTarget?: string;
+    forkRx?: string;
+    forkTx?: string;
   },
 ): string[] {
   switch (action) {
@@ -289,8 +305,13 @@ function buildActionArgs(
       return ["calls:actions", "pause-recording", "--call-control-id", opts.callControlId];
     case "resume-recording":
       return ["calls:actions", "resume-recording", "--call-control-id", opts.callControlId];
-    case "start-forking":
-      return ["calls:actions", "start-forking", "--call-control-id", opts.callControlId];
+    case "start-forking": {
+      const forkArgs = ["calls:actions", "start-forking", "--call-control-id", opts.callControlId];
+      if (opts.forkTarget) forkArgs.push("--target", opts.forkTarget);
+      if (opts.forkRx) forkArgs.push("--rx", opts.forkRx);
+      if (opts.forkTx) forkArgs.push("--tx", opts.forkTx);
+      return forkArgs;
+    }
     case "stop-forking":
       return ["calls:actions", "stop-forking", "--call-control-id", opts.callControlId];
     case "start-siprec":

--- a/cli/src/commands/call-control.ts
+++ b/cli/src/commands/call-control.ts
@@ -235,11 +235,14 @@ function buildActionArgs(
     case "dtmf":
       return ["calls:actions", "send-dtmf", "--call-control-id", opts.callControlId, "--digits", opts.digits!];
     case "start-recording":
+      // The Go CLI treats --channels and --format as required for
+      // start-recording. Supply safe defaults (single/mp3) when the caller
+      // omits them so the command works out of the box instead of erroring.
       return [
         "calls:actions", "start-recording",
         "--call-control-id", opts.callControlId,
-        ...(opts.channels ? ["--channels", opts.channels] : []),
-        ...(opts.format ? ["--format", opts.format] : []),
+        "--channels", opts.channels ?? "single",
+        "--format", opts.format ?? "mp3",
       ];
     case "stop-recording":
       return ["calls:actions", "stop-recording", "--call-control-id", opts.callControlId];

--- a/cli/src/commands/call-control.ts
+++ b/cli/src/commands/call-control.ts
@@ -7,7 +7,11 @@
  *
  * Supported actions:
  *   answer, hangup, transfer, dtmf, start-recording, stop-recording,
- *   start-noise-suppression, stop-noise-suppression, speak, bridge, refer, reject
+ *   start-noise-suppression, stop-noise-suppression, speak, bridge, refer, reject,
+ *   gather, stop-gather, start-playback, stop-playback, start-transcription,
+ *   stop-transcription, pause-recording, resume-recording, start-forking,
+ *   stop-forking, start-siprec, stop-siprec, start-streaming, stop-streaming,
+ *   enqueue, leave-queue, send-sip-info, update-client-state
  */
 
 import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
@@ -18,6 +22,15 @@ const ACTIONS = [
   "start-recording", "stop-recording",
   "start-noise-suppression", "stop-noise-suppression",
   "speak", "bridge", "refer", "reject",
+  "gather", "stop-gather",
+  "start-playback", "stop-playback",
+  "start-transcription", "stop-transcription",
+  "pause-recording", "resume-recording",
+  "start-forking", "stop-forking",
+  "start-siprec", "stop-siprec",
+  "start-streaming", "stop-streaming",
+  "enqueue", "leave-queue",
+  "send-sip-info", "update-client-state",
 ] as const;
 type Action = (typeof ACTIONS)[number];
 
@@ -45,6 +58,12 @@ export async function callControlCommand(flags: Record<string, string | boolean>
   const deepfakeDetection = flags["deepfake-detection"] === true;
   const record = flags.record === true;
   const webhookUrl = flags["webhook-url"] as string | undefined;
+  // Flags for the advanced call-control actions.
+  const audioUrl = flags["audio-url"] as string | undefined;
+  const queueName = flags["queue-name"] as string | undefined;
+  const content = flags["content"] as string | undefined;
+  const clientState = flags["client-state"] as string | undefined;
+  const commandId = flags["command-id"] as string | undefined;
 
   if (!action) {
     printError(`--action is required. Valid actions: ${ACTIONS.join(", ")}`);
@@ -99,6 +118,27 @@ export async function callControlCommand(flags: Record<string, string | boolean>
       process.exit(1);
     }
   }
+  // gather requires client-state and command-id per the Call Control API.
+  if (act === "gather" && (!clientState || !commandId)) {
+    printError("--client-state and --command-id are required for gather");
+    process.exit(1);
+  }
+  if (act === "start-playback" && !audioUrl) {
+    printError("--audio-url is required for start-playback (URL of audio to play)");
+    process.exit(1);
+  }
+  if (act === "enqueue" && !queueName) {
+    printError("--queue-name is required for enqueue");
+    process.exit(1);
+  }
+  if (act === "send-sip-info" && !content) {
+    printError("--content is required for send-sip-info (SIP INFO body content)");
+    process.exit(1);
+  }
+  if (act === "update-client-state" && !clientState) {
+    printError("--client-state is required for update-client-state");
+    process.exit(1);
+  }
 
   const args = buildActionArgs(act, {
     callControlId,
@@ -113,6 +153,11 @@ export async function callControlCommand(flags: Record<string, string | boolean>
     deepfakeDetection,
     record,
     webhookUrl,
+    audioUrl,
+    queueName,
+    content,
+    clientState,
+    commandId,
   });
 
   try {
@@ -162,6 +207,11 @@ function buildActionArgs(
     deepfakeDetection: boolean;
     record: boolean;
     webhookUrl?: string;
+    audioUrl?: string;
+    queueName?: string;
+    content?: string;
+    clientState?: string;
+    commandId?: string;
   },
 ): string[] {
   switch (action) {
@@ -209,6 +259,63 @@ function buildActionArgs(
       return ["calls:actions", "refer", "--call-control-id", opts.callControlId, "--sip-address", opts.sipAddress!];
     case "reject":
       return ["calls:actions", "reject", "--call-control-id", opts.callControlId];
+    case "gather":
+      return [
+        "calls:actions", "gather",
+        "--call-control-id", opts.callControlId,
+        "--client-state", opts.clientState!,
+        "--command-id", opts.commandId!,
+      ];
+    case "stop-gather":
+      return ["calls:actions", "stop-gather", "--call-control-id", opts.callControlId];
+    case "start-playback":
+      return [
+        "calls:actions", "start-playback",
+        "--call-control-id", opts.callControlId,
+        "--audio-url", opts.audioUrl!,
+      ];
+    case "stop-playback":
+      return ["calls:actions", "stop-playback", "--call-control-id", opts.callControlId];
+    case "start-transcription":
+      return ["calls:actions", "start-transcription", "--call-control-id", opts.callControlId];
+    case "stop-transcription":
+      return ["calls:actions", "stop-transcription", "--call-control-id", opts.callControlId];
+    case "pause-recording":
+      return ["calls:actions", "pause-recording", "--call-control-id", opts.callControlId];
+    case "resume-recording":
+      return ["calls:actions", "resume-recording", "--call-control-id", opts.callControlId];
+    case "start-forking":
+      return ["calls:actions", "start-forking", "--call-control-id", opts.callControlId];
+    case "stop-forking":
+      return ["calls:actions", "stop-forking", "--call-control-id", opts.callControlId];
+    case "start-siprec":
+      return ["calls:actions", "start-siprec", "--call-control-id", opts.callControlId];
+    case "stop-siprec":
+      return ["calls:actions", "stop-siprec", "--call-control-id", opts.callControlId];
+    case "start-streaming":
+      return ["calls:actions", "start-streaming", "--call-control-id", opts.callControlId];
+    case "stop-streaming":
+      return ["calls:actions", "stop-streaming", "--call-control-id", opts.callControlId];
+    case "enqueue":
+      return [
+        "calls:actions", "enqueue",
+        "--call-control-id", opts.callControlId,
+        "--queue-name", opts.queueName!,
+      ];
+    case "leave-queue":
+      return ["calls:actions", "leave-queue", "--call-control-id", opts.callControlId];
+    case "send-sip-info":
+      return [
+        "calls:actions", "send-sip-info",
+        "--call-control-id", opts.callControlId,
+        "--content", opts.content!,
+      ];
+    case "update-client-state":
+      return [
+        "calls:actions", "update-client-state",
+        "--call-control-id", opts.callControlId,
+        "--client-state", opts.clientState!,
+      ];
   }
 }
 

--- a/cli/src/commands/call-control.ts
+++ b/cli/src/commands/call-control.ts
@@ -37,6 +37,9 @@ type Action = (typeof ACTIONS)[number];
 /** E.164: a leading '+' then 1-15 digits, country code must not start with 0. */
 const E164_RE = /^\+[1-9]\d{1,14}$/;
 
+/** Valid causes for the Reject API (required by POST /calls/{id}/actions/reject). */
+const REJECT_CAUSES = ["CALL_REJECTED", "USER_BUSY"] as const;
+
 interface CallControlResult {
   action: string;
   call_control_id: string | null;
@@ -58,17 +61,8 @@ export async function callControlCommand(flags: Record<string, string | boolean>
   const deepfakeDetection = flags["deepfake-detection"] === true;
   const record = flags.record === true;
   const webhookUrl = flags["webhook-url"] as string | undefined;
-  // Flags for the advanced call-control actions.
-  const audioUrl = flags["audio-url"] as string | undefined;
-  const queueName = flags["queue-name"] as string | undefined;
-  const body = flags["body"] as string | undefined;
-  const contentType = flags["content-type"] as string | undefined;
-  const clientState = flags["client-state"] as string | undefined;
-  const commandId = flags["command-id"] as string | undefined;
-  // Flags for media forking (start-forking).
-  const forkTarget = flags["fork-target"] as string | undefined;
-  const forkRx = flags["fork-rx"] as string | undefined;
-  const forkTx = flags["fork-tx"] as string | undefined;
+  // --cause defaults to CALL_REJECTED, the generic rejection cause.
+  const cause = (typeof flags.cause === "string" ? flags.cause : undefined) ?? "CALL_REJECTED";
 
   if (!action) {
     printError(`--action is required. Valid actions: ${ACTIONS.join(", ")}`);
@@ -111,6 +105,10 @@ export async function callControlCommand(flags: Record<string, string | boolean>
   }
   if (act === "refer" && !sipAddress) {
     printError("--sip-address is required for refer (e.g. sip:user@example.com)");
+    process.exit(1);
+  }
+  if (act === "reject" && !REJECT_CAUSES.includes(cause as (typeof REJECT_CAUSES)[number])) {
+    printError(`Invalid --cause: ${cause}. Must be one of: ${REJECT_CAUSES.join(", ")}`);
     process.exit(1);
   }
   if (act === "start-recording") {
@@ -166,15 +164,7 @@ export async function callControlCommand(flags: Record<string, string | boolean>
     deepfakeDetection,
     record,
     webhookUrl,
-    audioUrl,
-    queueName,
-    body,
-    contentType,
-    clientState,
-    commandId,
-    forkTarget,
-    forkRx,
-    forkTx,
+    cause,
   });
 
   try {
@@ -224,15 +214,7 @@ function buildActionArgs(
     deepfakeDetection: boolean;
     record: boolean;
     webhookUrl?: string;
-    audioUrl?: string;
-    queueName?: string;
-    body?: string;
-    contentType?: string;
-    clientState?: string;
-    commandId?: string;
-    forkTarget?: string;
-    forkRx?: string;
-    forkTx?: string;
+    cause: string;
   },
 ): string[] {
   switch (action) {
@@ -240,8 +222,10 @@ function buildActionArgs(
       return [
         "calls:actions", "answer",
         "--call-control-id", opts.callControlId,
-        ...(opts.deepfakeDetection ? ["--deepfake-detection"] : []),
-        ...(opts.record ? ["--record"] : []),
+        // deepfake_detection is an object in the Answer API; the Go CLI exposes it via inner flags.
+        ...(opts.deepfakeDetection ? ["--deepfake-detection.enabled"] : []),
+        // The Go CLI's --record flag takes the event to record from, not a boolean.
+        ...(opts.record ? ["--record", "record-from-answer"] : []),
         ...(opts.webhookUrl ? ["--webhook-url", opts.webhookUrl] : []),
       ];
     case "hangup":
@@ -279,70 +263,8 @@ function buildActionArgs(
     case "refer":
       return ["calls:actions", "refer", "--call-control-id", opts.callControlId, "--sip-address", opts.sipAddress!];
     case "reject":
-      return ["calls:actions", "reject", "--call-control-id", opts.callControlId];
-    case "gather":
-      return [
-        "calls:actions", "gather",
-        "--call-control-id", opts.callControlId,
-        ...(opts.clientState ? ["--client-state", opts.clientState] : []),
-        ...(opts.commandId ? ["--command-id", opts.commandId] : []),
-      ];
-    case "stop-gather":
-      return ["calls:actions", "stop-gather", "--call-control-id", opts.callControlId];
-    case "start-playback":
-      return [
-        "calls:actions", "start-playback",
-        "--call-control-id", opts.callControlId,
-        "--audio-url", opts.audioUrl!,
-      ];
-    case "stop-playback":
-      return ["calls:actions", "stop-playback", "--call-control-id", opts.callControlId];
-    case "start-transcription":
-      return ["calls:actions", "start-transcription", "--call-control-id", opts.callControlId];
-    case "stop-transcription":
-      return ["calls:actions", "stop-transcription", "--call-control-id", opts.callControlId];
-    case "pause-recording":
-      return ["calls:actions", "pause-recording", "--call-control-id", opts.callControlId];
-    case "resume-recording":
-      return ["calls:actions", "resume-recording", "--call-control-id", opts.callControlId];
-    case "start-forking": {
-      const forkArgs = ["calls:actions", "start-forking", "--call-control-id", opts.callControlId];
-      if (opts.forkTarget) forkArgs.push("--target", opts.forkTarget);
-      if (opts.forkRx) forkArgs.push("--rx", opts.forkRx);
-      if (opts.forkTx) forkArgs.push("--tx", opts.forkTx);
-      return forkArgs;
-    }
-    case "stop-forking":
-      return ["calls:actions", "stop-forking", "--call-control-id", opts.callControlId];
-    case "start-siprec":
-      return ["calls:actions", "start-siprec", "--call-control-id", opts.callControlId];
-    case "stop-siprec":
-      return ["calls:actions", "stop-siprec", "--call-control-id", opts.callControlId];
-    case "start-streaming":
-      return ["calls:actions", "start-streaming", "--call-control-id", opts.callControlId];
-    case "stop-streaming":
-      return ["calls:actions", "stop-streaming", "--call-control-id", opts.callControlId];
-    case "enqueue":
-      return [
-        "calls:actions", "enqueue",
-        "--call-control-id", opts.callControlId,
-        "--queue-name", opts.queueName!,
-      ];
-    case "leave-queue":
-      return ["calls:actions", "leave-queue", "--call-control-id", opts.callControlId];
-    case "send-sip-info":
-      return [
-        "calls:actions", "send-sip-info",
-        "--call-control-id", opts.callControlId,
-        "--body", opts.body!,
-        "--content-type", opts.contentType!,
-      ];
-    case "update-client-state":
-      return [
-        "calls:actions", "update-client-state",
-        "--call-control-id", opts.callControlId,
-        "--client-state", opts.clientState!,
-      ];
+      // The Reject API requires a cause (CALL_REJECTED or USER_BUSY).
+      return ["calls:actions", "reject", "--call-control-id", opts.callControlId, "--cause", opts.cause];
   }
 }
 

--- a/cli/src/commands/call-dial.ts
+++ b/cli/src/commands/call-dial.ts
@@ -18,6 +18,9 @@ interface CallDialResult {
 /** E.164: a leading '+' then 1-15 digits, country code must not start with 0. */
 const E164_RE = /^\+[1-9]\d{1,14}$/;
 
+/** Valid HTTP methods for --webhook-url-method. */
+const HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"] as const;
+
 export async function callDialCommand(flags: Record<string, string | boolean>): Promise<void> {
   const jsonOutput = flags.json === true;
   const connectionId = flags["connection-id"] as string | undefined;
@@ -29,6 +32,16 @@ export async function callDialCommand(flags: Record<string, string | boolean>): 
   const webhookUrl = flags["webhook-url"] as string | undefined;
   const audioUrl = flags["audio-url"] as string | undefined;
   const timeoutSecs = flags["timeout-secs"] as string | undefined;
+  // New flags (number masking + advanced dial options).
+  const privacy = flags["privacy"] as string | undefined;
+  const fromDisplayName = flags["from-display-name"] as string | undefined;
+  const timeLimitSecs = flags["time-limit-secs"] as string | undefined;
+  const transcription = flags["transcription"] === true;
+  const mediaEncryption = flags["media-encryption"] as string | undefined;
+  const clientState = flags["client-state"] as string | undefined;
+  const commandId = flags["command-id"] as string | undefined;
+  const webhookUrlMethod = flags["webhook-url-method"] as string | undefined;
+  const webhookUrls = flags["webhook-urls"] as string | undefined;
 
   // Validate required flags
   if (!connectionId) {
@@ -55,6 +68,18 @@ export async function callDialCommand(flags: Record<string, string | boolean>): 
     printError(`Invalid --timeout-secs: ${timeoutSecs}. Must be a positive integer`);
     process.exit(1);
   }
+  if (privacy !== undefined && !["id", "none"].includes(privacy)) {
+    printError(`Invalid --privacy: ${privacy}. Must be 'id' (number masking) or 'none'`);
+    process.exit(1);
+  }
+  if (timeLimitSecs !== undefined && (!/^\d+$/.test(timeLimitSecs) || Number(timeLimitSecs) <= 0)) {
+    printError(`Invalid --time-limit-secs: ${timeLimitSecs}. Must be a positive integer`);
+    process.exit(1);
+  }
+  if (webhookUrlMethod !== undefined && !HTTP_METHODS.includes(webhookUrlMethod.toUpperCase() as (typeof HTTP_METHODS)[number])) {
+    printError(`Invalid --webhook-url-method: ${webhookUrlMethod}. Must be one of ${HTTP_METHODS.join(", ")}`);
+    process.exit(1);
+  }
 
   const args: string[] = [
     "calls", "dial",
@@ -68,6 +93,15 @@ export async function callDialCommand(flags: Record<string, string | boolean>): 
   if (webhookUrl) args.push("--webhook-url", webhookUrl);
   if (audioUrl) args.push("--audio-url", audioUrl);
   if (timeoutSecs) args.push("--timeout-secs", timeoutSecs);
+  if (privacy) args.push("--privacy", privacy);
+  if (fromDisplayName) args.push("--from-display-name", fromDisplayName);
+  if (timeLimitSecs) args.push("--time-limit-secs", timeLimitSecs);
+  if (transcription) args.push("--transcription");
+  if (mediaEncryption) args.push("--media-encryption", mediaEncryption);
+  if (clientState) args.push("--client-state", clientState);
+  if (commandId) args.push("--command-id", commandId);
+  if (webhookUrlMethod) args.push("--webhook-url-method", webhookUrlMethod);
+  if (webhookUrls) args.push("--webhook-urls", webhookUrls);
 
   try {
     if (!jsonOutput) {
@@ -75,6 +109,8 @@ export async function callDialCommand(flags: Record<string, string | boolean>): 
       console.log(`  From:           ${from}`);
       console.log(`  To:             ${to}`);
       console.log(`  Connection ID:  ${connectionId}`);
+      if (privacy === "id") console.log(`  Privacy:        number masking (caller ID hidden)`);
+      if (fromDisplayName) console.log(`  Caller ID Name: ${fromDisplayName}`);
       console.log();
     }
 
@@ -98,9 +134,12 @@ export async function callDialCommand(flags: Record<string, string | boolean>): 
         "To": to,
         "Connection ID": connectionId,
       };
+      if (privacy === "id") details["Privacy"] = "number masking (caller ID hidden)";
+      if (fromDisplayName) details["Caller ID Name"] = fromDisplayName;
       if (answeringMachineDetection) details["AMD"] = "enabled";
       if (deepfakeDetection) details["Deepfake Detection"] = "enabled";
       if (record) details["Recording"] = "enabled";
+      if (transcription) details["Transcription"] = "enabled";
       printSuccess("Outbound call placed!", details);
     }
   } catch (err) {

--- a/cli/src/commands/call-dial.ts
+++ b/cli/src/commands/call-dial.ts
@@ -1,0 +1,121 @@
+/**
+ * telnyx-agent call-dial — Make an outbound call via Telnyx Call Control.
+ *
+ * Wraps the Go CLI's `calls dial` subcommand. Returns the new call-control-id so
+ * the agent can immediately drive the call with `call-control`.
+ */
+
+import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
+import { printSuccess, printError, outputJson } from "../utils/output.ts";
+
+interface CallDialResult {
+  call_control_id: string;
+  call_leg_id?: string;
+  call_session_id?: string;
+  is_alive?: boolean;
+}
+
+/** E.164: a leading '+' then 1-15 digits, country code must not start with 0. */
+const E164_RE = /^\+[1-9]\d{1,14}$/;
+
+export async function callDialCommand(flags: Record<string, string | boolean>): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const connectionId = flags["connection-id"] as string | undefined;
+  const from = flags["from"] as string | undefined;
+  const to = flags["to"] as string | undefined;
+  const answeringMachineDetection = flags["answering-machine-detection"] === true;
+  const deepfakeDetection = flags["deepfake-detection"] === true;
+  const record = flags.record === true;
+  const webhookUrl = flags["webhook-url"] as string | undefined;
+  const audioUrl = flags["audio-url"] as string | undefined;
+  const timeoutSecs = flags["timeout-secs"] as string | undefined;
+
+  // Validate required flags
+  if (!connectionId) {
+    printError("--connection-id is required (the Call Control connection to dial from)");
+    process.exit(1);
+  }
+  if (!from) {
+    printError("--from is required (E.164 number to call from, e.g. +13125550000)");
+    process.exit(1);
+  }
+  if (!E164_RE.test(from)) {
+    printError(`Invalid --from number: ${from}. Must be E.164 (e.g. +13125550000)`);
+    process.exit(1);
+  }
+  if (!to) {
+    printError("--to is required (E.164 number to call, e.g. +13125551234)");
+    process.exit(1);
+  }
+  if (!E164_RE.test(to)) {
+    printError(`Invalid --to number: ${to}. Must be E.164 (e.g. +13125551234)`);
+    process.exit(1);
+  }
+  if (timeoutSecs !== undefined && (!/^\d+$/.test(timeoutSecs) || Number(timeoutSecs) <= 0)) {
+    printError(`Invalid --timeout-secs: ${timeoutSecs}. Must be a positive integer`);
+    process.exit(1);
+  }
+
+  const args: string[] = [
+    "calls", "dial",
+    "--connection-id", connectionId,
+    "--from", from,
+    "--to", to,
+  ];
+  if (answeringMachineDetection) args.push("--answering-machine-detection");
+  if (deepfakeDetection) args.push("--deepfake-detection");
+  if (record) args.push("--record");
+  if (webhookUrl) args.push("--webhook-url", webhookUrl);
+  if (audioUrl) args.push("--audio-url", audioUrl);
+  if (timeoutSecs) args.push("--timeout-secs", timeoutSecs);
+
+  try {
+    if (!jsonOutput) {
+      console.log("\n📞 Dialing outbound call...");
+      console.log(`  From:           ${from}`);
+      console.log(`  To:             ${to}`);
+      console.log(`  Connection ID:  ${connectionId}`);
+      console.log();
+    }
+
+    const res = await telnyxCli(args);
+    const data = (res?.data ?? res ?? {}) as Record<string, unknown>;
+    const callControlId = String(data.call_control_id ?? "");
+
+    const result: CallDialResult = {
+      call_control_id: callControlId,
+      call_leg_id: data.call_leg_id as string | undefined,
+      call_session_id: data.call_session_id as string | undefined,
+      is_alive: data.is_alive as boolean | undefined,
+    };
+
+    if (jsonOutput) {
+      outputJson(result);
+    } else {
+      const details: Record<string, string | number | boolean> = {
+        "Call Control ID": callControlId,
+        "From": from,
+        "To": to,
+        "Connection ID": connectionId,
+      };
+      if (answeringMachineDetection) details["AMD"] = "enabled";
+      if (deepfakeDetection) details["Deepfake Detection"] = "enabled";
+      if (record) details["Recording"] = "enabled";
+      printSuccess("Outbound call placed!", details);
+    }
+  } catch (err) {
+    const msg = errorMsg(err);
+    if (jsonOutput) {
+      outputJson({ error: msg });
+    } else {
+      printError(msg);
+    }
+    process.exit(1);
+  }
+}
+
+function errorMsg(err: unknown): string {
+  if (err instanceof TelnyxCLIError) return err.stderr || err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/cli/src/commands/call-dial.ts
+++ b/cli/src/commands/call-dial.ts
@@ -18,15 +18,17 @@ interface CallDialResult {
 /** E.164: a leading '+' then 1-15 digits, country code must not start with 0. */
 const E164_RE = /^\+[1-9]\d{1,14}$/;
 
-/** Valid HTTP methods for --webhook-url-method (Voice API only accepts GET/POST). */
-const HTTP_METHODS = ["GET", "POST"] as const;
+/** Valid answering_machine_detection modes accepted by the Dial API. */
+const AMD_MODES = ["premium", "detect", "detect_beep", "detect_words", "greeting_end", "disabled"] as const;
 
 export async function callDialCommand(flags: Record<string, string | boolean>): Promise<void> {
   const jsonOutput = flags.json === true;
   const connectionId = flags["connection-id"] as string | undefined;
   const from = flags["from"] as string | undefined;
   const to = flags["to"] as string | undefined;
-  const answeringMachineDetection = flags["answering-machine-detection"] === true;
+  // --answering-machine-detection [mode] — bare flag enables standard detection ("detect").
+  const amdRaw = flags["answering-machine-detection"];
+  const answeringMachineDetection = amdRaw === true ? "detect" : (amdRaw as string | undefined);
   const deepfakeDetection = flags["deepfake-detection"] === true;
   const record = flags.record === true;
   const webhookUrl = flags["webhook-url"] as string | undefined;
@@ -68,16 +70,8 @@ export async function callDialCommand(flags: Record<string, string | boolean>): 
     printError(`Invalid --timeout-secs: ${timeoutSecs}. Must be a positive integer`);
     process.exit(1);
   }
-  if (privacy !== undefined && !["id", "none"].includes(privacy)) {
-    printError(`Invalid --privacy: ${privacy}. Must be 'id' (number masking) or 'none'`);
-    process.exit(1);
-  }
-  if (timeLimitSecs !== undefined && (!/^\d+$/.test(timeLimitSecs) || Number(timeLimitSecs) <= 0)) {
-    printError(`Invalid --time-limit-secs: ${timeLimitSecs}. Must be a positive integer`);
-    process.exit(1);
-  }
-  if (webhookUrlMethod !== undefined && !HTTP_METHODS.includes(webhookUrlMethod.toUpperCase() as (typeof HTTP_METHODS)[number])) {
-    printError(`Invalid --webhook-url-method: ${webhookUrlMethod}. Must be one of ${HTTP_METHODS.join(", ")}`);
+  if (answeringMachineDetection !== undefined && !AMD_MODES.includes(answeringMachineDetection as (typeof AMD_MODES)[number])) {
+    printError(`Invalid --answering-machine-detection mode: ${answeringMachineDetection}. Must be one of: ${AMD_MODES.join(", ")}`);
     process.exit(1);
   }
 
@@ -87,9 +81,12 @@ export async function callDialCommand(flags: Record<string, string | boolean>): 
     "--from", from,
     "--to", to,
   ];
-  if (answeringMachineDetection) args.push("--answering-machine-detection");
-  if (deepfakeDetection) args.push("--deepfake-detection");
-  if (record) args.push("--record");
+  // The Go CLI's --answering-machine-detection flag takes a mode value (default "disabled").
+  if (answeringMachineDetection) args.push("--answering-machine-detection", answeringMachineDetection);
+  // deepfake_detection is an object in the Dial API; the Go CLI exposes it via inner flags.
+  if (deepfakeDetection) args.push("--deepfake-detection.enabled");
+  // The Go CLI's --record flag takes the event to record from, not a boolean.
+  if (record) args.push("--record", "record-from-answer");
   if (webhookUrl) args.push("--webhook-url", webhookUrl);
   if (audioUrl) args.push("--audio-url", audioUrl);
   if (timeoutSecs) args.push("--timeout-secs", timeoutSecs);
@@ -134,9 +131,7 @@ export async function callDialCommand(flags: Record<string, string | boolean>): 
         "To": to,
         "Connection ID": connectionId,
       };
-      if (privacy === "id") details["Privacy"] = "number masking (caller ID hidden)";
-      if (fromDisplayName) details["Caller ID Name"] = fromDisplayName;
-      if (answeringMachineDetection) details["AMD"] = "enabled";
+      if (answeringMachineDetection) details["AMD"] = answeringMachineDetection;
       if (deepfakeDetection) details["Deepfake Detection"] = "enabled";
       if (record) details["Recording"] = "enabled";
       if (transcription) details["Transcription"] = "enabled";

--- a/cli/src/commands/call-dial.ts
+++ b/cli/src/commands/call-dial.ts
@@ -90,14 +90,18 @@ export async function callDialCommand(flags: Record<string, string | boolean>): 
   if (webhookUrl) args.push("--webhook-url", webhookUrl);
   if (audioUrl) args.push("--audio-url", audioUrl);
   if (timeoutSecs) args.push("--timeout-secs", timeoutSecs);
-  if (privacy) args.push("--privacy", privacy);
+  // Note: --privacy (number masking) is a Telnyx API feature but the
+  // generated Go CLI does not expose it as a flag, so we validate it
+  // for documentation but do not forward it to the CLI.
+  if (privacy) {/* validated but not forwarded */}
   if (fromDisplayName) args.push("--from-display-name", fromDisplayName);
   if (timeLimitSecs) args.push("--time-limit-secs", timeLimitSecs);
   if (transcription) args.push("--transcription");
   if (mediaEncryption) args.push("--media-encryption", mediaEncryption);
   if (clientState) args.push("--client-state", clientState);
   if (commandId) args.push("--command-id", commandId);
-  if (webhookUrlMethod) args.push("--webhook-url-method", webhookUrlMethod);
+  // Forward the normalized uppercase value so the API receives POST/GET, not post/get.
+  if (webhookUrlMethod) args.push("--webhook-url-method", webhookUrlMethod.toUpperCase());
   if (webhookUrls) args.push("--webhook-urls", webhookUrls);
 
   try {

--- a/cli/src/commands/call-dial.ts
+++ b/cli/src/commands/call-dial.ts
@@ -18,8 +18,8 @@ interface CallDialResult {
 /** E.164: a leading '+' then 1-15 digits, country code must not start with 0. */
 const E164_RE = /^\+[1-9]\d{1,14}$/;
 
-/** Valid HTTP methods for --webhook-url-method. */
-const HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"] as const;
+/** Valid HTTP methods for --webhook-url-method (Voice API only accepts GET/POST). */
+const HTTP_METHODS = ["GET", "POST"] as const;
 
 export async function callDialCommand(flags: Record<string, string | boolean>): Promise<void> {
   const jsonOutput = flags.json === true;

--- a/cli/src/commands/call-dial.ts
+++ b/cli/src/commands/call-dial.ts
@@ -18,8 +18,11 @@ interface CallDialResult {
 /** E.164: a leading '+' then 1-15 digits, country code must not start with 0. */
 const E164_RE = /^\+[1-9]\d{1,14}$/;
 
-/** Valid answering_machine_detection modes accepted by the Dial API. */
+/** Valid AMD modes (Go CLI accepts these as the --answering-machine-detection value). */
 const AMD_MODES = ["premium", "detect", "detect_beep", "detect_words", "greeting_end", "disabled"] as const;
+
+/** Valid HTTP methods for --webhook-url-method (Voice API only accepts GET/POST). */
+const HTTP_METHODS = ["GET", "POST"] as const;
 
 export async function callDialCommand(flags: Record<string, string | boolean>): Promise<void> {
   const jsonOutput = flags.json === true;
@@ -70,6 +73,19 @@ export async function callDialCommand(flags: Record<string, string | boolean>): 
     printError(`Invalid --timeout-secs: ${timeoutSecs}. Must be a positive integer`);
     process.exit(1);
   }
+  if (privacy !== undefined && !["id", "none"].includes(privacy)) {
+    printError(`Invalid --privacy: ${privacy}. Must be 'id' (number masking) or 'none'`);
+    process.exit(1);
+  }
+  if (timeLimitSecs !== undefined && (!/^\d+$/.test(timeLimitSecs) || Number(timeLimitSecs) <= 0)) {
+    printError(`Invalid --time-limit-secs: ${timeLimitSecs}. Must be a positive integer`);
+    process.exit(1);
+  }
+  if (webhookUrlMethod !== undefined && !HTTP_METHODS.includes(webhookUrlMethod.toUpperCase() as (typeof HTTP_METHODS)[number])) {
+    printError(`Invalid --webhook-url-method: ${webhookUrlMethod}. Must be one of ${HTTP_METHODS.join(", ")}`);
+    process.exit(1);
+  }
+
   if (answeringMachineDetection !== undefined && !AMD_MODES.includes(answeringMachineDetection as (typeof AMD_MODES)[number])) {
     printError(`Invalid --answering-machine-detection mode: ${answeringMachineDetection}. Must be one of: ${AMD_MODES.join(", ")}`);
     process.exit(1);
@@ -81,19 +97,15 @@ export async function callDialCommand(flags: Record<string, string | boolean>): 
     "--from", from,
     "--to", to,
   ];
-  // The Go CLI's --answering-machine-detection flag takes a mode value (default "disabled").
   if (answeringMachineDetection) args.push("--answering-machine-detection", answeringMachineDetection);
-  // deepfake_detection is an object in the Dial API; the Go CLI exposes it via inner flags.
   if (deepfakeDetection) args.push("--deepfake-detection.enabled");
-  // The Go CLI's --record flag takes the event to record from, not a boolean.
+  // --record takes the event to record from (default: record-from-answer).
   if (record) args.push("--record", "record-from-answer");
   if (webhookUrl) args.push("--webhook-url", webhookUrl);
   if (audioUrl) args.push("--audio-url", audioUrl);
   if (timeoutSecs) args.push("--timeout-secs", timeoutSecs);
-  // Note: --privacy (number masking) is a Telnyx API feature but the
-  // generated Go CLI does not expose it as a flag, so we validate it
-  // for documentation but do not forward it to the CLI.
-  if (privacy) {/* validated but not forwarded */}
+  // --privacy is supported by the v0.21 Go CLI (BodyPath: "privacy").
+  if (privacy) args.push("--privacy", privacy);
   if (fromDisplayName) args.push("--from-display-name", fromDisplayName);
   if (timeLimitSecs) args.push("--time-limit-secs", timeLimitSecs);
   if (transcription) args.push("--transcription");
@@ -135,6 +147,8 @@ export async function callDialCommand(flags: Record<string, string | boolean>): 
         "To": to,
         "Connection ID": connectionId,
       };
+      if (privacy === "id") details["Privacy"] = "number masking (caller ID hidden)";
+      if (fromDisplayName) details["Caller ID Name"] = fromDisplayName;
       if (answeringMachineDetection) details["AMD"] = answeringMachineDetection;
       if (deepfakeDetection) details["Deepfake Detection"] = "enabled";
       if (record) details["Recording"] = "enabled";

--- a/cli/src/commands/call-status.ts
+++ b/cli/src/commands/call-status.ts
@@ -1,0 +1,55 @@
+/**
+ * telnyx-agent call-status — Get the status of a call via Telnyx Call Control.
+ *
+ * Wraps the Go CLI's `calls retrieve-status` subcommand.
+ */
+
+import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
+import { printSuccess, printError, outputJson } from "../utils/output.ts";
+
+export async function callStatusCommand(flags: Record<string, string | boolean>): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const callControlId = flags["call-control-id"] as string | undefined;
+
+  if (!callControlId) {
+    printError("--call-control-id is required");
+    process.exit(1);
+  }
+
+  try {
+    if (!jsonOutput) console.log(`\n📞 Retrieving call status for ${callControlId}...`);
+
+    const res = await telnyxCli(["calls", "retrieve-status", "--call-control-id", callControlId]);
+    const data = (res?.data ?? res ?? {}) as Record<string, unknown>;
+    const ccId = String(data.call_control_id ?? callControlId);
+    const callStatus = data.call_status;
+    const isAlive = data.is_alive === true;
+
+    if (jsonOutput) {
+      outputJson({
+        call_control_id: ccId,
+        ...data,
+      });
+    } else {
+      printSuccess("Call status retrieved", {
+        "Call Control ID": ccId,
+        "Call Status": String(callStatus ?? "unknown"),
+        "Is Alive": isAlive ? "yes" : "no",
+      });
+    }
+  } catch (err) {
+    const msg = errorMsg(err);
+    if (jsonOutput) {
+      outputJson({ error: msg });
+    } else {
+      printError(msg);
+    }
+    process.exit(1);
+  }
+}
+
+function errorMsg(err: unknown): string {
+  if (err instanceof TelnyxCLIError) return err.stderr || err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/cli/src/commands/capabilities.ts
+++ b/cli/src/commands/capabilities.ts
@@ -15,7 +15,7 @@ const CAPABILITIES: Record<string, Capability[]> = {
     { name: "SMS / MMS", description: "Send, schedule, and manage text and multimedia messages", actions: ["send_sms", "send_mms", "send_group_mms", "schedule_sms", "check_sms_status", "cancel_scheduled_sms", "list_messaging_profiles", "create_messaging_profile"] },
   ],
   "📞 Voice": [
-    { name: "Call Control", description: "Make and manage voice calls via SIP connections", actions: ["make_call", "list_connections", "answer_call", "hangup_call", "transfer_call", "send_dtmf", "start_recording", "stop_recording", "start_noise_suppression", "stop_noise_suppression", "speak_tts", "bridge_calls", "refer_call", "reject_call", "get_call_status", "answering_machine_detection", "deepfake_detection"] },
+    { name: "Call Control", description: "Make and manage voice calls via SIP connections", actions: ["make_call", "list_connections", "answer_call", "hangup_call", "transfer_call", "send_dtmf", "start_recording", "stop_recording", "start_noise_suppression", "stop_noise_suppression", "speak_tts", "bridge_calls", "refer_call", "reject_call", "get_call_status", "answering_machine_detection", "deepfake_detection", "number_masking", "from_display_name", "time_limit", "media_encryption", "transcription", "gather", "stop_gather", "start_playback", "stop_playback", "start_transcription", "stop_transcription", "pause_recording", "resume_recording", "start_forking", "stop_forking", "start_siprec", "stop_siprec", "start_streaming", "stop_streaming", "enqueue", "leave_queue", "send_sip_info", "update_client_state"] },
   ],
   "🔢 Numbers": [
     { name: "Phone Numbers", description: "Search, buy, and manage phone numbers", actions: ["list_phone_numbers", "search_phone_numbers", "buy_phone_number"] },
@@ -91,7 +91,7 @@ const COMPOSITE_COMMANDS = [
   { name: "telnyx-agent status", description: "Account health overview — balance, numbers, profiles, connections" },
   { name: "telnyx-agent capabilities", description: "This command — lists all available API capabilities" },
   { name: "telnyx-agent call-dial", description: "Make an outbound call via Call Control (AMD, deepfake detection, recording optional)" },
-  { name: "telnyx-agent call-control", description: "Call Control actions: answer, hangup, transfer, DTMF, recording, noise suppression, speak (TTS), bridge, refer, reject" },
+  { name: "telnyx-agent call-control", description: "Call Control actions: answer, hangup, transfer, DTMF, recording, noise suppression, speak (TTS), bridge, refer, reject, gather, playback, transcription, forking, siprec, streaming, enqueue, send-sip-info, update-client-state" },
   { name: "telnyx-agent call-status", description: "Get the status of a call by call-control-id" },
 ];
 

--- a/cli/src/commands/capabilities.ts
+++ b/cli/src/commands/capabilities.ts
@@ -15,7 +15,7 @@ const CAPABILITIES: Record<string, Capability[]> = {
     { name: "SMS / MMS", description: "Send, schedule, and manage text and multimedia messages", actions: ["send_sms", "send_mms", "send_group_mms", "schedule_sms", "check_sms_status", "cancel_scheduled_sms", "list_messaging_profiles", "create_messaging_profile"] },
   ],
   "📞 Voice": [
-    { name: "Call Control", description: "Make and manage voice calls via SIP connections", actions: ["make_call", "list_connections"] },
+    { name: "Call Control", description: "Make and manage voice calls via SIP connections", actions: ["make_call", "list_connections", "answer_call", "hangup_call", "transfer_call", "send_dtmf", "start_recording", "stop_recording", "start_noise_suppression", "stop_noise_suppression", "speak_tts", "bridge_calls", "refer_call", "reject_call", "get_call_status", "answering_machine_detection", "deepfake_detection"] },
   ],
   "🔢 Numbers": [
     { name: "Phone Numbers", description: "Search, buy, and manage phone numbers", actions: ["list_phone_numbers", "search_phone_numbers", "buy_phone_number"] },
@@ -90,6 +90,9 @@ const COMPOSITE_COMMANDS = [
   { name: "telnyx-agent setup-whatsapp", description: "Zero to WhatsApp: lists WABA, buys number, initializes & verifies, sets profile" },
   { name: "telnyx-agent status", description: "Account health overview — balance, numbers, profiles, connections" },
   { name: "telnyx-agent capabilities", description: "This command — lists all available API capabilities" },
+  { name: "telnyx-agent call-dial", description: "Make an outbound call via Call Control (AMD, deepfake detection, recording optional)" },
+  { name: "telnyx-agent call-control", description: "Call Control actions: answer, hangup, transfer, DTMF, recording, noise suppression, speak (TTS), bridge, refer, reject" },
+  { name: "telnyx-agent call-status", description: "Get the status of a call by call-control-id" },
 ];
 
 export async function capabilitiesCommand(flags: Record<string, string | boolean>): Promise<void> {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -177,12 +177,13 @@ Voice Call Flags:
   --time-limit-secs              Max call duration in seconds (call-dial)
   --transcription                Enable real-time transcription on dial (call-dial)
   --media-encryption             Media encryption mode (call-dial)
-  --client-state                 Opaque client-state string (call-dial; call-control gather/update-client-state, required)
-  --command-id                   Idempotency/command UUID (call-dial; call-control gather, required)
+  --client-state                 Opaque client-state string (call-dial; call-control update-client-state, required; call-control gather, optional)
+  --command-id                   Idempotency/command UUID (call-dial; call-control gather, optional)
   --webhook-url-method           HTTP method for --webhook-url (call-dial: GET|POST|PUT|PATCH|DELETE)
   --webhook-urls                 Comma-separated additional webhook URLs (call-dial)
   --queue-name                   Queue to place the call into (call-control enqueue, required)
-  --content                      SIP INFO body content (call-control send-sip-info, required)
+  --body                         SIP INFO body content (call-control send-sip-info, required)
+  --content-type                 SIP INFO Content-Type header (call-control send-sip-info, required, e.g. application/dtmf-relay)
 
 Environment:
   TELNYX_API_KEY    API key (or configure ~/.config/telnyx/config.json)
@@ -241,7 +242,7 @@ Examples:
   telnyx-agent call-control --action start-streaming --call-control-id <id>
   telnyx-agent call-control --action enqueue --call-control-id <id> --queue-name support
   telnyx-agent call-control --action leave-queue --call-control-id <id>
-  telnyx-agent call-control --action send-sip-info --call-control-id <id> --content "hello"
+  telnyx-agent call-control --action send-sip-info --call-control-id <id> --body "hello" --content-type application/dtmf-relay
   telnyx-agent call-control --action update-client-state --call-control-id <id> --client-state state-2
   telnyx-agent call-status --call-control-id <id> --json
 `;

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -166,7 +166,10 @@ Voice Call Flags:
   --sip-address      SIP address to refer to (call-control refer, e.g. sip:user@example.com)
   --channels         Recording channels: single|dual (call-control start-recording)
   --format           Recording format: mp3|wav (call-control start-recording)
-  --answering-machine-detection  Enable answering machine detection (call-dial)
+  --cause            Rejection cause: CALL_REJECTED|USER_BUSY (call-control reject, default: CALL_REJECTED)
+  --answering-machine-detection [mode]  Enable answering machine detection (call-dial)
+                    Valid: premium, detect, detect_beep, detect_words, greeting_end, disabled
+                    (bare flag defaults to detect)
   --deepfake-detection           Enable deepfake detection (call-dial, call-control answer)
   --record                       Record the call (call-dial, call-control answer)
   --webhook-url                  Webhook URL override (call-dial, call-control answer)
@@ -244,6 +247,7 @@ Examples:
   telnyx-agent call-control --action leave-queue --call-control-id <id>
   telnyx-agent call-control --action send-sip-info --call-control-id <id> --body "hello" --content-type application/dtmf-relay
   telnyx-agent call-control --action update-client-state --call-control-id <id> --client-state state-2
+  telnyx-agent call-control --action reject --call-control-id <id> --cause USER_BUSY
   telnyx-agent call-status --call-control-id <id> --json
 `;
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -154,7 +154,11 @@ Voice Call Flags:
   --call-control-id Call Control ID of the call (call-control, call-status, required)
   --action           Call Control action (call-control, required)
                     Valid: answer, hangup, transfer, dtmf, start-recording, stop-recording,
-                    start-noise-suppression, stop-noise-suppression, speak, bridge, refer, reject
+                    start-noise-suppression, stop-noise-suppression, speak, bridge, refer, reject,
+                    gather, stop-gather, start-playback, stop-playback, start-transcription,
+                    stop-transcription, pause-recording, resume-recording, start-forking,
+                    stop-forking, start-siprec, stop-siprec, start-streaming, stop-streaming,
+                    enqueue, leave-queue, send-sip-info, update-client-state
   --digits           DTMF digits to send (call-control dtmf)
   --payload          Text to synthesize and speak (call-control speak)
   --voice            TTS voice to use (call-control speak, default: female)
@@ -166,8 +170,19 @@ Voice Call Flags:
   --deepfake-detection           Enable deepfake detection (call-dial, call-control answer)
   --record                       Record the call (call-dial, call-control answer)
   --webhook-url                  Webhook URL override (call-dial, call-control answer)
-  --audio-url                    Audio URL to play on answer (call-dial)
+  --audio-url                    Audio URL to play on answer (call-dial); audio to play (call-control start-playback, required)
   --timeout-secs                 Dial timeout in seconds (call-dial)
+  --privacy                      Number masking: 'id' hides caller ID, 'none' is normal (call-dial, default: none)
+  --from-display-name            Caller ID display name (call-dial)
+  --time-limit-secs              Max call duration in seconds (call-dial)
+  --transcription                Enable real-time transcription on dial (call-dial)
+  --media-encryption             Media encryption mode (call-dial)
+  --client-state                 Opaque client-state string (call-dial; call-control gather/update-client-state, required)
+  --command-id                   Idempotency/command UUID (call-dial; call-control gather, required)
+  --webhook-url-method           HTTP method for --webhook-url (call-dial: GET|POST|PUT|PATCH|DELETE)
+  --webhook-urls                 Comma-separated additional webhook URLs (call-dial)
+  --queue-name                   Queue to place the call into (call-control enqueue, required)
+  --content                      SIP INFO body content (call-control send-sip-info, required)
 
 Environment:
   TELNYX_API_KEY    API key (or configure ~/.config/telnyx/config.json)
@@ -211,6 +226,23 @@ Examples:
   telnyx-agent call-control --action speak --call-control-id <id> --payload "Hello there" --voice female
   telnyx-agent call-control --action start-recording --call-control-id <id> --channels dual --format mp3
   telnyx-agent call-control --action bridge --call-control-id <id> --call-control-id-2 <id2>
+  telnyx-agent call-dial --connection-id <id> --from +131****0000 --to +131****1234 --privacy id
+  telnyx-agent call-dial --connection-id <id> --from +131****0000 --to +131****1234 --transcription --time-limit-secs 600
+  telnyx-agent call-control --action start-playback --call-control-id <id> --audio-url https://example.com/hello.wav
+  telnyx-agent call-control --action stop-playback --call-control-id <id>
+  telnyx-agent call-control --action gather --call-control-id <id> --client-state state-1 --command-id cmd-1
+  telnyx-agent call-control --action stop-gather --call-control-id <id>
+  telnyx-agent call-control --action start-transcription --call-control-id <id>
+  telnyx-agent call-control --action stop-transcription --call-control-id <id>
+  telnyx-agent call-control --action pause-recording --call-control-id <id>
+  telnyx-agent call-control --action resume-recording --call-control-id <id>
+  telnyx-agent call-control --action start-forking --call-control-id <id>
+  telnyx-agent call-control --action start-siprec --call-control-id <id>
+  telnyx-agent call-control --action start-streaming --call-control-id <id>
+  telnyx-agent call-control --action enqueue --call-control-id <id> --queue-name support
+  telnyx-agent call-control --action leave-queue --call-control-id <id>
+  telnyx-agent call-control --action send-sip-info --call-control-id <id> --content "hello"
+  telnyx-agent call-control --action update-client-state --call-control-id <id> --client-state state-2
   telnyx-agent call-status --call-control-id <id> --json
 `;
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -25,6 +25,9 @@ import { sendSmsCommand } from "./commands/send-sms.ts";
 import { sendGroupMmsCommand } from "./commands/send-group-mms.ts";
 import { scheduleSmsCommand } from "./commands/schedule-sms.ts";
 import { smsStatusCommand } from "./commands/sms-status.ts";
+import { callDialCommand } from "./commands/call-dial.ts";
+import { callControlCommand } from "./commands/call-control.ts";
+import { callStatusCommand } from "./commands/call-status.ts";
 import { parseFlags } from "./utils/output.ts";
 
 const HELP = `
@@ -57,6 +60,9 @@ Commands:
   send-group-mms    Send a group MMS to multiple recipients (--to comma-separated)
   schedule-sms      Schedule an SMS for future delivery (--send-at ISO 8601)
   sms-status        Check SMS delivery status, or cancel a scheduled message (--cancel)
+  call-dial         Make an outbound call via Call Control
+  call-control      Call Control actions (answer, hangup, transfer, dtmf, record, speak, ...)
+  call-status       Get the status of a call by call-control-id
 
 Global Flags:
   --json            Output structured JSON instead of human-readable text
@@ -141,6 +147,27 @@ WhatsApp Flags:
   --language        Template language, default en_US (whatsapp-templates, create)
   --component       Template components as a JSON array string (whatsapp-templates, create)
   --status          Filter templates by status: APPROVED|PENDING|REJECTED (whatsapp-templates, list)
+Voice Call Flags:
+  --connection-id   Call Control connection ID (call-dial, required)
+  --from             E.164 number to call from (call-dial, required)
+  --to               E.164 destination (call-dial, call-control transfer)
+  --call-control-id Call Control ID of the call (call-control, call-status, required)
+  --action           Call Control action (call-control, required)
+                    Valid: answer, hangup, transfer, dtmf, start-recording, stop-recording,
+                    start-noise-suppression, stop-noise-suppression, speak, bridge, refer, reject
+  --digits           DTMF digits to send (call-control dtmf)
+  --payload          Text to synthesize and speak (call-control speak)
+  --voice            TTS voice to use (call-control speak, default: female)
+  --call-control-id-2 Second call-control-id to bridge with (call-control bridge)
+  --sip-address      SIP address to refer to (call-control refer, e.g. sip:user@example.com)
+  --channels         Recording channels: single|dual (call-control start-recording)
+  --format           Recording format: mp3|wav (call-control start-recording)
+  --answering-machine-detection  Enable answering machine detection (call-dial)
+  --deepfake-detection           Enable deepfake detection (call-dial, call-control answer)
+  --record                       Record the call (call-dial, call-control answer)
+  --webhook-url                  Webhook URL override (call-dial, call-control answer)
+  --audio-url                    Audio URL to play on answer (call-dial)
+  --timeout-secs                 Dial timeout in seconds (call-dial)
 
 Environment:
   TELNYX_API_KEY    API key (or configure ~/.config/telnyx/config.json)
@@ -176,6 +203,15 @@ Examples:
   telnyx-agent schedule-sms --from +131****0000 --to +131****0001 --text "Later" --send-at 2024-12-31T00:00:00Z
   telnyx-agent sms-status --id 3fa85f64-5717-4562-b3fc-2c963f66afa6
   telnyx-agent sms-status --id 3fa85f64-5717-4562-b3fc-2c963f66afa6 --cancel
+  telnyx-agent call-dial --connection-id <id> --from +131****0000 --to +131****1234
+  telnyx-agent call-dial --connection-id <id> --from +131****0000 --to +131****1234 --answering-machine-detection --json
+  telnyx-agent call-control --action hangup --call-control-id <id>
+  telnyx-agent call-control --action transfer --call-control-id <id> --to +131****9999
+  telnyx-agent call-control --action dtmf --call-control-id <id> --digits 1234
+  telnyx-agent call-control --action speak --call-control-id <id> --payload "Hello there" --voice female
+  telnyx-agent call-control --action start-recording --call-control-id <id> --channels dual --format mp3
+  telnyx-agent call-control --action bridge --call-control-id <id> --call-control-id-2 <id2>
+  telnyx-agent call-status --call-control-id <id> --json
 `;
 
 const COMMANDS: Record<string, (flags: Record<string, string | boolean>) => Promise<void>> = {
@@ -202,6 +238,9 @@ const COMMANDS: Record<string, (flags: Record<string, string | boolean>) => Prom
   "send-group-mms": sendGroupMmsCommand,
   "schedule-sms": scheduleSmsCommand,
   "sms-status": smsStatusCommand,
+  "call-dial": callDialCommand,
+  "call-control": callControlCommand,
+  "call-status": callStatusCommand,
 };
 
 export async function run(argv: string[]): Promise<void> {

--- a/cli/tests/voice.test.ts
+++ b/cli/tests/voice.test.ts
@@ -102,7 +102,7 @@ describe("Voice API action commands", () => {
     assert.ok(!dialCall!.includes("--deepfake-detection"));
   });
 
-  it("call-dial forwards --answering-machine-detection and --deepfake-detection flags", () => {
+  it("call-dial forwards AMD mode, deepfake and record flags in Go CLI syntax", () => {
     const fake = setupFakeTelnyx();
     run(
       [
@@ -112,6 +112,7 @@ describe("Voice API action commands", () => {
         "--to", "+13125551234",
         "--answering-machine-detection",
         "--deepfake-detection",
+        "--record",
         "--json",
       ],
       fake.env,
@@ -120,8 +121,49 @@ describe("Voice API action commands", () => {
     const calls = readLoggedArgs(fake.logPath);
     const dialCall = calls.find((a) => a.slice(0, 2).join(" ") === "calls dial");
     assert.ok(dialCall, "should invoke `calls dial`");
-    assert.ok(dialCall!.includes("--answering-machine-detection"), "must include --answering-machine-detection");
-    assert.ok(dialCall!.includes("--deepfake-detection"), "must include --deepfake-detection");
+    // Bare --answering-machine-detection defaults to the "detect" mode value.
+    assertFlagValue(dialCall!, "--answering-machine-detection", "detect");
+    // deepfake_detection is an object; the Go CLI takes the inner --deepfake-detection.enabled flag.
+    assert.ok(dialCall!.includes("--deepfake-detection.enabled"), "must include --deepfake-detection.enabled");
+    // --record takes the event to record from, not a boolean.
+    assertFlagValue(dialCall!, "--record", "record-from-answer");
+  });
+
+  it("call-dial forwards an explicit --answering-machine-detection mode", () => {
+    const fake = setupFakeTelnyx();
+    run(
+      [
+        "call-dial",
+        "--connection-id", "conn-1",
+        "--from", "+13125550000",
+        "--to", "+13125551234",
+        "--answering-machine-detection", "premium",
+        "--json",
+      ],
+      fake.env,
+    );
+
+    const calls = readLoggedArgs(fake.logPath);
+    const dialCall = calls.find((a) => a.slice(0, 2).join(" ") === "calls dial");
+    assert.ok(dialCall, "should invoke `calls dial`");
+    assertFlagValue(dialCall!, "--answering-machine-detection", "premium");
+  });
+
+  it("call-dial rejects an invalid --answering-machine-detection mode", () => {
+    const fake = setupFakeTelnyx();
+    assert.throws(() =>
+      run(
+        [
+          "call-dial",
+          "--connection-id", "conn-1",
+          "--from", "+13125550000",
+          "--to", "+13125551234",
+          "--answering-machine-detection", "bogus",
+          "--json",
+        ],
+        fake.env,
+      ),
+    );
   });
 
   it("call-control --action hangup calls `calls:actions hangup`", () => {
@@ -215,6 +257,52 @@ describe("Voice API action commands", () => {
     assert.ok(bridgeCall, "should invoke `calls:actions bridge`");
     assertFlagValue(bridgeCall!, "--call-control-id-to-bridge", "call-1");
     assertFlagValue(bridgeCall!, "--call-control-id-to-bridge-with", "call-2");
+  });
+
+  it("call-control --action reject forwards --cause (default CALL_REJECTED)", () => {
+    const fake = setupFakeTelnyx();
+    run(["call-control", "--action", "reject", "--call-control-id", "call-1", "--json"], fake.env);
+
+    const calls = readLoggedArgs(fake.logPath);
+    const rejectCall = calls.find((a) => a.slice(0, 2).join(" ") === "calls:actions reject");
+    assert.ok(rejectCall, "should invoke `calls:actions reject`");
+    assertFlagValue(rejectCall!, "--call-control-id", "call-1");
+    // The Reject API requires a cause; default to CALL_REJECTED.
+    assertFlagValue(rejectCall!, "--cause", "CALL_REJECTED");
+  });
+
+  it("call-control --action reject forwards an explicit --cause and rejects invalid ones", () => {
+    const fake = setupFakeTelnyx();
+    run(
+      ["call-control", "--action", "reject", "--call-control-id", "call-1", "--cause", "USER_BUSY", "--json"],
+      fake.env,
+    );
+
+    const calls = readLoggedArgs(fake.logPath);
+    const rejectCall = calls.find((a) => a.slice(0, 2).join(" ") === "calls:actions reject");
+    assert.ok(rejectCall);
+    assertFlagValue(rejectCall!, "--cause", "USER_BUSY");
+
+    assert.throws(() =>
+      run(
+        ["call-control", "--action", "reject", "--call-control-id", "call-1", "--cause", "NOT_A_CAUSE", "--json"],
+        fake.env,
+      ),
+    );
+  });
+
+  it("call-control --action answer forwards deepfake/record flags in Go CLI syntax", () => {
+    const fake = setupFakeTelnyx();
+    run(
+      ["call-control", "--action", "answer", "--call-control-id", "call-1", "--deepfake-detection", "--record", "--json"],
+      fake.env,
+    );
+
+    const calls = readLoggedArgs(fake.logPath);
+    const answerCall = calls.find((a) => a.slice(0, 2).join(" ") === "calls:actions answer");
+    assert.ok(answerCall, "should invoke `calls:actions answer`");
+    assert.ok(answerCall!.includes("--deepfake-detection.enabled"), "must include --deepfake-detection.enabled");
+    assertFlagValue(answerCall!, "--record", "record-from-answer");
   });
 
   it("call-status calls `calls retrieve-status`", () => {

--- a/cli/tests/voice.test.ts
+++ b/cli/tests/voice.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Tests for the Voice API action commands (call-dial, call-control, call-status).
+ *
+ * Uses a fake `telnyx` binary that logs every invocation to a file and returns
+ * canned JSON, so we can assert exactly which Go CLI flags the wrapper passes.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliRoot = join(__dirname, "..");
+const cliBin = join(cliRoot, "bin", "telnyx-agent.ts");
+
+function setupFakeTelnyx(): { logPath: string; env: NodeJS.ProcessEnv } {
+  const tempDir = mkdtempSync(join(tmpdir(), "telnyx-agent-voice-"));
+  const binDir = join(tempDir, "bin");
+  const logPath = join(tempDir, "args.jsonl");
+  mkdirSync(binDir, { recursive: true });
+
+  const fakeTelnyx = join(binDir, "telnyx");
+  writeFileSync(
+    fakeTelnyx,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.TELNYX_FAKE_ARGS_LOG, JSON.stringify(args) + "\\n");
+
+// Strip --format json for command matching (the wrapper always appends it).
+const command = args.filter((a) => a !== "--format" && a !== "json");
+
+if (command[0] === "calls" && command[1] === "dial") {
+  console.log(JSON.stringify({ data: { call_control_id: "call-dial-123", call_leg_id: "leg-1", call_session_id: "sess-1", is_alive: true } }));
+} else if (command[0] === "calls" && command[1] === "retrieve-status") {
+  console.log(JSON.stringify({ data: { call_control_id: "call-status-123", call_status: "active", is_alive: true } }));
+} else if (command[0] === "calls:actions") {
+  console.log(JSON.stringify({ data: { result: "ok", call_control_id: "call-control-123", command: command.slice(2).join(" ") } }));
+} else {
+  console.log(JSON.stringify({ data: {} }));
+}
+`,
+  );
+  chmodSync(fakeTelnyx, 0o755);
+
+  return {
+    logPath,
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH}`,
+      TELNYX_CLI_PATH: fakeTelnyx,
+      TELNYX_FAKE_ARGS_LOG: logPath,
+    },
+  };
+}
+
+function readLoggedArgs(logPath: string): string[][] {
+  return readFileSync(logPath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function run(args: string[], env?: NodeJS.ProcessEnv): string {
+  return execFileSync("npx", ["tsx", cliBin, ...args], {
+    cwd: cliRoot,
+    encoding: "utf8",
+    env: env ?? { ...process.env },
+    timeout: 30000,
+  });
+}
+
+function assertFlagValue(args: string[], flag: string, value: string): void {
+  const index = args.indexOf(flag);
+  assert.notEqual(index, -1, `expected ${flag} in ${args.join(" ")}`);
+  assert.equal(args[index + 1], value, `expected ${flag} ${value} in ${args.join(" ")}`);
+}
+
+describe("Voice API action commands", () => {
+  it("call-dial passes the correct flags to `calls dial`", () => {
+    const fake = setupFakeTelnyx();
+    const output = run(
+      ["call-dial", "--connection-id", "conn-1", "--from", "+13125550000", "--to", "+13125551234", "--json"],
+      fake.env,
+    );
+
+    const data = JSON.parse(output);
+    assert.equal(data.call_control_id, "call-dial-123");
+
+    const calls = readLoggedArgs(fake.logPath);
+    const dialCall = calls.find((a) => a.slice(0, 2).join(" ") === "calls dial");
+    assert.ok(dialCall, "should invoke `calls dial`");
+    assertFlagValue(dialCall!, "--connection-id", "conn-1");
+    assertFlagValue(dialCall!, "--from", "+13125550000");
+    assertFlagValue(dialCall!, "--to", "+13125551234");
+    // Boolean/detection flags should NOT be present when not requested.
+    assert.ok(!dialCall!.includes("--answering-machine-detection"));
+    assert.ok(!dialCall!.includes("--deepfake-detection"));
+  });
+
+  it("call-dial forwards --answering-machine-detection and --deepfake-detection flags", () => {
+    const fake = setupFakeTelnyx();
+    run(
+      [
+        "call-dial",
+        "--connection-id", "conn-1",
+        "--from", "+13125550000",
+        "--to", "+13125551234",
+        "--answering-machine-detection",
+        "--deepfake-detection",
+        "--json",
+      ],
+      fake.env,
+    );
+
+    const calls = readLoggedArgs(fake.logPath);
+    const dialCall = calls.find((a) => a.slice(0, 2).join(" ") === "calls dial");
+    assert.ok(dialCall, "should invoke `calls dial`");
+    assert.ok(dialCall!.includes("--answering-machine-detection"), "must include --answering-machine-detection");
+    assert.ok(dialCall!.includes("--deepfake-detection"), "must include --deepfake-detection");
+  });
+
+  it("call-control --action hangup calls `calls:actions hangup`", () => {
+    const fake = setupFakeTelnyx();
+    const output = run(["call-control", "--action", "hangup", "--call-control-id", "call-1", "--json"], fake.env);
+
+    const data = JSON.parse(output);
+    assert.equal(data.action, "hangup");
+    assert.equal(data.call_control_id, "call-1");
+
+    const calls = readLoggedArgs(fake.logPath);
+    const hangupCall = calls.find((a) => a.slice(0, 2).join(" ") === "calls:actions hangup");
+    assert.ok(hangupCall, "should invoke `calls:actions hangup`");
+    assertFlagValue(hangupCall!, "--call-control-id", "call-1");
+  });
+
+  it("call-control --action transfer calls `calls:actions transfer` with --to", () => {
+    const fake = setupFakeTelnyx();
+    run(
+      ["call-control", "--action", "transfer", "--call-control-id", "call-1", "--to", "+13125559999", "--json"],
+      fake.env,
+    );
+
+    const calls = readLoggedArgs(fake.logPath);
+    const transferCall = calls.find((a) => a.slice(0, 2).join(" ") === "calls:actions transfer");
+    assert.ok(transferCall, "should invoke `calls:actions transfer`");
+    assertFlagValue(transferCall!, "--call-control-id", "call-1");
+    assertFlagValue(transferCall!, "--to", "+13125559999");
+  });
+
+  it("call-control --action dtmf calls `calls:actions send-dtmf` with --digits", () => {
+    const fake = setupFakeTelnyx();
+    run(["call-control", "--action", "dtmf", "--call-control-id", "call-1", "--digits", "1234", "--json"], fake.env);
+
+    const calls = readLoggedArgs(fake.logPath);
+    const dtmfCall = calls.find((a) => a.slice(0, 2).join(" ") === "calls:actions send-dtmf");
+    assert.ok(dtmfCall, "should invoke `calls:actions send-dtmf`");
+    assertFlagValue(dtmfCall!, "--call-control-id", "call-1");
+    assertFlagValue(dtmfCall!, "--digits", "1234");
+  });
+
+  it("call-control --action start-recording calls `calls:actions start-recording` with channels/format", () => {
+    const fake = setupFakeTelnyx();
+    run(
+      ["call-control", "--action", "start-recording", "--call-control-id", "call-1", "--channels", "dual", "--format", "mp3", "--json"],
+      fake.env,
+    );
+
+    const calls = readLoggedArgs(fake.logPath);
+    const recCall = calls.find((a) => a.slice(0, 2).join(" ") === "calls:actions start-recording");
+    assert.ok(recCall, "should invoke `calls:actions start-recording`");
+    assertFlagValue(recCall!, "--call-control-id", "call-1");
+    assertFlagValue(recCall!, "--channels", "dual");
+    assertFlagValue(recCall!, "--format", "mp3");
+  });
+
+  it("call-control --action speak calls `calls:actions speak` with --payload and --voice", () => {
+    const fake = setupFakeTelnyx();
+    run(
+      ["call-control", "--action", "speak", "--call-control-id", "call-1", "--payload", "Hello world", "--voice", "female", "--json"],
+      fake.env,
+    );
+
+    const calls = readLoggedArgs(fake.logPath);
+    const speakCall = calls.find((a) => a.slice(0, 2).join(" ") === "calls:actions speak");
+    assert.ok(speakCall, "should invoke `calls:actions speak`");
+    assertFlagValue(speakCall!, "--call-control-id", "call-1");
+    assertFlagValue(speakCall!, "--payload", "Hello world");
+    assertFlagValue(speakCall!, "--voice", "female");
+  });
+
+  it("call-control --action speak defaults --voice to female when omitted", () => {
+    const fake = setupFakeTelnyx();
+    run(["call-control", "--action", "speak", "--call-control-id", "call-1", "--payload", "Hi", "--json"], fake.env);
+
+    const calls = readLoggedArgs(fake.logPath);
+    const speakCall = calls.find((a) => a.slice(0, 2).join(" ") === "calls:actions speak");
+    assert.ok(speakCall);
+    assertFlagValue(speakCall!, "--voice", "female");
+  });
+
+  it("call-control --action bridge uses --call-control-id-to-bridge / -with flags", () => {
+    const fake = setupFakeTelnyx();
+    run(
+      ["call-control", "--action", "bridge", "--call-control-id", "call-1", "--call-control-id-2", "call-2", "--json"],
+      fake.env,
+    );
+
+    const calls = readLoggedArgs(fake.logPath);
+    const bridgeCall = calls.find((a) => a.slice(0, 2).join(" ") === "calls:actions bridge");
+    assert.ok(bridgeCall, "should invoke `calls:actions bridge`");
+    assertFlagValue(bridgeCall!, "--call-control-id-to-bridge", "call-1");
+    assertFlagValue(bridgeCall!, "--call-control-id-to-bridge-with", "call-2");
+  });
+
+  it("call-status calls `calls retrieve-status`", () => {
+    const fake = setupFakeTelnyx();
+    const output = run(["call-status", "--call-control-id", "call-1", "--json"], fake.env);
+
+    const data = JSON.parse(output);
+    assert.equal(data.call_status, "active");
+
+    const calls = readLoggedArgs(fake.logPath);
+    const statusCall = calls.find((a) => a.slice(0, 2).join(" ") === "calls retrieve-status");
+    assert.ok(statusCall, "should invoke `calls retrieve-status`");
+    assertFlagValue(statusCall!, "--call-control-id", "call-1");
+  });
+
+  it("help text includes the voice commands", () => {
+    const output = run(["help"]);
+    assert.ok(output.includes("call-dial"), "help should list call-dial");
+    assert.ok(output.includes("call-control"), "help should list call-control");
+    assert.ok(output.includes("call-status"), "help should list call-status");
+    assert.ok(output.includes("--answering-machine-detection"), "help should document AMD flag");
+  });
+
+  it("capabilities lists the voice actions and composite commands", () => {
+    const fake = setupFakeTelnyx();
+    const output = run(["capabilities", "--json"], fake.env);
+    const data = JSON.parse(output);
+
+    const voice = data.api_capabilities["📞 Voice"] as Array<{ name: string; actions: string[] }>;
+    assert.ok(voice, "Voice category should exist");
+    const actions = voice[0].actions;
+    for (const a of ["answer_call", "hangup_call", "transfer_call", "send_dtmf", "speak_tts", "bridge_calls", "get_call_status", "deepfake_detection"]) {
+      assert.ok(actions.includes(a), `Voice actions should include ${a}`);
+    }
+
+    const composite = data.composite_commands.map((c: any) => c.name);
+    assert.ok(composite.some((c: string) => c.includes("call-dial")));
+    assert.ok(composite.some((c: string) => c.includes("call-control")));
+    assert.ok(composite.some((c: string) => c.includes("call-status")));
+  });
+});

--- a/cli/tests/voice.test.ts
+++ b/cli/tests/voice.test.ts
@@ -346,7 +346,7 @@ describe("Voice API action commands", () => {
 
   // === Gap PR tests: number masking + advanced call-control actions ===
 
-  it("call-dial with --privacy id passes number masking flag to Go CLI", () => {
+  it("call-dial with --privacy id validates but does not forward to Go CLI", () => {
     const fake = setupFakeTelnyx();
     run(
       ["call-dial", "--connection-id", "conn-1", "--from", "+13125550000", "--to", "+13125551234", "--privacy", "id", "--json"],
@@ -356,7 +356,9 @@ describe("Voice API action commands", () => {
     const calls = readLoggedArgs(fake.logPath);
     const dialCall = calls.find((a) => a.slice(0, 2).join(" ") === "calls dial");
     assert.ok(dialCall, "should invoke `calls dial`");
-    assertFlagValue(dialCall!, "--privacy", "id");
+    // The Go CLI does not expose --privacy; we validate it for documentation
+    // but do not forward it, so it should NOT appear in the CLI args.
+    assert.equal(dialCall!.indexOf("--privacy"), -1, "must not forward --privacy to Go CLI");
   });
 
   it("call-dial with --from-display-name passes the flag through", () => {

--- a/cli/tests/voice.test.ts
+++ b/cli/tests/voice.test.ts
@@ -297,7 +297,7 @@ describe("Voice API action commands", () => {
     assert.ok(dialCall!.includes("--transcription"), "should include --transcription flag");
   });
 
-  it("call-control --action gather calls `calls:actions gather`", () => {
+  it("call-control --action gather calls `calls:actions gather` and forwards client-state/command-id", () => {
     const fake = setupFakeTelnyx();
     run(
       ["call-control", "--action", "gather", "--call-control-id", "call-1", "--client-state", "state-1", "--command-id", "cmd-1", "--json"],
@@ -308,6 +308,38 @@ describe("Voice API action commands", () => {
     const gatherCall = calls.find((a) => a.slice(0, 2).join(" ") === "calls:actions gather");
     assert.ok(gatherCall, "should invoke `calls:actions gather`");
     assertFlagValue(gatherCall!, "--call-control-id", "call-1");
+    assertFlagValue(gatherCall!, "--client-state", "state-1");
+    assertFlagValue(gatherCall!, "--command-id", "cmd-1");
+  });
+
+  it("call-control --action gather works without --client-state/--command-id (optional)", () => {
+    const fake = setupFakeTelnyx();
+    run(
+      ["call-control", "--action", "gather", "--call-control-id", "call-1", "--json"],
+      fake.env,
+    );
+
+    const calls = readLoggedArgs(fake.logPath);
+    const gatherCall = calls.find((a) => a.slice(0, 2).join(" ") === "calls:actions gather");
+    assert.ok(gatherCall, "should invoke `calls:actions gather`");
+    assertFlagValue(gatherCall!, "--call-control-id", "call-1");
+    assert.ok(!gatherCall!.includes("--client-state"), "must not include --client-state when omitted");
+    assert.ok(!gatherCall!.includes("--command-id"), "must not include --command-id when omitted");
+  });
+
+  it("call-control --action send-sip-info forwards --body and --content-type", () => {
+    const fake = setupFakeTelnyx();
+    run(
+      ["call-control", "--action", "send-sip-info", "--call-control-id", "call-1", "--body", "Signal=1234", "--content-type", "application/dtmf-relay", "--json"],
+      fake.env,
+    );
+
+    const calls = readLoggedArgs(fake.logPath);
+    const sipCall = calls.find((a) => a.slice(0, 2).join(" ") === "calls:actions send-sip-info");
+    assert.ok(sipCall, "should invoke `calls:actions send-sip-info`");
+    assertFlagValue(sipCall!, "--call-control-id", "call-1");
+    assertFlagValue(sipCall!, "--body", "Signal=1234");
+    assertFlagValue(sipCall!, "--content-type", "application/dtmf-relay");
   });
 
   it("call-control --action start-playback calls `calls:actions start-playback` with --audio-url", () => {

--- a/cli/tests/voice.test.ts
+++ b/cli/tests/voice.test.ts
@@ -255,4 +255,114 @@ describe("Voice API action commands", () => {
     assert.ok(composite.some((c: string) => c.includes("call-control")));
     assert.ok(composite.some((c: string) => c.includes("call-status")));
   });
+
+  // === Gap PR tests: number masking + advanced call-control actions ===
+
+  it("call-dial with --privacy id passes number masking flag to Go CLI", () => {
+    const fake = setupFakeTelnyx();
+    run(
+      ["call-dial", "--connection-id", "conn-1", "--from", "+13125550000", "--to", "+13125551234", "--privacy", "id", "--json"],
+      fake.env,
+    );
+
+    const calls = readLoggedArgs(fake.logPath);
+    const dialCall = calls.find((a) => a.slice(0, 2).join(" ") === "calls dial");
+    assert.ok(dialCall, "should invoke `calls dial`");
+    assertFlagValue(dialCall!, "--privacy", "id");
+  });
+
+  it("call-dial with --from-display-name passes the flag through", () => {
+    const fake = setupFakeTelnyx();
+    run(
+      ["call-dial", "--connection-id", "conn-1", "--from", "+13125550000", "--to", "+13125551234", "--from-display-name", "Acme Corp", "--json"],
+      fake.env,
+    );
+
+    const calls = readLoggedArgs(fake.logPath);
+    const dialCall = calls.find((a) => a.slice(0, 2).join(" ") === "calls dial");
+    assert.ok(dialCall);
+    assertFlagValue(dialCall!, "--from-display-name", "Acme Corp");
+  });
+
+  it("call-dial with --transcription flag passes through", () => {
+    const fake = setupFakeTelnyx();
+    run(
+      ["call-dial", "--connection-id", "conn-1", "--from", "+13125550000", "--to", "+13125551234", "--transcription", "--json"],
+      fake.env,
+    );
+
+    const calls = readLoggedArgs(fake.logPath);
+    const dialCall = calls.find((a) => a.slice(0, 2).join(" ") === "calls dial");
+    assert.ok(dialCall);
+    assert.ok(dialCall!.includes("--transcription"), "should include --transcription flag");
+  });
+
+  it("call-control --action gather calls `calls:actions gather`", () => {
+    const fake = setupFakeTelnyx();
+    run(
+      ["call-control", "--action", "gather", "--call-control-id", "call-1", "--client-state", "state-1", "--command-id", "cmd-1", "--json"],
+      fake.env,
+    );
+
+    const calls = readLoggedArgs(fake.logPath);
+    const gatherCall = calls.find((a) => a.slice(0, 2).join(" ") === "calls:actions gather");
+    assert.ok(gatherCall, "should invoke `calls:actions gather`");
+    assertFlagValue(gatherCall!, "--call-control-id", "call-1");
+  });
+
+  it("call-control --action start-playback calls `calls:actions start-playback` with --audio-url", () => {
+    const fake = setupFakeTelnyx();
+    run(
+      ["call-control", "--action", "start-playback", "--call-control-id", "call-1", "--audio-url", "https://example.com/hello.wav", "--json"],
+      fake.env,
+    );
+
+    const calls = readLoggedArgs(fake.logPath);
+    const playbackCall = calls.find((a) => a.slice(0, 2).join(" ") === "calls:actions start-playback");
+    assert.ok(playbackCall, "should invoke `calls:actions start-playback`");
+    assertFlagValue(playbackCall!, "--call-control-id", "call-1");
+    assertFlagValue(playbackCall!, "--audio-url", "https://example.com/hello.wav");
+  });
+
+  it("call-control --action stop-gather calls `calls:actions stop-gather`", () => {
+    const fake = setupFakeTelnyx();
+    run(
+      ["call-control", "--action", "stop-gather", "--call-control-id", "call-1", "--json"],
+      fake.env,
+    );
+
+    const calls = readLoggedArgs(fake.logPath);
+    const stopCall = calls.find((a) => a.slice(0, 2).join(" ") === "calls:actions stop-gather");
+    assert.ok(stopCall, "should invoke `calls:actions stop-gather`");
+  });
+
+  it("call-control --action pause-recording calls `calls:actions pause-recording`", () => {
+    const fake = setupFakeTelnyx();
+    run(
+      ["call-control", "--action", "pause-recording", "--call-control-id", "call-1", "--json"],
+      fake.env,
+    );
+
+    const calls = readLoggedArgs(fake.logPath);
+    const pauseCall = calls.find((a) => a.slice(0, 2).join(" ") === "calls:actions pause-recording");
+    assert.ok(pauseCall, "should invoke `calls:actions pause-recording`");
+  });
+
+  it("call-control --action start-transcription calls `calls:actions start-transcription`", () => {
+    const fake = setupFakeTelnyx();
+    run(
+      ["call-control", "--action", "start-transcription", "--call-control-id", "call-1", "--json"],
+      fake.env,
+    );
+
+    const calls = readLoggedArgs(fake.logPath);
+    const transCall = calls.find((a) => a.slice(0, 2).join(" ") === "calls:actions start-transcription");
+    assert.ok(transCall, "should invoke `calls:actions start-transcription`");
+  });
+
+  it("help text includes --privacy flag for number masking", () => {
+    const output = run(["help"]);
+    assert.ok(output.includes("--privacy"), "help should document --privacy flag");
+    assert.ok(output.includes("number masking") || output.includes("Number masking") || output.includes("caller ID"), "help should mention number masking");
+  });
 });

--- a/cli/tests/voice.test.ts
+++ b/cli/tests/voice.test.ts
@@ -346,7 +346,7 @@ describe("Voice API action commands", () => {
 
   // === Gap PR tests: number masking + advanced call-control actions ===
 
-  it("call-dial with --privacy id validates but does not forward to Go CLI", () => {
+  it("call-dial with --privacy id passes number masking flag to Go CLI", () => {
     const fake = setupFakeTelnyx();
     run(
       ["call-dial", "--connection-id", "conn-1", "--from", "+13125550000", "--to", "+13125551234", "--privacy", "id", "--json"],
@@ -356,9 +356,8 @@ describe("Voice API action commands", () => {
     const calls = readLoggedArgs(fake.logPath);
     const dialCall = calls.find((a) => a.slice(0, 2).join(" ") === "calls dial");
     assert.ok(dialCall, "should invoke `calls dial`");
-    // The Go CLI does not expose --privacy; we validate it for documentation
-    // but do not forward it, so it should NOT appear in the CLI args.
-    assert.equal(dialCall!.indexOf("--privacy"), -1, "must not forward --privacy to Go CLI");
+    // The v0.21 Go CLI exposes --privacy (BodyPath: "privacy").
+    assertFlagValue(dialCall!, "--privacy", "id");
   });
 
   it("call-dial with --from-display-name passes the flag through", () => {


### PR DESCRIPTION
## Summary\n\nAdds Voice API action commands to the agent CLI \u2014 previously only  (composite setup) existed with no way to make calls or control them.\n\n### New Commands\n\n**** \u2014 Make an outbound call:\n- Supports , , \n- Returns call-control-id for subsequent actions\n\n**** \u2014 Control an active call via  flag:\n-  \u2014 Answer an inbound call (supports , )\n-  \u2014 Hang up a call\n-  \u2014 Transfer a call to another number ()\n-  \u2014 Send DTMF tones ()\n-  /  \u2014 Record call audio\n-  /  \u2014 Noise suppression\n-  \u2014 Text-to-speech on a call (, )\n-  \u2014 Bridge two calls ()\n-  \u2014 SIP refer/transfer ()\n-  \u2014 Reject an inbound call\n\n**** \u2014 Get call status\n\n### Files Changed\n-  (new)\n-  (new)\n-  (new)\n-  \u2014 register 3 commands, help text, examples\n-  \u2014 update Voice capabilities\n-  \u2014 12 mock-binary tests (all passing)\n\n### Test Results\n