### PR TITLE
feat: Add AI inference to agent CLI

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "tsx bin/telnyx-agent.ts",
-    "test": "tsx --test tests/edge-handoff.test.ts tests/integration.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
+    "test": "tsx --test tests/ai.test.ts tests/edge-handoff.test.ts tests/integration.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
     "typecheck": "tsc --noEmit",
     "postinstall": "tsx scripts/postinstall.ts",
     "build": "npm run typecheck"

--- a/cli/src/commands/ai-chat.ts
+++ b/cli/src/commands/ai-chat.ts
@@ -1,0 +1,149 @@
+/**
+ * telnyx-agent ai-chat — OpenAI-compatible chat completion.
+ *
+ * Wraps the current Go CLI command `ai:openai:chat create-completion`.
+ */
+
+import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
+import { outputJson, printError, printSuccess } from "../utils/output.ts";
+
+interface ChatMessage {
+  role: "system" | "user" | "assistant" | "tool";
+  content: unknown;
+}
+
+function parseMessages(raw: string): ChatMessage[] {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    throw new Error("--messages must be a JSON array of {role, content} objects");
+  }
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error("--messages must be a non-empty JSON array of {role, content} objects");
+  }
+  for (const message of value) {
+    if (!message || typeof message !== "object") {
+      throw new Error("each --messages item must be an object");
+    }
+    const role = (message as Record<string, unknown>).role;
+    if (!["system", "user", "assistant", "tool"].includes(String(role))) {
+      throw new Error("each --messages item must have role system, user, assistant, or tool");
+    }
+    if (!("content" in message)) {
+      throw new Error("each --messages item must include content");
+    }
+  }
+  return value as ChatMessage[];
+}
+
+function unwrap(response: unknown): Record<string, unknown> {
+  if (!response || typeof response !== "object") return {};
+  const object = response as Record<string, unknown>;
+  const data = object.data;
+  return data && !Array.isArray(data) && typeof data === "object"
+    ? (data as Record<string, unknown>)
+    : object;
+}
+
+function firstChoice(data: Record<string, unknown>): Record<string, unknown> {
+  const choices = data.choices;
+  return Array.isArray(choices) && choices[0] && typeof choices[0] === "object"
+    ? (choices[0] as Record<string, unknown>)
+    : {};
+}
+
+function choiceContent(choice: Record<string, unknown>): string {
+  const message = choice.message;
+  if (!message || typeof message !== "object") return "";
+  const content = (message as Record<string, unknown>).content;
+  return typeof content === "string" ? content : content == null ? "" : JSON.stringify(content);
+}
+
+export async function aiChatCommand(flags: Record<string, string | boolean>): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const prompt = flags.message as string | undefined;
+  const rawMessages = flags.messages as string | undefined;
+  const system = flags.system as string | undefined;
+
+  let messages: ChatMessage[];
+  try {
+    if (rawMessages) {
+      messages = parseMessages(rawMessages);
+    } else if (prompt) {
+      messages = [];
+      if (system) messages.push({ role: "system", content: system });
+      messages.push({ role: "user", content: prompt });
+    } else {
+      throw new Error("--message or --messages is required");
+    }
+  } catch (err) {
+    fail(errorMsg(err), jsonOutput);
+  }
+
+  try {
+    if (!jsonOutput) console.log("\n🤖 Generating chat completion...\n");
+
+    const args = ["ai:openai:chat", "create-completion"];
+    for (const message of messages!) args.push("--message", JSON.stringify(message));
+
+    // These names and value types mirror the current generated Go CLI schema.
+    const valueFlags = [
+      "api-key-ref",
+      "best-of",
+      "frequency-penalty",
+      "guided-json",
+      "guided-regex",
+      "length-penalty",
+      "max-tokens",
+      "min-p",
+      "model",
+      "n",
+      "presence-penalty",
+      "response-format",
+      "seed",
+      "stop",
+      "temperature",
+      "tool-choice",
+      "top-logprobs",
+      "top-p",
+    ];
+    for (const flag of valueFlags) {
+      const value = flags[flag];
+      if (value !== undefined) args.push(`--${flag}`, String(value));
+    }
+    for (const flag of ["early-stopping", "enable-thinking", "logprobs", "use-beam-search"]) {
+      const value = flags[flag];
+      if (value !== undefined) args.push(`--${flag}`, String(value));
+    }
+
+    const response = await telnyxCli(args);
+    const data = unwrap(response);
+    const choice = firstChoice(data);
+    const content = choiceContent(choice);
+
+    if (jsonOutput) {
+      outputJson({ ...data, content });
+    } else {
+      printSuccess("Chat completion generated", {
+        Model: String(data.model ?? flags.model ?? "(API default)"),
+        "Finish Reason": String(choice.finish_reason ?? "unknown"),
+        Content: content || "(no text content returned)",
+      });
+    }
+  } catch (err) {
+    fail(errorMsg(err), jsonOutput);
+  }
+}
+
+function fail(message: string, jsonOutput: boolean): never {
+  if (jsonOutput) outputJson({ error: message });
+  else printError(message);
+  process.exit(1);
+}
+
+function errorMsg(err: unknown): string {
+  if (err instanceof TelnyxCLIError) return err.stderr || err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/cli/src/commands/ai-embed.ts
+++ b/cli/src/commands/ai-embed.ts
@@ -1,0 +1,79 @@
+/**
+ * telnyx-agent ai-embed — OpenAI-compatible text embeddings.
+ *
+ * Wraps the current Go CLI command `ai:openai:embeddings create-embeddings`.
+ */
+
+import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
+import { outputJson, printError, printSuccess } from "../utils/output.ts";
+
+interface Embedding {
+  embedding?: unknown[];
+  index?: number;
+  [key: string]: unknown;
+}
+
+function extractData(response: unknown): Record<string, unknown> {
+  return response && typeof response === "object" ? (response as Record<string, unknown>) : {};
+}
+
+export async function aiEmbedCommand(flags: Record<string, string | boolean>): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const input = flags.input as string | undefined;
+  const model = flags.model as string | undefined;
+
+  if (!input) fail("--input is required", jsonOutput);
+  if (!model) fail("--model is required", jsonOutput);
+
+  try {
+    if (!jsonOutput) console.log("\n🧠 Generating embeddings...\n");
+
+    const args = [
+      "ai:openai:embeddings",
+      "create-embeddings",
+      "--input",
+      input,
+      "--model",
+      model,
+    ];
+    for (const flag of ["dimensions", "encoding-format", "user"]) {
+      const value = flags[flag];
+      if (value !== undefined) args.push(`--${flag}`, String(value));
+    }
+
+    const response = await telnyxCli(args);
+    const payload = extractData(response);
+    const embeddings = Array.isArray(payload.data) ? (payload.data as Embedding[]) : [];
+
+    if (jsonOutput) {
+      outputJson({
+        model: payload.model ?? model,
+        object: payload.object,
+        count: embeddings.length,
+        embeddings,
+        ...(payload.usage !== undefined ? { usage: payload.usage } : {}),
+      });
+    } else {
+      const firstVector = embeddings[0]?.embedding;
+      printSuccess("Embeddings generated", {
+        Model: String(payload.model ?? model),
+        Count: embeddings.length,
+        Dimensions: Array.isArray(firstVector) ? firstVector.length : flags.dimensions ?? "unknown",
+      });
+    }
+  } catch (err) {
+    fail(errorMsg(err), jsonOutput);
+  }
+}
+
+function fail(message: string, jsonOutput: boolean): never {
+  if (jsonOutput) outputJson({ error: message });
+  else printError(message);
+  process.exit(1);
+}
+
+function errorMsg(err: unknown): string {
+  if (err instanceof TelnyxCLIError) return err.stderr || err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/cli/src/commands/ai-models.ts
+++ b/cli/src/commands/ai-models.ts
@@ -1,0 +1,57 @@
+/**
+ * telnyx-agent ai-models — List models available to Telnyx inference.
+ *
+ * Wraps the current Go CLI command `ai:openai list-models`.
+ */
+
+import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
+import { outputJson, printError, printSuccess } from "../utils/output.ts";
+
+interface AiModel {
+  id?: string;
+  owned_by?: string;
+  [key: string]: unknown;
+}
+
+function extractModels(response: unknown): AiModel[] {
+  if (Array.isArray(response)) return response as AiModel[];
+  if (!response || typeof response !== "object") return [];
+  const object = response as Record<string, unknown>;
+  if (Array.isArray(object.data)) return object.data as AiModel[];
+  if (Array.isArray(object.models)) return object.models as AiModel[];
+  return [];
+}
+
+export async function aiModelsCommand(flags: Record<string, string | boolean>): Promise<void> {
+  const jsonOutput = flags.json === true;
+
+  try {
+    if (!jsonOutput) console.log("\n🤖 Listing AI inference models...\n");
+
+    const response = await telnyxCli(["ai:openai", "list-models"]);
+    const models = extractModels(response);
+
+    if (jsonOutput) {
+      outputJson({ models, count: models.length });
+    } else {
+      printSuccess("AI inference models retrieved", { Count: models.length });
+      for (const model of models) {
+        const owner = model.owned_by ? ` — ${model.owned_by}` : "";
+        console.log(`  • ${model.id ?? "(unknown)"}${owner}`);
+      }
+      if (models.length === 0) console.log("  (no models returned)");
+      console.log();
+    }
+  } catch (err) {
+    const message = errorMsg(err);
+    if (jsonOutput) outputJson({ error: message });
+    else printError(message);
+    process.exit(1);
+  }
+}
+
+function errorMsg(err: unknown): string {
+  if (err instanceof TelnyxCLIError) return err.stderr || err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/cli/src/commands/capabilities.ts
+++ b/cli/src/commands/capabilities.ts
@@ -23,6 +23,7 @@ const CAPABILITIES: Record<string, Capability[]> = {
   "🤖 AI": [
     { name: "Chat Completions", description: "LLM inference via Telnyx AI", actions: ["ai_chat"] },
     { name: "Embeddings", description: "Generate text embeddings", actions: ["ai_embed"] },
+    { name: "Inference Models", description: "List models available to the account on Telnyx AI inference", actions: ["list_ai_models"] },
     { name: "Assistants", description: "Create and manage AI voice assistants", actions: ["list_ai_assistants", "create_ai_assistant"] },
   ],
   "🔊 Text-to-Speech": [
@@ -83,6 +84,9 @@ const COMPOSITE_COMMANDS = [
   { name: "telnyx-agent setup-voice", description: "Zero to voice: creates SIP connection, buys number, assigns it" },
   { name: "telnyx-agent setup-iot", description: "Zero to IoT: lists SIMs, creates group, activates SIM" },
   { name: "telnyx-agent setup-ai", description: "Zero to AI assistant: creates assistant, buys number, wires them together" },
+  { name: "telnyx-agent ai-chat", description: "Generate an OpenAI-compatible chat completion with Telnyx AI inference" },
+  { name: "telnyx-agent ai-embed", description: "Generate OpenAI-compatible embeddings for text or a JSON array of texts" },
+  { name: "telnyx-agent ai-models", description: "List models currently available to the account on Telnyx AI inference" },
   { name: "telnyx-agent setup-wireguard", description: "Zero to VPN: creates network, WireGuard interface, peer — outputs ready-to-use WG config" },
   { name: "telnyx-edge ship", description: "Deploy an Edge Compute function with the dedicated telnyx-edge CLI (referenced by the Edge Compute guide)" },
   { name: "telnyx-agent edge-doctor", description: "Validate Edge Compute handoff prerequisites and point to the next concrete telnyx-edge steps" },

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -32,6 +32,9 @@ import { callControlCommand } from "./commands/call-control.ts";
 import { callStatusCommand } from "./commands/call-status.ts";
 import { sttCommand } from "./commands/stt.ts";
 import { sttProvidersCommand } from "./commands/stt-providers.ts";
+import { aiChatCommand } from "./commands/ai-chat.ts";
+import { aiEmbedCommand } from "./commands/ai-embed.ts";
+import { aiModelsCommand } from "./commands/ai-models.ts";
 import { parseFlags } from "./utils/output.ts";
 
 const HELP = `
@@ -71,6 +74,9 @@ Commands:
   call-status       Get the status of a call by call-control-id
   stt               Transcribe audio to text (speech-to-text)
   stt-providers     List available speech-to-text providers
+  ai-chat           Generate an OpenAI-compatible chat completion
+  ai-embed          Generate OpenAI-compatible text embeddings
+  ai-models         List models available to Telnyx AI inference
 
 Global Flags:
   --json            Output structured JSON instead of human-readable text
@@ -215,6 +221,23 @@ STT-providers Flags:
   --provider        Filter providers by name (optional)
   --service-type    Filter providers by service type (optional)
 
+AI Chat Flags:
+  --message <text>  User message (required unless --messages is provided)
+  --messages <json> JSON array of {role, content} messages
+  --system <text>   System message prepended to --message
+  --model <id>      Inference model (optional; uses the Go CLI default when omitted)
+  --max-tokens <n>  Maximum completion tokens
+  --temperature <n> Sampling temperature (default is controlled by the Go CLI)
+  --top-p <n>       Nucleus sampling probability
+  --seed <n>        Best-effort deterministic sampling seed
+
+AI Embed Flags:
+  --input <text>    Text or JSON array of strings to embed (required)
+  --model <id>      Embedding model ID (required)
+  --dimensions <n>  Output dimensions (supported models only)
+  --encoding-format Embedding encoding format (Go CLI default: float)
+  --user <id>       End-user identifier for monitoring and abuse detection
+
 Environment:
   TELNYX_API_KEY    API key (or configure ~/.config/telnyx/config.json)
 
@@ -284,6 +307,11 @@ Examples:
   telnyx-agent stt --audio-url https://example.com/audio.mp3 --model openai/whisper-large-v3-turbo --language es --json
   telnyx-agent stt-providers --json
   telnyx-agent stt-providers --provider telnyx --service-type transcription --json
+  telnyx-agent ai-chat --message "Explain SIP in one sentence" --json
+  telnyx-agent ai-chat --system "Be concise" --message "What is WebRTC?" --model meta-llama/Meta-Llama-3.1-8B-Instruct
+  telnyx-agent ai-embed --model intfloat/multilingual-e5-large --input "Telnyx makes communications programmable" --json
+  telnyx-agent ai-embed --model intfloat/multilingual-e5-large --input '["first text","second text"]' --json
+  telnyx-agent ai-models --json
 `;
 
 const COMMANDS: Record<string, (flags: Record<string, string | boolean>) => Promise<void>> = {
@@ -317,6 +345,9 @@ const COMMANDS: Record<string, (flags: Record<string, string | boolean>) => Prom
   "call-status": callStatusCommand,
   stt: sttCommand,
   "stt-providers": sttProvidersCommand,
+  "ai-chat": aiChatCommand,
+  "ai-embed": aiEmbedCommand,
+  "ai-models": aiModelsCommand,
 };
 
 export async function run(argv: string[]): Promise<void> {

--- a/cli/tests/ai.test.ts
+++ b/cli/tests/ai.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Mock-binary tests for Telnyx AI inference commands.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliRoot = join(__dirname, "..");
+const cliBin = join(cliRoot, "bin", "telnyx-agent.ts");
+
+function setupFakeTelnyx(): { logPath: string; env: NodeJS.ProcessEnv } {
+  const tempDir = mkdtempSync(join(tmpdir(), "telnyx-agent-ai-"));
+  const binDir = join(tempDir, "bin");
+  const logPath = join(tempDir, "args.jsonl");
+  mkdirSync(binDir, { recursive: true });
+
+  const fakeTelnyx = join(binDir, "telnyx");
+  writeFileSync(
+    fakeTelnyx,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.TELNYX_FAKE_ARGS_LOG, JSON.stringify(args) + "\\n");
+
+if (args[0] === "ai:openai:chat" && args[1] === "create-completion") {
+  console.log(JSON.stringify({
+    id: "chatcmpl_test",
+    object: "chat.completion",
+    model: "meta-llama/Meta-Llama-3.1-8B-Instruct",
+    choices: [{ index: 0, message: { role: "assistant", content: "SIP establishes and manages real-time communication sessions." }, finish_reason: "stop" }],
+    usage: { prompt_tokens: 9, completion_tokens: 8, total_tokens: 17 }
+  }));
+} else if (args[0] === "ai:openai:embeddings" && args[1] === "create-embeddings") {
+  console.log(JSON.stringify({
+    object: "list",
+    model: "intfloat/multilingual-e5-large",
+    data: [
+      { object: "embedding", index: 0, embedding: [0.1, 0.2, 0.3] },
+      { object: "embedding", index: 1, embedding: [0.4, 0.5, 0.6] }
+    ],
+    usage: { prompt_tokens: 4, total_tokens: 4 }
+  }));
+} else if (args[0] === "ai:openai" && args[1] === "list-models") {
+  console.log(JSON.stringify({ object: "list", data: [
+    { id: "meta-llama/Meta-Llama-3.1-8B-Instruct", object: "model", owned_by: "telnyx" },
+    { id: "intfloat/multilingual-e5-large", object: "model", owned_by: "telnyx" }
+  ] }));
+} else {
+  console.error("unexpected command: " + args.join(" "));
+  process.exit(2);
+}
+`,
+  );
+  chmodSync(fakeTelnyx, 0o755);
+
+  return {
+    logPath,
+    env: {
+      ...process.env,
+      TELNYX_CLI_PATH: fakeTelnyx,
+      TELNYX_FAKE_ARGS_LOG: logPath,
+      TELNYX_API_KEY: "KEY_fake_test",
+    },
+  };
+}
+
+function runCli(args: string[], env: NodeJS.ProcessEnv): { stdout: string; status: number } {
+  try {
+    const stdout = execFileSync("npx", ["tsx", cliBin, ...args], {
+      cwd: cliRoot,
+      encoding: "utf8",
+      env,
+      timeout: 30000,
+    });
+    return { stdout, status: 0 };
+  } catch (err: any) {
+    return { stdout: err.stdout?.toString() ?? "", status: err.status ?? 1 };
+  }
+}
+
+function readLoggedArgs(logPath: string): string[][] {
+  if (!existsSync(logPath)) return [];
+  return readFileSync(logPath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function assertFlagValue(args: string[], flag: string, value: string): void {
+  const index = args.indexOf(flag);
+  assert.notEqual(index, -1, `expected ${flag} in ${args.join(" ")}`);
+  assert.equal(args[index + 1], value);
+}
+
+function valuesForFlag(args: string[], flag: string): string[] {
+  return args.flatMap((arg, index) => (arg === flag ? [args[index + 1]] : []));
+}
+
+describe("AI inference commands", () => {
+  it("ai-chat uses the current ai:openai:chat path and serializes the user message", () => {
+    const fake = setupFakeTelnyx();
+    const { stdout, status } = runCli(["ai-chat", "--message", "Explain SIP", "--json"], fake.env);
+
+    assert.equal(status, 0);
+    const output = JSON.parse(stdout);
+    assert.equal(output.content, "SIP establishes and manages real-time communication sessions.");
+    assert.equal(output.choices[0].finish_reason, "stop");
+    assert.equal(output.usage.total_tokens, 17);
+
+    const args = readLoggedArgs(fake.logPath)[0];
+    assert.deepEqual(args.slice(0, 2), ["ai:openai:chat", "create-completion"]);
+    assert.ok(!args.includes("ai:chat"), "must not use the deprecated ai:chat command");
+    assert.deepEqual(JSON.parse(valuesForFlag(args, "--message")[0]), {
+      role: "user",
+      content: "Explain SIP",
+    });
+    assertFlagValue(args, "--format", "json");
+  });
+
+  it("ai-chat prepends --system and forwards common completion flags", () => {
+    const fake = setupFakeTelnyx();
+    const { status } = runCli(
+      [
+        "ai-chat",
+        "--system", "Be concise",
+        "--message", "What is WebRTC?",
+        "--model", "meta-llama/Meta-Llama-3.1-8B-Instruct",
+        "--max-tokens", "64",
+        "--temperature", "0.2",
+        "--top-p", "0.9",
+        "--enable-thinking", "false",
+        "--json",
+      ],
+      fake.env,
+    );
+
+    assert.equal(status, 0);
+    const args = readLoggedArgs(fake.logPath)[0];
+    const messages = valuesForFlag(args, "--message").map((message) => JSON.parse(message));
+    assert.deepEqual(messages, [
+      { role: "system", content: "Be concise" },
+      { role: "user", content: "What is WebRTC?" },
+    ]);
+    assertFlagValue(args, "--model", "meta-llama/Meta-Llama-3.1-8B-Instruct");
+    assertFlagValue(args, "--max-tokens", "64");
+    assertFlagValue(args, "--temperature", "0.2");
+    assertFlagValue(args, "--top-p", "0.9");
+    assertFlagValue(args, "--enable-thinking", "false");
+  });
+
+  it("ai-chat expands a --messages JSON conversation into repeated Go CLI flags", () => {
+    const fake = setupFakeTelnyx();
+    const conversation = JSON.stringify([
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi" },
+      { role: "user", content: "Explain SIP" },
+    ]);
+    const { status } = runCli(["ai-chat", "--messages", conversation, "--json"], fake.env);
+
+    assert.equal(status, 0);
+    const args = readLoggedArgs(fake.logPath)[0];
+    assert.deepEqual(valuesForFlag(args, "--message").map((value) => JSON.parse(value)), JSON.parse(conversation));
+  });
+
+  it("ai-chat rejects missing or malformed messages before invoking telnyx", () => {
+    for (const args of [["ai-chat", "--json"], ["ai-chat", "--messages", "not-json", "--json"]]) {
+      const fake = setupFakeTelnyx();
+      const result = runCli(args, fake.env);
+      assert.notEqual(result.status, 0);
+      assert.ok(JSON.parse(result.stdout).error);
+      assert.deepEqual(readLoggedArgs(fake.logPath), []);
+    }
+  });
+
+  it("ai-embed uses ai:openai:embeddings and forwards the exact embedding flags", () => {
+    const fake = setupFakeTelnyx();
+    const { stdout, status } = runCli(
+      [
+        "ai-embed",
+        "--input", "[\"first\",\"second\"]",
+        "--model", "intfloat/multilingual-e5-large",
+        "--dimensions", "3",
+        "--encoding-format", "float",
+        "--user", "agent-test",
+        "--json",
+      ],
+      fake.env,
+    );
+
+    assert.equal(status, 0);
+    const output = JSON.parse(stdout);
+    assert.equal(output.count, 2);
+    assert.equal(output.model, "intfloat/multilingual-e5-large");
+    assert.deepEqual(output.embeddings[0].embedding, [0.1, 0.2, 0.3]);
+    assert.equal(output.usage.total_tokens, 4);
+
+    const args = readLoggedArgs(fake.logPath)[0];
+    assert.deepEqual(args.slice(0, 2), ["ai:openai:embeddings", "create-embeddings"]);
+    assertFlagValue(args, "--input", "[\"first\",\"second\"]");
+    assertFlagValue(args, "--model", "intfloat/multilingual-e5-large");
+    assertFlagValue(args, "--dimensions", "3");
+    assertFlagValue(args, "--encoding-format", "float");
+    assertFlagValue(args, "--user", "agent-test");
+  });
+
+  it("ai-embed requires both --input and --model", () => {
+    for (const args of [
+      ["ai-embed", "--model", "intfloat/multilingual-e5-large", "--json"],
+      ["ai-embed", "--input", "hello", "--json"],
+    ]) {
+      const fake = setupFakeTelnyx();
+      const result = runCli(args, fake.env);
+      assert.notEqual(result.status, 0);
+      assert.ok(JSON.parse(result.stdout).error);
+      assert.deepEqual(readLoggedArgs(fake.logPath), []);
+    }
+  });
+
+  it("ai-models uses ai:openai list-models and normalizes the model list", () => {
+    const fake = setupFakeTelnyx();
+    const { stdout, status } = runCli(["ai-models", "--json"], fake.env);
+
+    assert.equal(status, 0);
+    const output = JSON.parse(stdout);
+    assert.equal(output.count, 2);
+    assert.equal(output.models[0].id, "meta-llama/Meta-Llama-3.1-8B-Instruct");
+
+    const args = readLoggedArgs(fake.logPath)[0];
+    assert.deepEqual(args.slice(0, 2), ["ai:openai", "list-models"]);
+    assertFlagValue(args, "--format", "json");
+  });
+
+  it("help and capabilities expose all three executable AI commands", () => {
+    const fake = setupFakeTelnyx();
+    const help = runCli(["help"], fake.env);
+    assert.equal(help.status, 0);
+    for (const command of ["ai-chat", "ai-embed", "ai-models"]) {
+      assert.ok(help.stdout.includes(command), `help must include ${command}`);
+    }
+    assert.ok(help.stdout.includes("--messages"));
+    assert.ok(help.stdout.includes("--dimensions"));
+
+    const capabilities = runCli(["capabilities", "--json"], fake.env);
+    assert.equal(capabilities.status, 0);
+    const data = JSON.parse(capabilities.stdout);
+    const compositeNames = data.composite_commands.map((entry: { name: string }) => entry.name);
+    for (const command of ["telnyx-agent ai-chat", "telnyx-agent ai-embed", "telnyx-agent ai-models"]) {
+      assert.ok(compositeNames.includes(command), `capabilities must include ${command}`);
+    }
+    const aiActions = data.api_capabilities["🤖 AI"].flatMap((entry: { actions: string[] }) => entry.actions);
+    assert.ok(aiActions.includes("ai_chat"));
+    assert.ok(aiActions.includes("ai_embed"));
+    assert.ok(aiActions.includes("list_ai_models"));
+  });
+});


### PR DESCRIPTION
## Summary
- add `ai-chat`, `ai-embed`, and `ai-models` wrappers
- use current `ai:openai:*` Go CLI paths, not deprecated AI resources
- add help/capability wiring and mock-binary coverage

## Audit finding
AI chat and embeddings were advertised as capabilities but had no executable Agent CLI handlers.

## Validation
- `npx tsc --noEmit`
- `npm test` (118/118)