### PR TITLE
feat: Add voice AI call actions to agent CLI

### DIFF
--- a/cli/src/commands/call-control.ts
+++ b/cli/src/commands/call-control.ts
@@ -11,7 +11,11 @@
  *   gather, stop-gather, start-playback, stop-playback, start-transcription,
  *   stop-transcription, pause-recording, resume-recording, start-forking,
  *   stop-forking, start-siprec, stop-siprec, start-streaming, stop-streaming,
- *   enqueue, leave-queue, send-sip-info, update-client-state
+ *   enqueue, leave-queue, send-sip-info, update-client-state,
+ *   add-ai-assistant-messages, gather-using-ai, gather-using-audio,
+ *   gather-using-speak, join-ai-assistant, start-ai-assistant,
+ *   start-conversation-relay, stop-ai-assistant, stop-conversation-relay,
+ *   switch-supervisor-role
  */
 
 import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
@@ -31,11 +35,18 @@ const ACTIONS = [
   "start-streaming", "stop-streaming",
   "enqueue", "leave-queue",
   "send-sip-info", "update-client-state",
+  "add-ai-assistant-messages",
+  "gather-using-ai", "gather-using-audio", "gather-using-speak",
+  "join-ai-assistant", "start-ai-assistant", "start-conversation-relay",
+  "stop-ai-assistant", "stop-conversation-relay", "switch-supervisor-role",
 ] as const;
 type Action = (typeof ACTIONS)[number];
 
 /** Valid causes for the Reject API (required by POST /calls/{id}/actions/reject). */
 const REJECT_CAUSES = ["CALL_REJECTED", "USER_BUSY"] as const;
+
+/** Valid supervisor roles for a bridged call. */
+const SUPERVISOR_ROLES = ["barge", "whisper", "monitor"] as const;
 
 /** E.164: a leading '+' then 1-15 digits, country code must not start with 0. */
 const E164_RE = /^\+[1-9]\d{1,14}$/;
@@ -75,6 +86,10 @@ export async function callControlCommand(flags: Record<string, string | boolean>
   const forkStreamType = flags["fork-stream-type"] as string | undefined;
   // --cause defaults to CALL_REJECTED, the generic rejection cause.
   const cause = (typeof flags.cause === "string" ? flags.cause : undefined) ?? "CALL_REJECTED";
+  // Voice/AI action flags. Rich object and array values remain raw JSON strings and
+  // are handed directly to the Go CLI, which owns their schemas.
+  const conversationId = flags["conversation-id"] as string | undefined;
+  const role = flags.role as string | undefined;
 
   if (!action) {
     printError(`--action is required. Valid actions: ${ACTIONS.join(", ")}`);
@@ -162,6 +177,24 @@ export async function callControlCommand(flags: Record<string, string | boolean>
     printError(`Invalid --cause: ${cause}. Must be one of: ${REJECT_CAUSES.join(", ")}`);
     process.exit(1);
   }
+  if (act === "gather-using-speak" && !payload) {
+    printError("--payload is required for gather-using-speak (text or SSML to synthesize)");
+    process.exit(1);
+  }
+  if (act === "join-ai-assistant" && !conversationId) {
+    printError("--conversation-id is required for join-ai-assistant");
+    process.exit(1);
+  }
+  if (act === "switch-supervisor-role") {
+    if (!role) {
+      printError("--role is required for switch-supervisor-role");
+      process.exit(1);
+    }
+    if (!SUPERVISOR_ROLES.includes(role as (typeof SUPERVISOR_ROLES)[number])) {
+      printError(`Invalid --role: ${role}. Must be one of: ${SUPERVISOR_ROLES.join(", ")}`);
+      process.exit(1);
+    }
+  }
 
   const args = buildActionArgs(act, {
     callControlId,
@@ -186,6 +219,7 @@ export async function callControlCommand(flags: Record<string, string | boolean>
     forkTx,
     forkStreamType,
     cause,
+    flags,
   });
 
   try {
@@ -245,6 +279,7 @@ function buildActionArgs(
     forkTx?: string;
     forkStreamType?: string;
     cause: string;
+    flags: Record<string, string | boolean>;
   },
 ): string[] {
   switch (action) {
@@ -358,7 +393,135 @@ function buildActionArgs(
         "--call-control-id", opts.callControlId,
         "--client-state", opts.clientState!,
       ];
+    case "add-ai-assistant-messages":
+      return actionArgs(action, opts.callControlId, opts.flags, [
+        "client-state", "command-id", "message",
+      ]);
+    case "gather-using-ai":
+      return actionArgs(action, opts.callControlId, opts.flags, [
+        "parameters", "assistant", "client-state", "command-id",
+        "gather-ended-speech", "greeting", "interruption-settings", "language",
+        "message-history", "send-message-history-updates", "send-partial-results",
+        "transcription", "user-response-timeout-ms", "voice", "voice-settings",
+        "assistant.instructions", "assistant.model", "assistant.openai-api-key-ref",
+        "assistant.tools", "interruption-settings.enable", "transcription.language",
+        "transcription.model",
+      ], {
+        "assistant-instructions": "assistant.instructions",
+        "assistant-model": "assistant.model",
+      });
+    case "gather-using-audio":
+      return actionArgs(action, opts.callControlId, opts.flags, [
+        "audio-url", "client-state", "command-id", "inter-digit-timeout-millis",
+        "invalid-audio-url", "invalid-media-name", "maximum-digits", "maximum-tries",
+        "media-name", "minimum-digits", "terminating-digit", "timeout-millis",
+        "valid-digits",
+      ]);
+    case "gather-using-speak":
+      return [
+        "calls:actions", action, "--call-control-id", opts.callControlId,
+        "--payload", opts.payload!,
+        "--voice", typeof opts.flags.voice === "string" ? opts.flags.voice : opts.voice,
+        ...forwardFlags(opts.flags, [
+          "client-state", "command-id", "inter-digit-timeout-millis", "invalid-payload",
+          "language", "maximum-digits", "maximum-tries", "minimum-digits",
+          "payload-type", "service-level", "terminating-digit", "timeout-millis",
+          "valid-digits", "voice-settings",
+        ]),
+      ];
+    case "join-ai-assistant":
+      return actionArgs(action, opts.callControlId, opts.flags, [
+        "conversation-id", "participant", "client-state", "command-id",
+        "participant.id", "participant.role", "participant.name", "participant.on-hangup",
+      ], {
+        "participant-id": "participant.id",
+        "participant-role": "participant.role",
+        "participant-name": "participant.name",
+        "participant-on-hangup": "participant.on-hangup",
+      });
+    case "start-ai-assistant":
+      return actionArgs(action, opts.callControlId, opts.flags, [
+        "assistant", "client-state", "command-id", "greeting", "interruption-settings",
+        "message-history", "participant", "send-message-history-updates",
+        "transcription", "voice", "voice-settings",
+        "assistant.id", "assistant.dynamic-variables", "assistant.external-llm",
+        "assistant.fallback-config", "assistant.greeting", "assistant.instructions",
+        "assistant.llm-api-key-ref", "assistant.mcp-servers", "assistant.model",
+        "assistant.name", "assistant.observability-settings", "assistant.openai-api-key-ref",
+        "assistant.tools", "interruption-settings.enable", "participant.id",
+        "participant.role", "participant.name", "participant.on-hangup",
+        "transcription.language", "transcription.model",
+      ], {
+        "assistant-id": "assistant.id",
+        "assistant-instructions": "assistant.instructions",
+        "assistant-model": "assistant.model",
+      });
+    case "start-conversation-relay":
+      return actionArgs(action, opts.callControlId, opts.flags, [
+        "assistant", "client-state", "command-id", "conversation-relay-dtmf-detection",
+        "conversation-relay-settings", "conversation-relay-url", "custom-parameters",
+        "dtmf-detection", "greeting", "interruptible", "interruptible-greeting",
+        "interruption-settings", "language", "provider", "structured-provider",
+        "transcription", "transcription-engine", "transcription-engine-config", "tts-provider", "url",
+        "voice", "voice-settings", "assistant.dynamic-variables",
+        "conversation-relay-settings.url", "conversation-relay-settings.dtmf-detection",
+        "conversation-relay-settings.interruptible",
+        "conversation-relay-settings.interruptible-greeting",
+        "conversation-relay-settings.languages", "interruption-settings.enable",
+        "interruption-settings.interruptible", "interruption-settings.interruptible-greeting",
+        "interruption-settings.welcome-greeting-interruptible", "language.language",
+        "language.speech-model", "language.transcription-engine",
+        "language.transcription-engine-config", "language.transcription-provider",
+        "language.tts-provider", "language.voice", "language.voice-settings",
+      ], { "assistant-dynamic-variables": "assistant.dynamic-variables" });
+    case "stop-ai-assistant":
+    case "stop-conversation-relay":
+      return actionArgs(action, opts.callControlId, opts.flags, ["client-state", "command-id"]);
+    case "switch-supervisor-role":
+      return actionArgs(action, opts.callControlId, opts.flags, ["role"]);
   }
+}
+
+/** Build an action invocation while preserving JSON flag values byte-for-byte. */
+function actionArgs(
+  action: Action,
+  callControlId: string,
+  flags: Record<string, string | boolean>,
+  names: string[],
+  aliases: Record<string, string> = {},
+): string[] {
+  return [
+    "calls:actions", action, "--call-control-id", callControlId,
+    ...forwardFlags(flags, names),
+    ...forwardMappedFlags(flags, aliases),
+  ];
+}
+
+/** Forward only explicitly supplied flags, using the exact names accepted by the Go CLI. */
+function forwardFlags(flags: Record<string, string | boolean>, names: string[]): string[] {
+  const args: string[] = [];
+  for (const name of names) {
+    const value = flags[name];
+    if (typeof value === "string") args.push(`--${name}`, value);
+    else if (value === true) args.push(`--${name}`);
+  }
+  return args;
+}
+
+/** Map agent-friendly aliases to the corresponding structured Go CLI flag. */
+function forwardMappedFlags(
+  flags: Record<string, string | boolean>,
+  aliases: Record<string, string>,
+): string[] {
+  const args: string[] = [];
+  for (const [alias, goName] of Object.entries(aliases)) {
+    // If both forms are supplied, the exact Go flag takes precedence.
+    if (flags[goName] !== undefined) continue;
+    const value = flags[alias];
+    if (typeof value === "string") args.push(`--${goName}`, value);
+    else if (value === true) args.push(`--${goName}`);
+  }
+  return args;
 }
 
 function errorMsg(err: unknown): string {

--- a/cli/src/commands/capabilities.ts
+++ b/cli/src/commands/capabilities.ts
@@ -15,7 +15,7 @@ const CAPABILITIES: Record<string, Capability[]> = {
     { name: "SMS / MMS", description: "Send, schedule, and manage text and multimedia messages", actions: ["send_sms", "send_mms", "send_group_mms", "schedule_sms", "check_sms_status", "cancel_scheduled_sms", "list_messaging_profiles", "create_messaging_profile"] },
   ],
   "📞 Voice": [
-    { name: "Call Control", description: "Make and manage voice calls via SIP connections", actions: ["make_call", "list_connections", "answer_call", "hangup_call", "transfer_call", "send_dtmf", "start_recording", "stop_recording", "start_noise_suppression", "stop_noise_suppression", "speak_tts", "bridge_calls", "refer_call", "reject_call", "get_call_status", "answering_machine_detection", "deepfake_detection", "number_masking", "from_display_name", "time_limit", "media_encryption", "transcription", "gather", "stop_gather", "start_playback", "stop_playback", "start_transcription", "stop_transcription", "pause_recording", "resume_recording", "start_forking", "stop_forking", "start_siprec", "stop_siprec", "start_streaming", "stop_streaming", "enqueue", "leave_queue", "send_sip_info", "update_client_state"] },
+    { name: "Call Control", description: "Make and manage voice calls via SIP connections", actions: ["make_call", "list_connections", "answer_call", "hangup_call", "transfer_call", "send_dtmf", "start_recording", "stop_recording", "start_noise_suppression", "stop_noise_suppression", "speak_tts", "bridge_calls", "refer_call", "reject_call", "get_call_status", "answering_machine_detection", "deepfake_detection", "number_masking", "from_display_name", "time_limit", "media_encryption", "transcription", "gather", "stop_gather", "start_playback", "stop_playback", "start_transcription", "stop_transcription", "pause_recording", "resume_recording", "start_forking", "stop_forking", "start_siprec", "stop_siprec", "start_streaming", "stop_streaming", "enqueue", "leave_queue", "send_sip_info", "update_client_state", "add_ai_assistant_messages", "gather_using_ai", "gather_using_audio", "gather_using_speak", "join_ai_assistant", "start_ai_assistant", "start_conversation_relay", "stop_ai_assistant", "stop_conversation_relay", "switch_supervisor_role"] },
   ],
   "🔢 Numbers": [
     { name: "Phone Numbers", description: "Search, buy, and manage phone numbers", actions: ["list_phone_numbers", "search_phone_numbers", "buy_phone_number"] },
@@ -102,7 +102,7 @@ const COMPOSITE_COMMANDS = [
   { name: "telnyx-agent status", description: "Account health overview — balance, numbers, profiles, connections" },
   { name: "telnyx-agent capabilities", description: "This command — lists all available API capabilities" },
   { name: "telnyx-agent call-dial", description: "Make an outbound call via Call Control (AMD, deepfake detection, recording optional)" },
-  { name: "telnyx-agent call-control", description: "Call Control actions: answer, hangup, transfer, DTMF, recording, noise suppression, speak (TTS), bridge, refer, reject, gather, playback, transcription, forking, siprec, streaming, enqueue, send-sip-info, update-client-state" },
+  { name: "telnyx-agent call-control", description: "Full Call Control actions, including recording/media, AI assistant lifecycle and messages, AI/audio/speak gathers, Conversation Relay, and supervisor roles" },
   { name: "telnyx-agent call-status", description: "Get the status of a call by call-control-id" },
 ];
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -176,7 +176,11 @@ Voice Call Flags:
                     gather, stop-gather, start-playback, stop-playback, start-transcription,
                     stop-transcription, pause-recording, resume-recording, start-forking,
                     stop-forking, start-siprec, stop-siprec, start-streaming, stop-streaming,
-                    enqueue, leave-queue, send-sip-info, update-client-state
+                    enqueue, leave-queue, send-sip-info, update-client-state,
+                    add-ai-assistant-messages, gather-using-ai, gather-using-audio,
+                    gather-using-speak, join-ai-assistant, start-ai-assistant,
+                    start-conversation-relay, stop-ai-assistant, stop-conversation-relay,
+                    switch-supervisor-role
   --digits           DTMF digits to send (call-control dtmf)
   --payload          Text to synthesize and speak (call-control speak)
   --voice            TTS voice to use (call-control speak, default: female)
@@ -205,6 +209,22 @@ Voice Call Flags:
   --queue-name                   Queue to place the call into (call-control enqueue, required)
   --body                         SIP INFO body content (call-control send-sip-info, required)
   --content-type                 SIP INFO Content-Type header (call-control send-sip-info, required, e.g. application/dtmf-relay)
+  --message                      Raw JSON message array (add-ai-assistant-messages)
+  --parameters                   Raw JSON Schema object (gather-using-ai, required)
+  --assistant                    Raw JSON assistant object (gather/start AI assistant or Conversation Relay)
+  --assistant-id                 Stored assistant ID (maps to Go --assistant.id)
+  --assistant-instructions       Per-call instructions (maps to Go --assistant.instructions)
+  --assistant-model              Per-call model (maps to Go --assistant.model)
+  --message-history              Raw JSON message array (gather/start-ai-assistant)
+  --conversation-id              Existing AI conversation ID (join-ai-assistant, required)
+  --participant                  Raw JSON participant object/array (join/start-ai-assistant)
+  --participant-id               Participant call-control ID (maps to Go --participant.id)
+  --participant-role             Participant role (maps to Go --participant.role)
+  --url                          Conversation Relay WebSocket URL (start-conversation-relay, required)
+  --custom-parameters            Raw JSON key/value object (start-conversation-relay)
+  --role                         Supervisor role: barge|whisper|monitor (switch-supervisor-role)
+  Rich object/array flags are forwarded as raw JSON. Exact Go inner flags such as
+  --assistant.dynamic-variables, --participant.role, and --transcription.model are also supported.
 STT Flags:
   --audio-url <url> URL of the audio file to transcribe (required)
   --model           Transcription model (default: distil-whisper/distil-large-v2; also openai/whisper-large-v3-turbo, deepgram/nova-3)

--- a/cli/tests/voice.test.ts
+++ b/cli/tests/voice.test.ts
@@ -305,6 +305,136 @@ describe("Voice API action commands", () => {
     assertFlagValue(answerCall!, "--record", "record-from-answer");
   });
 
+  it("call-control dispatches all ten AI/Conversation Relay actions with exact Go CLI flags", () => {
+    const cases: Array<{
+      action: string;
+      flags?: string[];
+      expected: Record<string, string | true>;
+    }> = [
+      {
+        action: "add-ai-assistant-messages",
+        flags: ["--message", '[{"role":"user","content":"hello"}]'],
+        expected: { "--message": '[{"role":"user","content":"hello"}]' },
+      },
+      {
+        action: "gather-using-ai",
+        flags: [
+          "--parameters", '{"type":"object","properties":{"name":{"type":"string"}}}',
+          "--assistant.instructions", "Ask for the caller name",
+          "--assistant.model", "openai/gpt-4o-mini",
+          "--send-partial-results",
+        ],
+        expected: {
+          "--parameters": '{"type":"object","properties":{"name":{"type":"string"}}}',
+          "--assistant.instructions": "Ask for the caller name",
+          "--assistant.model": "openai/gpt-4o-mini",
+          "--send-partial-results": true,
+        },
+      },
+      {
+        action: "gather-using-audio",
+        flags: ["--audio-url", "https://example.com/menu.wav", "--maximum-digits", "4"],
+        expected: { "--audio-url": "https://example.com/menu.wav", "--maximum-digits": "4" },
+      },
+      {
+        action: "gather-using-speak",
+        flags: ["--payload", "Enter your PIN", "--voice", "Telnyx.KokoroTTS.af", "--valid-digits", "0123456789"],
+        expected: {
+          "--payload": "Enter your PIN",
+          "--voice": "Telnyx.KokoroTTS.af",
+          "--valid-digits": "0123456789",
+        },
+      },
+      {
+        action: "join-ai-assistant",
+        flags: ["--conversation-id", "conv-1", "--participant", '{"id":"call-2","role":"user"}'],
+        expected: { "--conversation-id": "conv-1", "--participant": '{"id":"call-2","role":"user"}' },
+      },
+      {
+        action: "start-ai-assistant",
+        flags: [
+          "--assistant-id", "assistant-1",
+          "--assistant-instructions", "Be concise",
+          "--message-history", '[{"role":"user","content":"context"}]',
+        ],
+        expected: {
+          "--assistant.id": "assistant-1",
+          "--assistant.instructions": "Be concise",
+          "--message-history": '[{"role":"user","content":"context"}]',
+        },
+      },
+      {
+        action: "start-conversation-relay",
+        flags: [
+          "--url", "wss://relay.example.com/ws",
+          "--custom-parameters", '{"account_id":"acct-1"}',
+          "--dtmf-detection",
+        ],
+        expected: {
+          "--url": "wss://relay.example.com/ws",
+          "--custom-parameters": '{"account_id":"acct-1"}',
+          "--dtmf-detection": true,
+        },
+      },
+      {
+        action: "stop-ai-assistant",
+        flags: ["--command-id", "cmd-stop-ai"],
+        expected: { "--command-id": "cmd-stop-ai" },
+      },
+      {
+        action: "stop-conversation-relay",
+        flags: ["--client-state", "c3RhdGU="],
+        expected: { "--client-state": "c3RhdGU=" },
+      },
+      {
+        action: "switch-supervisor-role",
+        flags: ["--role", "whisper"],
+        expected: { "--role": "whisper" },
+      },
+    ];
+
+    for (const testCase of cases) {
+      const fake = setupFakeTelnyx();
+      run([
+        "call-control", "--action", testCase.action, "--call-control-id", "call-ai-1",
+        ...(testCase.flags ?? []), "--json",
+      ], fake.env);
+
+      const calls = readLoggedArgs(fake.logPath);
+      const invocation = calls.find((args) =>
+        args[0] === "calls:actions" && args[1] === testCase.action);
+      assert.ok(invocation, `should invoke calls:actions ${testCase.action}`);
+      assertFlagValue(invocation!, "--call-control-id", "call-ai-1");
+      for (const [flag, value] of Object.entries(testCase.expected)) {
+        if (value === true) assert.ok(invocation!.includes(flag), `expected bare ${flag}`);
+        else assertFlagValue(invocation!, flag, value);
+      }
+    }
+  });
+
+  it("call-control validates upstream-required AI action flags and supervisor roles", () => {
+    const fake = setupFakeTelnyx();
+    for (const args of [
+      ["gather-using-speak"],
+      ["join-ai-assistant"],
+      ["switch-supervisor-role", "--role", "invalid"],
+    ]) {
+      assert.throws(() => run([
+        "call-control", "--action", ...args, "--call-control-id", "call-1", "--json",
+      ], fake.env));
+    }
+  });
+
+  it("does not reject optional generated fields for AI gather and Conversation Relay", () => {
+    for (const action of ["gather-using-ai", "gather-using-audio", "start-conversation-relay"]) {
+      const fake = setupFakeTelnyx();
+      run(["call-control", "--action", action, "--call-control-id", "call-1", "--json"], fake.env);
+      const invocation = readLoggedArgs(fake.logPath).find((args) =>
+        args[0] === "calls:actions" && args[1] === action);
+      assert.ok(invocation, `should invoke calls:actions ${action}`);
+    }
+  });
+
   it("call-status calls `calls retrieve-status`", () => {
     const fake = setupFakeTelnyx();
     const output = run(["call-status", "--call-control-id", "call-1", "--json"], fake.env);
@@ -324,6 +454,17 @@ describe("Voice API action commands", () => {
     assert.ok(output.includes("call-control"), "help should list call-control");
     assert.ok(output.includes("call-status"), "help should list call-status");
     assert.ok(output.includes("--answering-machine-detection"), "help should document AMD flag");
+    for (const action of [
+      "add-ai-assistant-messages", "gather-using-ai", "gather-using-audio",
+      "gather-using-speak", "join-ai-assistant", "start-ai-assistant",
+      "start-conversation-relay", "stop-ai-assistant", "stop-conversation-relay",
+      "switch-supervisor-role",
+    ]) {
+      assert.ok(output.includes(action), `help should document ${action}`);
+    }
+    assert.ok(output.includes("--assistant-id"), "help should document agent-friendly assistant flags");
+    assert.ok(output.includes("--assistant.id"), "help should document the mapped Go assistant flag");
+    assert.ok(output.includes("raw JSON"), "help should document raw JSON inputs");
   });
 
   it("capabilities lists the voice actions and composite commands", () => {
@@ -334,7 +475,14 @@ describe("Voice API action commands", () => {
     const voice = data.api_capabilities["📞 Voice"] as Array<{ name: string; actions: string[] }>;
     assert.ok(voice, "Voice category should exist");
     const actions = voice[0].actions;
-    for (const a of ["answer_call", "hangup_call", "transfer_call", "send_dtmf", "speak_tts", "bridge_calls", "get_call_status", "deepfake_detection"]) {
+    for (const a of [
+      "answer_call", "hangup_call", "transfer_call", "send_dtmf", "speak_tts",
+      "bridge_calls", "get_call_status", "deepfake_detection",
+      "add_ai_assistant_messages", "gather_using_ai", "gather_using_audio",
+      "gather_using_speak", "join_ai_assistant", "start_ai_assistant",
+      "start_conversation_relay", "stop_ai_assistant", "stop_conversation_relay",
+      "switch_supervisor_role",
+    ]) {
       assert.ok(actions.includes(a), `Voice actions should include ${a}`);
     }
 


### PR DESCRIPTION
## Summary
- extend `call-control --action` with ten upstream AI/Conversation Relay actions
- forward generated structured flags while preserving raw JSON
- update help/capabilities and mock-binary coverage

## Audit finding
The Agent CLI claimed the full Call Control surface but omitted ten current upstream actions, including AI assistant and Conversation Relay lifecycle operations.

## Validation
- `npx tsc --noEmit`
- `npm test` (113/113)