### PR TITLE
feat: Add AI Call Control actions to agent CLI

### DIFF
--- a/cli/src/commands/call-control.ts
+++ b/cli/src/commands/call-control.ts
@@ -109,6 +109,14 @@ const NEW_ACTION_REQUIRED_FLAGS: Partial<Record<Action, readonly string[]>> = {
   "switch-supervisor-role": ["role"],
 };
 
+const REPEATED_OBJECT_FLAGS = new Set([
+  "message",
+  "message-history",
+  "assistant.mcp-servers",
+  "assistant.tools",
+  "conversation-relay-settings.languages",
+]);
+
 /** Valid causes for the Reject API (required by POST /calls/{id}/actions/reject). */
 const REJECT_CAUSES = ["CALL_REJECTED", "USER_BUSY"] as const;
 
@@ -465,12 +473,25 @@ function buildGeneratedActionArgs(
   for (const flag of NEW_ACTION_FLAGS[action] ?? []) {
     const value = flags[flag];
     if (typeof value === "string") {
-      args.push(`--${flag}`, value);
+      const values = REPEATED_OBJECT_FLAGS.has(flag) ? parseObjectArray(value) : undefined;
+      for (const item of values ?? [value]) args.push(`--${flag}`, item);
     } else if (value === true) {
       args.push(`--${flag}`);
     }
   }
   return args;
+}
+
+function parseObjectArray(value: string): string[] | undefined {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (Array.isArray(parsed) && parsed.every((item) => typeof item === "object" && item !== null && !Array.isArray(item))) {
+      return parsed.map((item) => JSON.stringify(item));
+    }
+  } catch {
+    // Preserve non-JSON values for the generated CLI to handle as before.
+  }
+  return undefined;
 }
 
 function errorMsg(err: unknown): string {

--- a/cli/src/commands/call-control.ts
+++ b/cli/src/commands/call-control.ts
@@ -11,7 +11,11 @@
  *   gather, stop-gather, start-playback, stop-playback, start-transcription,
  *   stop-transcription, pause-recording, resume-recording, start-forking,
  *   stop-forking, start-siprec, stop-siprec, start-streaming, stop-streaming,
- *   enqueue, leave-queue, send-sip-info, update-client-state
+ *   enqueue, leave-queue, send-sip-info, update-client-state,
+ *   add-ai-assistant-messages, gather-using-ai, gather-using-audio,
+ *   gather-using-speak, join-ai-assistant, start-ai-assistant,
+ *   stop-ai-assistant, start-conversation-relay, stop-conversation-relay,
+ *   switch-supervisor-role
  */
 
 import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
@@ -31,8 +35,79 @@ const ACTIONS = [
   "start-streaming", "stop-streaming",
   "enqueue", "leave-queue",
   "send-sip-info", "update-client-state",
+  "add-ai-assistant-messages",
+  "gather-using-ai", "gather-using-audio", "gather-using-speak",
+  "join-ai-assistant", "start-ai-assistant", "stop-ai-assistant",
+  "start-conversation-relay", "stop-conversation-relay",
+  "switch-supervisor-role",
 ] as const;
 type Action = (typeof ACTIONS)[number];
+
+/**
+ * Flags exposed by the generated Go commands for the ten AI/relay actions.
+ * Values are forwarded exactly as supplied; omitted optional flags are left to
+ * the Go CLI/API defaults. This includes the generated inner (dotted) flags.
+ */
+const NEW_ACTION_FLAGS: Partial<Record<Action, readonly string[]>> = {
+  "add-ai-assistant-messages": [
+    "client-state", "command-id", "message",
+  ],
+  "gather-using-ai": [
+    "parameters", "assistant", "client-state", "command-id", "gather-ended-speech", "greeting",
+    "interruption-settings", "language", "message-history", "send-message-history-updates",
+    "send-partial-results", "transcription", "user-response-timeout-ms", "voice", "voice-settings",
+    "assistant.instructions", "assistant.model", "assistant.openai-api-key-ref", "assistant.tools",
+    "interruption-settings.enable", "message-history.content", "message-history.role",
+    "transcription.language", "transcription.model",
+  ],
+  "gather-using-audio": [
+    "audio-url", "client-state", "command-id", "inter-digit-timeout-millis", "invalid-audio-url",
+    "invalid-media-name", "maximum-digits", "maximum-tries", "media-name", "minimum-digits",
+    "terminating-digit", "timeout-millis", "valid-digits",
+  ],
+  "gather-using-speak": [
+    "payload", "voice", "client-state", "command-id", "inter-digit-timeout-millis", "invalid-payload",
+    "language", "maximum-digits", "maximum-tries", "minimum-digits", "payload-type", "service-level",
+    "terminating-digit", "timeout-millis", "valid-digits", "voice-settings",
+  ],
+  "join-ai-assistant": [
+    "conversation-id", "participant", "client-state", "command-id", "participant.id", "participant.role",
+    "participant.name", "participant.on-hangup",
+  ],
+  "start-ai-assistant": [
+    "assistant", "client-state", "command-id", "greeting", "interruption-settings", "message-history",
+    "participant", "send-message-history-updates", "transcription", "voice", "voice-settings",
+    "assistant.id", "assistant.dynamic-variables", "assistant.external-llm", "assistant.fallback-config",
+    "assistant.greeting", "assistant.instructions", "assistant.llm-api-key-ref", "assistant.mcp-servers",
+    "assistant.model", "assistant.name", "assistant.observability-settings", "assistant.openai-api-key-ref",
+    "assistant.tools", "interruption-settings.enable", "participant.id", "participant.role",
+    "participant.name", "participant.on-hangup", "transcription.language", "transcription.model",
+  ],
+  "stop-ai-assistant": ["client-state", "command-id"],
+  "start-conversation-relay": [
+    "assistant", "client-state", "command-id", "conversation-relay-dtmf-detection",
+    "conversation-relay-settings", "conversation-relay-url", "custom-parameters", "dtmf-detection",
+    "greeting", "interruptible", "interruptible-greeting", "interruption-settings", "language", "provider",
+    "structured-provider", "transcription", "transcription-engine", "transcription-engine-config", "tts-provider",
+    "url", "voice", "voice-settings", "assistant.dynamic-variables", "conversation-relay-settings.url",
+    "conversation-relay-settings.dtmf-detection", "conversation-relay-settings.interruptible",
+    "conversation-relay-settings.interruptible-greeting", "conversation-relay-settings.languages",
+    "interruption-settings.enable", "interruption-settings.interruptible",
+    "interruption-settings.interruptible-greeting", "interruption-settings.welcome-greeting-interruptible",
+    "language.language", "language.speech-model", "language.transcription-engine",
+    "language.transcription-engine-config", "language.transcription-provider", "language.tts-provider",
+    "language.voice", "language.voice-settings",
+  ],
+  "stop-conversation-relay": ["client-state", "command-id"],
+  "switch-supervisor-role": ["role"],
+};
+
+const NEW_ACTION_REQUIRED_FLAGS: Partial<Record<Action, readonly string[]>> = {
+  "gather-using-ai": ["parameters"],
+  "gather-using-speak": ["payload", "voice"],
+  "join-ai-assistant": ["conversation-id", "participant"],
+  "switch-supervisor-role": ["role"],
+};
 
 /** Valid causes for the Reject API (required by POST /calls/{id}/actions/reject). */
 const REJECT_CAUSES = ["CALL_REJECTED", "USER_BUSY"] as const;
@@ -162,6 +237,13 @@ export async function callControlCommand(flags: Record<string, string | boolean>
     printError(`Invalid --cause: ${cause}. Must be one of: ${REJECT_CAUSES.join(", ")}`);
     process.exit(1);
   }
+  for (const requiredFlag of NEW_ACTION_REQUIRED_FLAGS[act] ?? []) {
+    const value = flags[requiredFlag];
+    if (typeof value !== "string" || value.length === 0) {
+      printError(`--${requiredFlag} is required for ${act}`);
+      process.exit(1);
+    }
+  }
 
   const args = buildActionArgs(act, {
     callControlId,
@@ -186,6 +268,7 @@ export async function callControlCommand(flags: Record<string, string | boolean>
     forkTx,
     forkStreamType,
     cause,
+    actionFlags: flags,
   });
 
   try {
@@ -245,6 +328,7 @@ function buildActionArgs(
     forkTx?: string;
     forkStreamType?: string;
     cause: string;
+    actionFlags: Record<string, string | boolean>;
   },
 ): string[] {
   switch (action) {
@@ -358,7 +442,35 @@ function buildActionArgs(
         "--call-control-id", opts.callControlId,
         "--client-state", opts.clientState!,
       ];
+    case "add-ai-assistant-messages":
+    case "gather-using-ai":
+    case "gather-using-audio":
+    case "gather-using-speak":
+    case "join-ai-assistant":
+    case "start-ai-assistant":
+    case "stop-ai-assistant":
+    case "start-conversation-relay":
+    case "stop-conversation-relay":
+    case "switch-supervisor-role":
+      return buildGeneratedActionArgs(action, opts.callControlId, opts.actionFlags);
   }
+}
+
+function buildGeneratedActionArgs(
+  action: Action,
+  callControlId: string,
+  flags: Record<string, string | boolean>,
+): string[] {
+  const args = ["calls:actions", action, "--call-control-id", callControlId];
+  for (const flag of NEW_ACTION_FLAGS[action] ?? []) {
+    const value = flags[flag];
+    if (typeof value === "string") {
+      args.push(`--${flag}`, value);
+    } else if (value === true) {
+      args.push(`--${flag}`);
+    }
+  }
+  return args;
 }
 
 function errorMsg(err: unknown): string {

--- a/cli/src/commands/capabilities.ts
+++ b/cli/src/commands/capabilities.ts
@@ -15,7 +15,7 @@ const CAPABILITIES: Record<string, Capability[]> = {
     { name: "SMS / MMS", description: "Send, schedule, and manage text and multimedia messages", actions: ["send_sms", "send_mms", "send_group_mms", "schedule_sms", "check_sms_status", "cancel_scheduled_sms", "list_messaging_profiles", "create_messaging_profile"] },
   ],
   "📞 Voice": [
-    { name: "Call Control", description: "Make and manage voice calls via SIP connections", actions: ["make_call", "list_connections", "answer_call", "hangup_call", "transfer_call", "send_dtmf", "start_recording", "stop_recording", "start_noise_suppression", "stop_noise_suppression", "speak_tts", "bridge_calls", "refer_call", "reject_call", "get_call_status", "answering_machine_detection", "deepfake_detection", "number_masking", "from_display_name", "time_limit", "media_encryption", "transcription", "gather", "stop_gather", "start_playback", "stop_playback", "start_transcription", "stop_transcription", "pause_recording", "resume_recording", "start_forking", "stop_forking", "start_siprec", "stop_siprec", "start_streaming", "stop_streaming", "enqueue", "leave_queue", "send_sip_info", "update_client_state"] },
+    { name: "Call Control", description: "Make and manage voice calls via SIP connections", actions: ["make_call", "list_connections", "answer_call", "hangup_call", "transfer_call", "send_dtmf", "start_recording", "stop_recording", "start_noise_suppression", "stop_noise_suppression", "speak_tts", "bridge_calls", "refer_call", "reject_call", "get_call_status", "answering_machine_detection", "deepfake_detection", "number_masking", "from_display_name", "time_limit", "media_encryption", "transcription", "gather", "stop_gather", "start_playback", "stop_playback", "start_transcription", "stop_transcription", "pause_recording", "resume_recording", "start_forking", "stop_forking", "start_siprec", "stop_siprec", "start_streaming", "stop_streaming", "enqueue", "leave_queue", "send_sip_info", "update_client_state", "add_ai_assistant_messages", "gather_using_ai", "gather_using_audio", "gather_using_speak", "join_ai_assistant", "start_ai_assistant", "stop_ai_assistant", "start_conversation_relay", "stop_conversation_relay", "switch_supervisor_role"] },
   ],
   "🔢 Numbers": [
     { name: "Phone Numbers", description: "Search, buy, and manage phone numbers", actions: ["list_phone_numbers", "search_phone_numbers", "buy_phone_number"] },
@@ -102,7 +102,7 @@ const COMPOSITE_COMMANDS = [
   { name: "telnyx-agent status", description: "Account health overview — balance, numbers, profiles, connections" },
   { name: "telnyx-agent capabilities", description: "This command — lists all available API capabilities" },
   { name: "telnyx-agent call-dial", description: "Make an outbound call via Call Control (AMD, deepfake detection, recording optional)" },
-  { name: "telnyx-agent call-control", description: "Call Control actions: answer, hangup, transfer, DTMF, recording, noise suppression, speak (TTS), bridge, refer, reject, gather, playback, transcription, forking, siprec, streaming, enqueue, send-sip-info, update-client-state" },
+  { name: "telnyx-agent call-control", description: "Call Control actions: answer, hangup, transfer, DTMF, recording, noise suppression, speak (TTS), bridge, refer, reject, gather, playback, transcription, forking, siprec, streaming, enqueue, send-sip-info, update-client-state, AI assistant lifecycle/messages/gather/join, Conversation Relay, supervisor roles" },
   { name: "telnyx-agent call-status", description: "Get the status of a call by call-control-id" },
 ];
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -176,10 +176,13 @@ Voice Call Flags:
                     gather, stop-gather, start-playback, stop-playback, start-transcription,
                     stop-transcription, pause-recording, resume-recording, start-forking,
                     stop-forking, start-siprec, stop-siprec, start-streaming, stop-streaming,
-                    enqueue, leave-queue, send-sip-info, update-client-state
+                    enqueue, leave-queue, send-sip-info, update-client-state,
+                    add-ai-assistant-messages, gather-using-ai, gather-using-audio,
+                    gather-using-speak, join-ai-assistant, start-ai-assistant, stop-ai-assistant,
+                    start-conversation-relay, stop-conversation-relay, switch-supervisor-role
   --digits           DTMF digits to send (call-control dtmf)
-  --payload          Text to synthesize and speak (call-control speak)
-  --voice            TTS voice to use (call-control speak, default: female)
+  --payload          Text/SSML to synthesize (speak; gather-using-speak, required)
+  --voice            TTS voice (speak default: female; gather-using-speak, required; AI/relay optional)
   --call-control-id-2 Second call-control-id to bridge with (call-control bridge)
   --sip-address      SIP address to refer to (call-control refer, e.g. sip:user@example.com)
   --channels         Recording channels: single|dual (call-control start-recording)
@@ -191,20 +194,31 @@ Voice Call Flags:
   --deepfake-detection           Enable deepfake detection (call-dial, call-control answer)
   --record                       Record the call (call-dial, call-control answer)
   --webhook-url                  Webhook URL override (call-dial, call-control answer)
-  --audio-url                    Audio URL to play on answer (call-dial); audio to play (call-control start-playback, required)
+  --audio-url                    Audio URL to play on answer (call-dial); start-playback (required); gather-using-audio (optional)
   --timeout-secs                 Dial timeout in seconds (call-dial)
   --privacy                      Number masking: 'id' hides caller ID, 'none' is normal (call-dial, default: none)
   --from-display-name            Caller ID display name (call-dial)
   --time-limit-secs              Max call duration in seconds (call-dial)
   --transcription                Enable real-time transcription on dial (call-dial)
   --media-encryption             Media encryption mode (call-dial)
-  --client-state                 Opaque client-state string (call-dial; call-control update-client-state, required; call-control gather, optional)
-  --command-id                   Idempotency/command UUID (call-dial; call-control gather, optional)
+  --client-state                 Opaque client-state string (call-dial; update-client-state required; gather/AI/relay actions optional)
+  --command-id                   Idempotency/command UUID (call-dial; gather/AI/relay actions optional)
   --webhook-url-method           HTTP method for --webhook-url (call-dial: GET|POST|PUT|PATCH|DELETE)
   --webhook-urls                 Comma-separated additional webhook URLs (call-dial)
   --queue-name                   Queue to place the call into (call-control enqueue, required)
   --body                         SIP INFO body content (call-control send-sip-info, required)
   --content-type                 SIP INFO Content-Type header (call-control send-sip-info, required, e.g. application/dtmf-relay)
+  --message                      AI message array as JSON (add-ai-assistant-messages, optional)
+  --parameters                   JSON Schema object (gather-using-ai, required)
+  --assistant                    Assistant configuration as JSON (gather/start AI and conversation relay, optional)
+  --greeting                     Initial spoken greeting (gather-using-ai, start-ai-assistant/start-conversation-relay, optional)
+  --conversation-id              Existing AI conversation ID (join-ai-assistant, required)
+  --participant                  Participant object as JSON (join-ai-assistant, required; start-ai-assistant, optional)
+  --url                          WebSocket URL (start-conversation-relay, optional)
+  --dtmf-detection               Enable relay DTMF detection (start-conversation-relay, optional)
+  --role                         Supervisor role: barge|whisper|monitor (switch-supervisor-role, required)
+                    Generated optional JSON, scalar, boolean, and dotted inner flags for these actions
+                    are forwarded unchanged to the Go CLI (for example --assistant.id).
 STT Flags:
   --audio-url <url> URL of the audio file to transcribe (required)
   --model           Transcription model (default: distil-whisper/distil-large-v2; also openai/whisper-large-v3-turbo, deepgram/nova-3)
@@ -279,6 +293,12 @@ Examples:
   telnyx-agent call-control --action send-sip-info --call-control-id <id> --body "hello" --content-type application/dtmf-relay
   telnyx-agent call-control --action update-client-state --call-control-id <id> --client-state state-2
   telnyx-agent call-control --action reject --call-control-id <id> --cause USER_BUSY
+  telnyx-agent call-control --action gather-using-ai --call-control-id <id> --parameters '{"type":"object","properties":{"name":{"type":"string"}}}'
+  telnyx-agent call-control --action gather-using-speak --call-control-id <id> --payload "Enter your PIN" --voice Telnyx.KokoroTTS.af
+  telnyx-agent call-control --action join-ai-assistant --call-control-id <id> --conversation-id <conversation-id> --participant '{"id":"call-2","role":"user"}'
+  telnyx-agent call-control --action start-ai-assistant --call-control-id <id> --assistant.id <assistant-id>
+  telnyx-agent call-control --action start-conversation-relay --call-control-id <id> --url wss://example.com/relay
+  telnyx-agent call-control --action switch-supervisor-role --call-control-id <id> --role whisper
   telnyx-agent call-status --call-control-id <id> --json
   telnyx-agent stt --audio-url https://example.com/audio.mp3
   telnyx-agent stt --audio-url https://example.com/audio.mp3 --model openai/whisper-large-v3-turbo --language es --json

--- a/cli/tests/voice.test.ts
+++ b/cli/tests/voice.test.ts
@@ -511,8 +511,8 @@ describe("Voice API action commands", () => {
   }> = [
     {
       action: "add-ai-assistant-messages",
-      flags: ["--message", '[{"role":"user","content":"hello"}]', "--client-state", "state-1", "--command-id", "cmd-1"],
-      values: [["--message", '[{"role":"user","content":"hello"}]'], ["--client-state", "state-1"], ["--command-id", "cmd-1"]],
+      flags: ["--message", '{"role":"user","content":"hello"}', "--client-state", "state-1", "--command-id", "cmd-1"],
+      values: [["--message", '{"role":"user","content":"hello"}'], ["--client-state", "state-1"], ["--command-id", "cmd-1"]],
     },
     {
       action: "gather-using-ai",
@@ -578,6 +578,37 @@ describe("Voice API action commands", () => {
       assertFlagValue(actionCall!, "--call-control-id", "call-ai-1");
       for (const [flag, value] of testCase.values) assertFlagValue(actionCall!, flag, value);
       for (const flag of testCase.bare ?? []) assert.ok(actionCall!.includes(flag), `expected ${flag}`);
+    });
+  }
+
+  const repeatedObjectFlags = [
+    { action: "add-ai-assistant-messages", flag: "message" },
+    { action: "gather-using-ai", flag: "message-history", required: ["--parameters", '{"type":"object"}'] },
+    { action: "gather-using-ai", flag: "assistant.tools", required: ["--parameters", '{"type":"object"}'] },
+    { action: "start-ai-assistant", flag: "message-history" },
+    { action: "start-ai-assistant", flag: "assistant.mcp-servers" },
+    { action: "start-ai-assistant", flag: "assistant.tools" },
+    { action: "start-conversation-relay", flag: "conversation-relay-settings.languages" },
+  ];
+  for (const testCase of repeatedObjectFlags) {
+    it(`call-control --action ${testCase.action} expands a JSON array into repeated --${testCase.flag} flags`, () => {
+      const fake = setupFakeTelnyx();
+      run(
+        [
+          "call-control", "--action", testCase.action, "--call-control-id", "call-ai-1",
+          ...(testCase.required ?? []),
+          `--${testCase.flag}`, '[{"id":"one"},{"id":"two"}]', "--json",
+        ],
+        fake.env,
+      );
+
+      const calls = readLoggedArgs(fake.logPath);
+      const actionCall = calls.find((a) => a.slice(0, 2).join(" ") === `calls:actions ${testCase.action}`);
+      assert.ok(actionCall);
+      const values = actionCall!
+        .map((arg, index) => arg === `--${testCase.flag}` ? actionCall![index + 1] : undefined)
+        .filter((value): value is string => value !== undefined);
+      assert.deepEqual(values, ['{"id":"one"}', '{"id":"two"}']);
     });
   }
 

--- a/cli/tests/voice.test.ts
+++ b/cli/tests/voice.test.ts
@@ -6,8 +6,8 @@
  */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -72,6 +72,22 @@ function run(args: string[], env?: NodeJS.ProcessEnv): string {
     env: env ?? { ...process.env },
     timeout: 30000,
   });
+}
+
+function runFailure(args: string[], env: NodeJS.ProcessEnv): string {
+  const result = spawnSync("npx", ["tsx", cliBin, ...args], {
+    cwd: cliRoot,
+    encoding: "utf8",
+    env,
+    timeout: 30000,
+  });
+  assert.notEqual(result.status, 0, `expected command to fail: ${args.join(" ")}`);
+  assert.equal(result.error, undefined);
+  return result.stderr;
+}
+
+function assertNoLoggedCalls(logPath: string): void {
+  assert.ok(!existsSync(logPath) || readFileSync(logPath, "utf8") === "", "validation must fail before invoking telnyx");
 }
 
 function assertFlagValue(args: string[], flag: string, value: string): void {
@@ -485,5 +501,145 @@ describe("Voice API action commands", () => {
     const output = run(["help"]);
     assert.ok(output.includes("--privacy"), "help should document --privacy flag");
     assert.ok(output.includes("number masking") || output.includes("Number masking") || output.includes("caller ID"), "help should mention number masking");
+  });
+
+  const newActionDispatches: Array<{
+    action: string;
+    flags: string[];
+    values: Array<[string, string]>;
+    bare?: string[];
+  }> = [
+    {
+      action: "add-ai-assistant-messages",
+      flags: ["--message", '[{"role":"user","content":"hello"}]', "--client-state", "state-1", "--command-id", "cmd-1"],
+      values: [["--message", '[{"role":"user","content":"hello"}]'], ["--client-state", "state-1"], ["--command-id", "cmd-1"]],
+    },
+    {
+      action: "gather-using-ai",
+      flags: ["--parameters", '{"type":"object"}', "--greeting", "What is your name?", "--assistant.model", "openai/gpt-4o", "--send-partial-results"],
+      values: [["--parameters", '{"type":"object"}'], ["--greeting", "What is your name?"], ["--assistant.model", "openai/gpt-4o"]],
+      bare: ["--send-partial-results"],
+    },
+    {
+      action: "gather-using-audio",
+      flags: ["--audio-url", "https://example.com/menu.wav", "--maximum-digits", "4", "--valid-digits", "1234"],
+      values: [["--audio-url", "https://example.com/menu.wav"], ["--maximum-digits", "4"], ["--valid-digits", "1234"]],
+    },
+    {
+      action: "gather-using-speak",
+      flags: ["--payload", "Enter your PIN", "--voice", "Telnyx.KokoroTTS.af", "--invalid-payload", "Try again", "--minimum-digits", "4"],
+      values: [["--payload", "Enter your PIN"], ["--voice", "Telnyx.KokoroTTS.af"], ["--invalid-payload", "Try again"], ["--minimum-digits", "4"]],
+    },
+    {
+      action: "join-ai-assistant",
+      flags: ["--conversation-id", "conv-1", "--participant", '{"id":"call-2","role":"user"}', "--participant.name", "Caller"],
+      values: [["--conversation-id", "conv-1"], ["--participant", '{"id":"call-2","role":"user"}'], ["--participant.name", "Caller"]],
+    },
+    {
+      action: "start-ai-assistant",
+      flags: ["--assistant.id", "assistant-1", "--greeting", "Hello", "--send-message-history-updates"],
+      values: [["--assistant.id", "assistant-1"], ["--greeting", "Hello"]],
+      bare: ["--send-message-history-updates"],
+    },
+    {
+      action: "stop-ai-assistant",
+      flags: ["--client-state", "state-stop", "--command-id", "cmd-stop"],
+      values: [["--client-state", "state-stop"], ["--command-id", "cmd-stop"]],
+    },
+    {
+      action: "start-conversation-relay",
+      flags: ["--url", "wss://example.com/relay", "--voice", "Telnyx.KokoroTTS.af", "--conversation-relay-settings.url", "wss://nested.example.com/relay", "--dtmf-detection"],
+      values: [["--url", "wss://example.com/relay"], ["--voice", "Telnyx.KokoroTTS.af"], ["--conversation-relay-settings.url", "wss://nested.example.com/relay"]],
+      bare: ["--dtmf-detection"],
+    },
+    {
+      action: "stop-conversation-relay",
+      flags: ["--client-state", "relay-state", "--command-id", "relay-stop"],
+      values: [["--client-state", "relay-state"], ["--command-id", "relay-stop"]],
+    },
+    {
+      action: "switch-supervisor-role",
+      flags: ["--role", "whisper"],
+      values: [["--role", "whisper"]],
+    },
+  ];
+
+  for (const testCase of newActionDispatches) {
+    it(`call-control --action ${testCase.action} dispatches the generated Go command and flags`, () => {
+      const fake = setupFakeTelnyx();
+      run(
+        ["call-control", "--action", testCase.action, "--call-control-id", "call-ai-1", ...testCase.flags, "--json"],
+        fake.env,
+      );
+
+      const calls = readLoggedArgs(fake.logPath);
+      const actionCall = calls.find((a) => a.slice(0, 2).join(" ") === `calls:actions ${testCase.action}`);
+      assert.ok(actionCall, `should invoke calls:actions ${testCase.action}`);
+      assertFlagValue(actionCall!, "--call-control-id", "call-ai-1");
+      for (const [flag, value] of testCase.values) assertFlagValue(actionCall!, flag, value);
+      for (const flag of testCase.bare ?? []) assert.ok(actionCall!.includes(flag), `expected ${flag}`);
+    });
+  }
+
+  const actionsWithOnlyCallIdRequired = [
+    "add-ai-assistant-messages",
+    "gather-using-audio",
+    "start-ai-assistant",
+    "stop-ai-assistant",
+    "start-conversation-relay",
+    "stop-conversation-relay",
+  ];
+  for (const action of actionsWithOnlyCallIdRequired) {
+    it(`call-control --action ${action} does not invent optional Go flags`, () => {
+      const fake = setupFakeTelnyx();
+      run(["call-control", "--action", action, "--call-control-id", "call-ai-1", "--json"], fake.env);
+      const calls = readLoggedArgs(fake.logPath);
+      const actionCall = calls.find((a) => a.slice(0, 2).join(" ") === `calls:actions ${action}`);
+      assert.ok(actionCall);
+      assert.deepEqual(actionCall!.slice(0, -2), ["calls:actions", action, "--call-control-id", "call-ai-1"]);
+    });
+  }
+
+  const newActionsWithRequiredCallId = newActionDispatches.map(({ action, flags }) => ({ action, flags }));
+  for (const testCase of newActionsWithRequiredCallId) {
+    it(`call-control --action ${testCase.action} validates --call-control-id before dispatch`, () => {
+      const fake = setupFakeTelnyx();
+      const stderr = runFailure(["call-control", "--action", testCase.action, ...testCase.flags, "--json"], fake.env);
+      assert.match(stderr, /--call-control-id is required/);
+      assertNoLoggedCalls(fake.logPath);
+    });
+  }
+
+  const actionSpecificRequiredFlags = [
+    { action: "gather-using-ai", missing: "parameters", flags: [] },
+    { action: "gather-using-speak", missing: "payload", flags: ["--voice", "Telnyx.KokoroTTS.af"] },
+    { action: "gather-using-speak", missing: "voice", flags: ["--payload", "Enter digits"] },
+    { action: "join-ai-assistant", missing: "conversation-id", flags: ["--participant", '{"id":"call-2"}'] },
+    { action: "join-ai-assistant", missing: "participant", flags: ["--conversation-id", "conv-1"] },
+    { action: "switch-supervisor-role", missing: "role", flags: [] },
+  ];
+  for (const testCase of actionSpecificRequiredFlags) {
+    it(`call-control --action ${testCase.action} validates required --${testCase.missing}`, () => {
+      const fake = setupFakeTelnyx();
+      const stderr = runFailure(
+        ["call-control", "--action", testCase.action, "--call-control-id", "call-ai-1", ...testCase.flags, "--json"],
+        fake.env,
+      );
+      assert.match(stderr, new RegExp(`--${testCase.missing} is required for ${testCase.action}`));
+      assertNoLoggedCalls(fake.logPath);
+    });
+  }
+
+  it("help and capabilities advertise all ten AI/relay Call Control actions", () => {
+    const help = run(["help"]);
+    for (const testCase of newActionDispatches) assert.ok(help.includes(testCase.action), `help should include ${testCase.action}`);
+
+    const fake = setupFakeTelnyx();
+    const capabilities = JSON.parse(run(["capabilities", "--json"], fake.env));
+    const actions = capabilities.api_capabilities["📞 Voice"][0].actions as string[];
+    for (const testCase of newActionDispatches) {
+      const capability = testCase.action.replaceAll("-", "_");
+      assert.ok(actions.includes(capability), `capabilities should include ${capability}`);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- wrap the 10 agent-relevant Call Control actions missing from the agent CLI
- forward the generated Go CLI flags and validate required fields
- update help/capabilities and add mock-binary coverage

## Verification
- `npx tsc --noEmit`
- `npx tsx --test tests/voice.test.ts` (61 passed)
- `npm test` (143 passed)