### PR TITLE
feat: Add 10DLC campaign builder support to agent CLI

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "tsx bin/telnyx-agent.ts",
-    "test": "tsx --test tests/edge-handoff.test.ts tests/integration.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
+    "test": "tsx --test tests/edge-handoff.test.ts tests/integration.test.ts tests/setup-10dlc.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
     "typecheck": "tsc --noEmit",
     "postinstall": "tsx scripts/postinstall.ts",
     "build": "npm run typecheck"

--- a/cli/src/commands/setup-10dlc.ts
+++ b/cli/src/commands/setup-10dlc.ts
@@ -91,6 +91,37 @@ interface Setup10dlcResult {
   steps: StepResult[];
 }
 
+function nonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function parseCampaignResponse(response: unknown): { id: string; status: string } {
+  const root = response && typeof response === "object"
+    ? response as Record<string, unknown>
+    : {};
+  const data = root.data && typeof root.data === "object"
+    ? root.data as Record<string, unknown>
+    : {};
+  const id = [data.id, data.CampaignID, data.campaignId, root.id, root.CampaignID, root.campaignId]
+    .map(nonEmptyString)
+    .find((value): value is string => value !== undefined);
+
+  if (!id) {
+    throw new Error("Campaign submission response did not include a campaign id");
+  }
+
+  return {
+    id,
+    status: nonEmptyString(data.status)
+      ?? nonEmptyString(data.Status)
+      ?? nonEmptyString(root.status)
+      ?? nonEmptyString(root.Status)
+      ?? "PENDING",
+  };
+}
+
 // ─── Compliance helpers ──────────────────────────────────────────────────────
 
 /** Generate the message_flow based on opt-in method + brand + optional website. */
@@ -339,9 +370,9 @@ export async function setup10dlcCommand(flags: Record<string, string | boolean>)
       ];
       if (sample2) campaignArgs.push("--sample2", sample2);
       const campaignRes = await telnyxCli(campaignArgs);
-      const campaignData = campaignRes.data as Record<string, unknown>;
-      campaignId = String(campaignData.id);
-      campaignStatus = String(campaignData.status ?? "PENDING");
+      const campaign = parseCampaignResponse(campaignRes);
+      campaignId = campaign.id;
+      campaignStatus = campaign.status;
       steps.push({ step: 2, name: "Create campaign", status: "completed", resourceId: campaignId, detail: USE_CASE_LABELS[usecase] ?? usecase, elapsedMs: Date.now() - step2Start });
     } catch (err) {
       steps.push({ step: 2, name: "Create campaign", status: "failed", detail: errorMsg(err), elapsedMs: Date.now() - step2Start });

--- a/cli/src/commands/setup-10dlc.ts
+++ b/cli/src/commands/setup-10dlc.ts
@@ -322,17 +322,20 @@ export async function setup10dlcCommand(flags: Record<string, string | boolean>)
     }
     if (!jsonOutput) printStep(steps[steps.length - 1], totalSteps);
 
-    // Step 2: Create campaign via CLI
+    // Step 2: Submit campaign via CLI
     const description = (flags.description as string) || "Agent-provisioned campaign for customer communications";
     const step2Start = Date.now();
     try {
       const campaignArgs = [
-        "messaging-10dlc:campaign", "create",
+        "messaging-10dlc:campaign-builder", "submit",
         "--brand-id", brandId,
         "--usecase", usecase,
         "--description", description,
         "--sample1", sample1,
         "--message-flow", messageFlow,
+        "--help-message", helpMsg,
+        "--optout-message", stopMsg,
+        "--optin-message", startMsg,
       ];
       if (sample2) campaignArgs.push("--sample2", sample2);
       const campaignRes = await telnyxCli(campaignArgs);

--- a/cli/tests/fixtures/campaign-builder-submit.json
+++ b/cli/tests/fixtures/campaign-builder-submit.json
@@ -1,0 +1,4 @@
+{
+  "CampaignID": "campaign-builder-789",
+  "status": "PENDING"
+}

--- a/cli/tests/setup-10dlc.test.ts
+++ b/cli/tests/setup-10dlc.test.ts
@@ -6,7 +6,7 @@
  */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -16,7 +16,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const cliRoot = join(__dirname, "..");
 const cliBin = join(cliRoot, "bin", "telnyx-agent.ts");
 
-function setupFakeTelnyx(): { logPath: string; env: NodeJS.ProcessEnv } {
+function setupFakeTelnyx(campaignResponse?: unknown): { logPath: string; env: NodeJS.ProcessEnv } {
   const tempDir = mkdtempSync(join(tmpdir(), "telnyx-agent-10dlc-"));
   const binDir = join(tempDir, "bin");
   const logPath = join(tempDir, "args.jsonl");
@@ -33,7 +33,9 @@ fs.appendFileSync(process.env.TELNYX_FAKE_ARGS_LOG, JSON.stringify(args) + "\\n"
 if (args[0] === "messaging-10dlc:brand" && args[1] === "create") {
   console.log(JSON.stringify({ data: { id: "brand-123", status: "PENDING" } }));
 } else if (args[0] === "messaging-10dlc:campaign-builder" && args[1] === "submit") {
-  console.log(JSON.stringify({ data: { id: "campaign-456", status: "PENDING" } }));
+  console.log(process.env.TELNYX_FAKE_CAMPAIGN_RESPONSE || JSON.stringify({ data: { id: "campaign-456", status: "PENDING" } }));
+} else if (args[0] === "messaging-10dlc:phone-number-campaigns" && args[1] === "create") {
+  console.log(JSON.stringify({ data: { phone_number: args[3] } }));
 } else {
   console.error("Unexpected telnyx command: " + args.join(" "));
   process.exit(2);
@@ -49,12 +51,24 @@ if (args[0] === "messaging-10dlc:brand" && args[1] === "create") {
       PATH: `${binDir}:${process.env.PATH}`,
       TELNYX_CLI_PATH: fakeTelnyx,
       TELNYX_FAKE_ARGS_LOG: logPath,
+      ...(campaignResponse === undefined
+        ? {}
+        : { TELNYX_FAKE_CAMPAIGN_RESPONSE: JSON.stringify(campaignResponse) }),
     },
   };
 }
 
+function runFailure(args: string[], env: NodeJS.ProcessEnv) {
+  return spawnSync(process.execPath, ["--import", "tsx", cliBin, ...args], {
+    cwd: cliRoot,
+    encoding: "utf8",
+    env,
+    timeout: 30000,
+  });
+}
+
 function run(args: string[], env: NodeJS.ProcessEnv): string {
-  return execFileSync("npx", ["tsx", cliBin, ...args], {
+  return execFileSync(process.execPath, ["--import", "tsx", cliBin, ...args], {
     cwd: cliRoot,
     encoding: "utf8",
     env,
@@ -71,6 +85,58 @@ function readLoggedArgs(logPath: string): string[][] {
 }
 
 describe("setup-10dlc campaign submission", () => {
+  it("uses the campaign id from the real campaign-builder response for output and assignment", () => {
+    const fixture = JSON.parse(
+      readFileSync(join(__dirname, "fixtures", "campaign-builder-submit.json"), "utf8"),
+    );
+    const fake = setupFakeTelnyx(fixture);
+
+    const output = run(
+      [
+        "setup-10dlc",
+        "--phone", "+15551234567",
+        "--email", "ops@acme.example",
+        "--brand-name", "Acme",
+        "--phone-number-id", "+15559876543",
+        "--json",
+      ],
+      fake.env,
+    );
+
+    assert.equal(JSON.parse(output).campaign_id, "campaign-builder-789");
+    const calls = readLoggedArgs(fake.logPath);
+    assert.deepEqual(calls[2], [
+      "messaging-10dlc:phone-number-campaigns",
+      "create",
+      "--phone-number", "+15559876543",
+      "--campaign-id", "campaign-builder-789",
+      "--format", "json",
+    ]);
+  });
+
+  it("fails before phone-number assignment when campaign submission returns no id", () => {
+    const fake = setupFakeTelnyx({ status: "PENDING" });
+
+    const result = runFailure(
+      [
+        "setup-10dlc",
+        "--phone", "+15551234567",
+        "--email", "ops@acme.example",
+        "--brand-name", "Acme",
+        "--phone-number-id", "+15559876543",
+        "--json",
+      ],
+      fake.env,
+    );
+
+    assert.equal(result.status, 1);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.status, "failed");
+    assert.equal(output.campaign_id, null);
+    assert.match(output.error, /campaign id/i);
+    assert.equal(readLoggedArgs(fake.logPath).length, 2);
+  });
+
   it("uses campaign-builder submit and maps every explicit campaign value to its generated flag", () => {
     const fake = setupFakeTelnyx();
     const messageFlow =

--- a/cli/tests/setup-10dlc.test.ts
+++ b/cli/tests/setup-10dlc.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for setup-10dlc's mapping to the generated Go CLI surface.
+ *
+ * Uses a fake `telnyx` binary so the tests can assert the exact command path
+ * and arguments without making live API requests.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliRoot = join(__dirname, "..");
+const cliBin = join(cliRoot, "bin", "telnyx-agent.ts");
+
+function setupFakeTelnyx(): { logPath: string; env: NodeJS.ProcessEnv } {
+  const tempDir = mkdtempSync(join(tmpdir(), "telnyx-agent-10dlc-"));
+  const binDir = join(tempDir, "bin");
+  const logPath = join(tempDir, "args.jsonl");
+  mkdirSync(binDir, { recursive: true });
+
+  const fakeTelnyx = join(binDir, "telnyx");
+  writeFileSync(
+    fakeTelnyx,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.TELNYX_FAKE_ARGS_LOG, JSON.stringify(args) + "\\n");
+
+if (args[0] === "messaging-10dlc:brand" && args[1] === "create") {
+  console.log(JSON.stringify({ data: { id: "brand-123", status: "PENDING" } }));
+} else if (args[0] === "messaging-10dlc:campaign-builder" && args[1] === "submit") {
+  console.log(JSON.stringify({ data: { id: "campaign-456", status: "PENDING" } }));
+} else {
+  console.error("Unexpected telnyx command: " + args.join(" "));
+  process.exit(2);
+}
+`,
+  );
+  chmodSync(fakeTelnyx, 0o755);
+
+  return {
+    logPath,
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH}`,
+      TELNYX_CLI_PATH: fakeTelnyx,
+      TELNYX_FAKE_ARGS_LOG: logPath,
+    },
+  };
+}
+
+function run(args: string[], env: NodeJS.ProcessEnv): string {
+  return execFileSync("npx", ["tsx", cliBin, ...args], {
+    cwd: cliRoot,
+    encoding: "utf8",
+    env,
+    timeout: 30000,
+  });
+}
+
+function readLoggedArgs(logPath: string): string[][] {
+  return readFileSync(logPath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+describe("setup-10dlc campaign submission", () => {
+  it("uses campaign-builder submit and maps every explicit campaign value to its generated flag", () => {
+    const fake = setupFakeTelnyx();
+    const messageFlow =
+      "Consumers opt in by agreeing to receive messages from Acme. Message frequency may vary. Message and data rates may apply. Reply STOP to opt out, HELP for help. We will not share your mobile information with third parties.";
+    const sample1 = "Acme: Your weekly offer is ready. Reply STOP to opt out.";
+    const sample2 = "Acme: Your account update is available. Reply STOP to opt out.";
+    const helpMessage = "Acme support: Reply HELP or call +15551234567. Reply STOP to unsubscribe.";
+    const stopMessage = "You have been unsubscribed from Acme messages. Reply START to resubscribe.";
+    const startMessage = "Acme: You have resubscribed. Reply STOP to unsubscribe, HELP for help.";
+
+    const output = run(
+      [
+        "setup-10dlc",
+        "--phone", "+15551234567",
+        "--email", "ops@acme.example",
+        "--brand-name", "Acme",
+        "--usecase", "MARKETING",
+        "--description", "Acme customer updates",
+        "--sample-message", sample1,
+        "--sample-message-2", sample2,
+        "--message-flow", messageFlow,
+        "--help-message", helpMessage,
+        "--stop-message", stopMessage,
+        "--start-message", startMessage,
+        "--json",
+      ],
+      fake.env,
+    );
+
+    const result = JSON.parse(output);
+    assert.equal(result.campaign_id, "campaign-456");
+    assert.equal(result.help_message, helpMessage);
+    assert.equal(result.stop_message, stopMessage);
+    assert.equal(result.start_message, startMessage);
+
+    const calls = readLoggedArgs(fake.logPath);
+    assert.equal(calls.length, 2);
+    assert.deepEqual(calls[1], [
+      "messaging-10dlc:campaign-builder",
+      "submit",
+      "--brand-id", "brand-123",
+      "--usecase", "MARKETING",
+      "--description", "Acme customer updates",
+      "--sample1", sample1,
+      "--message-flow", messageFlow,
+      "--help-message", helpMessage,
+      "--optout-message", stopMessage,
+      "--optin-message", startMessage,
+      "--sample2", sample2,
+      "--format", "json",
+    ]);
+  });
+
+  it("submits the generated HELP, STOP, and START defaults and preserves optional sample behavior", () => {
+    const fake = setupFakeTelnyx();
+    const brandName = "Default Brand";
+    const phone = "+15557654321";
+    const email = "support@default.example";
+    const website = "https://default.example/sms-opt-in";
+    const sample1 = "Default Brand: Your appointment is confirmed. Reply STOP to opt out.";
+    const messageFlow = `Consumers opt in by submitting the web form located at ${website}. The form includes clear SMS consent language: By submitting this form, you agree to receive SMS messages from ${brandName}. Message frequency may vary. Message and data rates may apply. Reply STOP to opt out, HELP for help. We will not share your mobile information with third parties for marketing purposes.`;
+    const helpMessage = `${brandName} Support: For help, reply HELP or contact us at ${email} or ${phone}. Msg & data rates may apply. Reply STOP to unsubscribe.`;
+    const stopMessage = `You have been unsubscribed from ${brandName} messages. No further messages will be sent. Reply START to resubscribe.`;
+    const startMessage = `${brandName}: You have resubscribed to receive SMS messages. Msg frequency may vary. Msg & data rates may apply. Reply STOP to unsubscribe, HELP for help.`;
+
+    run(
+      [
+        "setup-10dlc",
+        "--phone", phone,
+        "--email", email,
+        "--brand-name", brandName,
+        "--website", website,
+        "--sample-message", sample1,
+        "--json",
+      ],
+      fake.env,
+    );
+
+    const calls = readLoggedArgs(fake.logPath);
+    assert.deepEqual(calls[1], [
+      "messaging-10dlc:campaign-builder",
+      "submit",
+      "--brand-id", "brand-123",
+      "--usecase", "CUSTOMER_CARE",
+      "--description", "Agent-provisioned campaign for customer communications",
+      "--sample1", sample1,
+      "--message-flow", messageFlow,
+      "--help-message", helpMessage,
+      "--optout-message", stopMessage,
+      "--optin-message", startMessage,
+      "--format", "json",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- replace the nonexistent `messaging-10dlc:campaign create` dispatch
- submit campaigns through `messaging-10dlc:campaign-builder submit`
- map HELP/STOP/START messages to generated CLI flags and add mock-binary tests

## Verification
- `npx tsc --noEmit`
- `npx tsx --test tests/setup-10dlc.test.ts` (2 passed)
- `npm test` (112 passed)