### PR TITLE
feat: Add Edge CLI v0.2.5 support to agent CLI

### DIFF
--- a/cli/src/commands/edge-doctor.ts
+++ b/cli/src/commands/edge-doctor.ts
@@ -2,12 +2,19 @@
  * telnyx-agent edge-doctor — Validate local Edge Compute prerequisites.
  *
  * Thin handoff only: this does not deploy or manage Edge Compute directly.
- * It checks that the dedicated `telnyx-edge` CLI is available and whether
- * it is authenticated, preferring API-key auth for agent use.
  */
 
 import { outputJson, printError, printSuccess, printWarning } from "../utils/output.ts";
-import { getEdgeAuthStatus, getEdgeHelp, getEdgeVersion, hasEdgeCli, supportsApiKeyAuth, supportsStatefulActors } from "../edge-cli.ts";
+import {
+  getEdgeAuthStatus,
+  getEdgeHelp,
+  getEdgeRootStatus,
+  getEdgeVersion,
+  supportsActorInstances,
+  supportsApiKeyAuth,
+  supportsInspect,
+  supportsStatefulActors,
+} from "../edge-cli.ts";
 
 interface EdgeDoctorResult {
   ready: boolean;
@@ -15,28 +22,37 @@ interface EdgeDoctorResult {
   telnyx_edge_version: string | null;
   authenticated: boolean;
   auth_mode: "api_key" | "oauth" | "none" | "unknown";
+  root_status_passed: boolean;
   api_key_auth_supported: boolean;
   stateful_actors_supported: boolean;
+  inspect_supported: boolean;
+  actor_instances_supported: boolean;
   checks: Array<{ name: string; ok: boolean; detail: string }>;
   next_steps: string[];
 }
 
 export async function edgeDoctorCommand(flags: Record<string, string | boolean>): Promise<void> {
   const jsonOutput = flags.json === true;
-
   const checks: EdgeDoctorResult["checks"] = [];
   let installed = false;
   let version: string | null = null;
   let authenticated = false;
   let authMode: EdgeDoctorResult["auth_mode"] = "none";
+  let rootStatusPassed = false;
   let apiKeyAuthSupported = false;
   let statefulActorsSupported = false;
+  let inspectSupported = false;
+  let actorInstancesSupported = false;
 
   try {
-    const out = getEdgeHelp();
-    installed = hasEdgeCli();
-    version = getEdgeVersion() ?? extractVersion(out) ?? "installed";
-    checks.push({ name: "telnyx-edge installed", ok: true, detail: version });
+    getEdgeHelp();
+    installed = true;
+    version = getEdgeVersion();
+    checks.push({
+      name: "telnyx-edge installed",
+      ok: true,
+      detail: version ?? "installed (version unavailable)",
+    });
   } catch (err: any) {
     const detail = err?.code === "ENOENT"
       ? "telnyx-edge not found on PATH"
@@ -46,19 +62,33 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
 
   if (installed) {
     apiKeyAuthSupported = supportsApiKeyAuth();
+    statefulActorsSupported = supportsStatefulActors();
+    inspectSupported = supportsInspect();
+    actorInstancesSupported = supportsActorInstances();
+
     checks.push({
       name: "API-key auth supported",
       ok: apiKeyAuthSupported,
       detail: apiKeyAuthSupported ? "auth api-key set is available" : "no auth api-key set support detected",
     });
-
-    statefulActorsSupported = supportsStatefulActors();
     checks.push({
       name: "Stateful actors supported",
       ok: statefulActorsSupported,
       detail: statefulActorsSupported
-        ? "new-func --actor available (v0.2.3+)"
-        : "new-func --actor not available — upgrade to v0.2.3+ for stateful actors",
+        ? "new-func --actor is available"
+        : "new-func --actor was not detected",
+    });
+    checks.push({
+      name: "Function inspect supported",
+      ok: inspectSupported,
+      detail: inspectSupported ? "inspect <function> is available" : "inspect --help capability not detected",
+    });
+    checks.push({
+      name: "Actor instances supported",
+      ok: actorInstancesSupported,
+      detail: actorInstancesSupported
+        ? "actors instances <type> is available"
+        : "actors instances --help capability not detected (added in telnyx-edge v0.2.5)",
     });
 
     try {
@@ -66,48 +96,80 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
       authenticated = status.authenticated;
       authMode = status.mode;
       checks.push({
-        name: "Authenticated",
+        name: "Positively authenticated",
         ok: authenticated,
-        detail: authenticated ? `mode: ${authMode}` : "not authenticated",
+        detail: authenticated
+          ? `mode: ${authMode}`
+          : authMode === "unknown"
+            ? "auth status output was not recognized as an authenticated state"
+            : `not authenticated (mode: ${authMode})`,
       });
     } catch (err: any) {
+      authMode = "unknown";
       checks.push({
-        name: "Authenticated",
+        name: "Positively authenticated",
         ok: false,
         detail: err?.stderr?.toString?.() || err?.message || "failed to read auth status",
       });
     }
+
+    try {
+      const status = getEdgeRootStatus();
+      rootStatusPassed = status.passed;
+      checks.push({
+        name: "CLI config, credentials, and connectivity",
+        ok: rootStatusPassed,
+        detail: rootStatusPassed
+          ? "telnyx-edge status: all checks passed"
+          : "telnyx-edge status did not report that all checks passed",
+      });
+    } catch (err: any) {
+      checks.push({
+        name: "CLI config, credentials, and connectivity",
+        ok: false,
+        detail: err?.stderr?.toString?.() || err?.message || "telnyx-edge status failed",
+      });
+    }
   }
 
-  const ready = installed && authenticated;
-
+  const ready = installed && authenticated && rootStatusPassed;
   let nextSteps: string[];
   if (!installed) {
     nextSteps = [
-      "Install the dedicated Edge Compute CLI from team-telnyx/edge-compute releases.",
-      "Then authenticate: telnyx-edge auth api-key set <your-api-key> (preferred) or telnyx-edge auth login",
-      "Then start from a real example such as examples/ts/mcp-server or examples/js/webhook-receiver.",
+      "Install telnyx-edge from https://github.com/team-telnyx/edge-compute/releases.",
+      "Authenticate: telnyx-edge auth api-key set <your-api-key> (non-interactive) or telnyx-edge auth login.",
+      "Run telnyx-agent edge-doctor again.",
     ];
   } else if (!authenticated) {
     nextSteps = apiKeyAuthSupported
       ? [
           "Authenticate non-interactively: telnyx-edge auth api-key set <your-api-key>",
-          "Verify with: telnyx-edge auth status",
-          "Then start from a real example and deploy with telnyx-edge ship.",
+          "Confirm the positive marker with: telnyx-edge auth status",
+          "Validate credentials and connectivity with: telnyx-edge status",
         ]
       : [
           "Authenticate with: telnyx-edge auth login",
-          "Verify with: telnyx-edge auth status",
-          "Then start from a real example and deploy with telnyx-edge ship.",
+          "Confirm the positive marker with: telnyx-edge auth status",
+          "Validate credentials and connectivity with: telnyx-edge status",
         ];
+  } else if (!rootStatusPassed) {
+    nextSteps = [
+      "Run telnyx-edge status and resolve every failed config, credential, or connectivity check.",
+      "If credentials are invalid, authenticate again and rerun telnyx-edge status.",
+      "Run telnyx-agent edge-doctor again; readiness requires the final 'All checks passed' marker.",
+    ];
   } else {
     nextSteps = [
-      "Start from a real example: telnyx-edge new-func --from-dir=examples/ts/mcp-server --name=my-mcp-server",
-      "Deploy with: telnyx-edge ship",
-      "Then connect the exposed HTTP or MCP boundary back into your AI workflow.",
+      "Create an executable MCP handoff: telnyx-agent setup-edge-mcp --name my-mcp-server",
+      "Or create a signed webhook handoff: telnyx-agent setup-edge-webhook --name my-webhook",
     ];
-    if (statefulActorsSupported) {
-      nextSteps.push("For stateful workloads (carts, sessions, call legs): telnyx-edge new-func --actor --language ts --name my-actor");
+    if (inspectSupported) {
+      nextSteps.push("After shipping, verify deploy details with: telnyx-edge inspect <function-name>");
+    }
+    if (actorInstancesSupported) {
+      nextSteps.push("For actors, inspect persisted instance metadata with: telnyx-edge actors instances <type>");
+    } else if (statefulActorsSupported) {
+      nextSteps.push("Actor scaffolding is available, but this CLI does not expose actors instances; upgrade telnyx-edge for that view.");
     }
   }
 
@@ -117,8 +179,11 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
     telnyx_edge_version: version,
     authenticated,
     auth_mode: authMode,
+    root_status_passed: rootStatusPassed,
     api_key_auth_supported: apiKeyAuthSupported,
     stateful_actors_supported: statefulActorsSupported,
+    inspect_supported: inspectSupported,
+    actor_instances_supported: actorInstancesSupported,
     checks,
     next_steps: nextSteps,
   };
@@ -132,6 +197,7 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
     printSuccess("Edge Compute handoff is ready", {
       "telnyx-edge": version ?? "installed",
       Auth: authMode,
+      "Root status": "all checks passed",
       Ready: "✓",
     });
   } else {
@@ -140,8 +206,10 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
       printWarning("Install telnyx-edge first — team-telnyx/ai does not own Edge lifecycle directly.");
     } else if (!authenticated) {
       printWarning(apiKeyAuthSupported
-        ? "telnyx-edge is installed but not authenticated. Prefer API-key auth for agents."
-        : "telnyx-edge is installed but not authenticated.");
+        ? "telnyx-edge is installed but not positively authenticated. Prefer API-key auth for agents."
+        : "telnyx-edge is installed but not positively authenticated.");
+    } else {
+      printWarning("Authentication is present, but telnyx-edge status did not pass every config/connectivity/credential check.");
     }
   }
 
@@ -154,9 +222,4 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
     console.log(`    - ${step}`);
   }
   console.log();
-}
-
-function extractVersion(text: string): string | null {
-  const match = text.match(/v?\d+\.\d+\.\d+/);
-  return match?.[0] ?? null;
 }

--- a/cli/src/commands/setup-edge-mcp.ts
+++ b/cli/src/commands/setup-edge-mcp.ts
@@ -3,59 +3,118 @@
  */
 
 import { outputJson, printError, printSuccess, printWarning } from "../utils/output.ts";
-import { getEdgeAuthStatus, hasEdgeCli, supportsApiKeyAuth, supportsStatefulActors } from "../edge-cli.ts";
+import {
+  getEdgeAuthStatus,
+  hasEdgeCli,
+  supportsActorInstances,
+  supportsApiKeyAuth,
+  supportsInspect,
+  supportsStatefulActors,
+  validateEdgeFunctionName,
+} from "../edge-cli.ts";
 
 interface SetupEdgeMcpResult {
   ready: boolean;
+  telnyx_edge_installed: boolean;
   authenticated: boolean;
   auth_mode: "api_key" | "oauth" | "none" | "unknown";
   api_key_auth_supported: boolean;
   stateful_actors_supported: boolean;
+  inspect_supported: boolean;
+  actor_instances_supported: boolean;
+  source_repo: string;
+  source_path: string;
   example: string;
   auth_command: string;
   deploy_command: string;
+  setup_commands: string[];
   prerequisites: string[];
+  next_steps: string[];
   notes: string[];
 }
 
-const MCP_EXAMPLE = "examples/ts/mcp-server";
+const SOURCE_REPO = "https://github.com/team-telnyx/edge-compute.git";
+const MCP_SOURCE_PATH = "examples/ts/mcp-server";
 
 export async function setupEdgeMcpCommand(flags: Record<string, string | boolean>): Promise<void> {
   const jsonOutput = flags.json === true;
   const name = (flags.name as string) || "my-mcp-server";
+  validateEdgeFunctionName(name);
 
   const hasEdge = hasEdgeCli();
   const apiKeyAuthSupported = hasEdge ? supportsApiKeyAuth() : false;
   const statefulActorsSupported = hasEdge ? supportsStatefulActors() : false;
+  const inspectSupported = hasEdge ? supportsInspect() : false;
+  const actorInstancesSupported = hasEdge ? supportsActorInstances() : false;
   const authStatus = hasEdge ? safeAuthStatus() : { authenticated: false, mode: "none" as const };
   const authCommand = apiKeyAuthSupported
-    ? "telnyx-edge auth api-key set <your-api-key>"
+    ? `: "\${TELNYX_API_KEY:?Export TELNYX_API_KEY first}" && telnyx-edge auth api-key set "$TELNYX_API_KEY"`
     : "telnyx-edge auth login";
-  const deployCommand = `telnyx-edge new-func --from-dir=${MCP_EXAMPLE} --name=${name} && cd ${name} && telnyx-edge ship`;
+
+  const setupCommands = [
+    `: "\${TELNYX_API_KEY:?Export TELNYX_API_KEY before running this flow}"`,
+    `: "\${SHARED_SECRET:?Export SHARED_SECRET before running this flow (generate one with openssl rand -hex 32)}"`,
+    `EDGE_COMPUTE_SRC="$(mktemp -d)/edge-compute"`,
+    `git clone --depth 1 "${SOURCE_REPO}" "$EDGE_COMPUTE_SRC"`,
+    `telnyx-edge new-func --from-dir="$EDGE_COMPUTE_SRC/${MCP_SOURCE_PATH}" --name=${name}`,
+    `cd ${name}`,
+    "npm install",
+    "npm run build",
+    `telnyx-edge secrets add TELNYX_API_KEY "$TELNYX_API_KEY"`,
+    `telnyx-edge secrets add SHARED_SECRET "$SHARED_SECRET"`,
+    "telnyx-edge ship",
+    `telnyx-edge inspect ${name}`,
+  ];
+  const deployCommand = setupCommands.join(" && ");
 
   const notes = [
-    "team-telnyx/ai provides the integration pattern, not the Edge lifecycle.",
-    "Use telnyx-edge for auth, deploy, secrets, bindings, and lifecycle management.",
-    "After deploy, connect the exposed MCP or HTTP boundary back into your AI workflow.",
+    "The source path is inside a team-telnyx/edge-compute checkout; this flow clones that repository before using --from-dir.",
+    "SHARED_SECRET is required inbound bearer authentication. Never expose this MCP endpoint without it.",
+    "Keep TELNYX_API_KEY and SHARED_SECRET in environment variables or a secret manager; do not paste their values into source or logs.",
+    "The flow installs dependencies, builds TypeScript, adds both runtime secrets, ships, and inspects the deployed function.",
   ];
-  if (statefulActorsSupported) {
-    notes.push("For stateful MCP/webhook scenarios (per-user sessions, connection state): consider telnyx-edge new-func --actor --language ts");
+  if (!inspectSupported && hasEdge) {
+    notes.push("This installed CLI did not expose inspect --help; upgrade telnyx-edge before running the final inspect step.");
   }
+  if (statefulActorsSupported) {
+    notes.push("For per-user state, actor scaffolding is available via telnyx-edge new-func --actor --language ts.");
+  }
+  if (actorInstancesSupported) {
+    notes.push("Persisted actor instance metadata can be listed with telnyx-edge actors instances <type>.");
+  }
+
+  const nextSteps = !hasEdge
+    ? ["Install telnyx-edge from the Edge Compute releases page, then rerun this command."]
+    : !authStatus.authenticated
+      ? [`Authenticate first: ${authCommand}`, "Run telnyx-edge status, then rerun this handoff."]
+      : [
+          "Export TELNYX_API_KEY and a high-entropy SHARED_SECRET (for example, openssl rand -hex 32).",
+          "Run deploy_command from the directory where you want the function project created.",
+          "Configure the MCP client to send Authorization: Bearer <SHARED_SECRET> to the inspected invoke URL.",
+        ];
 
   const result: SetupEdgeMcpResult = {
     ready: hasEdge && authStatus.authenticated,
+    telnyx_edge_installed: hasEdge,
     authenticated: authStatus.authenticated,
     auth_mode: authStatus.mode,
     api_key_auth_supported: apiKeyAuthSupported,
     stateful_actors_supported: statefulActorsSupported,
-    example: MCP_EXAMPLE,
+    inspect_supported: inspectSupported,
+    actor_instances_supported: actorInstancesSupported,
+    source_repo: SOURCE_REPO,
+    source_path: MCP_SOURCE_PATH,
+    example: MCP_SOURCE_PATH,
     auth_command: authCommand,
     deploy_command: deployCommand,
+    setup_commands: setupCommands,
     prerequisites: [
-      "Install telnyx-edge",
-      `Authenticate with ${authCommand}`,
-      "Use a real Edge Compute example as the starting point",
+      "Install telnyx-edge and git",
+      `Authenticate with: ${authCommand}`,
+      "Have Node.js/npm available for the TypeScript install and build",
+      "Export TELNYX_API_KEY and SHARED_SECRET without committing either value",
     ],
+    next_steps: nextSteps,
     notes,
   };
 
@@ -66,22 +125,30 @@ export async function setupEdgeMcpCommand(flags: Record<string, string | boolean
 
   if (result.ready) {
     printSuccess("Edge MCP handoff is ready", {
-      Example: MCP_EXAMPLE,
+      Source: `${SOURCE_REPO}#${MCP_SOURCE_PATH}`,
       Auth: authStatus.mode,
       Ready: "✓",
     });
   } else {
-    printError(hasEdge ? "telnyx-edge is not authenticated." : "telnyx-edge is not installed.");
+    printError(hasEdge ? "telnyx-edge is not positively authenticated." : "telnyx-edge is not installed.");
     printWarning(hasEdge
       ? `Authenticate first with: ${authCommand}`
       : "This command is a handoff helper — it depends on the dedicated Edge Compute CLI.");
   }
 
-  console.log(`  Example template: ${MCP_EXAMPLE}`);
+  console.log(`  Source repository: ${SOURCE_REPO}`);
+  console.log(`  Source path: ${MCP_SOURCE_PATH}`);
   console.log(`  Auth step: ${authCommand}`);
-  console.log(`  Suggested flow: ${deployCommand}`);
+  console.log("  Suggested executable flow:");
+  for (const command of setupCommands) {
+    console.log(`    ${command}`);
+  }
+  console.log("\n  Next steps:");
+  for (const step of nextSteps) {
+    console.log(`    - ${step}`);
+  }
   console.log("\n  Notes:");
-  for (const note of result.notes) {
+  for (const note of notes) {
     console.log(`    - ${note}`);
   }
   console.log();

--- a/cli/src/commands/setup-edge-mcp.ts
+++ b/cli/src/commands/setup-edge-mcp.ts
@@ -63,18 +63,20 @@ export async function setupEdgeMcpCommand(flags: Record<string, string | boolean
     `telnyx-edge secrets add TELNYX_API_KEY "$TELNYX_API_KEY"`,
     `telnyx-edge secrets add SHARED_SECRET "$SHARED_SECRET"`,
     "telnyx-edge ship",
-    `telnyx-edge inspect ${name}`,
   ];
+  if (inspectSupported) {
+    setupCommands.push(`telnyx-edge inspect ${name}`);
+  }
   const deployCommand = setupCommands.join(" && ");
 
   const notes = [
     "The source path is inside a team-telnyx/edge-compute checkout; this flow clones that repository before using --from-dir.",
     "SHARED_SECRET is required inbound bearer authentication. Never expose this MCP endpoint without it.",
     "Keep TELNYX_API_KEY and SHARED_SECRET in environment variables or a secret manager; do not paste their values into source or logs.",
-    "The flow installs dependencies, builds TypeScript, adds both runtime secrets, ships, and inspects the deployed function.",
+    `The flow installs dependencies, builds TypeScript, adds both runtime secrets, and ships the function${inspectSupported ? ", then inspects the deployment" : ""}.`,
   ];
   if (!inspectSupported && hasEdge) {
-    notes.push("This installed CLI did not expose inspect --help; upgrade telnyx-edge before running the final inspect step.");
+    notes.push("This installed CLI did not expose inspect --help; upgrade telnyx-edge to inspect the function after deployment.");
   }
   if (statefulActorsSupported) {
     notes.push("For per-user state, actor scaffolding is available via telnyx-edge new-func --actor --language ts.");
@@ -90,7 +92,7 @@ export async function setupEdgeMcpCommand(flags: Record<string, string | boolean
       : [
           "Export TELNYX_API_KEY and a high-entropy SHARED_SECRET (for example, openssl rand -hex 32).",
           "Run deploy_command from the directory where you want the function project created.",
-          "Configure the MCP client to send Authorization: Bearer <SHARED_SECRET> to the inspected invoke URL.",
+          `Configure the MCP client to send Authorization: Bearer <SHARED_SECRET> to the ${inspectSupported ? "inspected" : "deployed function's"} invoke URL.`,
         ];
 
   const result: SetupEdgeMcpResult = {

--- a/cli/src/commands/setup-edge-webhook.ts
+++ b/cli/src/commands/setup-edge-webhook.ts
@@ -59,8 +59,10 @@ export async function setupEdgeWebhookCommand(flags: Record<string, string | boo
     `cd ${name}`,
     `telnyx-edge secrets add WEBHOOK_SECRET "$WEBHOOK_SECRET"`,
     "telnyx-edge ship",
-    `telnyx-edge inspect ${name}`,
   ];
+  if (inspectSupported) {
+    setupCommands.push(`telnyx-edge inspect ${name}`);
+  }
   const deployCommand = setupCommands.join(" && ");
 
   const notes = [
@@ -70,7 +72,7 @@ export async function setupEdgeWebhookCommand(flags: Record<string, string | boo
     "Sign the exact request bytes and send x-webhook-signature as sha256=<hex digest>; reject requests whose HMAC does not verify.",
   ];
   if (!inspectSupported && hasEdge) {
-    notes.push("This installed CLI did not expose inspect --help; upgrade telnyx-edge before running the final inspect step.");
+    notes.push("This installed CLI did not expose inspect --help; upgrade telnyx-edge to inspect the function after deployment.");
   }
   if (statefulActorsSupported) {
     notes.push("For per-entity webhook state, actor scaffolding is available via telnyx-edge new-func --actor --language ts.");

--- a/cli/src/commands/setup-edge-webhook.ts
+++ b/cli/src/commands/setup-edge-webhook.ts
@@ -3,59 +3,114 @@
  */
 
 import { outputJson, printError, printSuccess, printWarning } from "../utils/output.ts";
-import { getEdgeAuthStatus, hasEdgeCli, supportsApiKeyAuth, supportsStatefulActors } from "../edge-cli.ts";
+import {
+  getEdgeAuthStatus,
+  hasEdgeCli,
+  supportsActorInstances,
+  supportsApiKeyAuth,
+  supportsInspect,
+  supportsStatefulActors,
+  validateEdgeFunctionName,
+} from "../edge-cli.ts";
 
 interface SetupEdgeWebhookResult {
   ready: boolean;
+  telnyx_edge_installed: boolean;
   authenticated: boolean;
   auth_mode: "api_key" | "oauth" | "none" | "unknown";
   api_key_auth_supported: boolean;
   stateful_actors_supported: boolean;
+  inspect_supported: boolean;
+  actor_instances_supported: boolean;
+  source_repo: string;
+  source_path: string;
   example: string;
   auth_command: string;
   deploy_command: string;
+  setup_commands: string[];
   prerequisites: string[];
+  next_steps: string[];
   notes: string[];
 }
 
-const WEBHOOK_EXAMPLE = "examples/js/webhook-receiver";
+const SOURCE_REPO = "https://github.com/team-telnyx/edge-compute.git";
+const WEBHOOK_SOURCE_PATH = "examples/js/webhook-receiver";
 
 export async function setupEdgeWebhookCommand(flags: Record<string, string | boolean>): Promise<void> {
   const jsonOutput = flags.json === true;
   const name = (flags.name as string) || "my-webhook-receiver";
+  validateEdgeFunctionName(name);
 
   const hasEdge = hasEdgeCli();
   const apiKeyAuthSupported = hasEdge ? supportsApiKeyAuth() : false;
   const statefulActorsSupported = hasEdge ? supportsStatefulActors() : false;
+  const inspectSupported = hasEdge ? supportsInspect() : false;
+  const actorInstancesSupported = hasEdge ? supportsActorInstances() : false;
   const authStatus = hasEdge ? safeAuthStatus() : { authenticated: false, mode: "none" as const };
   const authCommand = apiKeyAuthSupported
-    ? "telnyx-edge auth api-key set <your-api-key>"
+    ? `: "\${TELNYX_API_KEY:?Export TELNYX_API_KEY first}" && telnyx-edge auth api-key set "$TELNYX_API_KEY"`
     : "telnyx-edge auth login";
-  const deployCommand = `telnyx-edge new-func --from-dir=${WEBHOOK_EXAMPLE} --name=${name} && cd ${name} && telnyx-edge ship`;
+
+  const setupCommands = [
+    `: "\${WEBHOOK_SECRET:?Export a high-entropy WEBHOOK_SECRET before running this flow}"`,
+    `EDGE_COMPUTE_SRC="$(mktemp -d)/edge-compute"`,
+    `git clone --depth 1 "${SOURCE_REPO}" "$EDGE_COMPUTE_SRC"`,
+    `telnyx-edge new-func --from-dir="$EDGE_COMPUTE_SRC/${WEBHOOK_SOURCE_PATH}" --name=${name}`,
+    `cd ${name}`,
+    `telnyx-edge secrets add WEBHOOK_SECRET "$WEBHOOK_SECRET"`,
+    "telnyx-edge ship",
+    `telnyx-edge inspect ${name}`,
+  ];
+  const deployCommand = setupCommands.join(" && ");
 
   const notes = [
-    "Use this when your AI workflow needs an HTTP ingress point at the edge.",
-    "The deployed function lifecycle is still owned by telnyx-edge.",
-    "After deploy, point your webhook-producing system at the Edge endpoint and let team-telnyx/ai handle orchestration guidance.",
+    "The source path is inside a team-telnyx/edge-compute checkout; this flow clones that repository before using --from-dir.",
+    "WEBHOOK_SECRET enables HMAC-SHA256 verification of the x-webhook-signature header; do not deploy production webhook ingress without it.",
+    "Keep WEBHOOK_SECRET in an environment variable or secret manager and configure the webhook producer with the same key.",
+    "Sign the exact request bytes and send x-webhook-signature as sha256=<hex digest>; reject requests whose HMAC does not verify.",
   ];
-  if (statefulActorsSupported) {
-    notes.push("For stateful MCP/webhook scenarios (per-user sessions, connection state): consider telnyx-edge new-func --actor --language ts");
+  if (!inspectSupported && hasEdge) {
+    notes.push("This installed CLI did not expose inspect --help; upgrade telnyx-edge before running the final inspect step.");
   }
+  if (statefulActorsSupported) {
+    notes.push("For per-entity webhook state, actor scaffolding is available via telnyx-edge new-func --actor --language ts.");
+  }
+  if (actorInstancesSupported) {
+    notes.push("Persisted actor instance metadata can be listed with telnyx-edge actors instances <type>.");
+  }
+
+  const nextSteps = !hasEdge
+    ? ["Install telnyx-edge from the Edge Compute releases page, then rerun this command."]
+    : !authStatus.authenticated
+      ? [`Authenticate first: ${authCommand}`, "Run telnyx-edge status, then rerun this handoff."]
+      : [
+          "Export a high-entropy WEBHOOK_SECRET (for example: export WEBHOOK_SECRET=\"$(openssl rand -hex 32)\").",
+          "Run deploy_command from the directory where you want the function project created.",
+          "Configure the producer with the same secret and HMAC-sign the exact payload bytes before sending.",
+        ];
 
   const result: SetupEdgeWebhookResult = {
     ready: hasEdge && authStatus.authenticated,
+    telnyx_edge_installed: hasEdge,
     authenticated: authStatus.authenticated,
     auth_mode: authStatus.mode,
     api_key_auth_supported: apiKeyAuthSupported,
     stateful_actors_supported: statefulActorsSupported,
-    example: WEBHOOK_EXAMPLE,
+    inspect_supported: inspectSupported,
+    actor_instances_supported: actorInstancesSupported,
+    source_repo: SOURCE_REPO,
+    source_path: WEBHOOK_SOURCE_PATH,
+    example: WEBHOOK_SOURCE_PATH,
     auth_command: authCommand,
     deploy_command: deployCommand,
+    setup_commands: setupCommands,
     prerequisites: [
-      "Install telnyx-edge",
-      `Authenticate with ${authCommand}`,
-      "Start from the webhook receiver example",
+      "Install telnyx-edge and git",
+      `Authenticate with: ${authCommand}`,
+      "Export a high-entropy WEBHOOK_SECRET without committing it",
+      "Configure the webhook producer to generate HMAC-SHA256 signatures with the same secret",
     ],
+    next_steps: nextSteps,
     notes,
   };
 
@@ -66,22 +121,31 @@ export async function setupEdgeWebhookCommand(flags: Record<string, string | boo
 
   if (result.ready) {
     printSuccess("Edge webhook handoff is ready", {
-      Example: WEBHOOK_EXAMPLE,
+      Source: `${SOURCE_REPO}#${WEBHOOK_SOURCE_PATH}`,
       Auth: authStatus.mode,
+      HMAC: "WEBHOOK_SECRET required",
       Ready: "✓",
     });
   } else {
-    printError(hasEdge ? "telnyx-edge is not authenticated." : "telnyx-edge is not installed.");
+    printError(hasEdge ? "telnyx-edge is not positively authenticated." : "telnyx-edge is not installed.");
     printWarning(hasEdge
       ? `Authenticate first with: ${authCommand}`
       : "This command is a handoff helper — it depends on the dedicated Edge Compute CLI.");
   }
 
-  console.log(`  Example template: ${WEBHOOK_EXAMPLE}`);
+  console.log(`  Source repository: ${SOURCE_REPO}`);
+  console.log(`  Source path: ${WEBHOOK_SOURCE_PATH}`);
   console.log(`  Auth step: ${authCommand}`);
-  console.log(`  Suggested flow: ${deployCommand}`);
+  console.log("  Suggested executable flow:");
+  for (const command of setupCommands) {
+    console.log(`    ${command}`);
+  }
+  console.log("\n  Next steps:");
+  for (const step of nextSteps) {
+    console.log(`    - ${step}`);
+  }
   console.log("\n  Notes:");
-  for (const note of result.notes) {
+  for (const note of notes) {
     console.log(`    - ${note}`);
   }
   console.log();

--- a/cli/src/edge-cli.ts
+++ b/cli/src/edge-cli.ts
@@ -1,13 +1,16 @@
 import { execFileSync } from "node:child_process";
 
+const DEFAULT_TIMEOUT_MS = 15000;
+const STATUS_TIMEOUT_MS = 45000;
+
 export function resolveEdgeBinary(): string {
   return process.env.TELNYX_EDGE_PATH || "telnyx-edge";
 }
 
-function runEdge(args: string[]): string {
+function runEdge(args: string[], timeout = DEFAULT_TIMEOUT_MS): string {
   return execFileSync(resolveEdgeBinary(), args, {
     encoding: "utf8",
-    timeout: 15000,
+    timeout,
     env: { ...process.env },
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -27,18 +30,15 @@ export function getEdgeHelp(): string {
 }
 
 /**
- * Resolve the installed telnyx-edge version.
- *
- * Prefers the first-class `--version` flag introduced in v0.2.3. If that is
- * unavailable (older CLI), falls back to parsing `--help` output with the
- * existing semver regex.
+ * Resolve the installed telnyx-edge version for display only.
+ * Capabilities are always detected by invoking their help surfaces instead.
  */
 export function getEdgeVersion(): string | null {
   try {
-    const v = matchVersion(runEdge(["--version"]));
-    if (v) return v;
+    const version = matchVersion(runEdge(["--version"]));
+    if (version) return version;
   } catch {
-    // older CLI without --version — fall back to --help parsing below
+    // Older CLIs may not have --version. Fall back to the root help banner.
   }
   try {
     return matchVersion(runEdge(["--help"]));
@@ -47,20 +47,30 @@ export function getEdgeVersion(): string | null {
   }
 }
 
-/**
- * Feature detection for Stateful Actors (Beta, telnyx-edge v0.2.3+).
- *
- * Checks whether `new-func` exposes the `--actor` flag — the documented
- * quick-start workflow (`telnyx-edge new-func --actor --name=account`).
- * This is the actual scaffolding capability the wrapper cares about, not
- * the account-scoped `actors` management subcommand. An actor-capable CLI
- * that lacks `actors --help` (e.g. a canary build or the minimal surface
- * described in the published quick start) still reports true here.
- */
+/** Detect actor scaffolding from the command that supplies it, not a version. */
 export function supportsStatefulActors(): boolean {
   try {
-    const out = runEdge(["new-func", "--help"]);
-    return /--actor\b/i.test(out);
+    return /--actor\b/i.test(runEdge(["new-func", "--help"]));
+  } catch {
+    return false;
+  }
+}
+
+/** Detect the root function-detail command introduced before v0.2.5. */
+export function supportsInspect(): boolean {
+  try {
+    const out = runEdge(["inspect", "--help"]);
+    return /\binspect(?:\s+<[^>]+>)?/i.test(out) && /\bfunction\b/i.test(out);
+  } catch {
+    return false;
+  }
+}
+
+/** Detect the v0.2.5 persisted actor-instance listing directly. */
+export function supportsActorInstances(): boolean {
+  try {
+    const out = runEdge(["actors", "instances", "--help"]);
+    return /\binstances(?:\s+<[^>]+>)?/i.test(out) && /\bactor\b/i.test(out);
   } catch {
     return false;
   }
@@ -72,38 +82,29 @@ export type EdgeAuthStatus = {
   raw: string;
 };
 
+/**
+ * Parse `auth status` conservatively. A zero exit code or unfamiliar text is
+ * not evidence of authentication: the CLI must identify a supported auth mode
+ * and print its affirmative authenticated marker.
+ */
 export function getEdgeAuthStatus(): EdgeAuthStatus {
   const raw = runEdge(["auth", "status"]);
   const text = raw.toLowerCase();
-  const authenticated =
-    !text.includes("authentication status: none") &&
-    !text.includes("not authenticated") &&
-    !text.includes("status: ❌") &&
-    !text.includes("status: x") &&
-    !text.includes("token expired") &&
-    !text.includes("⚠️");
 
   let mode: EdgeAuthStatus["mode"] = "unknown";
-  if (
-    text.includes("authentication status: none") ||
-    text.includes("not authenticated") ||
-    text.includes("status: ❌") ||
-    text.includes("status: x")
-  ) {
-    mode = "none";
-  } else if (
-    text.includes("authentication status: api key") ||
-    text.includes("api key")
-  ) {
+  if (/authentication status:\s*api key/i.test(raw)) {
     mode = "api_key";
-  } else if (
-    text.includes("authentication status: oauth") ||
-    text.includes("oauth") ||
-    text.includes("browser") ||
-    text.includes("logged in")
-  ) {
+  } else if (/authentication status:\s*oauth(?:\s*2\.0)?/i.test(raw)) {
     mode = "oauth";
+  } else if (/authentication status:\s*none/i.test(raw) || /not authenticated/i.test(raw)) {
+    mode = "none";
   }
+
+  const positiveMarker = /status:\s*(?:✅|✓)\s*authenticated\b/i.test(raw);
+  const negativeMarker =
+    /not authenticated|token expired|status:\s*(?:❌|x)\b|invalid/i.test(text);
+  const authenticated =
+    (mode === "api_key" || mode === "oauth") && positiveMarker && !negativeMarker;
 
   return { authenticated, mode, raw };
 }
@@ -111,9 +112,34 @@ export function getEdgeAuthStatus(): EdgeAuthStatus {
 export function supportsApiKeyAuth(): boolean {
   try {
     const out = runEdge(["auth", "api-key", "set", "--help"]);
-    return /Set API key for authentication/i.test(out);
+    return /set api key for authentication/i.test(out);
   } catch {
     return false;
+  }
+}
+
+export type EdgeRootStatus = {
+  passed: boolean;
+  raw: string;
+};
+
+/**
+ * Run the networked root diagnostic. telnyx-edge currently exits successfully
+ * even when an individual check fails, so require its affirmative final line.
+ * The upstream check can spend 5s on connectivity and 10s validating auth;
+ * allow extra process/network startup time beyond the normal help timeout.
+ */
+export function getEdgeRootStatus(): EdgeRootStatus {
+  const raw = runEdge(["status"], STATUS_TIMEOUT_MS);
+  const passed = /(?:✅|✓)\s*All checks passed\s*-\s*CLI is ready to use/i.test(raw);
+  return { passed, raw };
+}
+
+export function validateEdgeFunctionName(name: string): void {
+  if (!/^[A-Za-z0-9](?:[A-Za-z0-9-]{0,62}[A-Za-z0-9])?$/.test(name)) {
+    throw new Error(
+      "Invalid Edge function name: use 1–64 alphanumeric/dash characters with no leading or trailing dash.",
+    );
   }
 }
 

--- a/cli/tests/edge-handoff.test.ts
+++ b/cli/tests/edge-handoff.test.ts
@@ -238,6 +238,22 @@ describe("CLI — Edge Compute handoff", () => {
     assert.ok(data.next_steps.some((step: string) => step.includes("HMAC-sign")));
   });
 
+  it("setup handoffs omit inspect from executable flows when the authenticated CLI does not support it", () => {
+    const fake = withFakeEdgeCli({ auth: "api_key", inspect: false });
+    for (const [command, name] of [
+      ["setup-edge-mcp", "demo-mcp"],
+      ["setup-edge-webhook", "demo-webhook"],
+    ]) {
+      const data = JSON.parse(run([command, "--json", "--name", name], fake.env));
+      assert.equal(data.authenticated, true);
+      assert.equal(data.ready, true);
+      assert.equal(data.inspect_supported, false);
+      assert.ok(data.deploy_command.includes("telnyx-edge ship"));
+      assert.ok(!data.deploy_command.includes("telnyx-edge inspect"));
+      assert.ok(!data.setup_commands.some((step: string) => step.includes("telnyx-edge inspect")));
+    }
+  });
+
   it("setup handoffs conservatively reject unknown auth output", () => {
     const fake = withFakeEdgeCli({ auth: "unknown" });
     for (const command of ["setup-edge-mcp", "setup-edge-webhook"]) {

--- a/cli/tests/edge-handoff.test.ts
+++ b/cli/tests/edge-handoff.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, writeFileSync, chmodSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -9,49 +9,95 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CLI = join(__dirname, "..", "bin", "telnyx-agent.ts");
 
-function withFakeEdgeCli(mode: "none" | "oauth" | "api_key" | "expired_oauth" = "api_key") {
+type AuthMode = "none" | "oauth" | "api_key" | "expired_oauth" | "unknown";
+type FakeEdgeOptions = {
+  auth?: AuthMode;
+  rootStatus?: "pass" | "fail" | "unknown";
+  inspect?: boolean;
+  actorInstances?: boolean;
+  argLog?: boolean;
+};
+
+function withFakeEdgeCli(options: FakeEdgeOptions | AuthMode = "api_key") {
+  const config: FakeEdgeOptions = typeof options === "string" ? { auth: options } : options;
+  const auth = config.auth ?? "api_key";
+  const rootStatus = config.rootStatus ?? (auth === "api_key" || auth === "oauth" ? "pass" : "fail");
+  const inspect = config.inspect ?? true;
+  const actorInstances = config.actorInstances ?? true;
   const tempDir = mkdtempSync(join(tmpdir(), "telnyx-edge-fake-"));
   const binDir = join(tempDir, "bin");
+  const argsLog = join(tempDir, "args.jsonl");
   mkdirSync(binDir, { recursive: true });
   const fakeEdge = join(binDir, "telnyx-edge");
   writeFileSync(
     fakeEdge,
     `#!/usr/bin/env node
 const args = process.argv.slice(2);
+if (process.env.EDGE_ARGS_LOG) {
+  require('node:fs').appendFileSync(process.env.EDGE_ARGS_LOG, JSON.stringify(args) + "\\n");
+}
 if (args.includes('--version')) {
-  console.log('telnyx-edge v0.2.3');
+  console.log('telnyx-edge v0.2.5');
   process.exit(0);
 }
 if (args[0] === 'new-func' && args.includes('--help')) {
-  console.log(['Create a new edge computing function', '', 'Flags:', '      --actor             Scaffold a StatefulActor (telnyx.toml) project — TypeScript only', '      --from-dir string   Copy files from existing directory', '  -h, --help              help for new-func', '  -l, --language string   Language runtime (go, js, ts, python, quarkus)', '  -n, --name string       Name of the function to create'].join('\\n'));
+  console.log(['Create a new edge computing function', '', 'Flags:', '      --actor             Scaffold a StatefulActor project', '      --from-dir string   Copy files from existing directory', '  -h, --help              help for new-func', '  -n, --name string       Name of the function to create'].join('\\n'));
   process.exit(0);
 }
 if (args[0] === 'auth' && args[1] === 'api-key' && args[2] === 'set' && args.includes('--help')) {
   console.log('Set API key for authentication. The API key must be provided as an argument.');
   process.exit(0);
 }
-if (args.includes('--help')) {
-  console.log(['Telnyx Edge CLI v0.2.3', '', 'Available Commands:', '  actors      Manage StatefulActor types', '  auth        Authentication commands', '  ship        Ship a function', '  list        List functions', '  secrets     Manage secrets', '  bindings    Manage bindings'].join('\\n'));
+if (args[0] === 'inspect' && args.includes('--help')) {
+  if (${inspect}) {
+    console.log('Usage: telnyx-edge inspect <function>\\nShow a function full details and actor bindings');
+    process.exit(0);
+  }
+  process.stderr.write('unknown command "inspect"\\n');
+  process.exit(1);
+}
+if (args[0] === 'actors' && args[1] === 'instances' && args.includes('--help')) {
+  if (${actorInstances}) {
+    console.log('Usage: telnyx-edge actors instances <type>\\nList persisted instances of an actor type');
+    process.exit(0);
+  }
+  process.stderr.write('unknown command "instances"\\n');
+  process.exit(1);
+}
+if (args.length === 1 && args[0] === '--help') {
+  console.log(['Telnyx Edge CLI v0.2.5', '', 'Available Commands:', '  actors      Manage StatefulActor types', '  inspect     Show function details', '  auth        Authentication commands', '  ship        Ship a function', '  storage     Manage storage'].join('\\n'));
   process.exit(0);
 }
 if (args[0] === 'auth' && args[1] === 'status') {
-  if ('${mode}' === 'none') {
-    console.log(['API Endpoint: https://api.telnyx.com', '', 'Authentication Status: None', 'Status: ❌ Not authenticated', "Run 'telnyx-edge auth login' or 'telnyx-edge auth api-key set <api_key>' to authenticate"].join('\\n'));
+  if ('${auth}' === 'none') {
+    console.log(['API Endpoint: https://api.telnyx.com', '', 'Authentication Status: None', 'Status: ❌ Not authenticated'].join('\\n'));
     process.exit(0);
   }
-  if ('${mode}' === 'expired_oauth') {
-    console.log(['API Endpoint: https://api.telnyx.com', '', 'Authentication Status: OAuth 2.0', 'Token Type: Bearer', 'Scopes: admin', 'Expires: 2026-06-22 18:35:42 IST', 'Status: ⚠️ Token expired - run telnyx-edge auth login to refresh'].join('\\n'));
+  if ('${auth}' === 'unknown') {
+    console.log('Authentication cache loaded; contact support for details');
     process.exit(0);
   }
-  if ('${mode}' === 'oauth') {
-    console.log(['API Endpoint: https://api.telnyx.com', '', 'Authentication Status: OAuth 2.0', 'Token Type: Bearer', 'Scopes: admin', 'Expires: 2026-07-06 12:11:42 IST', 'Status: ✅ Authenticated'].join('\\n'));
+  if ('${auth}' === 'expired_oauth') {
+    console.log(['API Endpoint: https://api.telnyx.com', '', 'Authentication Status: OAuth 2.0', 'Status: ⚠️ Token expired - run telnyx-edge auth login to refresh'].join('\\n'));
     process.exit(0);
   }
-  console.log(['API Endpoint: https://api.telnyx.com', '', 'Authentication Status: API Key', 'Status: ✅ Authenticated'].join('\\n'));
+  if ('${auth}' === 'oauth') {
+    console.log(['API Endpoint: https://api.telnyx.com', '', 'Authentication Status: OAuth 2.0', 'Status: ✓ Authenticated'].join('\\n'));
+    process.exit(0);
+  }
+  console.log(['API Endpoint: https://api.telnyx.com', '', 'Authentication Status: API Key', 'Status: ✓ Authenticated'].join('\\n'));
   process.exit(0);
 }
-if (args[0] === 'auth' && args[1] === 'api-key' && args[2] === 'clear' && args.includes('--help')) {
-  console.log('Remove the stored API key from the configuration');
+if (args.length === 1 && args[0] === 'status') {
+  if ('${rootStatus}' === 'pass') {
+    console.log(['Telnyx Edge CLI Status Check', '✅ Config file OK', '✅ Reachable: https://api.telnyx.com (HTTP 200)', '✅ API key is valid', '', '✅ All checks passed - CLI is ready to use'].join('\\n'));
+    process.exit(0);
+  }
+  if ('${rootStatus}' === 'unknown') {
+    console.log('Status command completed');
+    process.exit(0);
+  }
+  console.log(['Telnyx Edge CLI Status Check', '✅ Config file OK', '❌ Failed: Cannot reach https://api.telnyx.com', '', '❌ Some checks failed - please review the issues above'].join('\\n'));
   process.exit(0);
 }
 console.log('ok');
@@ -59,10 +105,12 @@ console.log('ok');
   );
   chmodSync(fakeEdge, 0o755);
   return {
+    argsLog,
     env: {
       ...process.env,
       PATH: `${binDir}:${process.env.PATH}`,
       TELNYX_EDGE_PATH: fakeEdge,
+      ...(config.argLog ? { EDGE_ARGS_LOG: argsLog } : {}),
     },
   };
 }
@@ -75,6 +123,15 @@ function run(args: string[], env?: NodeJS.ProcessEnv): string {
   });
 }
 
+function runError(args: string[], env?: NodeJS.ProcessEnv): string {
+  try {
+    run(args, env);
+    assert.fail("expected command to fail");
+  } catch (err: any) {
+    return `${err?.stdout?.toString?.() ?? ""}${err?.stderr?.toString?.() ?? ""}`;
+  }
+}
+
 describe("CLI — Edge Compute handoff", () => {
   it("help lists edge handoff commands", () => {
     const output = run(["help"]);
@@ -83,115 +140,121 @@ describe("CLI — Edge Compute handoff", () => {
     assert.ok(output.includes("setup-edge-webhook"));
   });
 
-  it("capabilities JSON includes edge handoff entries", () => {
-    const output = run(["capabilities", "--json"]);
-    const data = JSON.parse(output);
-    const category = Object.keys(data.api_capabilities || {}).find((k) => k.includes("Edge Compute"));
+  it("capabilities JSON includes edge handoff and stateful actor entries", () => {
+    const data = JSON.parse(run(["capabilities", "--json"]));
+    const category = Object.keys(data.api_capabilities || {}).find((key) => key.includes("Edge Compute"));
     assert.ok(category);
-    const commands = data.composite_commands.map((c: any) => c.name || c.command || c);
-    assert.ok(commands.some((c: string) => c.includes("edge-doctor")));
-    assert.ok(commands.some((c: string) => c.includes("setup-edge-mcp")));
-    assert.ok(commands.some((c: string) => c.includes("setup-edge-webhook")));
+    const commands = data.composite_commands.map((entry: any) => entry.name || entry.command || entry);
+    assert.ok(commands.some((command: string) => command.includes("edge-doctor")));
+    assert.ok(commands.some((command: string) => command.includes("setup-edge-mcp")));
+    assert.ok(commands.some((command: string) => command.includes("setup-edge-webhook")));
+    const actor = data.api_capabilities[category as string]
+      .find((entry: { name: string }) => entry.name === "Stateful Actors");
+    assert.ok(actor?.description.toLowerCase().includes("per-entity"));
   });
 
-  it("capabilities JSON includes stateful actors entry", () => {
-    const output = run(["capabilities", "--json"]);
-    const data = JSON.parse(output);
-    const category = Object.keys(data.api_capabilities || {}).find((k) => k.includes("Edge Compute"));
-    assert.ok(category);
-    const caps = data.api_capabilities[category] as Array<{ name: string; description: string }>;
-    const actorCap = caps.find((c) => c.name === "Stateful Actors");
-    assert.ok(actorCap, "Stateful Actors capability should be listed");
-    assert.ok(actorCap!.description.toLowerCase().includes("per-entity"));
-  });
-
-  it("edge-doctor reports API-key auth support and readiness", () => {
-    const fake = withFakeEdgeCli("api_key");
-    const output = run(["edge-doctor", "--json"], fake.env);
-    const data = JSON.parse(output);
+  it("edge-doctor requires positive auth and the root connectivity/status check", () => {
+    const fake = withFakeEdgeCli({ auth: "api_key", rootStatus: "pass" });
+    const data = JSON.parse(run(["edge-doctor", "--json"], fake.env));
     assert.equal(data.ready, true);
     assert.equal(data.telnyx_edge_installed, true);
+    assert.equal(data.telnyx_edge_version, "v0.2.5");
     assert.equal(data.authenticated, true);
     assert.equal(data.auth_mode, "api_key");
+    assert.equal(data.root_status_passed, true);
     assert.equal(data.api_key_auth_supported, true);
     assert.equal(data.stateful_actors_supported, true);
-    assert.ok(Array.isArray(data.next_steps));
+    assert.equal(data.inspect_supported, true);
+    assert.equal(data.actor_instances_supported, true);
   });
 
-  it("edge-doctor shows unauthenticated but installable state", () => {
-    const fake = withFakeEdgeCli("none");
-    const output = run(["edge-doctor", "--json"], fake.env);
-    const data = JSON.parse(output);
+  it("edge-doctor stays unready when root status exits zero but reports a failed check", () => {
+    const fake = withFakeEdgeCli({ auth: "api_key", rootStatus: "fail" });
+    const data = JSON.parse(run(["edge-doctor", "--json"], fake.env));
+    assert.equal(data.authenticated, true);
+    assert.equal(data.root_status_passed, false);
     assert.equal(data.ready, false);
-    assert.equal(data.telnyx_edge_installed, true);
+    assert.ok(data.next_steps.some((step: string) => step.includes("telnyx-edge status")));
+  });
+
+  it("edge-doctor does not treat unknown auth output as authenticated", () => {
+    const fake = withFakeEdgeCli({ auth: "unknown", rootStatus: "pass" });
+    const data = JSON.parse(run(["edge-doctor", "--json"], fake.env));
+    assert.equal(data.auth_mode, "unknown");
     assert.equal(data.authenticated, false);
-    assert.equal(data.api_key_auth_supported, true);
-    assert.equal(data.stateful_actors_supported, true);
-    assert.ok(data.next_steps.some((s: string) => s.includes("auth api-key set")));
+    assert.equal(data.root_status_passed, true);
+    assert.equal(data.ready, false);
   });
 
-  it("edge-doctor detects expired OAuth token as not authenticated", () => {
-    const fake = withFakeEdgeCli("expired_oauth");
-    const output = run(["edge-doctor", "--json"], fake.env);
-    const data = JSON.parse(output);
-    assert.equal(data.ready, false);
+  it("edge-doctor rejects none and expired OAuth auth states", () => {
+    for (const auth of ["none", "expired_oauth"] as const) {
+      const fake = withFakeEdgeCli({ auth });
+      const data = JSON.parse(run(["edge-doctor", "--json"], fake.env));
+      assert.equal(data.authenticated, false);
+      assert.equal(data.ready, false);
+    }
+  });
+
+  it("edge-doctor probes inspect and actor instances instead of inferring from version", () => {
+    const fake = withFakeEdgeCli({ auth: "api_key", inspect: false, actorInstances: false, argLog: true });
+    const data = JSON.parse(run(["edge-doctor", "--json"], fake.env));
+    assert.equal(data.telnyx_edge_version, "v0.2.5");
+    assert.equal(data.inspect_supported, false);
+    assert.equal(data.actor_instances_supported, false);
+    const calls = readFileSync(fake.argsLog, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    assert.ok(calls.some((args) => JSON.stringify(args) === JSON.stringify(["inspect", "--help"])));
+    assert.ok(calls.some((args) => JSON.stringify(args) === JSON.stringify(["actors", "instances", "--help"])));
+  });
+
+  it("setup-edge-mcp emits a repository-aware secure build/deploy/inspect flow", () => {
+    const fake = withFakeEdgeCli("api_key");
+    const data = JSON.parse(run(["setup-edge-mcp", "--json", "--name", "demo-mcp"], fake.env));
+    assert.equal(data.ready, true);
     assert.equal(data.telnyx_edge_installed, true);
-    assert.equal(data.authenticated, false, "expired token should not be authenticated");
-    assert.equal(data.auth_mode, "oauth");
-    assert.equal(data.stateful_actors_supported, true);
+    assert.equal(data.inspect_supported, true);
+    assert.equal(data.actor_instances_supported, true);
+    assert.equal(data.source_repo, "https://github.com/team-telnyx/edge-compute.git");
+    assert.equal(data.source_path, "examples/ts/mcp-server");
+    assert.ok(data.deploy_command.includes("git clone --depth 1"));
+    assert.ok(data.deploy_command.includes("npm install"));
+    assert.ok(data.deploy_command.includes("npm run build"));
+    assert.ok(data.deploy_command.includes('secrets add TELNYX_API_KEY "$TELNYX_API_KEY"'));
+    assert.ok(data.deploy_command.includes('secrets add SHARED_SECRET "$SHARED_SECRET"'));
+    assert.ok(data.deploy_command.includes("telnyx-edge ship"));
+    assert.ok(data.deploy_command.includes("telnyx-edge inspect demo-mcp"));
+    assert.ok(!data.deploy_command.includes("<your-api-key>"));
   });
 
-  it("edge-doctor suggests stateful actors when supported and authenticated", () => {
+  it("setup-edge-webhook emits a repository-aware HMAC-secured deploy/inspect flow", () => {
     const fake = withFakeEdgeCli("api_key");
-    const output = run(["edge-doctor", "--json"], fake.env);
-    const data = JSON.parse(output);
+    const data = JSON.parse(run(["setup-edge-webhook", "--json", "--name", "demo-webhook"], fake.env));
     assert.equal(data.ready, true);
-    assert.ok(
-      data.next_steps.some((s: string) => s.includes("--actor")),
-      "next_steps should mention --actor when stateful actors are supported",
-    );
+    assert.equal(data.source_path, "examples/js/webhook-receiver");
+    assert.ok(data.deploy_command.includes("git clone --depth 1"));
+    assert.ok(data.deploy_command.includes('secrets add WEBHOOK_SECRET "$WEBHOOK_SECRET"'));
+    assert.ok(data.deploy_command.includes("telnyx-edge ship"));
+    assert.ok(data.deploy_command.includes("telnyx-edge inspect demo-webhook"));
+    assert.ok(data.notes.some((note: string) => note.includes("HMAC-SHA256")));
+    assert.ok(data.next_steps.some((step: string) => step.includes("HMAC-sign")));
   });
 
-  it("setup-edge-mcp returns API-key auth handoff when unauthenticated", () => {
-    const fake = withFakeEdgeCli("none");
-    const output = run(["setup-edge-mcp", "--json", "--name", "demo-mcp"], fake.env);
-    const data = JSON.parse(output);
-    assert.equal(data.ready, false);
-    assert.equal(data.api_key_auth_supported, true);
-    assert.equal(data.stateful_actors_supported, true);
-    assert.equal(data.auth_command, "telnyx-edge auth api-key set <your-api-key>");
-    assert.equal(data.example, "examples/ts/mcp-server");
-    assert.ok(data.deploy_command.includes("demo-mcp"));
+  it("setup handoffs conservatively reject unknown auth output", () => {
+    const fake = withFakeEdgeCli({ auth: "unknown" });
+    for (const command of ["setup-edge-mcp", "setup-edge-webhook"]) {
+      const data = JSON.parse(run([command, "--json"], fake.env));
+      assert.equal(data.authenticated, false);
+      assert.equal(data.auth_mode, "unknown");
+      assert.equal(data.ready, false);
+    }
   });
 
-  it("setup-edge-webhook returns concrete deploy handoff", () => {
+  it("validates Edge function names before building shell commands", () => {
     const fake = withFakeEdgeCli("api_key");
-    const output = run(["setup-edge-webhook", "--json", "--name", "demo-webhook"], fake.env);
-    const data = JSON.parse(output);
-    assert.equal(data.ready, true);
-    assert.equal(data.auth_mode, "api_key");
-    assert.equal(data.stateful_actors_supported, true);
-    assert.equal(data.example, "examples/js/webhook-receiver");
-    assert.ok(data.deploy_command.includes("demo-webhook"));
-  });
-
-  it("setup-edge-mcp notes mention stateful actors when supported", () => {
-    const fake = withFakeEdgeCli("api_key");
-    const output = run(["setup-edge-mcp", "--json"], fake.env);
-    const data = JSON.parse(output);
-    assert.ok(
-      data.notes.some((n: string) => n.includes("--actor")),
-      "notes should mention --actor when stateful actors are supported",
-    );
-  });
-
-  it("setup-edge-webhook notes mention stateful actors when supported", () => {
-    const fake = withFakeEdgeCli("api_key");
-    const output = run(["setup-edge-webhook", "--json"], fake.env);
-    const data = JSON.parse(output);
-    assert.ok(
-      data.notes.some((n: string) => n.includes("--actor")),
-      "notes should mention --actor when stateful actors are supported",
-    );
+    const leadingDash = runError(["setup-edge-mcp", "--json", "--name", "-bad"], fake.env);
+    assert.match(leadingDash, /Invalid Edge function name/);
+    const injection = runError(["setup-edge-webhook", "--json", "--name", "bad;touch-pwned"], fake.env);
+    assert.match(injection, /Invalid Edge function name/);
+    const tooLong = runError(["setup-edge-mcp", "--json", "--name", "a".repeat(65)], fake.env);
+    assert.match(tooLong, /1–64/);
   });
 });

--- a/guides/edge-compute.md
+++ b/guides/edge-compute.md
@@ -48,6 +48,10 @@ telnyx-agent edge-doctor --json
 
 Names must be 1–64 characters, contain only alphanumeric characters and dashes, and have no leading or trailing dash. Examples: `my-mcp-server`, `webhook-v2`, `report7`.
 
+## Quick Start
+
+Use one of the repository-aware handoff commands below for a complete clone, build, secrets, deploy, and inspect sequence. The expanded manual flows show exactly what each helper emits.
+
 ## Secure MCP server handoff
 
 The TypeScript MCP example requires two distinct secrets:
@@ -151,7 +155,7 @@ curl -X POST "https://<your-edge-endpoint>/" \
 
 Do not put `WEBHOOK_SECRET` in the request body or an Authorization header unless your own handler explicitly defines that separate protocol. Its purpose in this example is HMAC verification.
 
-## CLI lifecycle reference
+## API Reference
 
 ### Create, deploy, inspect, and recover
 
@@ -310,6 +314,22 @@ console.log(await response.json());
 ```
 
 If the function does not implement authentication, an Authorization header does not make it secure. Add and verify bearer-token or signature logic in the function, and use HTTPS.
+
+Python equivalent:
+
+```python
+import os
+import requests
+
+response = requests.post(
+    "https://<your-edge-endpoint>/",
+    headers={"Authorization": f"Bearer {os.environ['EDGE_ENDPOINT_TOKEN']}"},
+    json={"task": "redact_pii", "payload": {"text": "Call me at +1 555 123 4567"}},
+    timeout=30,
+)
+response.raise_for_status()
+print(response.json())
+```
 
 ## Practical end-to-end test
 

--- a/guides/edge-compute.md
+++ b/guides/edge-compute.md
@@ -1,330 +1,329 @@
 # Edge Compute
 
-Use Telnyx Edge Compute when your AI workflow needs low-latency code execution, webhook handling, or an MCP/webhook endpoint that runs on Telnyx edge infrastructure.
+Use Telnyx Edge Compute for low-latency HTTP execution, webhook ingress, MCP servers, and small AI-adjacent transforms on Telnyx edge infrastructure.
 
-## Important scope boundary
+## Ownership and repository context
 
-`team-telnyx/ai` does **not** manage Edge Compute lifecycle directly.
+`team-telnyx/ai` is the orchestration and guidance layer. It does **not** implement the Edge Compute lifecycle. The dedicated surfaces are:
 
-This repo helps you discover where Edge Compute fits into an AI workflow, but the actual function lifecycle is owned by:
+- source examples and product documentation: [`team-telnyx/edge-compute`](https://github.com/team-telnyx/edge-compute)
+- installable lifecycle tool: `telnyx-edge`
+- AI workflow and handoff guidance: `team-telnyx/ai` and `telnyx-agent`
 
-- the `team-telnyx/edge-compute` repo
-- the `telnyx-edge` CLI
+Commands such as `ship`, `inspect`, `reset-func`, secrets, bindings, storage, revisions, rollback, and actors belong to `telnyx-edge`.
 
-That means:
-- build/deploy/delete/secrets/bindings live in `telnyx-edge`
-- agent/orchestration logic can live in `team-telnyx/ai`
-- `team-telnyx/ai` should not pretend to replace Edge Compute
-
-A useful mental model:
-- **`ai` = brain / orchestration layer**
-- **Edge Compute = low-latency hands / execution layer**
-
-## When to use Edge Compute with `ai`
-
-Good bridge use cases:
-
-1. **MCP server adapters at the edge**
-   - expose AI-adjacent tools close to the runtime
-2. **Webhook ingestion + AI routing**
-   - receive webhook traffic, normalize it, then hand off to AI logic
-3. **AI-adjacent functions**
-   - redaction, enrichment, scoring, post-processing, lightweight transforms
-
-## Quick Start
+The example paths in this guide, such as `examples/ts/mcp-server`, are paths **inside an `edge-compute` checkout**. They do not exist in a normal `team-telnyx/ai` checkout. Clone the source repository first, or use the repository-aware `telnyx-agent setup-edge-*` output.
 
 ```bash
-# Authenticate with the dedicated Edge CLI (preferred for agents)
-telnyx-edge auth api-key set <your-api-key>
+git clone --depth 1 https://github.com/team-telnyx/edge-compute.git
+# Source examples are under ./edge-compute/examples/
+```
 
-# Start from the MCP server example
-telnyx-edge new-func --from-dir=examples/ts/mcp-server --name=my-mcp-server
+## Prerequisites and readiness
+
+1. Download the latest CLI from the [Edge Compute releases page](https://github.com/team-telnyx/edge-compute/releases).
+2. Authenticate interactively or with an API key stored by the CLI.
+3. Run the root status diagnostic. Unlike `auth status`, this validates configuration, credentials, and API connectivity.
+
+```bash
+# Interactive OAuth
+telnyx-edge auth login
+
+# Or non-interactive auth; avoid putting the literal key in shell history
+export TELNYX_API_KEY='***'
+telnyx-edge auth api-key set "$TELNYX_API_KEY"
+
+# Local auth marker, then end-to-end validation
+telnyx-edge auth status
+telnyx-edge status
+```
+
+`telnyx-agent edge-doctor --json` reports readiness only when all three conditions hold: `telnyx-edge` is installed, `auth status` is positively recognized as authenticated, and root `telnyx-edge status` reports that all checks passed. It probes command help surfaces instead of inferring capabilities from a version number.
+
+```bash
+telnyx-agent edge-doctor --json
+```
+
+## Function names
+
+Names must be 1–64 characters, contain only alphanumeric characters and dashes, and have no leading or trailing dash. Examples: `my-mcp-server`, `webhook-v2`, `report7`.
+
+## Secure MCP server handoff
+
+The TypeScript MCP example requires two distinct secrets:
+
+- `TELNYX_API_KEY`: credential used by MCP tools for upstream Telnyx API calls
+- `SHARED_SECRET`: inbound bearer token required on MCP requests
+
+Do not use the Telnyx API key as the inbound endpoint bearer token. Do not commit either value. The example rejects MCP requests when `SHARED_SECRET` is absent.
+
+The helper emits `source_repo`, `source_path`, capability booleans, and an executable clone/build/secret/ship/inspect flow:
+
+```bash
+telnyx-agent setup-edge-mcp --name my-mcp-server --json
+```
+
+Equivalent manual flow:
+
+```bash
+export TELNYX_API_KEY='***'
+export SHARED_SECRET="$(openssl rand -hex 32)"
+
+EDGE_COMPUTE_SRC="$(mktemp -d)/edge-compute"
+git clone --depth 1 https://github.com/team-telnyx/edge-compute.git "$EDGE_COMPUTE_SRC"
+telnyx-edge new-func \
+  --from-dir="$EDGE_COMPUTE_SRC/examples/ts/mcp-server" \
+  --name=my-mcp-server
 cd my-mcp-server
 
-# Add required secrets and deploy
-telnyx-edge secrets add TELNYX_API_KEY <your-api-key>
+npm install
+npm run build
+telnyx-edge secrets add TELNYX_API_KEY "$TELNYX_API_KEY"
+telnyx-edge secrets add SHARED_SECRET "$SHARED_SECRET"
 telnyx-edge ship
+telnyx-edge inspect my-mcp-server
 ```
 
-Once deployed, use `team-telnyx/ai` for orchestration and capability discovery, and use the deployed Edge endpoint for execution.
+Configure the MCP client with the inspected invoke URL and the **shared secret**, not the Telnyx API key:
 
-## API Reference
+```json
+{
+  "mcpServers": {
+    "telnyx-edge": {
+      "url": "https://<your-edge-endpoint>/",
+      "headers": {
+        "Authorization": "Bearer <your-shared-secret>"
+      }
+    }
+  }
+}
+```
 
-Edge Compute lifecycle is owned by the separate `telnyx-edge` CLI rather than the `team-telnyx/ai` SDK surface.
-
-Common lifecycle commands:
+A correctly quoted smoke test looks like this (reuse the `SHARED_SECRET` exported above):
 
 ```bash
-telnyx-edge auth status
-telnyx-edge list
-telnyx-edge secrets list
-telnyx-edge bindings get
+EDGE_MCP_TOKEN="$SHARED_SECRET"
+curl -X POST "https://<your-edge-endpoint>/" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Authorization: Bearer $EDGE_MCP_TOKEN" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"smoke-test","version":"1.0.0"}}}'
 ```
 
-| Command | Purpose |
-|---------|---------|
-| `telnyx-edge auth api-key set` | Authenticate the Edge CLI non-interactively |
-| `telnyx-edge new-func` | Scaffold a new function or clone an example |
-| `telnyx-edge ship` | Deploy the current function |
-| `telnyx-edge list` | List deployed functions |
-| `telnyx-edge secrets` | Manage runtime secrets |
-| `telnyx-edge bindings` | Manage Telnyx API key bindings |
+Health-check endpoints remain unauthenticated for platform probes; MCP traffic requires the bearer token.
 
-## Prerequisites
+## Secure webhook handoff
 
-- Telnyx account
-- Access to the dedicated `telnyx-edge` CLI
-- A use case where AI workflows need a real deployed HTTP or MCP execution surface
+The JavaScript webhook example supports HMAC-SHA256 verification through `WEBHOOK_SECRET`. Production ingress should set it and configure the producer with the same key. Sign the exact request bytes and send `x-webhook-signature: sha256=<hex>`.
 
-## Prerequisite: install `telnyx-edge`
-
-Edge Compute is managed through the separate CLI:
-
-```sh
-# See the edge-compute repo for install/setup details
-# https://github.com/team-telnyx/edge-compute
-
-telnyx-edge auth api-key set <your-api-key>
-telnyx-edge auth status
+```bash
+telnyx-agent setup-edge-webhook --name my-webhook --json
 ```
 
-Typical lifecycle commands live there:
+Equivalent manual flow:
 
-```sh
-telnyx-edge new-func
+```bash
+export WEBHOOK_SECRET="$(openssl rand -hex 32)"
+
+EDGE_COMPUTE_SRC="$(mktemp -d)/edge-compute"
+git clone --depth 1 https://github.com/team-telnyx/edge-compute.git "$EDGE_COMPUTE_SRC"
+telnyx-edge new-func \
+  --from-dir="$EDGE_COMPUTE_SRC/examples/js/webhook-receiver" \
+  --name=my-webhook
+cd my-webhook
+
+telnyx-edge secrets add WEBHOOK_SECRET "$WEBHOOK_SECRET"
 telnyx-edge ship
-telnyx-edge list
-telnyx-edge delete-func
-telnyx-edge secrets
-telnyx-edge bindings
+telnyx-edge inspect my-webhook
 ```
 
-## Reference architecture
+Signed test request:
 
-A practical pattern looks like this:
+```bash
+PAYLOAD='{"event":"message.received","id":"evt_123"}'
+SIGNATURE="sha256=$(printf '%s' "$PAYLOAD" | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" | cut -d' ' -f2)"
 
-1. Use `team-telnyx/ai` for:
-   - agent workflows
-   - prompts/orchestration
-   - guides and capability discovery
-   - Telnyx API integrations
-2. Use `team-telnyx/edge-compute` for:
-   - function scaffolding
-   - deployment
-   - secrets and bindings
-   - running webhook/MCP edge endpoints
-3. Connect them with a stable boundary:
-   - HTTP webhook
-   - MCP endpoint
-   - function call into an edge-hosted adapter
-
-## Endgame: what a good integration looks like
-
-The end state is **not** "move Edge Compute into `team-telnyx/ai`".
-
-The better endgame is a clear two-layer product:
-
-### Layer 1 — `team-telnyx/ai`
-This layer should:
-- expose Edge Compute as a first-class capability in docs/manifests/help output
-- provide AI-oriented patterns and recipes
-- explain when an agent should reach for edge execution
-- help users connect agent workflows to deployed edge endpoints
-
-### Layer 2 — `team-telnyx/edge-compute`
-This layer should continue to own:
-- auth
-- function creation
-- deployment
-- secrets
-- bindings
-- runtime lifecycle and operational ergonomics
-
-### Bridge between them
-The bridge should be explicit and boring:
-- `ai` produces orchestration guidance
-- Edge Compute provides execution endpoints
-- the contract between them is HTTP, MCP, or a documented function interface
-
-That keeps ownership clear and avoids duplicating deployment tooling.
-
-## Phased rollout
-
-### Phase 1 — Discoverability (this repo, now)
-- add Edge Compute capability visibility
-- add guide-level handoff and examples
-- make the README and capabilities output honest about scope
-
-### Phase 2 — Guided integration
-- add richer examples for webhook handlers, MCP adapters, and AI post-processing functions
-- add copy-paste scaffolds for how an AI app should call a deployed edge endpoint
-- document required secrets/bindings patterns
-
-### Phase 3 — CLI bridge
-Only if ownership stays clear:
-- lightweight helper commands or docs-driven handoff from `telnyx-agent` to `telnyx-edge`
-- examples: `edge doctor`, `setup-edge-mcp`, or explicit "next command" guidance
-- these should shell out to `telnyx-edge`, not reimplement lifecycle management
-
-### Phase 4 — Deeper integration (optional, later)
-Only if a stable contract exists:
-- standardized templates
-- stronger config generation
-- possibly a shared library or interface contract
-
-Not before.
-
-## Example: AI app calling an Edge endpoint
-
-A simple pattern is to let your AI app call a deployed edge function for specialized execution.
-
-```python
-import os
-import requests
-
-response = requests.post(
-    "https://<your-edge-endpoint>",
-    headers={
-        "content-type": "application/json",
-        "authorization": f"Bearer {os.environ['TELNYX_API_KEY']}",
-    },
-    json={
-        "task": "redact_pii",
-        "payload": {
-            "text": "Call me at +1 555 123 4567",
-        },
-    },
-)
-
-print(response.json())
+curl -X POST "https://<your-edge-endpoint>/" \
+  -H "Content-Type: application/json" \
+  -H "x-webhook-signature: $SIGNATURE" \
+  -d "$PAYLOAD"
 ```
+
+Do not put `WEBHOOK_SECRET` in the request body or an Authorization header unless your own handler explicitly defines that separate protocol. Its purpose in this example is HMAC verification.
+
+## CLI lifecycle reference
+
+### Create, deploy, inspect, and recover
+
+```bash
+# New generated project
+telnyx-edge new-func --language=ts --name=my-function
+
+# Or copy a checked-out source directory into a new project
+telnyx-edge new-func --from-dir=/absolute/source/path --name=my-function
+
+cd my-function
+telnyx-edge ship
+telnyx-edge inspect my-function
+```
+
+`inspect <function>` is the per-function detail view: deployment status, invoke URL, timestamps, and actor bindings. Probe it with `telnyx-edge inspect --help` when supporting multiple CLI releases.
+
+A failed function can be reset to `created` without changing its identity, fixed, and shipped again:
+
+```bash
+telnyx-edge reset-func my-function
+telnyx-edge ship --from-dir=./my-function
+```
+
+`reset-func` applies to failed states, not healthy deployments. Teardown is asynchronous.
+
+### Revisions and rollback
+
+Every successful ship creates an immutable revision.
+
+```bash
+telnyx-edge revisions list my-function
+telnyx-edge rollback my-function <revision-id>
+```
+
+Rollback retargets traffic to a prior healthy revision without rebuilding or re-uploading it.
+
+### Secrets and Telnyx bindings
+
+```bash
+telnyx-edge secrets add NAME "$VALUE"
+telnyx-edge secrets list
+telnyx-edge secrets delete NAME
+
+telnyx-edge bindings create
+telnyx-edge bindings get
+telnyx-edge bindings validate
+telnyx-edge bindings update
+telnyx-edge bindings delete
+```
+
+Use secrets for confidential values. Telnyx bindings provide managed Telnyx API access without hardcoding credentials in function source.
+
+### Persistent KV storage
+
+```bash
+# Namespace lifecycle
+telnyx-edge storage kv create --name my-data
+telnyx-edge storage kv list
+telnyx-edge storage kv get <namespace-id>
+telnyx-edge storage kv delete <namespace-id>
+
+# Keys
+telnyx-edge storage kv key put <namespace-id> greeting "hello"
+telnyx-edge storage kv key put <namespace-id> blob --path ./data.bin
+telnyx-edge storage kv key get <namespace-id> greeting
+telnyx-edge storage kv key list <namespace-id> --prefix config/
+telnyx-edge storage kv key delete <namespace-id> greeting
+```
+
+Declare a runtime binding in `telnyx.toml` or supported classic project manifests, then regenerate TypeScript declarations:
+
+```toml
+[storage.kv.CACHE]
+id = "<namespace-uuid>"
+```
+
+```bash
+telnyx-edge types
+```
+
+`types` generates `telnyx-env.d.ts`; KV handles are typed as `KvNamespace`. Rerun it whenever binding declarations change.
+
+### Cloud Storage binding types (v0.2.4)
+
+CLI v0.2.4 added `[storage.cloudstorage.<name>]` manifest bindings and `CloudStorageBucket` output from `telnyx-edge types`. JavaScript/TypeScript scaffolds include the Cloud Storage dependencies.
+
+```toml
+[storage.cloudstorage.ARCHIVE]
+bucket_name = "my-archive"
+region = "us-east-1"
+```
+
+```bash
+npm install @telnyx/edge-runtime@^0.3.0 @aws-sdk/client-s3
+telnyx-edge types
+```
+
+The generated `env.ARCHIVE` is a typed `CloudStorageBucket`. This is a runtime binding/type-generation feature; it is distinct from the `storage kv` control-plane commands.
+
+## Stateful Actors
+
+Probe actor capabilities directly:
+
+```bash
+telnyx-edge new-func --help
+telnyx-edge actors --help
+telnyx-edge actors instances --help
+```
+
+Scaffold and inspect actors:
+
+```bash
+telnyx-edge new-func --actor --language=ts --name=my-actor
+
+telnyx-edge actors list
+telnyx-edge actors inspect <type>
+telnyx-edge actors instances <type>
+telnyx-edge inspect <function>
+```
+
+The two inspect commands answer different questions:
+
+- `inspect <function>` shows one function and its actor bindings.
+- `actors inspect <type>` shows one account-scoped actor type, attached functions, and a best-effort live instance count.
+
+### v0.2.5 actor-instance support and limitations
+
+v0.2.5 added `actors instances <type>` and the instance count in `actors inspect <type>`. The instance command is intentionally limited:
+
+- read-only metadata, never stored state values
+- type/instance IDs, state-key names, aggregate size, and timestamps only
+- first page only, up to 50 instances, ordered by newest activity; no CLI pagination flags yet
+- instances are created on first `idFromName(...)`
+- instances are actor identities, not pods, and therefore have no pod health status
+- an instance count may display as `unknown` when the best-effort state-store count cannot be loaded
+
+Do not treat `actors instances` as a database dump, state-value inspection API, health monitor, or complete inventory when the reported total exceeds the displayed rows.
+
+## Calling an application-protected Edge endpoint
+
+Authentication is defined by the deployed function. Use an endpoint-specific credential, not automatically a Telnyx management API key:
 
 ```typescript
-const response = await fetch("https://<your-edge-endpoint>", {
+const response = await fetch("https://<your-edge-endpoint>/", {
   method: "POST",
   headers: {
     "content-type": "application/json",
-    authorization: `Bearer ${process.env.TELNYX_API_KEY}`,
+    authorization: `Bearer ${process.env.EDGE_ENDPOINT_TOKEN}`,
   },
-  body: JSON.stringify({
-    task: "redact_pii",
-    payload: {
-      text: "Call me at +1 555 123 4567",
-    },
-  }),
+  body: JSON.stringify({ task: "redact_pii", payload: { text: "Call me at +1 555 123 4567" } }),
 });
 
-const result = await response.json();
-console.log(result);
+if (!response.ok) throw new Error(`Edge request failed: ${response.status}`);
+console.log(await response.json());
 ```
 
-## Example patterns worth supporting
+If the function does not implement authentication, an Authorization header does not make it secure. Add and verify bearer-token or signature logic in the function, and use HTTPS.
 
-### 1. MCP server at the edge
-Use Edge Compute to host a narrow MCP adapter close to runtime, while `team-telnyx/ai` handles the surrounding agent experience and capability discovery.
+## Practical end-to-end test
 
-### 2. Webhook receiver + AI router
-Use Edge Compute to receive inbound webhooks, normalize payloads, and forward structured requests into AI workflows.
-
-### 3. Post-processing function
-Use Edge Compute for deterministic transforms such as:
-- redaction
-- enrichment
-- scoring
-- transcript cleanup
-- lightweight policy checks
-
-These are the sweet spot: small execution units attached to larger agent workflows.
-
-## Fastest path to a real test
-
-If you want to test the end product quickly, do **one** of these first:
-
-### Option A — MCP server on Edge
-Best when you want an AI-native demo.
-
-```sh
-telnyx-edge new-func --from-dir=examples/ts/mcp-server --name=my-mcp-server
-cd my-mcp-server
-telnyx-edge secrets add TELNYX_API_KEY <your-api-key>
-telnyx-edge ship
-```
-
-Then point your MCP client or agent runtime at the deployed endpoint.
-
-### Option B — Webhook receiver on Edge
-Best when you want a simple integration seam.
-
-```sh
-telnyx-edge new-func --from-dir=examples/js/webhook-receiver --name=my-webhook
-cd my-webhook
-telnyx-edge ship
-```
-
-Then have your AI workflow call or route into that edge endpoint.
-
-### Option C — Post-processing function
-Best when you want a narrow but real AI-adjacent utility.
-
-Example use cases:
-- redact PII before storage
-- enrich messages before downstream routing
-- score or classify inbound events
-- clean transcripts before analysis
-
-You can also smoke-test a deployed edge endpoint directly:
-
-```bash
-curl -X POST "https://<your-edge-endpoint>" \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $TELNYX_API_KEY" \
-  -d '{
-    "task": "redact_pii",
-    "payload": {
-      "text": "Call me at +1 555 123 4567"
-    }
-  }'
-```
-
-## What this repo should and should not claim
-
-This repo **can**:
-- explain how Edge Compute fits into AI-agent workflows
-- provide examples and bridge guidance
-- point users to the right product surface
-
-This repo **should not** claim that it:
-- deploys edge functions directly
-- manages rollbacks or lifecycle state
-- replaces `telnyx-edge`
-- provides complete native Edge Compute support
-
-## Test recipe
-
-Here is the most practical end-to-end test loop:
-
-1. install `telnyx-edge` and authenticate with `telnyx-edge auth api-key set <your-api-key>`
-2. start from a working example in `team-telnyx/edge-compute`
-3. deploy it with `telnyx-edge ship`
-4. expose a stable HTTP or MCP boundary
-5. call that deployed endpoint from an AI workflow
-6. iterate on the boundary, not on duplicated deployment logic
-
-That gives you a real integration test without pretending `team-telnyx/ai` owns lifecycle management.
-
-## Best next step
-
-If you want to use Edge Compute from an AI workflow today:
-
-1. install `telnyx-edge` and authenticate with `telnyx-edge auth api-key set <your-api-key>`
-2. create/deploy your function in `team-telnyx/edge-compute`
-3. expose a stable HTTP or MCP boundary
-4. use `team-telnyx/ai` to orchestrate calls into that deployed endpoint
-
-For deploy/runtime specifics, use the `edge-compute` repo as the source of truth.
+1. Install and authenticate `telnyx-edge`.
+2. Require `telnyx-edge status` to pass.
+3. Clone `team-telnyx/edge-compute` and copy a real example with an explicit valid name.
+4. Install/build dependencies where required.
+5. Set runtime secrets without committing or logging values.
+6. Ship, then use `inspect` to obtain and verify deployment details.
+7. Exercise the endpoint with its application-level bearer token or HMAC signature.
+8. Connect the stable HTTP/MCP boundary to the AI orchestration layer.
 
 ## Source of truth
 
-- AI workflow/orchestration guidance: `team-telnyx/ai`
-- Edge lifecycle and deployment: `team-telnyx/edge-compute`
-- Runtime deploy tool: `telnyx-edge`
+- Edge docs: https://developers.telnyx.com/docs/edge-compute
+- Edge examples and releases: https://github.com/team-telnyx/edge-compute
+- AI orchestration guidance: https://github.com/team-telnyx/ai


### PR DESCRIPTION
## Summary
- make Edge auth/readiness detection conservative and validate root `telnyx-edge status`
- detect function inspect and v0.2.5 actor-instance support
- make MCP/webhook handoffs repository-aware, executable, and secure
- refresh the Edge guide for inspect, reset, revisions, rollback, KV/cloud storage, and Stateful Actors

## Verification
- `npx tsc --noEmit`
- `npx tsx --test tests/edge-handoff.test.ts` (11 passed)
- `npm test` (110 passed)