### PR TITLE
docs: Update edge-compute guide for CLI v0.2.3

### DIFF
--- a/cli/src/commands/edge-doctor.ts
+++ b/cli/src/commands/edge-doctor.ts
@@ -7,19 +7,38 @@
  */
 
 import { outputJson, printError, printSuccess, printWarning } from "../utils/output.ts";
-import { getEdgeAuthStatus, getEdgeHelp, getEdgeVersion, hasEdgeCli, supportsApiKeyAuth, supportsStatefulActors } from "../edge-cli.ts";
+import {
+  type EdgeCapabilities,
+  getEdgeAuthStatus,
+  getEdgeCapabilities,
+  getEdgeHelp,
+  getEdgeVersion,
+  supportsApiKeyAuth,
+} from "../edge-cli.ts";
 
-interface EdgeDoctorResult {
+interface EdgeDoctorResult extends EdgeCapabilities {
   ready: boolean;
   telnyx_edge_installed: boolean;
   telnyx_edge_version: string | null;
   authenticated: boolean;
   auth_mode: "api_key" | "oauth" | "none" | "unknown";
   api_key_auth_supported: boolean;
-  stateful_actors_supported: boolean;
   checks: Array<{ name: string; ok: boolean; detail: string }>;
   next_steps: string[];
 }
+
+const NO_CAPABILITIES: EdgeCapabilities = {
+  reset_func_supported: false,
+  types_supported: false,
+  storage_kv_supported: false,
+  revisions_supported: false,
+  rollback_supported: false,
+  inspect_supported: false,
+  bindings_supported: false,
+  secrets_supported: false,
+  cloud_storage_supported: false,
+  stateful_actors_supported: false,
+};
 
 export async function edgeDoctorCommand(flags: Record<string, string | boolean>): Promise<void> {
   const jsonOutput = flags.json === true;
@@ -30,13 +49,17 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
   let authenticated = false;
   let authMode: EdgeDoctorResult["auth_mode"] = "none";
   let apiKeyAuthSupported = false;
-  let statefulActorsSupported = false;
+  let capabilities = { ...NO_CAPABILITIES };
 
   try {
-    const out = getEdgeHelp();
-    installed = hasEdgeCli();
-    version = getEdgeVersion() ?? extractVersion(out) ?? "installed";
-    checks.push({ name: "telnyx-edge installed", ok: true, detail: version });
+    const rootHelp = getEdgeHelp();
+    installed = true;
+    version = getEdgeVersion(rootHelp);
+    checks.push({
+      name: "telnyx-edge installed",
+      ok: true,
+      detail: version ?? "installed (version unknown)",
+    });
   } catch (err: any) {
     const detail = err?.code === "ENOENT"
       ? "telnyx-edge not found on PATH"
@@ -49,17 +72,11 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
     checks.push({
       name: "API-key auth supported",
       ok: apiKeyAuthSupported,
-      detail: apiKeyAuthSupported ? "auth api-key set is available" : "no auth api-key set support detected",
+      detail: apiKeyAuthSupported ? "auth api-key set help succeeded" : "auth api-key set help failed",
     });
 
-    statefulActorsSupported = supportsStatefulActors();
-    checks.push({
-      name: "Stateful actors supported",
-      ok: statefulActorsSupported,
-      detail: statefulActorsSupported
-        ? "new-func --actor available (v0.2.3+)"
-        : "new-func --actor not available — upgrade to v0.2.3+ for stateful actors",
-    });
+    capabilities = getEdgeCapabilities();
+    addCapabilityChecks(checks, capabilities);
 
     try {
       const status = getEdgeAuthStatus();
@@ -86,28 +103,35 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
     nextSteps = [
       "Install the dedicated Edge Compute CLI from team-telnyx/edge-compute releases.",
       "Then authenticate: telnyx-edge auth api-key set <your-api-key> (preferred) or telnyx-edge auth login",
-      "Then start from a real example such as examples/ts/mcp-server or examples/js/webhook-receiver.",
+      "Clone the examples: git clone https://github.com/team-telnyx/edge-compute.git && cd edge-compute",
     ];
   } else if (!authenticated) {
     nextSteps = apiKeyAuthSupported
       ? [
           "Authenticate non-interactively: telnyx-edge auth api-key set <your-api-key>",
           "Verify with: telnyx-edge auth status",
-          "Then start from a real example and deploy with telnyx-edge ship.",
+          "Then clone https://github.com/team-telnyx/edge-compute.git and use an example under docs/examples/.",
         ]
       : [
           "Authenticate with: telnyx-edge auth login",
           "Verify with: telnyx-edge auth status",
-          "Then start from a real example and deploy with telnyx-edge ship.",
+          "Then clone https://github.com/team-telnyx/edge-compute.git and use an example under docs/examples/.",
         ];
   } else {
     nextSteps = [
-      "Start from a real example: telnyx-edge new-func --from-dir=examples/ts/mcp-server --name=my-mcp-server",
-      "Deploy with: telnyx-edge ship",
+      "Clone examples: git clone https://github.com/team-telnyx/edge-compute.git && cd edge-compute",
+      "Scaffold: telnyx-edge new-func --from-dir=docs/examples/ts/mcp-server --name=my-mcp-server",
+      "Deploy: cd my-mcp-server && telnyx-edge ship",
       "Then connect the exposed HTTP or MCP boundary back into your AI workflow.",
     ];
-    if (statefulActorsSupported) {
-      nextSteps.push("For stateful workloads (carts, sessions, call legs): telnyx-edge new-func --actor --language ts --name my-actor");
+    if (capabilities.stateful_actors_supported) {
+      nextSteps.push("For stateful workloads: telnyx-edge new-func --actor --language ts --name my-actor && cd my-actor && telnyx-edge types");
+    }
+    if (capabilities.inspect_supported) {
+      nextSteps.push("Inspect a deployment (feature-detected): telnyx-edge inspect <function-name>");
+    }
+    if (capabilities.cloud_storage_supported) {
+      nextSteps.push("Cloud Storage TOML/type support was feature-detected; consult the installed CLI help before using it.");
     }
   }
 
@@ -118,7 +142,7 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
     authenticated,
     auth_mode: authMode,
     api_key_auth_supported: apiKeyAuthSupported,
-    stateful_actors_supported: statefulActorsSupported,
+    ...capabilities,
     checks,
     next_steps: nextSteps,
   };
@@ -130,7 +154,7 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
 
   if (ready) {
     printSuccess("Edge Compute handoff is ready", {
-      "telnyx-edge": version ?? "installed",
+      "telnyx-edge": version ?? "installed (version unknown)",
       Auth: authMode,
       Ready: "✓",
     });
@@ -156,7 +180,28 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
   console.log();
 }
 
-function extractVersion(text: string): string | null {
-  const match = text.match(/v?\d+\.\d+\.\d+/);
-  return match?.[0] ?? null;
+function addCapabilityChecks(
+  checks: EdgeDoctorResult["checks"],
+  capabilities: EdgeCapabilities,
+): void {
+  const detected: Array<[keyof EdgeCapabilities, string, string]> = [
+    ["reset_func_supported", "reset-func", "reset-func --help"],
+    ["types_supported", "TypeScript binding types", "types --help"],
+    ["storage_kv_supported", "KV storage/key operations", "storage kv --help"],
+    ["revisions_supported", "revisions", "revisions --help"],
+    ["rollback_supported", "rollback", "rollback --help"],
+    ["inspect_supported", "inspect (feature-detected)", "inspect --help"],
+    ["bindings_supported", "bindings", "bindings --help"],
+    ["secrets_supported", "secrets", "secrets --help"],
+    ["cloud_storage_supported", "Cloud Storage bindings (feature-detected)", "types help advertises Cloud Storage"],
+    ["stateful_actors_supported", "Stateful actors", "new-func help advertises --actor"],
+  ];
+
+  for (const [key, name, probe] of detected) {
+    checks.push({
+      name,
+      ok: capabilities[key],
+      detail: capabilities[key] ? `${probe} succeeded` : `${probe} not detected`,
+    });
+  }
 }

--- a/cli/src/commands/setup-edge-mcp.ts
+++ b/cli/src/commands/setup-edge-mcp.ts
@@ -14,11 +14,13 @@ interface SetupEdgeMcpResult {
   example: string;
   auth_command: string;
   deploy_command: string;
+  setup_commands: string[];
   prerequisites: string[];
   notes: string[];
 }
 
-const MCP_EXAMPLE = "examples/ts/mcp-server";
+const EDGE_REPO = "https://github.com/team-telnyx/edge-compute.git";
+const MCP_EXAMPLE = "docs/examples/ts/mcp-server";
 
 export async function setupEdgeMcpCommand(flags: Record<string, string | boolean>): Promise<void> {
   const jsonOutput = flags.json === true;
@@ -31,15 +33,16 @@ export async function setupEdgeMcpCommand(flags: Record<string, string | boolean
   const authCommand = apiKeyAuthSupported
     ? "telnyx-edge auth api-key set <your-api-key>"
     : "telnyx-edge auth login";
-  const deployCommand = `telnyx-edge new-func --from-dir=${MCP_EXAMPLE} --name=${name} && cd ${name} && telnyx-edge ship`;
+  const deployCommand = `git clone ${EDGE_REPO} && cd edge-compute && telnyx-edge new-func --from-dir=${MCP_EXAMPLE} --name=${name} && cd ${name} && telnyx-edge ship`;
 
   const notes = [
     "team-telnyx/ai provides the integration pattern, not the Edge lifecycle.",
     "Use telnyx-edge for auth, deploy, secrets, bindings, and lifecycle management.",
+    "Set TELNYX_API_KEY and a separate SHARED_SECRET as Edge secrets before deploying; never print or commit either value.",
     "After deploy, connect the exposed MCP or HTTP boundary back into your AI workflow.",
   ];
   if (statefulActorsSupported) {
-    notes.push("For stateful MCP/webhook scenarios (per-user sessions, connection state): consider telnyx-edge new-func --actor --language ts");
+    notes.push("For stateful MCP sessions: telnyx-edge new-func --actor --language ts --name my-mcp-actor && cd my-mcp-actor && telnyx-edge types");
   }
 
   const result: SetupEdgeMcpResult = {
@@ -51,10 +54,21 @@ export async function setupEdgeMcpCommand(flags: Record<string, string | boolean
     example: MCP_EXAMPLE,
     auth_command: authCommand,
     deploy_command: deployCommand,
+    setup_commands: [
+      `git clone ${EDGE_REPO}`,
+      "cd edge-compute",
+      `telnyx-edge new-func --from-dir=${MCP_EXAMPLE} --name=${name}`,
+      `cd ${name}`,
+      "telnyx-edge secrets add TELNYX_API_KEY <telnyx-api-key>",
+      "telnyx-edge secrets add SHARED_SECRET <independent-random-secret>",
+      "telnyx-edge ship",
+    ],
     prerequisites: [
       "Install telnyx-edge",
       `Authenticate with ${authCommand}`,
-      "Use a real Edge Compute example as the starting point",
+      `Clone the example repository: git clone ${EDGE_REPO} && cd edge-compute`,
+      "Configure TELNYX_API_KEY as an Edge secret without exposing its value",
+      "Configure a separate SHARED_SECRET as an Edge secret without exposing its value",
     ],
     notes,
   };
@@ -79,7 +93,8 @@ export async function setupEdgeMcpCommand(flags: Record<string, string | boolean
 
   console.log(`  Example template: ${MCP_EXAMPLE}`);
   console.log(`  Auth step: ${authCommand}`);
-  console.log(`  Suggested flow: ${deployCommand}`);
+  console.log("  Setup steps:");
+  for (const command of result.setup_commands) console.log(`    ${command}`);
   console.log("\n  Notes:");
   for (const note of result.notes) {
     console.log(`    - ${note}`);

--- a/cli/src/commands/setup-edge-webhook.ts
+++ b/cli/src/commands/setup-edge-webhook.ts
@@ -14,11 +14,13 @@ interface SetupEdgeWebhookResult {
   example: string;
   auth_command: string;
   deploy_command: string;
+  setup_commands: string[];
   prerequisites: string[];
   notes: string[];
 }
 
-const WEBHOOK_EXAMPLE = "examples/js/webhook-receiver";
+const EDGE_REPO = "https://github.com/team-telnyx/edge-compute.git";
+const WEBHOOK_EXAMPLE = "docs/examples/js/webhook-receiver";
 
 export async function setupEdgeWebhookCommand(flags: Record<string, string | boolean>): Promise<void> {
   const jsonOutput = flags.json === true;
@@ -31,15 +33,17 @@ export async function setupEdgeWebhookCommand(flags: Record<string, string | boo
   const authCommand = apiKeyAuthSupported
     ? "telnyx-edge auth api-key set <your-api-key>"
     : "telnyx-edge auth login";
-  const deployCommand = `telnyx-edge new-func --from-dir=${WEBHOOK_EXAMPLE} --name=${name} && cd ${name} && telnyx-edge ship`;
+  const deployCommand = `git clone ${EDGE_REPO} && cd edge-compute && telnyx-edge new-func --from-dir=${WEBHOOK_EXAMPLE} --name=${name} && cd ${name} && telnyx-edge ship`;
 
   const notes = [
     "Use this when your AI workflow needs an HTTP ingress point at the edge.",
     "The deployed function lifecycle is still owned by telnyx-edge.",
+    "Set WEBHOOK_SECRET as an Edge secret to enable HMAC verification; never print or commit its value.",
+    "The example buffer is in-memory; use KV or a Stateful Actor when webhook persistence must survive restarts.",
     "After deploy, point your webhook-producing system at the Edge endpoint and let team-telnyx/ai handle orchestration guidance.",
   ];
   if (statefulActorsSupported) {
-    notes.push("For stateful MCP/webhook scenarios (per-user sessions, connection state): consider telnyx-edge new-func --actor --language ts");
+    notes.push("For actor-backed webhook state: telnyx-edge new-func --actor --language ts --name my-webhook-actor && cd my-webhook-actor && telnyx-edge types");
   }
 
   const result: SetupEdgeWebhookResult = {
@@ -51,10 +55,19 @@ export async function setupEdgeWebhookCommand(flags: Record<string, string | boo
     example: WEBHOOK_EXAMPLE,
     auth_command: authCommand,
     deploy_command: deployCommand,
+    setup_commands: [
+      `git clone ${EDGE_REPO}`,
+      "cd edge-compute",
+      `telnyx-edge new-func --from-dir=${WEBHOOK_EXAMPLE} --name=${name}`,
+      `cd ${name}`,
+      "telnyx-edge secrets add WEBHOOK_SECRET <webhook-signing-secret>",
+      "telnyx-edge ship",
+    ],
     prerequisites: [
       "Install telnyx-edge",
       `Authenticate with ${authCommand}`,
-      "Start from the webhook receiver example",
+      `Clone the example repository: git clone ${EDGE_REPO} && cd edge-compute`,
+      "Configure WEBHOOK_SECRET as an Edge secret without exposing its value",
     ],
     notes,
   };
@@ -79,7 +92,8 @@ export async function setupEdgeWebhookCommand(flags: Record<string, string | boo
 
   console.log(`  Example template: ${WEBHOOK_EXAMPLE}`);
   console.log(`  Auth step: ${authCommand}`);
-  console.log(`  Suggested flow: ${deployCommand}`);
+  console.log("  Setup steps:");
+  for (const command of result.setup_commands) console.log(`    ${command}`);
   console.log("\n  Notes:");
   for (const note of result.notes) {
     console.log(`    - ${note}`);

--- a/cli/src/edge-cli.ts
+++ b/cli/src/edge-cli.ts
@@ -1,4 +1,7 @@
 import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 export function resolveEdgeBinary(): string {
   return process.env.TELNYX_EDGE_PATH || "telnyx-edge";
@@ -13,13 +16,25 @@ function runEdge(args: string[]): string {
   });
 }
 
-export function hasEdgeCli(): boolean {
+/**
+ * Invoke help for a command path. A successful invocation is the capability
+ * signal; output wording is only inspected when probing for a flag or manifest
+ * feature that does not have its own command.
+ */
+export function getEdgeCommandHelp(commandPath: readonly string[]): string | null {
   try {
-    runEdge(["--help"]);
-    return true;
+    return runEdge([...commandPath, "--help"]);
   } catch {
-    return false;
+    return null;
   }
+}
+
+export function supportsEdgeCommand(commandPath: readonly string[]): boolean {
+  return getEdgeCommandHelp(commandPath) !== null;
+}
+
+export function hasEdgeCli(): boolean {
+  return supportsEdgeCommand([]);
 }
 
 export function getEdgeHelp(): string {
@@ -30,39 +45,82 @@ export function getEdgeHelp(): string {
  * Resolve the installed telnyx-edge version.
  *
  * Prefers the first-class `--version` flag introduced in v0.2.3. If that is
- * unavailable (older CLI), falls back to parsing `--help` output with the
- * existing semver regex.
+ * unavailable, parses the supplied root help output or invokes root help once.
  */
-export function getEdgeVersion(): string | null {
+export function getEdgeVersion(rootHelp?: string): string | null {
   try {
-    const v = matchVersion(runEdge(["--version"]));
-    if (v) return v;
+    const version = matchVersion(runEdge(["--version"]));
+    if (version) return version;
   } catch {
-    // older CLI without --version — fall back to --help parsing below
+    // Older CLI without --version — fall back to root help below.
   }
-  try {
-    return matchVersion(runEdge(["--help"]));
-  } catch {
-    return null;
-  }
+
+  if (rootHelp !== undefined) return matchVersion(rootHelp);
+  return matchVersion(getEdgeCommandHelp([]) ?? "");
 }
 
 /**
- * Feature detection for Stateful Actors (Beta, telnyx-edge v0.2.3+).
+ * Feature detection for Stateful Actors.
  *
- * Checks whether `new-func` exposes the `--actor` flag — the documented
- * quick-start workflow (`telnyx-edge new-func --actor --name=account`).
- * This is the actual scaffolding capability the wrapper cares about, not
- * the account-scoped `actors` management subcommand. An actor-capable CLI
- * that lacks `actors --help` (e.g. a canary build or the minimal surface
- * described in the published quick start) still reports true here.
+ * `new-func --help` must both succeed and expose `--actor`. This probes the
+ * scaffolding workflow directly without assigning it a version minimum.
  */
 export function supportsStatefulActors(): boolean {
+  const help = getEdgeCommandHelp(["new-func"]);
+  return help !== null && /--actor\b/i.test(help);
+}
+
+export type EdgeCapabilities = {
+  reset_func_supported: boolean;
+  types_supported: boolean;
+  storage_kv_supported: boolean;
+  revisions_supported: boolean;
+  rollback_supported: boolean;
+  inspect_supported: boolean;
+  bindings_supported: boolean;
+  secrets_supported: boolean;
+  cloud_storage_supported: boolean;
+  stateful_actors_supported: boolean;
+};
+
+/** Probe the installed command surface instead of inferring it from a version. */
+export function getEdgeCapabilities(): EdgeCapabilities {
+  const typesHelp = getEdgeCommandHelp(["types"]);
+
+  return {
+    reset_func_supported: supportsEdgeCommand(["reset-func"]),
+    types_supported: typesHelp !== null,
+    storage_kv_supported: supportsEdgeCommand(["storage", "kv"]),
+    revisions_supported: supportsEdgeCommand(["revisions"]),
+    rollback_supported: supportsEdgeCommand(["rollback"]),
+    inspect_supported: supportsEdgeCommand(["inspect"]),
+    bindings_supported: supportsEdgeCommand(["bindings"]),
+    secrets_supported: supportsEdgeCommand(["secrets"]),
+    // Cloud Storage has no standalone command, and early builds that support
+    // it do not consistently advertise it in `types --help`. Probe `types`
+    // against an isolated manifest so edge-doctor never writes to the user's
+    // project or relies on release-note/version assumptions.
+    cloud_storage_supported: typesHelp !== null && supportsCloudStorageTypes(typesHelp),
+    stateful_actors_supported: supportsStatefulActors(),
+  };
+}
+
+function supportsCloudStorageTypes(typesHelp: string): boolean {
+  if (/storage\.cloudstorage|CloudStorageBucket|cloud storage/i.test(typesHelp)) return true;
+
+  const projectDir = mkdtempSync(join(tmpdir(), "telnyx-edge-cloud-storage-probe-"));
   try {
-    const out = runEdge(["new-func", "--help"]);
-    return /--actor\b/i.test(out);
+    writeFileSync(
+      join(projectDir, "func.toml"),
+      '[storage.cloudstorage.EDGE_DOCTOR_PROBE]\nbucket_name = "probe"\nregion = "us-east-1"\n',
+    );
+    runEdge(["types", "--from-dir", projectDir]);
+    const declarations = readFileSync(join(projectDir, "telnyx-env.d.ts"), "utf8");
+    return /CloudStorageBucket|EDGE_DOCTOR_PROBE/.test(declarations);
   } catch {
     return false;
+  } finally {
+    rmSync(projectDir, { recursive: true, force: true });
   }
 }
 
@@ -109,12 +167,7 @@ export function getEdgeAuthStatus(): EdgeAuthStatus {
 }
 
 export function supportsApiKeyAuth(): boolean {
-  try {
-    const out = runEdge(["auth", "api-key", "set", "--help"]);
-    return /Set API key for authentication/i.test(out);
-  } catch {
-    return false;
-  }
+  return supportsEdgeCommand(["auth", "api-key", "set"]);
 }
 
 function matchVersion(text: string): string | null {

--- a/cli/tests/edge-handoff.test.ts
+++ b/cli/tests/edge-handoff.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, writeFileSync, chmodSync } from "node:fs";
+import { chmodSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -9,15 +9,22 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CLI = join(__dirname, "..", "bin", "telnyx-agent.ts");
 
-function withFakeEdgeCli(mode: "none" | "oauth" | "api_key" | "expired_oauth" = "api_key") {
+function withFakeEdgeCli(
+  mode: "none" | "oauth" | "api_key" | "expired_oauth" = "api_key",
+  release: "v0.2.3" | "current-main" = "v0.2.3",
+) {
   const tempDir = mkdtempSync(join(tmpdir(), "telnyx-edge-fake-"));
   const binDir = join(tempDir, "bin");
   mkdirSync(binDir, { recursive: true });
   const fakeEdge = join(binDir, "telnyx-edge");
+  const logFile = join(tempDir, "calls.jsonl");
   writeFileSync(
     fakeEdge,
     `#!/usr/bin/env node
+const { appendFileSync, writeFileSync } = require('node:fs');
+const { join } = require('node:path');
 const args = process.argv.slice(2);
+appendFileSync(process.env.EDGE_FAKE_LOG, JSON.stringify(args) + '\\n');
 if (args.includes('--version')) {
   console.log('telnyx-edge v0.2.3');
   process.exit(0);
@@ -27,11 +34,36 @@ if (args[0] === 'new-func' && args.includes('--help')) {
   process.exit(0);
 }
 if (args[0] === 'auth' && args[1] === 'api-key' && args[2] === 'set' && args.includes('--help')) {
-  console.log('Set API key for authentication. The API key must be provided as an argument.');
+  console.log('credential setup help in a non-English or future wording');
   process.exit(0);
 }
-if (args.includes('--help')) {
-  console.log(['Telnyx Edge CLI v0.2.3', '', 'Available Commands:', '  actors      Manage StatefulActor types', '  auth        Authentication commands', '  ship        Ship a function', '  list        List functions', '  secrets     Manage secrets', '  bindings    Manage bindings'].join('\\n'));
+if (args.length === 1 && args[0] === '--help') {
+  console.log(['Telnyx Edge CLI v0.2.3', '', 'Available Commands:', '  actors', '  auth', '  bindings', '  reset-func', '  revisions', '  rollback', '  secrets', '  storage', '  types'].join('\\n'));
+  process.exit(0);
+}
+const helpPath = args.slice(0, -1).join(' ');
+if (args.at(-1) === '--help' && ['reset-func', 'storage kv', 'revisions', 'rollback', 'bindings', 'secrets'].includes(helpPath)) {
+  console.log('help for ' + helpPath);
+  process.exit(0);
+}
+if (args.at(-1) === '--help' && helpPath === 'types') {
+  // The v0.2.4/current-main implementation supports Cloud Storage even though
+  // its help text may still list only KV, so the doctor must behavior-probe it.
+  console.log('Generate binding types for [storage.kv.NAME]');
+  process.exit(0);
+}
+if (args.at(-1) === '--help' && helpPath === 'inspect') {
+  console.log('Inspect a deployed function');
+  process.exit(0);
+}
+if (args[0] === 'types' && args[1] === '--from-dir') {
+  writeFileSync(
+    join(args[2], 'telnyx-env.d.ts'),
+    '${release}' === 'current-main'
+      ? 'interface Env { EDGE_DOCTOR_PROBE: CloudStorageBucket }'
+      : 'interface Env {}',
+  );
+  console.log('generated types');
   process.exit(0);
 }
 if (args[0] === 'auth' && args[1] === 'status') {
@@ -50,11 +82,8 @@ if (args[0] === 'auth' && args[1] === 'status') {
   console.log(['API Endpoint: https://api.telnyx.com', '', 'Authentication Status: API Key', 'Status: ✅ Authenticated'].join('\\n'));
   process.exit(0);
 }
-if (args[0] === 'auth' && args[1] === 'api-key' && args[2] === 'clear' && args.includes('--help')) {
-  console.log('Remove the stored API key from the configuration');
-  process.exit(0);
-}
-console.log('ok');
+console.error('unsupported fake command: ' + JSON.stringify(args));
+process.exit(2);
 `,
   );
   chmodSync(fakeEdge, 0o755);
@@ -63,7 +92,9 @@ console.log('ok');
       ...process.env,
       PATH: `${binDir}:${process.env.PATH}`,
       TELNYX_EDGE_PATH: fakeEdge,
+      EDGE_FAKE_LOG: logFile,
     },
+    logFile,
   };
 }
 
@@ -105,7 +136,7 @@ describe("CLI — Edge Compute handoff", () => {
     assert.ok(actorCap!.description.toLowerCase().includes("per-entity"));
   });
 
-  it("edge-doctor reports API-key auth support and readiness", () => {
+  it("edge-doctor reports API-key auth support, capabilities, and readiness", () => {
     const fake = withFakeEdgeCli("api_key");
     const output = run(["edge-doctor", "--json"], fake.env);
     const data = JSON.parse(output);
@@ -115,7 +146,35 @@ describe("CLI — Edge Compute handoff", () => {
     assert.equal(data.auth_mode, "api_key");
     assert.equal(data.api_key_auth_supported, true);
     assert.equal(data.stateful_actors_supported, true);
+    assert.equal(data.reset_func_supported, true);
+    assert.equal(data.types_supported, true);
+    assert.equal(data.storage_kv_supported, true);
+    assert.equal(data.revisions_supported, true);
+    assert.equal(data.rollback_supported, true);
+    assert.equal(data.bindings_supported, true);
+    assert.equal(data.secrets_supported, true);
+    assert.equal(data.inspect_supported, true);
+    assert.equal(data.cloud_storage_supported, false);
     assert.ok(Array.isArray(data.next_steps));
+
+    const rawLog = readFileSync(fake.logFile, "utf8");
+    assert.ok(rawLog.endsWith("\n"), "fake CLI log must be newline-terminated JSONL");
+    const calls = rawLog.trimEnd().split("\n").map((line) => JSON.parse(line) as string[]);
+    assert.equal(
+      calls.filter((args) => args.length === 1 && args[0] === "--help").length,
+      1,
+      "edge-doctor should not duplicate the install/root-help probe",
+    );
+  });
+
+  it("edge-doctor feature-detects current-main inspect and Cloud Storage", () => {
+    const fake = withFakeEdgeCli("api_key", "current-main");
+    const output = run(["edge-doctor", "--json"], fake.env);
+    const data = JSON.parse(output);
+    assert.equal(data.inspect_supported, true);
+    assert.equal(data.cloud_storage_supported, true);
+    assert.ok(data.next_steps.some((s: string) => s.includes("inspect")));
+    assert.ok(data.next_steps.some((s: string) => s.includes("Cloud Storage")));
   });
 
   it("edge-doctor shows unauthenticated but installable state", () => {
@@ -141,14 +200,14 @@ describe("CLI — Edge Compute handoff", () => {
     assert.equal(data.stateful_actors_supported, true);
   });
 
-  it("edge-doctor suggests stateful actors when supported and authenticated", () => {
+  it("edge-doctor suggests a complete stateful actor flow when supported", () => {
     const fake = withFakeEdgeCli("api_key");
     const output = run(["edge-doctor", "--json"], fake.env);
     const data = JSON.parse(output);
     assert.equal(data.ready, true);
     assert.ok(
-      data.next_steps.some((s: string) => s.includes("--actor")),
-      "next_steps should mention --actor when stateful actors are supported",
+      data.next_steps.some((s: string) => s.includes("--actor") && s.includes("--name") && s.includes("types")),
+      "next_steps should provide a named actor scaffold and type-generation command",
     );
   });
 
@@ -160,8 +219,15 @@ describe("CLI — Edge Compute handoff", () => {
     assert.equal(data.api_key_auth_supported, true);
     assert.equal(data.stateful_actors_supported, true);
     assert.equal(data.auth_command, "telnyx-edge auth api-key set <your-api-key>");
-    assert.equal(data.example, "examples/ts/mcp-server");
+    assert.equal(data.example, "docs/examples/ts/mcp-server");
+    assert.ok(data.deploy_command.includes("git clone https://github.com/team-telnyx/edge-compute.git"));
+    assert.ok(data.deploy_command.includes("cd edge-compute"));
     assert.ok(data.deploy_command.includes("demo-mcp"));
+    assert.ok(data.prerequisites.some((p: string) => p.includes("TELNYX_API_KEY")));
+    assert.ok(data.prerequisites.some((p: string) => p.includes("SHARED_SECRET")));
+    assert.ok(data.setup_commands.some((s: string) => s.includes("secrets add TELNYX_API_KEY")));
+    assert.ok(data.setup_commands.some((s: string) => s.includes("secrets add SHARED_SECRET")));
+    assert.equal(data.setup_commands.at(-1), "telnyx-edge ship");
   });
 
   it("setup-edge-webhook returns concrete deploy handoff", () => {
@@ -171,8 +237,14 @@ describe("CLI — Edge Compute handoff", () => {
     assert.equal(data.ready, true);
     assert.equal(data.auth_mode, "api_key");
     assert.equal(data.stateful_actors_supported, true);
-    assert.equal(data.example, "examples/js/webhook-receiver");
+    assert.equal(data.example, "docs/examples/js/webhook-receiver");
+    assert.ok(data.deploy_command.includes("git clone https://github.com/team-telnyx/edge-compute.git"));
+    assert.ok(data.deploy_command.includes("cd edge-compute"));
     assert.ok(data.deploy_command.includes("demo-webhook"));
+    assert.ok(data.prerequisites.some((p: string) => p.includes("WEBHOOK_SECRET")));
+    assert.ok(data.setup_commands.some((s: string) => s.includes("secrets add WEBHOOK_SECRET")));
+    assert.equal(data.setup_commands.at(-1), "telnyx-edge ship");
+    assert.ok(data.notes.some((n: string) => n.includes("KV") && n.includes("Stateful Actor")));
   });
 
   it("setup-edge-mcp notes mention stateful actors when supported", () => {
@@ -180,8 +252,8 @@ describe("CLI — Edge Compute handoff", () => {
     const output = run(["setup-edge-mcp", "--json"], fake.env);
     const data = JSON.parse(output);
     assert.ok(
-      data.notes.some((n: string) => n.includes("--actor")),
-      "notes should mention --actor when stateful actors are supported",
+      data.notes.some((n: string) => n.includes("--actor") && n.includes("--name") && n.includes("types")),
+      "notes should provide a named actor scaffold and type-generation command",
     );
   });
 
@@ -190,8 +262,8 @@ describe("CLI — Edge Compute handoff", () => {
     const output = run(["setup-edge-webhook", "--json"], fake.env);
     const data = JSON.parse(output);
     assert.ok(
-      data.notes.some((n: string) => n.includes("--actor")),
-      "notes should mention --actor when stateful actors are supported",
+      data.notes.some((n: string) => n.includes("--actor") && n.includes("--name") && n.includes("types")),
+      "notes should provide a named actor scaffold and type-generation command",
     );
   });
 });

--- a/guides/edge-compute.md
+++ b/guides/edge-compute.md
@@ -1,182 +1,189 @@
 # Edge Compute
 
-Use Telnyx Edge Compute when your AI workflow needs low-latency code execution, webhook handling, or an MCP/webhook endpoint that runs on Telnyx edge infrastructure.
+Use Telnyx Edge Compute when an AI workflow needs a low-latency HTTP/MCP boundary, webhook ingestion, durable coordination, or a small deterministic transform close to the runtime.
 
-## Important scope boundary
+## Ownership and bridge
 
-`team-telnyx/ai` does **not** manage Edge Compute lifecycle directly.
+`team-telnyx/ai` provides orchestration guidance and thin handoff commands. It does **not** reimplement the Edge lifecycle.
 
-This repo helps you discover where Edge Compute fits into an AI workflow, but the actual function lifecycle is owned by:
-
-- the `team-telnyx/edge-compute` repo
-- the `telnyx-edge` CLI
-
-That means:
-- build/deploy/delete/secrets/bindings live in `telnyx-edge`
-- agent/orchestration logic can live in `team-telnyx/ai`
-- `team-telnyx/ai` should not pretend to replace Edge Compute
-
-A useful mental model:
-- **`ai` = brain / orchestration layer**
-- **Edge Compute = low-latency hands / execution layer**
-
-## When to use Edge Compute with `ai`
-
-Good bridge use cases:
-
-1. **MCP server adapters at the edge**
-   - expose AI-adjacent tools close to the runtime
-2. **Webhook ingestion + AI routing**
-   - receive webhook traffic, normalize it, then hand off to AI logic
-3. **AI-adjacent functions**
-   - redaction, enrichment, scoring, post-processing, lightweight transforms
-
-## Quick Start
-
-```bash
-# Authenticate with the dedicated Edge CLI (preferred for agents)
-telnyx-edge auth api-key set <your-api-key>
-
-# Start from the MCP server example
-telnyx-edge new-func --from-dir=examples/ts/mcp-server --name=my-mcp-server
-cd my-mcp-server
-
-# Add required secrets and deploy
-telnyx-edge secrets add TELNYX_API_KEY <your-api-key>
-telnyx-edge ship
-```
-
-Once deployed, use `team-telnyx/ai` for orchestration and capability discovery, and use the deployed Edge endpoint for execution.
-
-## API Reference
-
-Edge Compute lifecycle is owned by the separate `telnyx-edge` CLI rather than the `team-telnyx/ai` SDK surface.
-
-Common lifecycle commands:
-
-```bash
-telnyx-edge auth status
-telnyx-edge list
-telnyx-edge secrets list
-telnyx-edge bindings get
-```
-
-| Command | Purpose |
-|---------|---------|
-| `telnyx-edge auth api-key set` | Authenticate the Edge CLI non-interactively |
-| `telnyx-edge new-func` | Scaffold a new function or clone an example |
-| `telnyx-edge ship` | Deploy the current function |
-| `telnyx-edge list` | List deployed functions |
-| `telnyx-edge secrets` | Manage runtime secrets |
-| `telnyx-edge bindings` | Manage Telnyx API key bindings |
+- [`team-telnyx/edge-compute`](https://github.com/team-telnyx/edge-compute) owns examples and runtime documentation.
+- `telnyx-edge` owns authentication, scaffolding, deployment, storage, secrets, bindings, revisions, and rollback.
+- This repo's `edge-doctor`, `setup-edge-mcp`, and `setup-edge-webhook` commands detect the installed CLI surface and point to those tools.
+- HTTP or MCP is the stable boundary back to the AI workflow.
 
 ## Prerequisites
 
-- Telnyx account
-- Access to the dedicated `telnyx-edge` CLI
-- A use case where AI workflows need a real deployed HTTP or MCP execution surface
+- A Telnyx account and API key
+- The dedicated `telnyx-edge` CLI
+- Git for cloning the canonical examples
+- A separate inbound shared secret for any protected HTTP or MCP endpoint
 
-## Prerequisite: install `telnyx-edge`
+## Quick Start
 
-Edge Compute is managed through the separate CLI:
+Run the bridge check first:
 
-```sh
-# See the edge-compute repo for install/setup details
-# https://github.com/team-telnyx/edge-compute
+```bash
+telnyx-agent edge-doctor --json
+```
 
+The doctor probes command help rather than assuming that a version string guarantees a feature.
+
+Use the current handoff helpers for the canonical examples:
+
+```bash
+telnyx-agent setup-edge-mcp --name my-mcp-server --json
+telnyx-agent setup-edge-webhook --name my-webhook --json
+```
+
+Their JSON includes ordered `setup_commands`; review them, substitute credential values locally, and run them with `telnyx-edge`.
+
+## Install and authenticate
+
+Install `telnyx-edge` from the [Edge Compute releases](https://github.com/team-telnyx/edge-compute/releases), then authenticate:
+
+```bash
+# Preferred for non-interactive agent environments when supported
 telnyx-edge auth api-key set <your-api-key>
 telnyx-edge auth status
 ```
 
-Typical lifecycle commands live there:
+OAuth remains available with `telnyx-edge auth login`. Never commit API keys or print secret values into logs.
 
-```sh
-telnyx-edge new-func
-telnyx-edge ship
-telnyx-edge list
-telnyx-edge delete-func
-telnyx-edge secrets
-telnyx-edge bindings
+## API Reference
+
+### Released v0.2.3 baseline
+
+The released v0.2.3 command surface used by this bridge includes:
+
+| Capability | Example |
+|---|---|
+| Failed-function recovery | `telnyx-edge reset-func broken-func` |
+| KV namespace and key operations | `telnyx-edge storage kv ...` and `telnyx-edge storage kv key ...` |
+| TOML bindings and TypeScript declarations | declare bindings, then run `telnyx-edge types` |
+| Immutable deploy history | `telnyx-edge revisions list my-func` |
+| Traffic rollback | `telnyx-edge rollback my-func <revision-id>` |
+| Stateful Actor scaffolding/management | `new-func --actor` and `actors` |
+| Secrets and Telnyx bindings | `secrets` and `bindings` |
+| Function inspection | `telnyx-edge inspect <function-name>` |
+
+#### Reset, revisions, and rollback
+
+```bash
+# Reset a function that is in a failed state, then ship the repaired source
+telnyx-edge reset-func broken-func
+telnyx-edge ship --from-dir=broken-func
+
+# Review immutable deploy history and retarget traffic to a healthy revision
+telnyx-edge revisions list my-func
+telnyx-edge rollback my-func <revision-id>
 ```
 
-## Reference architecture
+#### KV and generated binding types
 
-A practical pattern looks like this:
+KV supports namespace `create`, `list`, `get`, and `delete`, plus key `list`, `get`, `put`, and `delete` operations. Key writes can also use `--path` and `--ttl`.
 
-1. Use `team-telnyx/ai` for:
-   - agent workflows
-   - prompts/orchestration
-   - guides and capability discovery
-   - Telnyx API integrations
-2. Use `team-telnyx/edge-compute` for:
-   - function scaffolding
-   - deployment
-   - secrets and bindings
-   - running webhook/MCP edge endpoints
-3. Connect them with a stable boundary:
-   - HTTP webhook
-   - MCP endpoint
-   - function call into an edge-hosted adapter
+```bash
+telnyx-edge storage kv create --name session-state
+telnyx-edge storage kv list
 
-## Endgame: what a good integration looks like
+telnyx-edge storage kv key put <namespace-id> sessions/demo '{"status":"active"}' --ttl 1h
+telnyx-edge storage kv key get <namespace-id> sessions/demo
+telnyx-edge storage kv key list <namespace-id> --prefix sessions/ --limit 100
+# Continue a paginated listing with the returned cursor:
+telnyx-edge storage kv key list <namespace-id> --cursor <cursor> --limit 100
+```
 
-The end state is **not** "move Edge Compute into `team-telnyx/ai`".
+Bind the namespace in `telnyx.toml` or `func.toml`, then generate TypeScript declarations:
 
-The better endgame is a clear two-layer product:
+```toml
+[storage.kv.SESSIONS]
+id = "<namespace-id>"
+```
 
-### Layer 1 — `team-telnyx/ai`
-This layer should:
-- expose Edge Compute as a first-class capability in docs/manifests/help output
-- provide AI-oriented patterns and recipes
-- explain when an agent should reach for edge execution
-- help users connect agent workflows to deployed edge endpoints
+```bash
+telnyx-edge types
+```
 
-### Layer 2 — `team-telnyx/edge-compute`
-This layer should continue to own:
-- auth
-- function creation
-- deployment
-- secrets
-- bindings
-- runtime lifecycle and operational ergonomics
+`types` generates the environment declarations for supported TOML bindings, including KV, Telnyx, secrets, and actors.
 
-### Bridge between them
-The bridge should be explicit and boring:
-- `ai` produces orchestration guidance
-- Edge Compute provides execution endpoints
-- the contract between them is HTTP, MCP, or a documented function interface
+#### Stateful Actors
 
-That keeps ownership clear and avoids duplicating deployment tooling.
+Actors are useful for per-entity coordination such as sessions, carts, call legs, and workflow state. Probe `new-func --help` for `--actor`; do not infer actor availability from a hard-coded minimum version.
 
-## Phased rollout
+```bash
+telnyx-edge new-func --actor --language ts --name session-actor
+cd session-actor
+telnyx-edge types
+telnyx-edge ship
 
-### Phase 1 — Discoverability (this repo, now)
-- add Edge Compute capability visibility
-- add guide-level handoff and examples
-- make the README and capabilities output honest about scope
+# Account-scoped actor type views
+telnyx-edge actors list
+```
 
-### Phase 2 — Guided integration
-- add richer examples for webhook handlers, MCP adapters, and AI post-processing functions
-- add copy-paste scaffolds for how an AI app should call a deployed edge endpoint
-- document required secrets/bindings patterns
+### Feature-detected newer surface
 
-### Phase 3 — CLI bridge
-Only if ownership stays clear:
-- lightweight helper commands or docs-driven handoff from `telnyx-agent` to `telnyx-edge`
-- examples: `edge doctor`, `setup-edge-mcp`, or explicit "next command" guidance
-- these should shell out to `telnyx-edge`, not reimplement lifecycle management
+Cloud Storage TOML/type support is **not** a v0.2.3 baseline capability. It is a current-main/upcoming v0.2.4 surface for the release line targeted by this guide and must be gated by the installed CLI. The published v0.2.3 binary already exposes `inspect`, even though `RELEASE_NOTES.md` groups that command under v0.2.4.
 
-### Phase 4 — Deeper integration (optional, later)
-Only if a stable contract exists:
-- standardized templates
-- stronger config generation
-- possibly a shared library or interface contract
+```bash
+telnyx-edge inspect --help
+telnyx-agent edge-doctor --json
+```
 
-Not before.
+`edge-doctor --json` reports `inspect_supported` from command help. Because early Cloud Storage builds do not consistently mention the binding in `types --help`, the doctor runs `types --from-dir` against an isolated temporary manifest and checks the generated declaration. It never modifies the current project. Only suggest or invoke Cloud Storage when `cloud_storage_supported` is true.
 
-## Example: AI app calling an Edge endpoint
+## MCP server on Edge
 
-A simple pattern is to let your AI app call a deployed edge function for specialized execution.
+The source example lives in `docs/examples/ts/mcp-server` in `team-telnyx/edge-compute`. Clone the repository before using `--from-dir`:
+
+```bash
+git clone https://github.com/team-telnyx/edge-compute.git
+cd edge-compute
+
+telnyx-edge new-func \
+  --from-dir=docs/examples/ts/mcp-server \
+  --name=my-mcp-server
+cd my-mcp-server
+npm install
+npm run build
+```
+
+Before deployment, configure both prerequisites as Edge secrets:
+
+- `TELNYX_API_KEY`: used only for upstream Telnyx API calls.
+- `SHARED_SECRET`: a separate random bearer secret used to authenticate inbound MCP requests. Do not reuse the Telnyx API key.
+
+```bash
+# Placeholders only: do not paste secret values into source, chat, or logs.
+telnyx-edge secrets add TELNYX_API_KEY <telnyx-api-key>
+telnyx-edge secrets add SHARED_SECRET <independent-random-secret>
+telnyx-edge ship
+```
+
+Clients authenticate to the MCP endpoint with an `Authorization: Bearer` header containing the independently generated inbound token, never with `TELNYX_API_KEY`.
+
+## Webhook receiver on Edge
+
+The JavaScript example lives in `docs/examples/js/webhook-receiver`:
+
+```bash
+git clone https://github.com/team-telnyx/edge-compute.git
+cd edge-compute
+
+telnyx-edge new-func \
+  --from-dir=docs/examples/js/webhook-receiver \
+  --name=my-webhook
+cd my-webhook
+
+# Set an HMAC secret without committing or logging its value.
+telnyx-edge secrets add WEBHOOK_SECRET <webhook-signing-secret>
+telnyx-edge ship
+```
+
+`WEBHOOK_SECRET` enables HMAC verification. The example's recent-webhook buffer is process memory only; it is not durable across restarts. Use KV for durable key/value persistence or a Stateful Actor for serialized per-entity state.
+
+## Calling a protected Edge endpoint
+
+Protect your own AI-to-Edge endpoint with an independent `EDGE_SHARED_SECRET`. It is an inbound application credential and must not be the Telnyx API key used for upstream API calls.
 
 ```python
 import os
@@ -186,16 +193,12 @@ response = requests.post(
     "https://<your-edge-endpoint>",
     headers={
         "content-type": "application/json",
-        "authorization": f"Bearer {os.environ['TELNYX_API_KEY']}",
+        "authorization": f"Bearer {os.environ['EDGE_SHARED_SECRET']}",
     },
-    json={
-        "task": "redact_pii",
-        "payload": {
-            "text": "Call me at +1 555 123 4567",
-        },
-    },
+    json={"task": "redact_pii", "payload": {"text": "Call me at +1 555 123 4567"}},
+    timeout=15,
 )
-
+response.raise_for_status()
 print(response.json())
 ```
 
@@ -204,127 +207,28 @@ const response = await fetch("https://<your-edge-endpoint>", {
   method: "POST",
   headers: {
     "content-type": "application/json",
-    authorization: `Bearer ${process.env.TELNYX_API_KEY}`,
+    authorization: `Bearer ${process.env.EDGE_SHARED_SECRET}`,
   },
   body: JSON.stringify({
     task: "redact_pii",
-    payload: {
-      text: "Call me at +1 555 123 4567",
-    },
+    payload: { text: "Call me at +1 555 123 4567" },
   }),
 });
 
-const result = await response.json();
-console.log(result);
+if (!response.ok) throw new Error(`Edge request failed: ${response.status}`);
+console.log(await response.json());
 ```
-
-## Example patterns worth supporting
-
-### 1. MCP server at the edge
-Use Edge Compute to host a narrow MCP adapter close to runtime, while `team-telnyx/ai` handles the surrounding agent experience and capability discovery.
-
-### 2. Webhook receiver + AI router
-Use Edge Compute to receive inbound webhooks, normalize payloads, and forward structured requests into AI workflows.
-
-### 3. Post-processing function
-Use Edge Compute for deterministic transforms such as:
-- redaction
-- enrichment
-- scoring
-- transcript cleanup
-- lightweight policy checks
-
-These are the sweet spot: small execution units attached to larger agent workflows.
-
-## Fastest path to a real test
-
-If you want to test the end product quickly, do **one** of these first:
-
-### Option A — MCP server on Edge
-Best when you want an AI-native demo.
-
-```sh
-telnyx-edge new-func --from-dir=examples/ts/mcp-server --name=my-mcp-server
-cd my-mcp-server
-telnyx-edge secrets add TELNYX_API_KEY <your-api-key>
-telnyx-edge ship
-```
-
-Then point your MCP client or agent runtime at the deployed endpoint.
-
-### Option B — Webhook receiver on Edge
-Best when you want a simple integration seam.
-
-```sh
-telnyx-edge new-func --from-dir=examples/js/webhook-receiver --name=my-webhook
-cd my-webhook
-telnyx-edge ship
-```
-
-Then have your AI workflow call or route into that edge endpoint.
-
-### Option C — Post-processing function
-Best when you want a narrow but real AI-adjacent utility.
-
-Example use cases:
-- redact PII before storage
-- enrich messages before downstream routing
-- score or classify inbound events
-- clean transcripts before analysis
-
-You can also smoke-test a deployed edge endpoint directly:
 
 ```bash
 curl -X POST "https://<your-edge-endpoint>" \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
+  -H "Authorization: Bearer ${EDGE_SHARED_SECRET}" \
   -d '{
     "task": "redact_pii",
-    "payload": {
-      "text": "Call me at +1 555 123 4567"
-    }
+    "payload": {"text": "Call me at +1 555 123 4567"}
   }'
 ```
 
-## What this repo should and should not claim
+## Operational source of truth
 
-This repo **can**:
-- explain how Edge Compute fits into AI-agent workflows
-- provide examples and bridge guidance
-- point users to the right product surface
-
-This repo **should not** claim that it:
-- deploys edge functions directly
-- manages rollbacks or lifecycle state
-- replaces `telnyx-edge`
-- provides complete native Edge Compute support
-
-## Test recipe
-
-Here is the most practical end-to-end test loop:
-
-1. install `telnyx-edge` and authenticate with `telnyx-edge auth api-key set <your-api-key>`
-2. start from a working example in `team-telnyx/edge-compute`
-3. deploy it with `telnyx-edge ship`
-4. expose a stable HTTP or MCP boundary
-5. call that deployed endpoint from an AI workflow
-6. iterate on the boundary, not on duplicated deployment logic
-
-That gives you a real integration test without pretending `team-telnyx/ai` owns lifecycle management.
-
-## Best next step
-
-If you want to use Edge Compute from an AI workflow today:
-
-1. install `telnyx-edge` and authenticate with `telnyx-edge auth api-key set <your-api-key>`
-2. create/deploy your function in `team-telnyx/edge-compute`
-3. expose a stable HTTP or MCP boundary
-4. use `team-telnyx/ai` to orchestrate calls into that deployed endpoint
-
-For deploy/runtime specifics, use the `edge-compute` repo as the source of truth.
-
-## Source of truth
-
-- AI workflow/orchestration guidance: `team-telnyx/ai`
-- Edge lifecycle and deployment: `team-telnyx/edge-compute`
-- Runtime deploy tool: `telnyx-edge`
+Use `team-telnyx/ai` for agent workflows and integration patterns. Use `team-telnyx/edge-compute` and the installed `telnyx-edge --help` for deployment/runtime behavior. When the installed help and this bridge differ, the detected CLI surface wins.


### PR DESCRIPTION
## Summary
- expand `edge-doctor` into help/behavior-based capability detection
- fix MCP/webhook example paths and return complete ordered setup steps
- refresh the Edge guide for KV, reset, revisions, rollback, actors, inspect, and gated Cloud Storage
- separate inbound endpoint credentials from the Telnyx API key

## Audit findings
The guide contained broken example paths and an obsolete roadmap, setup helpers omitted required credentials, and the doctor only detected actors. The published v0.2.3 artifact also contains `inspect` despite release notes grouping it under v0.2.4; Cloud Storage remains behavior-gated.

## Validation
- `npx tsc --noEmit`
- `npm test` (111/111)