### PR TITLE
feat: Add speech-to-text (STT) commands to agent CLI

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "tsx bin/telnyx-agent.ts",
-    "test": "tsx --test tests/edge-handoff.test.ts tests/integration.test.ts tests/sms.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
+    "test": "tsx --test tests/edge-handoff.test.ts tests/integration.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
     "typecheck": "tsc --noEmit",
     "postinstall": "tsx scripts/postinstall.ts",
     "build": "npm run typecheck"

--- a/cli/scripts/postinstall.ts
+++ b/cli/scripts/postinstall.ts
@@ -17,6 +17,14 @@ const PLATFORM_MAP: Record<string, string> = {
   "win32-x64": `telnyx_${VERSION}_windows_amd64.zip`,
 };
 
+/** True when `found` (e.g. [0,21,0]) is >= `want`, comparing major.minor.patch. */
+function isAtLeast(found: number[], want: number[]): boolean {
+  for (let i = 0; i < 3; i++) {
+    if ((found[i] ?? 0) !== (want[i] ?? 0)) return (found[i] ?? 0) > (want[i] ?? 0);
+  }
+  return true;
+}
+
 async function main() {
   // Skip if telnyx is already on PATH AND at the required version.
   // An older CLI on PATH would leave WhatsApp and other commands broken,

--- a/cli/src/commands/capabilities.ts
+++ b/cli/src/commands/capabilities.ts
@@ -28,6 +28,7 @@ const CAPABILITIES: Record<string, Capability[]> = {
   "🔊 Text-to-Speech": [
     { name: "Speech Synthesis", description: "Generate audio from text via Telnyx and third-party TTS providers (telnyx, aws, azure, elevenlabs, minimax, resemble, rime, xai)", actions: ["generate_speech"] },
     { name: "Voice Catalog", description: "List available TTS voices, optionally filtered by provider (telnyx, aws, azure, elevenlabs, minimax, resemble, rime, xai)", actions: ["list_voices"] },
+  ],
   "🎤 Speech-to-Text": [
     { name: "Transcription", description: "Transcribe hosted audio files to text via the OpenAI-compatible transcription endpoint, with model and language options", actions: ["ai_audio_transcribe"] },
     { name: "Providers", description: "List available speech-to-text providers and service types", actions: ["list_stt_providers"] },

--- a/cli/src/commands/capabilities.ts
+++ b/cli/src/commands/capabilities.ts
@@ -28,6 +28,9 @@ const CAPABILITIES: Record<string, Capability[]> = {
   "🔊 Text-to-Speech": [
     { name: "Speech Synthesis", description: "Generate audio from text via Telnyx and third-party TTS providers (telnyx, aws, azure, elevenlabs, minimax, resemble, rime, xai)", actions: ["generate_speech"] },
     { name: "Voice Catalog", description: "List available TTS voices, optionally filtered by provider (telnyx, aws, azure, elevenlabs, minimax, resemble, rime, xai)", actions: ["list_voices"] },
+  "🎤 Speech-to-Text": [
+    { name: "Transcription", description: "Transcribe audio files to text via Telnyx and third-party STT engines, with language, model, and keyword biasing options", actions: ["retrieve_transcription"] },
+    { name: "Providers", description: "List available speech-to-text providers and service types", actions: ["list_stt_providers"] },
   ],
   "📠 Fax": [
     { name: "Fax", description: "Send faxes programmatically", actions: ["send_fax"] },
@@ -92,6 +95,8 @@ const COMPOSITE_COMMANDS = [
   { name: "telnyx-agent tts", description: "Generate speech from text (text-to-speech) across multiple providers, returning base64-encoded audio data" },
   { name: "telnyx-agent tts-voices", description: "List available TTS voices, optionally filtered by provider (telnyx, aws, azure, elevenlabs, minimax, resemble, rime, xai)" },
   { name: "telnyx-agent setup-whatsapp", description: "Zero to WhatsApp: lists WABA, buys number, initializes & verifies, sets profile" },
+  { name: "telnyx-agent stt", description: "Transcribe audio to text (speech-to-text) — accepts an audio URL and returns the transcript with optional language, model, and keyword biasing" },
+  { name: "telnyx-agent stt-providers", description: "List available speech-to-text providers, optionally filtered by provider name or service type" },
   { name: "telnyx-agent status", description: "Account health overview — balance, numbers, profiles, connections" },
   { name: "telnyx-agent capabilities", description: "This command — lists all available API capabilities" },
   { name: "telnyx-agent call-dial", description: "Make an outbound call via Call Control (AMD, deepfake detection, recording optional)" },

--- a/cli/src/commands/capabilities.ts
+++ b/cli/src/commands/capabilities.ts
@@ -29,7 +29,7 @@ const CAPABILITIES: Record<string, Capability[]> = {
     { name: "Speech Synthesis", description: "Generate audio from text via Telnyx and third-party TTS providers (telnyx, aws, azure, elevenlabs, minimax, resemble, rime, xai)", actions: ["generate_speech"] },
     { name: "Voice Catalog", description: "List available TTS voices, optionally filtered by provider (telnyx, aws, azure, elevenlabs, minimax, resemble, rime, xai)", actions: ["list_voices"] },
   "🎤 Speech-to-Text": [
-    { name: "Transcription", description: "Transcribe audio files to text via Telnyx and third-party STT engines, with language, model, and keyword biasing options", actions: ["retrieve_transcription"] },
+    { name: "Transcription", description: "Transcribe hosted audio files to text via the OpenAI-compatible transcription endpoint, with model and language options", actions: ["ai_audio_transcribe"] },
     { name: "Providers", description: "List available speech-to-text providers and service types", actions: ["list_stt_providers"] },
   ],
   "📠 Fax": [
@@ -96,6 +96,7 @@ const COMPOSITE_COMMANDS = [
   { name: "telnyx-agent tts-voices", description: "List available TTS voices, optionally filtered by provider (telnyx, aws, azure, elevenlabs, minimax, resemble, rime, xai)" },
   { name: "telnyx-agent setup-whatsapp", description: "Zero to WhatsApp: lists WABA, buys number, initializes & verifies, sets profile" },
   { name: "telnyx-agent stt", description: "Transcribe audio to text (speech-to-text) — accepts an audio URL and returns the transcript with optional language, model, and keyword biasing" },
+  { name: "telnyx-agent stt", description: "Transcribe audio to text (speech-to-text) — accepts a hosted audio file URL and returns the transcript with optional model and language selection" },
   { name: "telnyx-agent stt-providers", description: "List available speech-to-text providers, optionally filtered by provider name or service type" },
   { name: "telnyx-agent status", description: "Account health overview — balance, numbers, profiles, connections" },
   { name: "telnyx-agent capabilities", description: "This command — lists all available API capabilities" },

--- a/cli/src/commands/stt-providers.ts
+++ b/cli/src/commands/stt-providers.ts
@@ -1,0 +1,66 @@
+/**
+ * telnyx-agent stt-providers — List available speech-to-text providers.
+ *
+ * Shells out to the telnyx CLI's `speech-to-text list-providers` subcommand
+ * and surfaces the available STT providers (optionally filtered by provider
+ * name or service type) to the caller in either human-readable or JSON form.
+ */
+
+import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
+import { printSuccess, printError, outputJson } from "../utils/output.ts";
+
+interface SttProvider {
+  provider: string;
+  service_type?: string;
+  [key: string]: unknown;
+}
+
+export async function sttProvidersCommand(flags: Record<string, string | boolean>): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const provider = flags.provider as string | undefined;
+  const serviceType = flags["service-type"] as string | undefined;
+
+  try {
+    if (!jsonOutput) {
+      console.log("\n🎤 Listing speech-to-text providers...\n");
+    }
+
+    const args = ["speech-to-text", "list-providers"];
+    if (provider) args.push("--provider", provider);
+    if (serviceType) args.push("--service-type", serviceType);
+
+    const response = await telnyxCli(args);
+    const data = (response as Record<string, unknown> | undefined)?.data ?? response;
+    const providers: SttProvider[] = Array.isArray(data)
+      ? (data as SttProvider[])
+      : Array.isArray(response)
+        ? (response as SttProvider[])
+        : [];
+
+    if (jsonOutput) {
+      outputJson({ providers, count: providers.length });
+    } else {
+      const details: Record<string, string | number | boolean> = {
+        Count: providers.length,
+        Providers: providers.map((p) => p.provider).join(", ") || "(none)",
+      };
+      if (provider) details["Provider Filter"] = provider;
+      if (serviceType) details["Service Type Filter"] = serviceType;
+      printSuccess("Available speech-to-text providers", details);
+    }
+  } catch (err) {
+    const msg = errorMsg(err);
+    if (jsonOutput) {
+      outputJson({ error: msg });
+    } else {
+      printError(msg);
+    }
+    process.exit(1);
+  }
+}
+
+function errorMsg(err: unknown): string {
+  if (err instanceof TelnyxCLIError) return err.stderr || err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/cli/src/commands/stt.ts
+++ b/cli/src/commands/stt.ts
@@ -26,6 +26,10 @@ interface SttResult {
   model: string;
   transcription: string;
   language?: string;
+  response_format?: string;
+  /** Full API response when a non-default --response-format is requested —
+   * verbose_json carries timestamps/segments the flat fields drop. */
+  response?: unknown;
 }
 
 /**
@@ -72,11 +76,16 @@ export async function sttCommand(flags: Record<string, string | boolean>): Promi
     const response = await telnyxCli(args);
     const transcription = extractTranscription(response);
 
+    const verbose = responseFormat !== undefined && responseFormat !== "json";
     const result: SttResult = {
       audio_url: audioUrl,
       model,
       transcription,
       ...(language ? { language } : {}),
+      ...(responseFormat ? { response_format: responseFormat } : {}),
+      ...(verbose
+        ? { response: (response as Record<string, unknown> | undefined)?.data ?? response }
+        : {}),
     };
 
     if (jsonOutput) {

--- a/cli/src/commands/stt.ts
+++ b/cli/src/commands/stt.ts
@@ -1,36 +1,44 @@
 /**
  * telnyx-agent stt — Speech-to-text transcription.
  *
- * Shells out to the telnyx CLI's `speech-to-text retrieve-transcription`
- * subcommand and surfaces the resulting transcription text to the caller in
- * either human-readable or JSON form.
+ * Shells out to the telnyx CLI's `ai:audio transcribe` subcommand (the
+ * OpenAI-compatible transcription endpoint) and surfaces the resulting
+ * transcription text to the caller in either human-readable or JSON form.
  *
- * The retrieve-transcription endpoint accepts an audio URL and returns the
- * transcribed text along with metadata (language, engine, model, etc.).
+ * The transcribe endpoint accepts a hosted audio file URL (`--file-url`)
+ * and returns the transcribed text. Note: the Go CLI's separate
+ * `speech-to-text retrieve-transcription` command is a WebSocket streaming
+ * API (no audio-URL support), so URL-based transcription must go through
+ * `ai:audio transcribe`.
  */
 
 import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
 import { printSuccess, printError, outputJson } from "../utils/output.ts";
 
+/**
+ * Default transcription model. `ai:audio transcribe` requires --model;
+ * this mirrors the Go CLI's own default (lower latency, English-only).
+ */
+const DEFAULT_MODEL = "distil-whisper/distil-large-v2";
+
 interface SttResult {
   audio_url: string;
-  language: string;
+  model: string;
   transcription: string;
-  transcription_engine?: string;
-  model?: string;
+  language?: string;
 }
 
 /**
- * Extract the transcription text from a telnyx CLI speech-to-text response.
- * The CLI wraps the API payload in a `data` envelope, but different engines
- * surface the transcript under different field names, so we check a few
- * common ones.
+ * Extract the transcription text from a telnyx CLI transcribe response.
+ * The endpoint is OpenAI-compatible and returns the transcript under
+ * `text`, but we defensively check a `data` envelope and a few common
+ * field names.
  */
 function extractTranscription(response: unknown): string {
   const data = (response as Record<string, unknown> | undefined)?.data ?? response;
   const obj = (data ?? {}) as Record<string, unknown>;
 
-  for (const key of ["transcription", "transcript", "text"]) {
+  for (const key of ["text", "transcription", "transcript"]) {
     const v = obj[key];
     if (typeof v === "string" && v) return v;
   }
@@ -41,14 +49,11 @@ function extractTranscription(response: unknown): string {
 export async function sttCommand(flags: Record<string, string | boolean>): Promise<void> {
   const jsonOutput = flags.json === true;
   const audioUrl = flags["audio-url"] as string;
-  const language = (flags.language as string) || "en";
-  const model = flags.model as string | undefined;
-  const transcriptionEngine = flags["transcription-engine"] as string | undefined;
-  const inputFormat = flags["input-format"] as string | undefined;
-  const interimResults = flags["interim-results"] === true;
-  const endpointing = flags.endpointing as string | undefined;
-  const redact = flags.redact === true;
-  const keywords = flags.keywords as string | undefined;
+  const model = (flags.model as string) || DEFAULT_MODEL;
+  // Only forward --language when explicitly provided: the default model
+  // (distil-whisper/distil-large-v2) rejects the language parameter.
+  const language = flags.language as string | undefined;
+  const responseFormat = flags["response-format"] as string | undefined;
 
   if (!audioUrl) {
     printError("--audio-url is required (e.g., --audio-url https://example.com/audio.mp3)");
@@ -60,25 +65,18 @@ export async function sttCommand(flags: Record<string, string | boolean>): Promi
       console.log("\n🎙️  Transcribing audio...\n");
     }
 
-    const args = ["speech-to-text", "retrieve-transcription", "--audio-url", audioUrl];
-    args.push("--language", language);
-    if (model) args.push("--model", model);
-    if (transcriptionEngine) args.push("--transcription-engine", transcriptionEngine);
-    if (inputFormat) args.push("--input-format", inputFormat);
-    if (interimResults) args.push("--interim-results");
-    if (endpointing) args.push("--endpointing", endpointing);
-    if (redact) args.push("--redact");
-    if (keywords) args.push("--keywords", keywords);
+    const args = ["ai:audio", "transcribe", "--file-url", audioUrl, "--model", model];
+    if (language) args.push("--language", language);
+    if (responseFormat) args.push("--response-format", responseFormat);
 
     const response = await telnyxCli(args);
     const transcription = extractTranscription(response);
 
     const result: SttResult = {
       audio_url: audioUrl,
-      language,
+      model,
       transcription,
-      ...(transcriptionEngine ? { transcription_engine: transcriptionEngine } : {}),
-      ...(model ? { model } : {}),
+      ...(language ? { language } : {}),
     };
 
     if (jsonOutput) {
@@ -86,10 +84,9 @@ export async function sttCommand(flags: Record<string, string | boolean>): Promi
     } else {
       const details: Record<string, string | number | boolean> = {
         "Audio URL": audioUrl,
-        Language: language,
+        Model: model,
       };
-      if (transcriptionEngine) details["Engine"] = transcriptionEngine;
-      if (model) details["Model"] = model;
+      if (language) details["Language"] = language;
       details["Transcription"] = transcription || "(no text returned)";
       printSuccess("Transcription complete!", details);
     }

--- a/cli/src/commands/stt.ts
+++ b/cli/src/commands/stt.ts
@@ -1,0 +1,111 @@
+/**
+ * telnyx-agent stt — Speech-to-text transcription.
+ *
+ * Shells out to the telnyx CLI's `speech-to-text retrieve-transcription`
+ * subcommand and surfaces the resulting transcription text to the caller in
+ * either human-readable or JSON form.
+ *
+ * The retrieve-transcription endpoint accepts an audio URL and returns the
+ * transcribed text along with metadata (language, engine, model, etc.).
+ */
+
+import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
+import { printSuccess, printError, outputJson } from "../utils/output.ts";
+
+interface SttResult {
+  audio_url: string;
+  language: string;
+  transcription: string;
+  transcription_engine?: string;
+  model?: string;
+}
+
+/**
+ * Extract the transcription text from a telnyx CLI speech-to-text response.
+ * The CLI wraps the API payload in a `data` envelope, but different engines
+ * surface the transcript under different field names, so we check a few
+ * common ones.
+ */
+function extractTranscription(response: unknown): string {
+  const data = (response as Record<string, unknown> | undefined)?.data ?? response;
+  const obj = (data ?? {}) as Record<string, unknown>;
+
+  for (const key of ["transcription", "transcript", "text"]) {
+    const v = obj[key];
+    if (typeof v === "string" && v) return v;
+  }
+
+  return "";
+}
+
+export async function sttCommand(flags: Record<string, string | boolean>): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const audioUrl = flags["audio-url"] as string;
+  const language = (flags.language as string) || "en";
+  const model = flags.model as string | undefined;
+  const transcriptionEngine = flags["transcription-engine"] as string | undefined;
+  const inputFormat = flags["input-format"] as string | undefined;
+  const interimResults = flags["interim-results"] === true;
+  const endpointing = flags.endpointing as string | undefined;
+  const redact = flags.redact === true;
+  const keywords = flags.keywords as string | undefined;
+
+  if (!audioUrl) {
+    printError("--audio-url is required (e.g., --audio-url https://example.com/audio.mp3)");
+    process.exit(1);
+  }
+
+  try {
+    if (!jsonOutput) {
+      console.log("\n🎙️  Transcribing audio...\n");
+    }
+
+    const args = ["speech-to-text", "retrieve-transcription", "--audio-url", audioUrl];
+    args.push("--language", language);
+    if (model) args.push("--model", model);
+    if (transcriptionEngine) args.push("--transcription-engine", transcriptionEngine);
+    if (inputFormat) args.push("--input-format", inputFormat);
+    if (interimResults) args.push("--interim-results");
+    if (endpointing) args.push("--endpointing", endpointing);
+    if (redact) args.push("--redact");
+    if (keywords) args.push("--keywords", keywords);
+
+    const response = await telnyxCli(args);
+    const transcription = extractTranscription(response);
+
+    const result: SttResult = {
+      audio_url: audioUrl,
+      language,
+      transcription,
+      ...(transcriptionEngine ? { transcription_engine: transcriptionEngine } : {}),
+      ...(model ? { model } : {}),
+    };
+
+    if (jsonOutput) {
+      outputJson(result);
+    } else {
+      const details: Record<string, string | number | boolean> = {
+        "Audio URL": audioUrl,
+        Language: language,
+      };
+      if (transcriptionEngine) details["Engine"] = transcriptionEngine;
+      if (model) details["Model"] = model;
+      details["Transcription"] = transcription || "(no text returned)";
+      printSuccess("Transcription complete!", details);
+    }
+  } catch (err) {
+    const msg = errorMsg(err);
+    if (jsonOutput) {
+      outputJson({ error: msg });
+    } else {
+      printError(msg);
+    }
+    process.exit(1);
+  }
+}
+
+function errorMsg(err: unknown): string {
+  if (err instanceof TelnyxCLIError) return err.stderr || err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -30,6 +30,8 @@ import { smsStatusCommand } from "./commands/sms-status.ts";
 import { callDialCommand } from "./commands/call-dial.ts";
 import { callControlCommand } from "./commands/call-control.ts";
 import { callStatusCommand } from "./commands/call-status.ts";
+import { sttCommand } from "./commands/stt.ts";
+import { sttProvidersCommand } from "./commands/stt-providers.ts";
 import { parseFlags } from "./utils/output.ts";
 
 const HELP = `
@@ -67,6 +69,8 @@ Commands:
   call-dial         Make an outbound call via Call Control
   call-control      Call Control actions (answer, hangup, transfer, dtmf, record, speak, ...)
   call-status       Get the status of a call by call-control-id
+  stt               Transcribe audio to text (speech-to-text)
+  stt-providers     List available speech-to-text providers
 
 Global Flags:
   --json            Output structured JSON instead of human-readable text
@@ -201,6 +205,20 @@ Voice Call Flags:
   --queue-name                   Queue to place the call into (call-control enqueue, required)
   --body                         SIP INFO body content (call-control send-sip-info, required)
   --content-type                 SIP INFO Content-Type header (call-control send-sip-info, required, e.g. application/dtmf-relay)
+STT Flags:
+  --audio-url <url> URL of the audio file to transcribe (required)
+  --language        Language code (default: en)
+  --model           Transcription model (optional, provider-specific)
+  --transcription-engine Transcription engine (optional)
+  --input-format    Audio input format (optional, e.g., mp3, wav)
+  --interim-results Return interim partial transcriptions (boolean)
+  --endpointing     Endpointing configuration (optional)
+  --redact          Redact sensitive content from the transcript (boolean)
+  --keywords        Comma-separated keywords to bias recognition (optional)
+
+STT-providers Flags:
+  --provider        Filter providers by name (optional)
+  --service-type    Filter providers by service type (optional)
 
 Environment:
   TELNYX_API_KEY    API key (or configure ~/.config/telnyx/config.json)
@@ -267,6 +285,10 @@ Examples:
   telnyx-agent call-control --action update-client-state --call-control-id <id> --client-state state-2
   telnyx-agent call-control --action reject --call-control-id <id> --cause USER_BUSY
   telnyx-agent call-status --call-control-id <id> --json
+  telnyx-agent stt --audio-url https://example.com/audio.mp3
+  telnyx-agent stt --audio-url https://example.com/audio.mp3 --language es --model whisper-large --json
+  telnyx-agent stt-providers --json
+  telnyx-agent stt-providers --provider telnyx --service-type transcription --json
 `;
 
 const COMMANDS: Record<string, (flags: Record<string, string | boolean>) => Promise<void>> = {
@@ -298,6 +320,8 @@ const COMMANDS: Record<string, (flags: Record<string, string | boolean>) => Prom
   "call-dial": callDialCommand,
   "call-control": callControlCommand,
   "call-status": callStatusCommand,
+  stt: sttCommand,
+  "stt-providers": sttProvidersCommand,
 };
 
 export async function run(argv: string[]): Promise<void> {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -207,14 +207,9 @@ Voice Call Flags:
   --content-type                 SIP INFO Content-Type header (call-control send-sip-info, required, e.g. application/dtmf-relay)
 STT Flags:
   --audio-url <url> URL of the audio file to transcribe (required)
-  --language        Language code (default: en)
-  --model           Transcription model (optional, provider-specific)
-  --transcription-engine Transcription engine (optional)
-  --input-format    Audio input format (optional, e.g., mp3, wav)
-  --interim-results Return interim partial transcriptions (boolean)
-  --endpointing     Endpointing configuration (optional)
-  --redact          Redact sensitive content from the transcript (boolean)
-  --keywords        Comma-separated keywords to bias recognition (optional)
+  --model           Transcription model (default: distil-whisper/distil-large-v2; also openai/whisper-large-v3-turbo, deepgram/nova-3)
+  --language        Language code (optional; not supported by the default model)
+  --response-format Transcript output format (optional, json or verbose_json)
 
 STT-providers Flags:
   --provider        Filter providers by name (optional)
@@ -286,7 +281,7 @@ Examples:
   telnyx-agent call-control --action reject --call-control-id <id> --cause USER_BUSY
   telnyx-agent call-status --call-control-id <id> --json
   telnyx-agent stt --audio-url https://example.com/audio.mp3
-  telnyx-agent stt --audio-url https://example.com/audio.mp3 --language es --model whisper-large --json
+  telnyx-agent stt --audio-url https://example.com/audio.mp3 --model openai/whisper-large-v3-turbo --language es --json
   telnyx-agent stt-providers --json
   telnyx-agent stt-providers --provider telnyx --service-type transcription --json
 `;

--- a/cli/tests/stt.test.ts
+++ b/cli/tests/stt.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for STT commands — verify correct Go CLI subcommand invocations
+ * and flag passing without making real API calls.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, chmodSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliRoot = join(__dirname, "..");
+const cliBin = join(cliRoot, "bin", "telnyx-agent.ts");
+
+function setupFakeTelnyx(): { fakeTelnyx: string; logPath: string; env: NodeJS.ProcessEnv } {
+  const tempDir = mkdtempSync(join(tmpdir(), "telnyx-agent-stt-"));
+  const binDir = join(tempDir, "bin");
+  const logPath = join(tempDir, "args.jsonl");
+  mkdirSync(binDir, { recursive: true });
+
+  const fakeTelnyx = join(binDir, "telnyx");
+  writeFileSync(
+    fakeTelnyx,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.TELNYX_FAKE_ARGS_LOG, JSON.stringify(args) + "\\n");
+
+const cmd = args.filter(a => a !== "--format" && a !== "json");
+
+if (cmd[0] === "speech-to-text" && cmd[1] === "retrieve-transcription") {
+  console.log(JSON.stringify({ data: { transcription: "Hello, this is a test transcription.", language: "en" } }));
+} else if (cmd[0] === "speech-to-text" && cmd[1] === "list-providers") {
+  console.log(JSON.stringify({ data: [{ provider: "telnyx", service_type: "batch" }, { provider: "aws", service_type: "batch" }] }));
+} else {
+  console.log(JSON.stringify({ data: {} }));
+}
+`,
+  );
+  chmodSync(fakeTelnyx, 0o755);
+
+  return {
+    fakeTelnyx,
+    logPath,
+    env: {
+      ...process.env,
+      TELNYX_CLI_PATH: fakeTelnyx,
+      TELNYX_FAKE_ARGS_LOG: logPath,
+      TELNYX_API_KEY: "KEY_fake_test",
+    },
+  };
+}
+
+function readLoggedArgs(logPath: string): string[][] {
+  if (!existsSync(logPath)) return [];
+  return readFileSync(logPath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function runCli(args: string[], env: NodeJS.ProcessEnv): string {
+  return execFileSync("npx", ["tsx", cliBin, ...args], {
+    cwd: cliRoot,
+    encoding: "utf8",
+    env,
+    timeout: 30000,
+  });
+}
+
+describe("STT commands", () => {
+  it("stt passes --audio-url flag correctly", () => {
+    const fake = setupFakeTelnyx();
+    const output = runCli(["stt", "--audio-url", "https://example.com/audio.mp3", "--json"], fake.env);
+
+    const data = JSON.parse(output);
+    assert.equal(data.audio_url, "https://example.com/audio.mp3");
+    assert.ok(data.transcription.length > 0);
+
+    const calls = readLoggedArgs(fake.logPath);
+    const sttCall = calls.find((a) => a.slice(0, 2).join(" ") === "speech-to-text retrieve-transcription");
+    assert.ok(sttCall, "must call speech-to-text retrieve-transcription");
+    assert.equal(sttCall![sttCall!.indexOf("--audio-url") + 1], "https://example.com/audio.mp3");
+  });
+
+  it("stt with --language and --model flags", () => {
+    const fake = setupFakeTelnyx();
+    runCli(["stt", "--audio-url", "https://example.com/audio.mp3", "--language", "es", "--model", "whisper-large", "--json"], fake.env);
+
+    const calls = readLoggedArgs(fake.logPath);
+    const sttCall = calls.find((a) => a.slice(0, 2).join(" ") === "speech-to-text retrieve-transcription");
+    assert.ok(sttCall, "must call speech-to-text retrieve-transcription");
+    assert.equal(sttCall![sttCall!.indexOf("--language") + 1], "es");
+    assert.equal(sttCall![sttCall!.indexOf("--model") + 1], "whisper-large");
+  });
+
+  it("stt with --transcription-engine flag", () => {
+    const fake = setupFakeTelnyx();
+    runCli(["stt", "--audio-url", "https://example.com/audio.mp3", "--transcription-engine", "telnyx", "--json"], fake.env);
+
+    const calls = readLoggedArgs(fake.logPath);
+    const sttCall = calls.find((a) => a.slice(0, 2).join(" ") === "speech-to-text retrieve-transcription");
+    assert.ok(sttCall!.includes("--transcription-engine"), "must include --transcription-engine");
+    assert.equal(sttCall![sttCall!.indexOf("--transcription-engine") + 1], "telnyx");
+  });
+
+  it("stt fails without --audio-url", () => {
+    const fake = setupFakeTelnyx();
+    try {
+      runCli(["stt", "--json"], fake.env);
+      assert.fail("should have exited with error");
+    } catch (err: any) {
+      assert.ok(err.status !== 0, "non-zero exit expected");
+    }
+  });
+
+  it("stt-providers calls speech-to-text list-providers", () => {
+    const fake = setupFakeTelnyx();
+    const output = runCli(["stt-providers", "--json"], fake.env);
+
+    const calls = readLoggedArgs(fake.logPath);
+    const providersCall = calls.find((a) => a.slice(0, 2).join(" ") === "speech-to-text list-providers");
+    assert.ok(providersCall, "must call speech-to-text list-providers");
+  });
+
+  it("help text includes stt commands", () => {
+    const fake = setupFakeTelnyx();
+    const output = runCli(["help"], fake.env);
+    assert.ok(output.includes("stt "), "help must list stt");
+    assert.ok(output.includes("stt-providers"), "help must list stt-providers");
+    assert.ok(output.includes("--audio-url"), "help must document --audio-url flag");
+  });
+});

--- a/cli/tests/stt.test.ts
+++ b/cli/tests/stt.test.ts
@@ -30,8 +30,8 @@ fs.appendFileSync(process.env.TELNYX_FAKE_ARGS_LOG, JSON.stringify(args) + "\\n"
 
 const cmd = args.filter(a => a !== "--format" && a !== "json");
 
-if (cmd[0] === "speech-to-text" && cmd[1] === "retrieve-transcription") {
-  console.log(JSON.stringify({ data: { transcription: "Hello, this is a test transcription.", language: "en" } }));
+if (cmd[0] === "ai:audio" && cmd[1] === "transcribe") {
+  console.log(JSON.stringify({ text: "Hello, this is a test transcription." }));
 } else if (cmd[0] === "speech-to-text" && cmd[1] === "list-providers") {
   console.log(JSON.stringify({ data: [{ provider: "telnyx", service_type: "batch" }, { provider: "aws", service_type: "batch" }] }));
 } else {
@@ -72,7 +72,7 @@ function runCli(args: string[], env: NodeJS.ProcessEnv): string {
 }
 
 describe("STT commands", () => {
-  it("stt passes --audio-url flag correctly", () => {
+  it("stt routes to ai:audio transcribe with --file-url and default model", () => {
     const fake = setupFakeTelnyx();
     const output = runCli(["stt", "--audio-url", "https://example.com/audio.mp3", "--json"], fake.env);
 
@@ -81,30 +81,35 @@ describe("STT commands", () => {
     assert.ok(data.transcription.length > 0);
 
     const calls = readLoggedArgs(fake.logPath);
-    const sttCall = calls.find((a) => a.slice(0, 2).join(" ") === "speech-to-text retrieve-transcription");
-    assert.ok(sttCall, "must call speech-to-text retrieve-transcription");
-    assert.equal(sttCall![sttCall!.indexOf("--audio-url") + 1], "https://example.com/audio.mp3");
+    const sttCall = calls.find((a) => a.slice(0, 2).join(" ") === "ai:audio transcribe");
+    assert.ok(sttCall, "must call ai:audio transcribe");
+    assert.equal(sttCall![sttCall!.indexOf("--file-url") + 1], "https://example.com/audio.mp3");
+    // --model is required by the Go CLI, so the wrapper must always pass it
+    assert.equal(sttCall![sttCall!.indexOf("--model") + 1], "distil-whisper/distil-large-v2");
+    // the default model rejects --language, so it must not be sent unless requested
+    assert.ok(!sttCall!.includes("--language"), "must not pass --language unless explicitly provided");
+    assert.ok(!sttCall!.includes("--audio-url"), "must not pass the unsupported --audio-url flag through");
   });
 
   it("stt with --language and --model flags", () => {
     const fake = setupFakeTelnyx();
-    runCli(["stt", "--audio-url", "https://example.com/audio.mp3", "--language", "es", "--model", "whisper-large", "--json"], fake.env);
+    runCli(["stt", "--audio-url", "https://example.com/audio.mp3", "--language", "es", "--model", "openai/whisper-large-v3-turbo", "--json"], fake.env);
 
     const calls = readLoggedArgs(fake.logPath);
-    const sttCall = calls.find((a) => a.slice(0, 2).join(" ") === "speech-to-text retrieve-transcription");
-    assert.ok(sttCall, "must call speech-to-text retrieve-transcription");
+    const sttCall = calls.find((a) => a.slice(0, 2).join(" ") === "ai:audio transcribe");
+    assert.ok(sttCall, "must call ai:audio transcribe");
     assert.equal(sttCall![sttCall!.indexOf("--language") + 1], "es");
-    assert.equal(sttCall![sttCall!.indexOf("--model") + 1], "whisper-large");
+    assert.equal(sttCall![sttCall!.indexOf("--model") + 1], "openai/whisper-large-v3-turbo");
   });
 
-  it("stt with --transcription-engine flag", () => {
+  it("stt with --response-format flag", () => {
     const fake = setupFakeTelnyx();
-    runCli(["stt", "--audio-url", "https://example.com/audio.mp3", "--transcription-engine", "telnyx", "--json"], fake.env);
+    runCli(["stt", "--audio-url", "https://example.com/audio.mp3", "--response-format", "verbose_json", "--json"], fake.env);
 
     const calls = readLoggedArgs(fake.logPath);
-    const sttCall = calls.find((a) => a.slice(0, 2).join(" ") === "speech-to-text retrieve-transcription");
-    assert.ok(sttCall!.includes("--transcription-engine"), "must include --transcription-engine");
-    assert.equal(sttCall![sttCall!.indexOf("--transcription-engine") + 1], "telnyx");
+    const sttCall = calls.find((a) => a.slice(0, 2).join(" ") === "ai:audio transcribe");
+    assert.ok(sttCall!.includes("--response-format"), "must include --response-format");
+    assert.equal(sttCall![sttCall!.indexOf("--response-format") + 1], "verbose_json");
   });
 
   it("stt fails without --audio-url", () => {
@@ -121,9 +126,23 @@ describe("STT commands", () => {
     const fake = setupFakeTelnyx();
     const output = runCli(["stt-providers", "--json"], fake.env);
 
+    const data = JSON.parse(output);
+    assert.equal(data.count, 2);
+
     const calls = readLoggedArgs(fake.logPath);
     const providersCall = calls.find((a) => a.slice(0, 2).join(" ") === "speech-to-text list-providers");
     assert.ok(providersCall, "must call speech-to-text list-providers");
+  });
+
+  it("stt-providers passes --provider and --service-type filters", () => {
+    const fake = setupFakeTelnyx();
+    runCli(["stt-providers", "--provider", "telnyx", "--service-type", "transcription", "--json"], fake.env);
+
+    const calls = readLoggedArgs(fake.logPath);
+    const providersCall = calls.find((a) => a.slice(0, 2).join(" ") === "speech-to-text list-providers");
+    assert.ok(providersCall, "must call speech-to-text list-providers");
+    assert.equal(providersCall![providersCall!.indexOf("--provider") + 1], "telnyx");
+    assert.equal(providersCall![providersCall!.indexOf("--service-type") + 1], "transcription");
   });
 
   it("help text includes stt commands", () => {

--- a/cli/tests/stt.test.ts
+++ b/cli/tests/stt.test.ts
@@ -31,7 +31,11 @@ fs.appendFileSync(process.env.TELNYX_FAKE_ARGS_LOG, JSON.stringify(args) + "\\n"
 const cmd = args.filter(a => a !== "--format" && a !== "json");
 
 if (cmd[0] === "ai:audio" && cmd[1] === "transcribe") {
-  console.log(JSON.stringify({ text: "Hello, this is a test transcription." }));
+  if (cmd.includes("verbose_json")) {
+    console.log(JSON.stringify({ text: "Hello, this is a test transcription.", duration: 2.5, segments: [{ id: 0, start: 0, end: 2.5, text: "Hello, this is a test transcription." }] }));
+  } else {
+    console.log(JSON.stringify({ text: "Hello, this is a test transcription." }));
+  }
 } else if (cmd[0] === "speech-to-text" && cmd[1] === "list-providers") {
   console.log(JSON.stringify({ data: [{ provider: "telnyx", service_type: "batch" }, { provider: "aws", service_type: "batch" }] }));
 } else {
@@ -110,6 +114,28 @@ describe("STT commands", () => {
     const sttCall = calls.find((a) => a.slice(0, 2).join(" ") === "ai:audio transcribe");
     assert.ok(sttCall!.includes("--response-format"), "must include --response-format");
     assert.equal(sttCall![sttCall!.indexOf("--response-format") + 1], "verbose_json");
+  });
+
+  it("stt preserves verbose response fields for --response-format verbose_json", () => {
+    const fake = setupFakeTelnyx();
+    const out = runCli(
+      ["stt", "--audio-url", "https://example.com/audio.mp3", "--response-format", "verbose_json", "--json"],
+      fake.env,
+    );
+    const data = JSON.parse(out);
+    assert.equal(data.response_format, "verbose_json");
+    assert.ok(data.response, "verbose response must be included");
+    assert.equal(data.response.segments.length, 1, "segments from the API must be preserved");
+    assert.equal(data.response.duration, 2.5);
+    assert.equal(data.transcription, "Hello, this is a test transcription.");
+  });
+
+  it("stt omits raw response for the default response format", () => {
+    const fake = setupFakeTelnyx();
+    const out = runCli(["stt", "--audio-url", "https://example.com/audio.mp3", "--json"], fake.env);
+    const data = JSON.parse(out);
+    assert.equal(data.response, undefined, "default format should keep the flat shape");
+    assert.equal(data.response_format, undefined);
   });
 
   it("stt fails without --audio-url", () => {


### PR DESCRIPTION
## Summary\n\nAdds speech-to-text (STT) commands to the agent CLI \u2014 previously no STT capability existed.\n\n### New Commands\n\n**** \u2014 Transcribe audio to text:\n- Accepts  (required) pointing to an audio file\n- Optional flags: , , , , , , , \n\n**** \u2014 List available STT providers:\n- Optional  and  filters\n\n### Files Changed\n-  (new) \u2014 transcription command\n-  (new) \u2014 provider listing\n-  \u2014 register 2 commands, help text, examples\n-  \u2014 add STT capability category\n-  \u2014 6 mock-binary tests (all passing)\n\n### Test Results\n