### PR TITLE
feat: Add number lookup to agent CLI

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "tsx bin/telnyx-agent.ts",
-    "test": "tsx --test tests/edge-handoff.test.ts tests/integration.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
+    "test": "tsx --test tests/edge-handoff.test.ts tests/integration.test.ts tests/number-lookup.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
     "typecheck": "tsc --noEmit",
     "postinstall": "tsx scripts/postinstall.ts",
     "build": "npm run typecheck"

--- a/cli/src/commands/capabilities.ts
+++ b/cli/src/commands/capabilities.ts
@@ -99,6 +99,7 @@ const COMPOSITE_COMMANDS = [
   { name: "telnyx-agent stt", description: "Transcribe audio to text (speech-to-text) — accepts an audio URL and returns the transcript with optional language, model, and keyword biasing" },
   { name: "telnyx-agent stt", description: "Transcribe audio to text (speech-to-text) — accepts a hosted audio file URL and returns the transcript with optional model and language selection" },
   { name: "telnyx-agent stt-providers", description: "List available speech-to-text providers, optionally filtered by provider name or service type" },
+  { name: "telnyx-agent lookup-number", description: "Retrieve carrier, caller-name, and portability information for a phone number" },
   { name: "telnyx-agent status", description: "Account health overview — balance, numbers, profiles, connections" },
   { name: "telnyx-agent capabilities", description: "This command — lists all available API capabilities" },
   { name: "telnyx-agent call-dial", description: "Make an outbound call via Call Control (AMD, deepfake detection, recording optional)" },

--- a/cli/src/commands/lookup-number.ts
+++ b/cli/src/commands/lookup-number.ts
@@ -1,0 +1,90 @@
+/**
+ * telnyx-agent lookup-number — Retrieve carrier and caller-name information.
+ *
+ * Shells out to the Go telnyx CLI `number-lookup retrieve` subcommand.
+ */
+
+import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
+import { printSuccess, printError, outputJson } from "../utils/output.ts";
+
+const VALID_LOOKUP_TYPES = ["carrier", "caller-name"] as const;
+type LookupType = (typeof VALID_LOOKUP_TYPES)[number];
+
+interface LookupSection {
+  [key: string]: unknown;
+}
+
+interface NumberLookupResult {
+  caller_name?: LookupSection;
+  carrier?: LookupSection;
+  country_code?: string;
+  fraud?: string | null;
+  national_format?: string;
+  phone_number?: string;
+  portability?: LookupSection;
+  record_type?: string;
+  [key: string]: unknown;
+}
+
+export async function lookupNumberCommand(flags: Record<string, string | boolean>): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const phoneNumber = flags["phone-number"] as string | undefined;
+  const type = flags.type as string | undefined;
+
+  if (!phoneNumber) {
+    printError("--phone-number is required (E.164 format, e.g., +131****0000)");
+    process.exit(1);
+  }
+  if (type && !VALID_LOOKUP_TYPES.includes(type as LookupType)) {
+    printError(`Invalid --type "${type}". Valid: ${VALID_LOOKUP_TYPES.join(", ")}`);
+    process.exit(1);
+  }
+
+  const args = ["number-lookup", "retrieve", "--phone-number", phoneNumber];
+  if (type) args.push("--type", type);
+
+  try {
+    if (!jsonOutput) console.log(`\n🔍 Looking up ${phoneNumber}...`);
+
+    const response = await telnyxCli(args);
+    const data = (response?.data ?? response ?? {}) as NumberLookupResult;
+
+    if (jsonOutput) {
+      // The API's data object is the useful lookup result. Preserve all fields,
+      // including carrier, caller_name, and portability details.
+      outputJson(data);
+    } else {
+      const carrier = asObject(data.carrier);
+      const callerName = asObject(data.caller_name);
+      const portability = asObject(data.portability);
+      printSuccess("Number lookup complete", {
+        "Phone Number": String(data.phone_number ?? phoneNumber),
+        ...(data.national_format ? { "National Format": data.national_format } : {}),
+        ...(data.country_code ? { "Country Code": data.country_code } : {}),
+        ...(carrier.name ? { "Carrier": String(carrier.name) } : {}),
+        ...(carrier.type ? { "Carrier Type": String(carrier.type) } : {}),
+        ...(callerName.caller_name ? { "Caller Name": String(callerName.caller_name) } : {}),
+        ...(portability.line_type ? { "Line Type": String(portability.line_type) } : {}),
+        ...(portability.ported_status ? { "Ported": String(portability.ported_status) } : {}),
+      });
+    }
+  } catch (err) {
+    const message = errorMsg(err);
+    if (jsonOutput) {
+      outputJson({ error: message, phone_number: phoneNumber });
+    } else {
+      printError(message);
+    }
+    process.exit(1);
+  }
+}
+
+function asObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? value as Record<string, unknown> : {};
+}
+
+function errorMsg(err: unknown): string {
+  if (err instanceof TelnyxCLIError) return err.stderr || err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -32,6 +32,7 @@ import { callControlCommand } from "./commands/call-control.ts";
 import { callStatusCommand } from "./commands/call-status.ts";
 import { sttCommand } from "./commands/stt.ts";
 import { sttProvidersCommand } from "./commands/stt-providers.ts";
+import { lookupNumberCommand } from "./commands/lookup-number.ts";
 import { parseFlags } from "./utils/output.ts";
 
 const HELP = `
@@ -71,6 +72,7 @@ Commands:
   call-status       Get the status of a call by call-control-id
   stt               Transcribe audio to text (speech-to-text)
   stt-providers     List available speech-to-text providers
+  lookup-number     Look up carrier and caller-name information for a phone number
 
 Global Flags:
   --json            Output structured JSON instead of human-readable text
@@ -215,6 +217,10 @@ STT-providers Flags:
   --provider        Filter providers by name (optional)
   --service-type    Filter providers by service type (optional)
 
+Number Lookup Flags:
+  --phone-number <e164> Phone number to look up in E.164 format (required)
+  --type <type>         Lookup type: carrier or caller-name (optional)
+
 Environment:
   TELNYX_API_KEY    API key (or configure ~/.config/telnyx/config.json)
 
@@ -284,6 +290,8 @@ Examples:
   telnyx-agent stt --audio-url https://example.com/audio.mp3 --model openai/whisper-large-v3-turbo --language es --json
   telnyx-agent stt-providers --json
   telnyx-agent stt-providers --provider telnyx --service-type transcription --json
+  telnyx-agent lookup-number --phone-number +131****0000
+  telnyx-agent lookup-number --phone-number +131****0000 --type caller-name --json
 `;
 
 const COMMANDS: Record<string, (flags: Record<string, string | boolean>) => Promise<void>> = {
@@ -317,6 +325,7 @@ const COMMANDS: Record<string, (flags: Record<string, string | boolean>) => Prom
   "call-status": callStatusCommand,
   stt: sttCommand,
   "stt-providers": sttProvidersCommand,
+  "lookup-number": lookupNumberCommand,
 };
 
 export async function run(argv: string[]): Promise<void> {

--- a/cli/tests/number-lookup.test.ts
+++ b/cli/tests/number-lookup.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Tests for lookup-number — verify the Agent CLI wraps the generated Go CLI's
+ * `number-lookup retrieve` command without making real API calls.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliRoot = join(__dirname, "..");
+const cliBin = join(cliRoot, "bin", "telnyx-agent.ts");
+
+function setupFakeTelnyx(): { logPath: string; env: NodeJS.ProcessEnv } {
+  const tempDir = mkdtempSync(join(tmpdir(), "telnyx-agent-number-lookup-"));
+  const binDir = join(tempDir, "bin");
+  const logPath = join(tempDir, "args.jsonl");
+  mkdirSync(binDir, { recursive: true });
+
+  const fakeTelnyx = join(binDir, "telnyx");
+  writeFileSync(
+    fakeTelnyx,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.TELNYX_FAKE_ARGS_LOG, JSON.stringify(args) + "\\n");
+
+const formatIndex = args.indexOf("--format");
+const command = args.filter((_arg, index) => index !== formatIndex && index !== formatIndex + 1);
+if (command[0] !== "number-lookup" || command[1] !== "retrieve") {
+  console.error("unexpected command: " + command.join(" "));
+  process.exit(2);
+}
+
+const phoneIndex = command.indexOf("--phone-number");
+const phoneNumber = phoneIndex >= 0 ? command[phoneIndex + 1] : "";
+console.log(JSON.stringify({
+  data: {
+    record_type: "number_lookup",
+    phone_number: phoneNumber,
+    national_format: "(312) 555-0100",
+    country_code: "US",
+    carrier: {
+      error_code: null,
+      mobile_country_code: "310",
+      mobile_network_code: "410",
+      name: "Example Wireless",
+      normalized_carrier: "Example",
+      type: "mobile"
+    },
+    caller_name: { caller_name: "EXAMPLE INC", error_code: "00000" },
+    portability: {
+      line_type: "wireless",
+      ported_status: "Y",
+      spid_carrier_name: "Example Wireless",
+      state: "IL"
+    }
+  }
+}));
+`,
+  );
+  chmodSync(fakeTelnyx, 0o755);
+
+  return {
+    logPath,
+    env: {
+      ...process.env,
+      TELNYX_CLI_PATH: fakeTelnyx,
+      TELNYX_FAKE_ARGS_LOG: logPath,
+      TELNYX_API_KEY: "KEY_fake_test",
+    },
+  };
+}
+
+function runAgent(args: string[], env: NodeJS.ProcessEnv): string {
+  return execFileSync("npx", ["tsx", cliBin, ...args], {
+    cwd: cliRoot,
+    encoding: "utf8",
+    env,
+    timeout: 30000,
+  });
+}
+
+function readLoggedArgs(logPath: string): string[][] {
+  if (!existsSync(logPath)) return [];
+  return readFileSync(logPath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+describe("lookup-number", () => {
+  it("calls the exact Go CLI command and forwards --type", () => {
+    const fake = setupFakeTelnyx();
+    runAgent(
+      ["lookup-number", "--phone-number", "+131****0100", "--type", "caller-name", "--json"],
+      fake.env,
+    );
+
+    assert.deepEqual(readLoggedArgs(fake.logPath), [[
+      "number-lookup",
+      "retrieve",
+      "--phone-number",
+      "+131****0100",
+      "--type",
+      "caller-name",
+      "--format",
+      "json",
+    ]]);
+  });
+
+  it("omits the optional --type flag when it is not provided", () => {
+    const fake = setupFakeTelnyx();
+    runAgent(["lookup-number", "--phone-number", "+131****0100", "--json"], fake.env);
+
+    assert.deepEqual(readLoggedArgs(fake.logPath), [[
+      "number-lookup",
+      "retrieve",
+      "--phone-number",
+      "+131****0100",
+      "--format",
+      "json",
+    ]]);
+  });
+
+  it("unwraps and preserves the complete number lookup response data", () => {
+    const fake = setupFakeTelnyx();
+    const output = runAgent(
+      ["lookup-number", "--phone-number", "+131****0100", "--type", "carrier", "--json"],
+      fake.env,
+    );
+    const result = JSON.parse(output);
+
+    assert.equal(result.record_type, "number_lookup");
+    assert.equal(result.phone_number, "+131****0100");
+    assert.equal(result.national_format, "(312) 555-0100");
+    assert.equal(result.country_code, "US");
+    assert.equal(result.carrier.name, "Example Wireless");
+    assert.equal(result.carrier.type, "mobile");
+    assert.equal(result.caller_name.caller_name, "EXAMPLE INC");
+    assert.equal(result.portability.line_type, "wireless");
+    assert.equal(result.portability.ported_status, "Y");
+  });
+
+  it("prints a useful human-readable summary", () => {
+    const fake = setupFakeTelnyx();
+    const output = runAgent(["lookup-number", "--phone-number", "+131****0100"], fake.env);
+
+    assert.match(output, /Number lookup complete/);
+    assert.match(output, /Example Wireless/);
+    assert.match(output, /EXAMPLE INC/);
+    assert.match(output, /wireless/);
+  });
+
+  it("requires --phone-number without invoking the Go CLI", () => {
+    const fake = setupFakeTelnyx();
+    const result = spawnSync("npx", ["tsx", cliBin, "lookup-number", "--json"], {
+      cwd: cliRoot,
+      encoding: "utf8",
+      env: fake.env,
+      timeout: 30000,
+    });
+
+    assert.notEqual(result.status, 0);
+    assert.match(`${result.stderr}${result.stdout}`, /--phone-number is required/);
+    assert.deepEqual(readLoggedArgs(fake.logPath), []);
+  });
+
+  it("rejects lookup types not supported by the Go API", () => {
+    const fake = setupFakeTelnyx();
+    const result = spawnSync(
+      "npx",
+      ["tsx", cliBin, "lookup-number", "--phone-number", "+131****0100", "--type", "fraud"],
+      { cwd: cliRoot, encoding: "utf8", env: fake.env, timeout: 30000 },
+    );
+
+    assert.notEqual(result.status, 0);
+    assert.match(`${result.stderr}${result.stdout}`, /Valid: carrier, caller-name/);
+    assert.deepEqual(readLoggedArgs(fake.logPath), []);
+  });
+
+  it("is documented in help and capabilities", () => {
+    const fake = setupFakeTelnyx();
+    const help = runAgent(["help"], fake.env);
+    assert.match(help, /lookup-number/);
+    assert.match(help, /--phone-number <e164>/);
+    assert.match(help, /carrier or caller-name/);
+
+    const capabilities = JSON.parse(runAgent(["capabilities", "--json"], fake.env));
+    assert.ok(
+      capabilities.api_capabilities["🔍 Lookup"][0].actions.includes("lookup_number"),
+      "Lookup capability must advertise lookup_number",
+    );
+    assert.ok(
+      capabilities.composite_commands.some((command: { name: string }) => command.name === "telnyx-agent lookup-number"),
+      "composite commands must list the executable lookup-number command",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add `lookup-number` over `number-lookup retrieve`
- expose carrier/caller-name lookup flags and structured output
- add mock-binary tests and CLI help/capability wiring

## Audit finding
`lookup_number` was advertised in capabilities but had no executable Agent CLI command.

## Validation
- `npx tsc --noEmit`
- `npm test` (117/117)