### PR TITLE
feat: add TTS and STT skills, bump plugin version to 0.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
     "email": "support@telnyx.com"
   },
   "metadata": {
-    "description": "Official Telnyx plugin for AI coding agents — MCP server, Agent Skills, and development tools",
-    "version": "0.1.0"
+    "description": "Official Telnyx plugin for AI coding agents \u2014 MCP server, Agent Skills, and development tools",
+    "version": "0.4.0"
   },
   "plugins": [
     {
       "name": "telnyx",
-      "version": "0.1.0",
-      "description": "Telnyx development plugin — MCP server for API access, plus skills for messaging, voice, numbers, AI, IoT, WebRTC, Twilio migration, and more.",
+      "version": "0.4.0",
+      "description": "Telnyx development plugin \u2014 MCP server for API access, plus skills for messaging, voice, numbers, AI, IoT, WebRTC, Twilio migration, and more.",
       "source": "./providers/claude/plugin/"
     }
   ]

--- a/providers/claude/plugin/.claude-plugin/plugin.json
+++ b/providers/claude/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "telnyx",
   "description": "Telnyx development plugin for Claude",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "author": {
     "name": "Telnyx",
     "url": "https://telnyx.com"
@@ -9,5 +9,14 @@
   "homepage": "https://developers.telnyx.com",
   "repository": "https://github.com/team-telnyx/ai",
   "license": "MIT",
-  "keywords": ["telnyx", "telecom", "messaging", "voice", "sms", "api", "webhooks", "ai"]
+  "keywords": [
+    "telnyx",
+    "telecom",
+    "messaging",
+    "voice",
+    "sms",
+    "api",
+    "webhooks",
+    "ai"
+  ]
 }

--- a/providers/claude/plugin/skills/telnyx-stt-python/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-stt-python/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: telnyx-stt-python
+description: >-
+  Transcribe audio to text via the OpenAI-compatible transcription endpoint.
+  Supports multiple models, languages, and keyword biasing. Also lists
+  available speech-to-text providers and service types.
+metadata:
+  author: telnyx
+  product: stt
+  language: python
+  generated_by: telnyx-ext-skills-generator
+  profile: northstar-v2
+---
+
+# Telnyx Speech-to-Text - Python
+
+## Installation
+
+```bash
+pip install telnyx
+```
+
+## Setup
+
+```python
+import os
+from telnyx import Telnyx
+
+client = Telnyx(
+    api_key=os.environ.get("TELNYX_API_KEY"),
+)
+```
+
+All examples below assume `client` is already initialized as shown above.
+
+## Error Handling
+
+All API calls can fail with network errors, rate limits (429), validation errors (422),
+or authentication errors (401). Always handle errors in production code:
+
+```python
+import telnyx
+
+try:
+    response = client.ai.audio.transcribe(
+        model="openai/whisper-large-v3-turbo",
+        url="https://example.com/audio.mp3",
+    )
+except telnyx.APIConnectionError:
+    print("Network error — check connectivity and retry")
+except telnyx.RateLimitError:
+    import time
+    time.sleep(1)
+except telnyx.APIStatusError as e:
+    print(f"API error {e.status_code}: {e.message}")
+```
+
+Common error codes: `401` invalid API key, `403` insufficient permissions,
+`404` resource not found, `422` validation error, `429` rate limited.
+
+## Core Tasks
+
+### Transcribe speech to text
+
+Transcribe an audio file to text. This endpoint is consistent with the
+[OpenAI Transcription API](https://platform.openai.com/docs/api-reference/audio/createTranscription)
+and may be used with the OpenAI JS or Python SDK.
+
+`POST /ai/audio/transcriptions`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `url` | string (URL) | Yes | URL of the audio file to transcribe. |
+| `model` | string | No | Model ID (e.g., `openai/whisper-large-v3-turbo`, `distil-whisper/distil-large-v2`). |
+| `language` | string | No | Language code (e.g., `en`, `es`, `fr`). |
+| `prompt` | string | No | Optional prompt to guide transcription style. |
+| `response_format` | enum | No | `json`, `text`, `srt`, `verbose_json`, `vtt`. Default: `json`. |
+| `temperature` | number | No | Sampling temperature (0-1). Default: 0. |
+| `keywords` | array[string] | No | Keyword biasing — improve accuracy for domain-specific terms. |
+
+```python
+# Basic transcription
+response = client.ai.audio.transcribe(
+    url="https://example.com/audio.mp3",
+)
+print(response.text)
+
+# With specific model and language
+response = client.ai.audio.transcribe(
+    url="https://example.com/audio.mp3",
+    model="openai/whisper-large-v3-turbo",
+    language="es",
+)
+print(response.text)
+
+# With keyword biasing for domain-specific terms
+response = client.ai.audio.transcribe(
+    url="https://example.com/audio.mp3",
+    keywords=["Telnyx", "API", "WebRTC", "SIP"],
+)
+print(response.text)
+
+# Verbose JSON with segments
+response = client.ai.audio.transcribe(
+    url="https://example.com/audio.mp3",
+    response_format="verbose_json",
+)
+for segment in response.segments:
+    print(f"[{segment.start:.1f}s - {segment.end:.1f}s] {segment.text}")
+```
+
+Primary response fields:
+- `response.text` — Full transcription text
+- `response.duration` — Audio duration in seconds
+- `response.segments` — Array of segment objects (with `start`, `end`, `text`) when using `verbose_json` format
+
+### List available STT providers
+
+Retrieve a list of available speech-to-text providers and their service types.
+
+`GET /ai/audio/transcriptions/providers`
+
+```python
+response = client.ai.audio.list_providers()
+for provider in response.providers:
+    print(f"{provider['name']} — {provider['service_type']}")
+
+# Filter by provider name
+response = client.ai.audio.list_providers(provider="telnyx")
+for provider in response.providers:
+    print(f"{provider['name']} — {provider['service_type']}")
+
+# Filter by service type
+response = client.ai.audio.list_providers(service_type="transcription")
+for provider in response.providers:
+    print(f"{provider['name']} — {provider['service_type']}")
+```
+
+Primary response fields:
+- `response.providers` — Array of provider objects with `name` and `service_type`
+
+## CLI Usage
+
+The Telnyx Agent CLI provides composite commands for STT:
+
+```bash
+# Transcribe audio
+telnyx-agent stt --audio-url https://example.com/audio.mp3 --json
+
+# With specific model and language
+telnyx-agent stt --audio-url https://example.com/audio.mp3 --model openai/whisper-large-v3-turbo --language es --json
+
+# List available providers
+telnyx-agent stt-providers --json
+
+# Filter by provider or service type
+telnyx-agent stt-providers --provider telnyx --service-type transcription --json
+```
+
+## Important Notes
+
+- **Audio URL**: The audio file must be publicly accessible via a URL. Supported formats include mp3, mp4, mpeg, mpga, m4a, wav, and webm.
+- **OpenAI compatibility**: The transcription endpoint is OpenAI-compatible — you can use the OpenAI Python or JS SDK by setting the base URL to `https://api.telnyx.com/v2/ai/openai`.
+- **Keyword biasing**: Use `keywords` to improve transcription accuracy for domain-specific terms, product names, or acronyms that generic models may mishear.
+- **Models**: Available models include `openai/whisper-large-v3-turbo` (fast, accurate) and `distil-whisper/distil-large-v2` (lightweight). Check `stt-providers` for the full list.
+- **Languages**: Use ISO 639-1 codes (`en`, `es`, `fr`, `de`, `ja`, etc.). Omit to auto-detect.
+- **Response formats**: Use `verbose_json` to get timestamps and segments. Use `srt` or `vtt` for subtitle files.

--- a/providers/claude/plugin/skills/telnyx-tts-python/SKILL.md
+++ b/providers/claude/plugin/skills/telnyx-tts-python/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: telnyx-tts-python
+description: >-
+  Generate speech from text using Telnyx and third-party TTS providers (AWS,
+  Azure, ElevenLabs, MiniMax, Resemble, Rime, xAI). Returns base64-encoded
+  audio or a binary stream. Also lists available voices per provider.
+metadata:
+  author: telnyx
+  product: tts
+  language: python
+  generated_by: telnyx-ext-skills-generator
+  profile: northstar-v2
+---
+
+# Telnyx Text-to-Speech - Python
+
+## Installation
+
+```bash
+pip install telnyx
+```
+
+## Setup
+
+```python
+import os
+from telnyx import Telnyx
+
+client = Telnyx(
+    api_key=os.environ.get("TELNYX_API_KEY"),
+)
+```
+
+All examples below assume `client` is already initialized as shown above.
+
+## Error Handling
+
+All API calls can fail with network errors, rate limits (429), validation errors (422),
+or authentication errors (401). Always handle errors in production code:
+
+```python
+import telnyx
+
+try:
+    response = client.text_to_speech.generate(text="Hello world")
+except telnyx.APIConnectionError:
+    print("Network error — check connectivity and retry")
+except telnyx.RateLimitError:
+    import time
+    time.sleep(1)
+except telnyx.APIStatusError as e:
+    print(f"API error {e.status_code}: {e.message}")
+```
+
+Common error codes: `401` invalid API key, `403` insufficient permissions,
+`404` resource not found, `422` validation error, `429` rate limited.
+
+## Core Tasks
+
+### Generate speech from text
+
+Generate synthesized speech audio from text input. Returns audio as base64-encoded
+JSON (`base64_output`) or a binary audio stream (`binary_output`).
+
+`POST /text-to-speech/speech`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `text` | string | Yes | The text to synthesize. |
+| `provider` | enum | No | TTS provider: `telnyx`, `aws`, `azure`, `elevenlabs`, `minimax`, `resemble`, `rime`. Default: `telnyx`. |
+| `voice` | string | No | Voice ID to use (e.g., `en-US-Standard-A` for AWS). |
+| `output_type` | enum | No | `binary_output` or `base64_output`. Default: `binary_output`. |
+| `text_type` | enum | No | `text` or `ssml`. Default: `text`. |
+| `language` | string | No | Language code (e.g., `en-US`). |
+| `voice_settings` | object | No | Advanced voice settings (speed, pitch, volume). |
+| `telnyx` | object | No | Telnyx-specific provider options. |
+| `aws` | object | No | AWS-specific provider options. |
+| `azure` | object | No | Azure-specific provider options. |
+| `elevenlabs` | object | No | ElevenLabs-specific provider options. |
+| `minimax` | object | No | MiniMax-specific provider options. |
+| `resemble` | object | No | Resemble-specific provider options. |
+| `rime` | object | No | Rime-specific provider options. |
+| `disable_cache` | boolean | No | Disable response caching. |
+
+```python
+# Default Telnyx provider
+response = client.text_to_speech.generate(
+    text="Hello from Telnyx!",
+)
+print(response.base64_audio)
+
+# AWS provider with specific voice
+response = client.text_to_speech.generate(
+    text="Hello from Telnyx!",
+    provider="aws",
+    voice="en-US-Standard-A",
+    output_type="base64_output",
+)
+print(response.base64_audio)
+
+# SSML input
+response = client.text_to_speech.generate(
+    text="<speak>Hello <break time='1s'/> world</speak>",
+    text_type="ssml",
+)
+print(response.base64_audio)
+
+# ElevenLabs provider
+response = client.text_to_speech.generate(
+    text="Hello from Telnyx!",
+    provider="elevenlabs",
+    voice="21m00Tcm4TlvDq8ikWAM",
+    output_type="base64_output",
+)
+print(response.base64_audio)
+```
+
+Primary response fields:
+- `response.base64_audio` — Base64-encoded audio data (when `output_type` is `base64_output`)
+- Binary stream (when `output_type` is `binary_output`)
+
+### List available voices
+
+Retrieve a list of available voices from one or all TTS providers.
+
+`GET /text-to-speech/voices`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `provider` | enum | No | Filter by provider: `telnyx`, `aws`, `azure`, `elevenlabs`, `minimax`, `resemble`, `rime`. |
+
+```python
+# List all voices across all providers
+response = client.text_to_speech.list_voices()
+for voice in response.voices:
+    print(f"{voice['name']} — {voice['provider']} ({voice['language']})")
+
+# List only AWS voices
+response = client.text_to_speech.list_voices(provider="aws")
+for voice in response.voices:
+    print(f"{voice['name']} — {voice['language']}")
+```
+
+Primary response fields:
+- `response.voices` — Array of voice objects with `name`, `provider`, `language`, `voice_id`
+
+## CLI Usage
+
+The Telnyx Agent CLI provides composite commands for TTS:
+
+```bash
+# Generate speech
+telnyx-agent tts --text "Hello world" --json
+
+# Generate with specific provider and voice
+telnyx-agent tts --text "Hello world" --provider aws --voice en-US-Standard-A --json
+
+# List available voices
+telnyx-agent tts-voices --json
+
+# Filter voices by provider
+telnyx-agent tts-voices --provider elevenlabs --json
+```
+
+## Important Notes
+
+- **Audio format**: When `output_type` is `base64_output`, decode the base64 string to get the audio bytes. When `binary_output`, the response is a raw audio stream.
+- **SSML**: Use `text_type: "ssml"` to send SSML markup for fine-grained control over pronunciation, pauses, and emphasis.
+- **Provider-specific options**: Each provider (`aws`, `azure`, `elevenlabs`, etc.) has its own object for provider-specific configuration (e.g., AWS engine type, ElevenLabs stability).
+- **Caching**: Responses are cached by default. Use `disable_cache: true` to bypass.
+- **xAI**: The xAI provider is available via the CLI (`--provider xai`) and supports voice listing.

--- a/providers/cursor/plugin/skills/telnyx-stt-python/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-stt-python/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: telnyx-stt-python
+description: >-
+  Transcribe audio to text via the OpenAI-compatible transcription endpoint.
+  Supports multiple models, languages, and keyword biasing. Also lists
+  available speech-to-text providers and service types.
+metadata:
+  author: telnyx
+  product: stt
+  language: python
+  generated_by: telnyx-ext-skills-generator
+  profile: northstar-v2
+---
+
+# Telnyx Speech-to-Text - Python
+
+## Installation
+
+```bash
+pip install telnyx
+```
+
+## Setup
+
+```python
+import os
+from telnyx import Telnyx
+
+client = Telnyx(
+    api_key=os.environ.get("TELNYX_API_KEY"),
+)
+```
+
+All examples below assume `client` is already initialized as shown above.
+
+## Error Handling
+
+All API calls can fail with network errors, rate limits (429), validation errors (422),
+or authentication errors (401). Always handle errors in production code:
+
+```python
+import telnyx
+
+try:
+    response = client.ai.audio.transcribe(
+        model="openai/whisper-large-v3-turbo",
+        url="https://example.com/audio.mp3",
+    )
+except telnyx.APIConnectionError:
+    print("Network error — check connectivity and retry")
+except telnyx.RateLimitError:
+    import time
+    time.sleep(1)
+except telnyx.APIStatusError as e:
+    print(f"API error {e.status_code}: {e.message}")
+```
+
+Common error codes: `401` invalid API key, `403` insufficient permissions,
+`404` resource not found, `422` validation error, `429` rate limited.
+
+## Core Tasks
+
+### Transcribe speech to text
+
+Transcribe an audio file to text. This endpoint is consistent with the
+[OpenAI Transcription API](https://platform.openai.com/docs/api-reference/audio/createTranscription)
+and may be used with the OpenAI JS or Python SDK.
+
+`POST /ai/audio/transcriptions`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `url` | string (URL) | Yes | URL of the audio file to transcribe. |
+| `model` | string | No | Model ID (e.g., `openai/whisper-large-v3-turbo`, `distil-whisper/distil-large-v2`). |
+| `language` | string | No | Language code (e.g., `en`, `es`, `fr`). |
+| `prompt` | string | No | Optional prompt to guide transcription style. |
+| `response_format` | enum | No | `json`, `text`, `srt`, `verbose_json`, `vtt`. Default: `json`. |
+| `temperature` | number | No | Sampling temperature (0-1). Default: 0. |
+| `keywords` | array[string] | No | Keyword biasing — improve accuracy for domain-specific terms. |
+
+```python
+# Basic transcription
+response = client.ai.audio.transcribe(
+    url="https://example.com/audio.mp3",
+)
+print(response.text)
+
+# With specific model and language
+response = client.ai.audio.transcribe(
+    url="https://example.com/audio.mp3",
+    model="openai/whisper-large-v3-turbo",
+    language="es",
+)
+print(response.text)
+
+# With keyword biasing for domain-specific terms
+response = client.ai.audio.transcribe(
+    url="https://example.com/audio.mp3",
+    keywords=["Telnyx", "API", "WebRTC", "SIP"],
+)
+print(response.text)
+
+# Verbose JSON with segments
+response = client.ai.audio.transcribe(
+    url="https://example.com/audio.mp3",
+    response_format="verbose_json",
+)
+for segment in response.segments:
+    print(f"[{segment.start:.1f}s - {segment.end:.1f}s] {segment.text}")
+```
+
+Primary response fields:
+- `response.text` — Full transcription text
+- `response.duration` — Audio duration in seconds
+- `response.segments` — Array of segment objects (with `start`, `end`, `text`) when using `verbose_json` format
+
+### List available STT providers
+
+Retrieve a list of available speech-to-text providers and their service types.
+
+`GET /ai/audio/transcriptions/providers`
+
+```python
+response = client.ai.audio.list_providers()
+for provider in response.providers:
+    print(f"{provider['name']} — {provider['service_type']}")
+
+# Filter by provider name
+response = client.ai.audio.list_providers(provider="telnyx")
+for provider in response.providers:
+    print(f"{provider['name']} — {provider['service_type']}")
+
+# Filter by service type
+response = client.ai.audio.list_providers(service_type="transcription")
+for provider in response.providers:
+    print(f"{provider['name']} — {provider['service_type']}")
+```
+
+Primary response fields:
+- `response.providers` — Array of provider objects with `name` and `service_type`
+
+## CLI Usage
+
+The Telnyx Agent CLI provides composite commands for STT:
+
+```bash
+# Transcribe audio
+telnyx-agent stt --audio-url https://example.com/audio.mp3 --json
+
+# With specific model and language
+telnyx-agent stt --audio-url https://example.com/audio.mp3 --model openai/whisper-large-v3-turbo --language es --json
+
+# List available providers
+telnyx-agent stt-providers --json
+
+# Filter by provider or service type
+telnyx-agent stt-providers --provider telnyx --service-type transcription --json
+```
+
+## Important Notes
+
+- **Audio URL**: The audio file must be publicly accessible via a URL. Supported formats include mp3, mp4, mpeg, mpga, m4a, wav, and webm.
+- **OpenAI compatibility**: The transcription endpoint is OpenAI-compatible — you can use the OpenAI Python or JS SDK by setting the base URL to `https://api.telnyx.com/v2/ai/openai`.
+- **Keyword biasing**: Use `keywords` to improve transcription accuracy for domain-specific terms, product names, or acronyms that generic models may mishear.
+- **Models**: Available models include `openai/whisper-large-v3-turbo` (fast, accurate) and `distil-whisper/distil-large-v2` (lightweight). Check `stt-providers` for the full list.
+- **Languages**: Use ISO 639-1 codes (`en`, `es`, `fr`, `de`, `ja`, etc.). Omit to auto-detect.
+- **Response formats**: Use `verbose_json` to get timestamps and segments. Use `srt` or `vtt` for subtitle files.

--- a/providers/cursor/plugin/skills/telnyx-tts-python/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-tts-python/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: telnyx-tts-python
+description: >-
+  Generate speech from text using Telnyx and third-party TTS providers (AWS,
+  Azure, ElevenLabs, MiniMax, Resemble, Rime, xAI). Returns base64-encoded
+  audio or a binary stream. Also lists available voices per provider.
+metadata:
+  author: telnyx
+  product: tts
+  language: python
+  generated_by: telnyx-ext-skills-generator
+  profile: northstar-v2
+---
+
+# Telnyx Text-to-Speech - Python
+
+## Installation
+
+```bash
+pip install telnyx
+```
+
+## Setup
+
+```python
+import os
+from telnyx import Telnyx
+
+client = Telnyx(
+    api_key=os.environ.get("TELNYX_API_KEY"),
+)
+```
+
+All examples below assume `client` is already initialized as shown above.
+
+## Error Handling
+
+All API calls can fail with network errors, rate limits (429), validation errors (422),
+or authentication errors (401). Always handle errors in production code:
+
+```python
+import telnyx
+
+try:
+    response = client.text_to_speech.generate(text="Hello world")
+except telnyx.APIConnectionError:
+    print("Network error — check connectivity and retry")
+except telnyx.RateLimitError:
+    import time
+    time.sleep(1)
+except telnyx.APIStatusError as e:
+    print(f"API error {e.status_code}: {e.message}")
+```
+
+Common error codes: `401` invalid API key, `403` insufficient permissions,
+`404` resource not found, `422` validation error, `429` rate limited.
+
+## Core Tasks
+
+### Generate speech from text
+
+Generate synthesized speech audio from text input. Returns audio as base64-encoded
+JSON (`base64_output`) or a binary audio stream (`binary_output`).
+
+`POST /text-to-speech/speech`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `text` | string | Yes | The text to synthesize. |
+| `provider` | enum | No | TTS provider: `telnyx`, `aws`, `azure`, `elevenlabs`, `minimax`, `resemble`, `rime`. Default: `telnyx`. |
+| `voice` | string | No | Voice ID to use (e.g., `en-US-Standard-A` for AWS). |
+| `output_type` | enum | No | `binary_output` or `base64_output`. Default: `binary_output`. |
+| `text_type` | enum | No | `text` or `ssml`. Default: `text`. |
+| `language` | string | No | Language code (e.g., `en-US`). |
+| `voice_settings` | object | No | Advanced voice settings (speed, pitch, volume). |
+| `telnyx` | object | No | Telnyx-specific provider options. |
+| `aws` | object | No | AWS-specific provider options. |
+| `azure` | object | No | Azure-specific provider options. |
+| `elevenlabs` | object | No | ElevenLabs-specific provider options. |
+| `minimax` | object | No | MiniMax-specific provider options. |
+| `resemble` | object | No | Resemble-specific provider options. |
+| `rime` | object | No | Rime-specific provider options. |
+| `disable_cache` | boolean | No | Disable response caching. |
+
+```python
+# Default Telnyx provider
+response = client.text_to_speech.generate(
+    text="Hello from Telnyx!",
+)
+print(response.base64_audio)
+
+# AWS provider with specific voice
+response = client.text_to_speech.generate(
+    text="Hello from Telnyx!",
+    provider="aws",
+    voice="en-US-Standard-A",
+    output_type="base64_output",
+)
+print(response.base64_audio)
+
+# SSML input
+response = client.text_to_speech.generate(
+    text="<speak>Hello <break time='1s'/> world</speak>",
+    text_type="ssml",
+)
+print(response.base64_audio)
+
+# ElevenLabs provider
+response = client.text_to_speech.generate(
+    text="Hello from Telnyx!",
+    provider="elevenlabs",
+    voice="21m00Tcm4TlvDq8ikWAM",
+    output_type="base64_output",
+)
+print(response.base64_audio)
+```
+
+Primary response fields:
+- `response.base64_audio` — Base64-encoded audio data (when `output_type` is `base64_output`)
+- Binary stream (when `output_type` is `binary_output`)
+
+### List available voices
+
+Retrieve a list of available voices from one or all TTS providers.
+
+`GET /text-to-speech/voices`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `provider` | enum | No | Filter by provider: `telnyx`, `aws`, `azure`, `elevenlabs`, `minimax`, `resemble`, `rime`. |
+
+```python
+# List all voices across all providers
+response = client.text_to_speech.list_voices()
+for voice in response.voices:
+    print(f"{voice['name']} — {voice['provider']} ({voice['language']})")
+
+# List only AWS voices
+response = client.text_to_speech.list_voices(provider="aws")
+for voice in response.voices:
+    print(f"{voice['name']} — {voice['language']}")
+```
+
+Primary response fields:
+- `response.voices` — Array of voice objects with `name`, `provider`, `language`, `voice_id`
+
+## CLI Usage
+
+The Telnyx Agent CLI provides composite commands for TTS:
+
+```bash
+# Generate speech
+telnyx-agent tts --text "Hello world" --json
+
+# Generate with specific provider and voice
+telnyx-agent tts --text "Hello world" --provider aws --voice en-US-Standard-A --json
+
+# List available voices
+telnyx-agent tts-voices --json
+
+# Filter voices by provider
+telnyx-agent tts-voices --provider elevenlabs --json
+```
+
+## Important Notes
+
+- **Audio format**: When `output_type` is `base64_output`, decode the base64 string to get the audio bytes. When `binary_output`, the response is a raw audio stream.
+- **SSML**: Use `text_type: "ssml"` to send SSML markup for fine-grained control over pronunciation, pauses, and emphasis.
+- **Provider-specific options**: Each provider (`aws`, `azure`, `elevenlabs`, etc.) has its own object for provider-specific configuration (e.g., AWS engine type, ElevenLabs stability).
+- **Caching**: Responses are cached by default. Use `disable_cache: true` to bypass.
+- **xAI**: The xAI provider is available via the CLI (`--provider xai`) and supports voice listing.

--- a/skills/telnyx-stt-python/SKILL.md
+++ b/skills/telnyx-stt-python/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: telnyx-stt-python
+description: >-
+  Transcribe audio to text via the OpenAI-compatible transcription endpoint.
+  Supports multiple models, languages, and keyword biasing. Also lists
+  available speech-to-text providers and service types.
+metadata:
+  author: telnyx
+  product: stt
+  language: python
+  generated_by: telnyx-ext-skills-generator
+  profile: northstar-v2
+---
+
+# Telnyx Speech-to-Text - Python
+
+## Installation
+
+```bash
+pip install telnyx
+```
+
+## Setup
+
+```python
+import os
+from telnyx import Telnyx
+
+client = Telnyx(
+    api_key=os.environ.get("TELNYX_API_KEY"),
+)
+```
+
+All examples below assume `client` is already initialized as shown above.
+
+## Error Handling
+
+All API calls can fail with network errors, rate limits (429), validation errors (422),
+or authentication errors (401). Always handle errors in production code:
+
+```python
+import telnyx
+
+try:
+    response = client.ai.audio.transcribe(
+        model="openai/whisper-large-v3-turbo",
+        url="https://example.com/audio.mp3",
+    )
+except telnyx.APIConnectionError:
+    print("Network error — check connectivity and retry")
+except telnyx.RateLimitError:
+    import time
+    time.sleep(1)
+except telnyx.APIStatusError as e:
+    print(f"API error {e.status_code}: {e.message}")
+```
+
+Common error codes: `401` invalid API key, `403` insufficient permissions,
+`404` resource not found, `422` validation error, `429` rate limited.
+
+## Core Tasks
+
+### Transcribe speech to text
+
+Transcribe an audio file to text. This endpoint is consistent with the
+[OpenAI Transcription API](https://platform.openai.com/docs/api-reference/audio/createTranscription)
+and may be used with the OpenAI JS or Python SDK.
+
+`POST /ai/audio/transcriptions`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `url` | string (URL) | Yes | URL of the audio file to transcribe. |
+| `model` | string | No | Model ID (e.g., `openai/whisper-large-v3-turbo`, `distil-whisper/distil-large-v2`). |
+| `language` | string | No | Language code (e.g., `en`, `es`, `fr`). |
+| `prompt` | string | No | Optional prompt to guide transcription style. |
+| `response_format` | enum | No | `json`, `text`, `srt`, `verbose_json`, `vtt`. Default: `json`. |
+| `temperature` | number | No | Sampling temperature (0-1). Default: 0. |
+| `keywords` | array[string] | No | Keyword biasing — improve accuracy for domain-specific terms. |
+
+```python
+# Basic transcription
+response = client.ai.audio.transcribe(
+    url="https://example.com/audio.mp3",
+)
+print(response.text)
+
+# With specific model and language
+response = client.ai.audio.transcribe(
+    url="https://example.com/audio.mp3",
+    model="openai/whisper-large-v3-turbo",
+    language="es",
+)
+print(response.text)
+
+# With keyword biasing for domain-specific terms
+response = client.ai.audio.transcribe(
+    url="https://example.com/audio.mp3",
+    keywords=["Telnyx", "API", "WebRTC", "SIP"],
+)
+print(response.text)
+
+# Verbose JSON with segments
+response = client.ai.audio.transcribe(
+    url="https://example.com/audio.mp3",
+    response_format="verbose_json",
+)
+for segment in response.segments:
+    print(f"[{segment.start:.1f}s - {segment.end:.1f}s] {segment.text}")
+```
+
+Primary response fields:
+- `response.text` — Full transcription text
+- `response.duration` — Audio duration in seconds
+- `response.segments` — Array of segment objects (with `start`, `end`, `text`) when using `verbose_json` format
+
+### List available STT providers
+
+Retrieve a list of available speech-to-text providers and their service types.
+
+`GET /ai/audio/transcriptions/providers`
+
+```python
+response = client.ai.audio.list_providers()
+for provider in response.providers:
+    print(f"{provider['name']} — {provider['service_type']}")
+
+# Filter by provider name
+response = client.ai.audio.list_providers(provider="telnyx")
+for provider in response.providers:
+    print(f"{provider['name']} — {provider['service_type']}")
+
+# Filter by service type
+response = client.ai.audio.list_providers(service_type="transcription")
+for provider in response.providers:
+    print(f"{provider['name']} — {provider['service_type']}")
+```
+
+Primary response fields:
+- `response.providers` — Array of provider objects with `name` and `service_type`
+
+## CLI Usage
+
+The Telnyx Agent CLI provides composite commands for STT:
+
+```bash
+# Transcribe audio
+telnyx-agent stt --audio-url https://example.com/audio.mp3 --json
+
+# With specific model and language
+telnyx-agent stt --audio-url https://example.com/audio.mp3 --model openai/whisper-large-v3-turbo --language es --json
+
+# List available providers
+telnyx-agent stt-providers --json
+
+# Filter by provider or service type
+telnyx-agent stt-providers --provider telnyx --service-type transcription --json
+```
+
+## Important Notes
+
+- **Audio URL**: The audio file must be publicly accessible via a URL. Supported formats include mp3, mp4, mpeg, mpga, m4a, wav, and webm.
+- **OpenAI compatibility**: The transcription endpoint is OpenAI-compatible — you can use the OpenAI Python or JS SDK by setting the base URL to `https://api.telnyx.com/v2/ai/openai`.
+- **Keyword biasing**: Use `keywords` to improve transcription accuracy for domain-specific terms, product names, or acronyms that generic models may mishear.
+- **Models**: Available models include `openai/whisper-large-v3-turbo` (fast, accurate) and `distil-whisper/distil-large-v2` (lightweight). Check `stt-providers` for the full list.
+- **Languages**: Use ISO 639-1 codes (`en`, `es`, `fr`, `de`, `ja`, etc.). Omit to auto-detect.
+- **Response formats**: Use `verbose_json` to get timestamps and segments. Use `srt` or `vtt` for subtitle files.

--- a/skills/telnyx-tts-python/SKILL.md
+++ b/skills/telnyx-tts-python/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: telnyx-tts-python
+description: >-
+  Generate speech from text using Telnyx and third-party TTS providers (AWS,
+  Azure, ElevenLabs, MiniMax, Resemble, Rime, xAI). Returns base64-encoded
+  audio or a binary stream. Also lists available voices per provider.
+metadata:
+  author: telnyx
+  product: tts
+  language: python
+  generated_by: telnyx-ext-skills-generator
+  profile: northstar-v2
+---
+
+# Telnyx Text-to-Speech - Python
+
+## Installation
+
+```bash
+pip install telnyx
+```
+
+## Setup
+
+```python
+import os
+from telnyx import Telnyx
+
+client = Telnyx(
+    api_key=os.environ.get("TELNYX_API_KEY"),
+)
+```
+
+All examples below assume `client` is already initialized as shown above.
+
+## Error Handling
+
+All API calls can fail with network errors, rate limits (429), validation errors (422),
+or authentication errors (401). Always handle errors in production code:
+
+```python
+import telnyx
+
+try:
+    response = client.text_to_speech.generate(text="Hello world")
+except telnyx.APIConnectionError:
+    print("Network error — check connectivity and retry")
+except telnyx.RateLimitError:
+    import time
+    time.sleep(1)
+except telnyx.APIStatusError as e:
+    print(f"API error {e.status_code}: {e.message}")
+```
+
+Common error codes: `401` invalid API key, `403` insufficient permissions,
+`404` resource not found, `422` validation error, `429` rate limited.
+
+## Core Tasks
+
+### Generate speech from text
+
+Generate synthesized speech audio from text input. Returns audio as base64-encoded
+JSON (`base64_output`) or a binary audio stream (`binary_output`).
+
+`POST /text-to-speech/speech`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `text` | string | Yes | The text to synthesize. |
+| `provider` | enum | No | TTS provider: `telnyx`, `aws`, `azure`, `elevenlabs`, `minimax`, `resemble`, `rime`. Default: `telnyx`. |
+| `voice` | string | No | Voice ID to use (e.g., `en-US-Standard-A` for AWS). |
+| `output_type` | enum | No | `binary_output` or `base64_output`. Default: `binary_output`. |
+| `text_type` | enum | No | `text` or `ssml`. Default: `text`. |
+| `language` | string | No | Language code (e.g., `en-US`). |
+| `voice_settings` | object | No | Advanced voice settings (speed, pitch, volume). |
+| `telnyx` | object | No | Telnyx-specific provider options. |
+| `aws` | object | No | AWS-specific provider options. |
+| `azure` | object | No | Azure-specific provider options. |
+| `elevenlabs` | object | No | ElevenLabs-specific provider options. |
+| `minimax` | object | No | MiniMax-specific provider options. |
+| `resemble` | object | No | Resemble-specific provider options. |
+| `rime` | object | No | Rime-specific provider options. |
+| `disable_cache` | boolean | No | Disable response caching. |
+
+```python
+# Default Telnyx provider
+response = client.text_to_speech.generate(
+    text="Hello from Telnyx!",
+)
+print(response.base64_audio)
+
+# AWS provider with specific voice
+response = client.text_to_speech.generate(
+    text="Hello from Telnyx!",
+    provider="aws",
+    voice="en-US-Standard-A",
+    output_type="base64_output",
+)
+print(response.base64_audio)
+
+# SSML input
+response = client.text_to_speech.generate(
+    text="<speak>Hello <break time='1s'/> world</speak>",
+    text_type="ssml",
+)
+print(response.base64_audio)
+
+# ElevenLabs provider
+response = client.text_to_speech.generate(
+    text="Hello from Telnyx!",
+    provider="elevenlabs",
+    voice="21m00Tcm4TlvDq8ikWAM",
+    output_type="base64_output",
+)
+print(response.base64_audio)
+```
+
+Primary response fields:
+- `response.base64_audio` — Base64-encoded audio data (when `output_type` is `base64_output`)
+- Binary stream (when `output_type` is `binary_output`)
+
+### List available voices
+
+Retrieve a list of available voices from one or all TTS providers.
+
+`GET /text-to-speech/voices`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `provider` | enum | No | Filter by provider: `telnyx`, `aws`, `azure`, `elevenlabs`, `minimax`, `resemble`, `rime`. |
+
+```python
+# List all voices across all providers
+response = client.text_to_speech.list_voices()
+for voice in response.voices:
+    print(f"{voice['name']} — {voice['provider']} ({voice['language']})")
+
+# List only AWS voices
+response = client.text_to_speech.list_voices(provider="aws")
+for voice in response.voices:
+    print(f"{voice['name']} — {voice['language']}")
+```
+
+Primary response fields:
+- `response.voices` — Array of voice objects with `name`, `provider`, `language`, `voice_id`
+
+## CLI Usage
+
+The Telnyx Agent CLI provides composite commands for TTS:
+
+```bash
+# Generate speech
+telnyx-agent tts --text "Hello world" --json
+
+# Generate with specific provider and voice
+telnyx-agent tts --text "Hello world" --provider aws --voice en-US-Standard-A --json
+
+# List available voices
+telnyx-agent tts-voices --json
+
+# Filter voices by provider
+telnyx-agent tts-voices --provider elevenlabs --json
+```
+
+## Important Notes
+
+- **Audio format**: When `output_type` is `base64_output`, decode the base64 string to get the audio bytes. When `binary_output`, the response is a raw audio stream.
+- **SSML**: Use `text_type: "ssml"` to send SSML markup for fine-grained control over pronunciation, pauses, and emphasis.
+- **Provider-specific options**: Each provider (`aws`, `azure`, `elevenlabs`, etc.) has its own object for provider-specific configuration (e.g., AWS engine type, ElevenLabs stability).
+- **Caching**: Responses are cached by default. Use `disable_cache: true` to bypass.
+- **xAI**: The xAI provider is available via the CLI (`--provider xai`) and supports voice listing.


### PR DESCRIPTION
## Summary

Three fixes to make the Claude Code plugin ready for the v0.4.0 release:

### 1. Plugin version bump (0.1.0 → 0.4.0)
The marketplace.json and plugin.json were stuck at 0.1.0 while the CLI shipped 0.4.0. Bumped both to match.

### 2. TTS skill — `telnyx-tts-python`
New skill covering text-to-speech via the Telnyx TTS API:
- `POST /text-to-speech/speech` — generate speech from text
- `GET /text-to-speech/voices` — list available voices
- 7 providers: telnyx, aws, azure, elevenlabs, minimax, resemble, rime, xai
- SSML support, base64/binary output, provider-specific options
- CLI usage examples (`telnyx-agent tts`, `telnyx-agent tts-voices`)

### 3. STT skill — `telnyx-stt-python`
New skill covering speech-to-text via the OpenAI-compatible transcription API:
- `POST /ai/audio/transcriptions` — transcribe audio to text
- `GET /ai/audio/transcriptions/providers` — list STT providers
- Model selection, language, keyword biasing, response formats (json, text, srt, vtt)
- CLI usage examples (`telnyx-agent stt`, `telnyx-agent stt-providers`)

Both skills follow the existing skill pattern (frontmatter, setup, error handling, core tasks, CLI usage).
Synced to `providers/claude/plugin/skills/` and `providers/cursor/plugin/skills/` via `scripts/sync-skills.sh`.

### Marketplace install

Users can now install the Telnyx plugin directly from GitHub:
```
/plugin marketplace add team-telnyx/ai
/plugin install telnyx@telnyx
```

236 skills total (up from 234).