### PR TITLE
feat: Add fax sending to agent CLI

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "tsx bin/telnyx-agent.ts",
-    "test": "tsx --test tests/edge-handoff.test.ts tests/integration.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
+    "test": "tsx --test tests/edge-handoff.test.ts tests/fax.test.ts tests/integration.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
     "typecheck": "tsc --noEmit",
     "postinstall": "tsx scripts/postinstall.ts",
     "build": "npm run typecheck"

--- a/cli/src/commands/capabilities.ts
+++ b/cli/src/commands/capabilities.ts
@@ -77,6 +77,7 @@ const CAPABILITIES: Record<string, Capability[]> = {
 const COMPOSITE_COMMANDS = [
   { name: "telnyx-agent setup-sms", description: "Zero to SMS: creates messaging profile, buys number, assigns it" },
   { name: "telnyx-agent send-sms", description: "Send an SMS or MMS message (pass --media-url to send MMS)" },
+  { name: "telnyx-agent send-fax", description: "Send a fax from a hosted document URL or a file pre-uploaded to the Telnyx Media API" },
   { name: "telnyx-agent send-group-mms", description: "Send a group MMS to multiple recipients (--to comma-separated E.164 numbers)" },
   { name: "telnyx-agent schedule-sms", description: "Schedule an SMS for future delivery at a given ISO 8601 time" },
   { name: "telnyx-agent sms-status", description: "Check SMS delivery status, or cancel a scheduled message with --cancel" },

--- a/cli/src/commands/send-fax.ts
+++ b/cli/src/commands/send-fax.ts
@@ -1,0 +1,159 @@
+/**
+ * telnyx-agent send-fax — Send a fax from a hosted or pre-uploaded document.
+ *
+ * Shells out to the Go telnyx CLI `faxes create` subcommand. The document can
+ * be supplied with --media-url or with --media-name after uploading it to the
+ * Telnyx Media API.
+ */
+
+import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
+import { printSuccess, printError, outputJson } from "../utils/output.ts";
+
+interface SendFaxResult {
+  fax_id: string;
+  status: string;
+  connection_id: string;
+  from: string;
+  to: string;
+  media_url?: string;
+  media_name?: string;
+}
+
+const QUALITY_VALUES = ["normal", "high", "very_high", "ultra_light", "ultra_dark"] as const;
+const PREVIEW_FORMAT_VALUES = ["pdf", "tiff"] as const;
+
+export async function sendFaxCommand(flags: Record<string, string | boolean>): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const connectionId = stringFlag(flags, "connection-id");
+  const from = stringFlag(flags, "from");
+  const to = stringFlag(flags, "to");
+  const mediaUrl = stringFlag(flags, "media-url");
+  const mediaName = stringFlag(flags, "media-name");
+  const blackThreshold = stringFlag(flags, "black-threshold");
+  const clientState = stringFlag(flags, "client-state");
+  const fromDisplayName = stringFlag(flags, "from-display-name");
+  const previewFormat = stringFlag(flags, "preview-format");
+  const quality = stringFlag(flags, "quality");
+  const webhookUrl = stringFlag(flags, "webhook-url");
+  const monochrome = booleanFlag(flags, "monochrome");
+  const storeMedia = booleanFlag(flags, "store-media");
+  const storePreview = booleanFlag(flags, "store-preview");
+  const t38Enabled = booleanFlag(flags, "t38-enabled");
+
+  if (!connectionId) fail("--connection-id is required (the fax application connection to use)");
+  if (!from) fail("--from is required (E.164 format, e.g. +131****0000)");
+  if (!to) fail("--to is required (E.164 format or a SIP URI)");
+  if (!mediaUrl && !mediaName) {
+    fail("One document source is required: pass --media-url or --media-name");
+  }
+  if (mediaUrl && mediaName) {
+    fail("--media-url and --media-name are mutually exclusive");
+  }
+  if (mediaName && storeMedia === true) {
+    fail("--store-media is not supported with --media-name");
+  }
+  if (blackThreshold !== undefined && (!/^\d+$/.test(blackThreshold) || Number(blackThreshold) > 100)) {
+    fail("--black-threshold must be an integer from 0 to 100");
+  }
+  if (previewFormat !== undefined && !PREVIEW_FORMAT_VALUES.includes(previewFormat as (typeof PREVIEW_FORMAT_VALUES)[number])) {
+    fail(`--preview-format must be one of: ${PREVIEW_FORMAT_VALUES.join(", ")}`);
+  }
+  if (quality !== undefined && !QUALITY_VALUES.includes(quality as (typeof QUALITY_VALUES)[number])) {
+    fail(`--quality must be one of: ${QUALITY_VALUES.join(", ")}`);
+  }
+
+  const args: string[] = [
+    "faxes", "create",
+    "--connection-id", connectionId,
+    "--from", from,
+    "--to", to,
+  ];
+  if (mediaUrl) args.push("--media-url", mediaUrl);
+  if (mediaName) args.push("--media-name", mediaName);
+  if (blackThreshold) args.push("--black-threshold", blackThreshold);
+  if (clientState) args.push("--client-state", clientState);
+  if (fromDisplayName) args.push("--from-display-name", fromDisplayName);
+  if (previewFormat) args.push("--preview-format", previewFormat);
+  if (quality) args.push("--quality", quality);
+  if (webhookUrl) args.push("--webhook-url", webhookUrl);
+  pushBooleanFlag(args, "monochrome", monochrome);
+  pushBooleanFlag(args, "store-media", storeMedia);
+  pushBooleanFlag(args, "store-preview", storePreview);
+  pushBooleanFlag(args, "t38-enabled", t38Enabled);
+
+  try {
+    const res = await telnyxCli(args);
+    const data = (res?.data ?? res ?? {}) as Record<string, unknown>;
+    const result: SendFaxResult = {
+      fax_id: valueOr(data.id ?? data.fax_id, ""),
+      status: valueOr(data.status, "queued"),
+      connection_id: valueOr(data.connection_id, connectionId),
+      from: valueOr(data.from, from),
+      to: valueOr(data.to, to),
+      media_url: optionalValue(data.media_url) ?? mediaUrl,
+      media_name: optionalValue(data.media_name) ?? mediaName,
+    };
+
+    if (jsonOutput) {
+      outputJson(result);
+    } else {
+      const details: Record<string, string | number | boolean> = {
+        "Fax ID": result.fax_id,
+        Status: result.status,
+        "Connection ID": result.connection_id,
+        From: result.from,
+        To: result.to,
+        "Document": result.media_name ?? result.media_url ?? "",
+      };
+      printSuccess("Fax submitted!", details);
+    }
+  } catch (err) {
+    const message = errorMsg(err);
+    if (jsonOutput) {
+      outputJson({ error: message });
+    } else {
+      printError(message);
+    }
+    process.exit(1);
+  }
+}
+
+function stringFlag(flags: Record<string, string | boolean>, name: string): string | undefined {
+  const value = flags[name];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function booleanFlag(flags: Record<string, string | boolean>, name: string): boolean | undefined {
+  const value = flags[name];
+  if (value === undefined) return undefined;
+  if (typeof value === "boolean") return value;
+  if (value.toLowerCase() === "true") return true;
+  if (value.toLowerCase() === "false") return false;
+  fail(`--${name} must be true or false`);
+}
+
+function pushBooleanFlag(args: string[], name: string, value: boolean | undefined): void {
+  if (value === undefined) return;
+  // Go boolean flags accept a bare flag for true. Use --flag=false as one argv
+  // token so urfave/cli does not interpret "false" as a positional argument.
+  args.push(value ? `--${name}` : `--${name}=false`);
+}
+
+function valueOr(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.length > 0 ? value : fallback;
+}
+
+function optionalValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function fail(message: string): never {
+  printError(message);
+  process.exit(1);
+}
+
+function errorMsg(err: unknown): string {
+  if (err instanceof TelnyxCLIError) return err.stderr || err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -24,6 +24,7 @@ import { setupWhatsappCommand } from "./commands/setup-whatsapp.ts";
 import { whatsappSendCommand } from "./commands/whatsapp-send.ts";
 import { whatsappTemplatesCommand } from "./commands/whatsapp-templates.ts";
 import { sendSmsCommand } from "./commands/send-sms.ts";
+import { sendFaxCommand } from "./commands/send-fax.ts";
 import { sendGroupMmsCommand } from "./commands/send-group-mms.ts";
 import { scheduleSmsCommand } from "./commands/schedule-sms.ts";
 import { smsStatusCommand } from "./commands/sms-status.ts";
@@ -63,6 +64,7 @@ Commands:
   whatsapp-send     Send a WhatsApp message (text or template)
   whatsapp-templates List or create WhatsApp message templates
   send-sms          Send an SMS or MMS message (--media-url sends MMS)
+  send-fax          Send a fax from a hosted URL or pre-uploaded media
   send-group-mms    Send a group MMS to multiple recipients (--to comma-separated)
   schedule-sms      Schedule an SMS for future delivery (--send-at ISO 8601)
   sms-status        Check SMS delivery status, or cancel a scheduled message (--cancel)
@@ -147,6 +149,23 @@ SMS Action Flags:
   --send-at <iso8601>    Send time, ISO 8601 (schedule-sms — required, e.g., 2024-12-31T00:00:00Z)
   --id <message-id>      Message ID (sms-status — required)
   --cancel               Cancel a scheduled message instead of retrieving status (sms-status)
+
+Fax Action Flags:
+  --connection-id <id>   Fax application connection ID (required)
+  --from <e164>          Sender number in E.164 format (required)
+  --to <e164|sip-uri>    Destination number or SIP URI (required)
+  --media-url <url>      Publicly accessible fax document URL (one document source required)
+  --media-name <name>    File previously uploaded to the Telnyx Media API (one document source required)
+  --quality <value>      normal, high, very_high, ultra_light, or ultra_dark
+  --monochrome [bool]    Produce a true black-and-white fax
+  --black-threshold <n>  Black threshold percentage for monochrome output (0-100)
+  --store-media [bool]   Store fax media on a temporary URL (not supported with --media-name)
+  --store-preview [bool] Store a fax preview on a temporary URL
+  --preview-format <fmt> Preview format: pdf or tiff
+  --t38-enabled [bool]   Enable or disable T.38 (default: true)
+  --from-display-name <name> Caller ID display name
+  --client-state <base64> Base64 state included in fax webhooks
+  --webhook-url <url>    Override the webhook URL for this fax
 
 WhatsApp Flags:
   --waba-id <id>    WhatsApp Business Account id (setup-whatsapp, whatsapp-templates)
@@ -248,6 +267,8 @@ Examples:
   telnyx-agent whatsapp-templates --waba-id <id> --create --name promo --category MARKETING --component '[]'
   telnyx-agent send-sms --from +131****0000 --to +131****0001 --text "Hello!"
   telnyx-agent send-sms --from +131****0000 --to +131****0001 --text "See this" --media-url https://example.com/img.png --subject "Photo"
+  telnyx-agent send-fax --connection-id <id> --from +131****0000 --to +131****0001 --media-url https://example.com/document.pdf
+  telnyx-agent send-fax --connection-id <id> --from +131****0000 --to +131****0001 --media-name uploaded-document.pdf --json
   telnyx-agent send-group-mms --from +131****0000 --to +131****0001,+131****0002,+131****0003 --text "Group hi!"
   telnyx-agent send-group-mms --from +131****0000 --to +131****0001,+131****0002 --media-url https://example.com/cat.png
   telnyx-agent schedule-sms --from +131****0000 --to +131****0001 --text "Later" --send-at 2024-12-31T00:00:00Z
@@ -309,6 +330,7 @@ const COMMANDS: Record<string, (flags: Record<string, string | boolean>) => Prom
   "whatsapp-send": whatsappSendCommand,
   "whatsapp-templates": whatsappTemplatesCommand,
   "send-sms": sendSmsCommand,
+  "send-fax": sendFaxCommand,
   "send-group-mms": sendGroupMmsCommand,
   "schedule-sms": scheduleSmsCommand,
   "sms-status": smsStatusCommand,

--- a/cli/tests/fax.test.ts
+++ b/cli/tests/fax.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Tests for send-fax — verify the Agent CLI's validation, output, and exact
+ * `faxes create` invocation without making real API calls.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliRoot = join(__dirname, "..");
+const cliBin = join(cliRoot, "bin", "telnyx-agent.ts");
+
+function setupFakeTelnyx(): { logPath: string; env: NodeJS.ProcessEnv } {
+  const tempDir = mkdtempSync(join(tmpdir(), "telnyx-agent-fax-"));
+  const binDir = join(tempDir, "bin");
+  const logPath = join(tempDir, "args.jsonl");
+  mkdirSync(binDir, { recursive: true });
+
+  const fakeTelnyx = join(binDir, "telnyx");
+  writeFileSync(
+    fakeTelnyx,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.TELNYX_FAKE_ARGS_LOG, JSON.stringify(args) + "\\n");
+
+const fmtIdx = args.indexOf("--format");
+const command = args.filter((_, i) => i !== fmtIdx && i !== fmtIdx + 1);
+function flag(name) {
+  const direct = command.indexOf(name);
+  if (direct >= 0) return command[direct + 1];
+  const assignment = command.find((arg) => arg.startsWith(name + "="));
+  return assignment ? assignment.slice(name.length + 1) : undefined;
+}
+
+if (command[0] === "faxes" && command[1] === "create") {
+  const data = {
+    id: "fax-123",
+    record_type: "fax",
+    status: "queued",
+    connection_id: flag("--connection-id"),
+    from: flag("--from"),
+    to: flag("--to"),
+    media_url: flag("--media-url"),
+    media_name: flag("--media-name"),
+  };
+  console.log(JSON.stringify({ data }));
+} else {
+  console.log(JSON.stringify({ data: {} }));
+}
+`,
+  );
+  chmodSync(fakeTelnyx, 0o755);
+
+  return {
+    logPath,
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH}`,
+      TELNYX_CLI_PATH: fakeTelnyx,
+      TELNYX_FAKE_ARGS_LOG: logPath,
+      TELNYX_API_KEY: "KEY_fake_test",
+    },
+  };
+}
+
+function runAgent(args: string[], env: NodeJS.ProcessEnv): string {
+  return execFileSync("npx", ["tsx", cliBin, ...args], {
+    cwd: cliRoot,
+    encoding: "utf8",
+    env,
+    timeout: 30000,
+  });
+}
+
+function readLoggedArgs(logPath: string): string[][] {
+  if (!existsSync(logPath)) return [];
+  return readFileSync(logPath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function faxCall(logPath: string): string[] {
+  const call = readLoggedArgs(logPath).find((args) => args[0] === "faxes" && args[1] === "create");
+  assert.ok(call, "must invoke faxes create");
+  return call;
+}
+
+function assertFlagValue(args: string[], name: string, expected: string): void {
+  const index = args.indexOf(name);
+  assert.notEqual(index, -1, `expected ${name} in ${args.join(" ")}`);
+  assert.equal(args[index + 1], expected);
+}
+
+function runAgentExpectingFailure(args: string[], env: NodeJS.ProcessEnv, expected: RegExp): void {
+  try {
+    runAgent(args, env);
+    assert.fail("expected command to fail");
+  } catch (err: any) {
+    assert.notEqual(err?.status, 0, "expected a non-zero exit status");
+    assert.match(`${err?.stderr ?? ""}${err?.stdout ?? ""}`, expected);
+  }
+}
+
+describe("send-fax", () => {
+  it("sends a hosted document URL with the required faxes create flags", () => {
+    const fake = setupFakeTelnyx();
+    const output = runAgent(
+      [
+        "send-fax",
+        "--connection-id", "conn-123",
+        "--from", "+131****0000",
+        "--to", "+131****0001",
+        "--media-url", "https://example.com/document.pdf",
+        "--json",
+      ],
+      fake.env,
+    );
+
+    assert.deepEqual(JSON.parse(output), {
+      fax_id: "fax-123",
+      status: "queued",
+      connection_id: "conn-123",
+      from: "+131****0000",
+      to: "+131****0001",
+      media_url: "https://example.com/document.pdf",
+    });
+
+    const call = faxCall(fake.logPath);
+    assertFlagValue(call, "--connection-id", "conn-123");
+    assertFlagValue(call, "--from", "+131****0000");
+    assertFlagValue(call, "--to", "+131****0001");
+    assertFlagValue(call, "--media-url", "https://example.com/document.pdf");
+    assert.ok(!call.includes("--media-name"));
+    assertFlagValue(call, "--format", "json");
+  });
+
+  it("sends pre-uploaded media and forwards all optional faxes create flags", () => {
+    const fake = setupFakeTelnyx();
+    const output = runAgent(
+      [
+        "send-fax",
+        "--connection-id", "conn-456",
+        "--from", "+131****0000",
+        "--to", "sip:fax@example.com",
+        "--media-name", "uploaded-document.pdf",
+        "--black-threshold", "90",
+        "--client-state", "c3RhdGU=",
+        "--from-display-name", "Acme Fax",
+        "--monochrome",
+        "--preview-format", "pdf",
+        "--quality", "very_high",
+        "--store-preview",
+        "--t38-enabled", "false",
+        "--webhook-url", "https://example.com/fax-events",
+        "--json",
+      ],
+      fake.env,
+    );
+
+    const result = JSON.parse(output);
+    assert.equal(result.fax_id, "fax-123");
+    assert.equal(result.media_name, "uploaded-document.pdf");
+    assert.equal(result.to, "sip:fax@example.com");
+
+    const call = faxCall(fake.logPath);
+    assertFlagValue(call, "--media-name", "uploaded-document.pdf");
+    assertFlagValue(call, "--black-threshold", "90");
+    assertFlagValue(call, "--client-state", "c3RhdGU=");
+    assertFlagValue(call, "--from-display-name", "Acme Fax");
+    assert.ok(call.includes("--monochrome"));
+    assertFlagValue(call, "--preview-format", "pdf");
+    assertFlagValue(call, "--quality", "very_high");
+    assert.ok(call.includes("--store-preview"));
+    assert.ok(call.includes("--t38-enabled=false"));
+    assertFlagValue(call, "--webhook-url", "https://example.com/fax-events");
+    assert.ok(!call.includes("--media-url"));
+  });
+
+  it("supports store-media for URL documents", () => {
+    const fake = setupFakeTelnyx();
+    runAgent(
+      [
+        "send-fax",
+        "--connection-id", "conn-123",
+        "--from", "+131****0000",
+        "--to", "+131****0001",
+        "--media-url", "https://example.com/document.pdf",
+        "--store-media",
+        "--json",
+      ],
+      fake.env,
+    );
+
+    assert.ok(faxCall(fake.logPath).includes("--store-media"));
+  });
+
+  it("requires a connection, sender, destination, and document source", () => {
+    const base = [
+      "send-fax",
+      "--connection-id", "conn-123",
+      "--from", "+131****0000",
+      "--to", "+131****0001",
+      "--media-url", "https://example.com/document.pdf",
+      "--json",
+    ];
+    const required = [
+      ["--connection-id", /--connection-id is required/],
+      ["--from", /--from is required/],
+      ["--to", /--to is required/],
+      ["--media-url", /One document source is required/],
+    ] as const;
+
+    for (const [flag, expected] of required) {
+      const fake = setupFakeTelnyx();
+      const index = base.indexOf(flag);
+      const args = [...base.slice(0, index), ...base.slice(index + 2)];
+      runAgentExpectingFailure(args, fake.env, expected);
+      assert.deepEqual(readLoggedArgs(fake.logPath), [], "validation must happen before invoking telnyx");
+    }
+  });
+
+  it("rejects mutually exclusive or incompatible media options", () => {
+    const both = setupFakeTelnyx();
+    runAgentExpectingFailure(
+      [
+        "send-fax",
+        "--connection-id", "conn-123",
+        "--from", "+131****0000",
+        "--to", "+131****0001",
+        "--media-url", "https://example.com/document.pdf",
+        "--media-name", "uploaded-document.pdf",
+      ],
+      both.env,
+      /--media-url and --media-name are mutually exclusive/,
+    );
+    assert.deepEqual(readLoggedArgs(both.logPath), []);
+
+    const storedUpload = setupFakeTelnyx();
+    runAgentExpectingFailure(
+      [
+        "send-fax",
+        "--connection-id", "conn-123",
+        "--from", "+131****0000",
+        "--to", "+131****0001",
+        "--media-name", "uploaded-document.pdf",
+        "--store-media",
+      ],
+      storedUpload.env,
+      /--store-media is not supported with --media-name/,
+    );
+    assert.deepEqual(readLoggedArgs(storedUpload.logPath), []);
+  });
+
+  it("documents send-fax flags and examples in help", () => {
+    const fake = setupFakeTelnyx();
+    const output = runAgent(["help"], fake.env);
+    assert.match(output, /send-fax/);
+    assert.match(output, /--connection-id <id>\s+Fax application connection ID/);
+    assert.match(output, /--media-url <url>/);
+    assert.match(output, /--media-name <name>/);
+    assert.match(output, /send-fax --connection-id <id>/);
+  });
+
+  it("advertises send-fax as the implementation of the send_fax capability", () => {
+    const fake = setupFakeTelnyx();
+    const output = runAgent(["capabilities", "--json"], fake.env);
+    const capabilities = JSON.parse(output);
+
+    assert.ok(capabilities.api_capabilities["📠 Fax"][0].actions.includes("send_fax"));
+    assert.ok(
+      capabilities.composite_commands.some((command: { name: string }) => command.name === "telnyx-agent send-fax"),
+      "send-fax must be listed among executable composite commands",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add `send-fax` over `faxes create`
- support URL and pre-uploaded media plus fax options
- add validation, help/capability wiring, and mock-binary tests

## Audit finding
`send_fax` was advertised in capabilities but had no executable Agent CLI command.

## Validation
- `npx tsc --noEmit`
- `npm test` (117/117)