### PR TITLE
feat: Add number actions to agent CLI

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "tsx bin/telnyx-agent.ts",
-    "test": "tsx --test tests/edge-handoff.test.ts tests/integration.test.ts tests/setup-10dlc.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
+    "test": "tsx --test tests/edge-handoff.test.ts tests/integration.test.ts tests/numbers.test.ts tests/setup-10dlc.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
     "typecheck": "tsc --noEmit",
     "postinstall": "tsx scripts/postinstall.ts",
     "build": "npm run typecheck"

--- a/cli/src/commands/capabilities.ts
+++ b/cli/src/commands/capabilities.ts
@@ -104,6 +104,10 @@ const COMPOSITE_COMMANDS = [
   { name: "telnyx-agent call-dial", description: "Make an outbound call via Call Control (AMD, deepfake detection, recording optional)" },
   { name: "telnyx-agent call-control", description: "Call Control actions: answer, hangup, transfer, DTMF, recording, noise suppression, speak (TTS), bridge, refer, reject, gather, playback, transcription, forking, siprec, streaming, enqueue, send-sip-info, update-client-state, AI assistant lifecycle/messages/gather/join, Conversation Relay, supervisor roles" },
   { name: "telnyx-agent call-status", description: "Get the status of a call by call-control-id" },
+  { name: "telnyx-agent list-phone-numbers", description: "List account-owned phone numbers with core filters and pagination" },
+  { name: "telnyx-agent search-phone-numbers", description: "Search available phone numbers by country, type, features, location, or number pattern" },
+  { name: "telnyx-agent buy-phone-number", description: "Purchase one phone number and optionally assign its connection or messaging profile" },
+  { name: "telnyx-agent lookup-number", description: "Look up carrier or caller-name information for an E.164 phone number" },
 ];
 
 export async function capabilitiesCommand(flags: Record<string, string | boolean>): Promise<void> {

--- a/cli/src/commands/numbers.ts
+++ b/cli/src/commands/numbers.ts
@@ -1,0 +1,269 @@
+/**
+ * Direct phone-number actions backed by the Stainless-generated Go CLI.
+ *
+ * The list commands deliberately request `--format raw`: current Go CLI list
+ * commands stream multiple JSON documents in JSON mode, while raw mode returns
+ * the API's single `{ data, meta }` envelope.
+ */
+
+import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
+import { outputJson, printError, printSuccess } from "../utils/output.ts";
+
+type Flags = Record<string, string | boolean>;
+type JsonRecord = Record<string, unknown>;
+
+interface NumberListResult {
+  count: number;
+  phone_numbers: JsonRecord[];
+  meta: JsonRecord;
+}
+
+interface BuyNumberResult {
+  order_id: string;
+  status: string;
+  phone_number: string;
+}
+
+interface LookupNumberResult {
+  phone_number: string;
+  country_code: unknown;
+  national_format: unknown;
+  carrier: unknown;
+  caller_name: unknown;
+}
+
+export async function listPhoneNumbersCommand(flags: Flags): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const args = ["phone-numbers", "list"];
+
+  addMappedFlag(args, flags, "phone-number", "--filter.phone-number");
+  addMappedFlag(args, flags, "status", "--filter.status");
+  addMappedFlag(args, flags, "country", "--filter.country-iso-alpha2");
+  addMappedFlag(args, flags, "connection-id", "--filter.connection-id");
+  addMappedFlag(args, flags, "tag", "--filter.tag");
+  addMappedFlag(args, flags, "source", "--filter.source");
+  addMappedFlag(args, flags, "billing-group-id", "--filter.billing-group-id");
+  addMappedFlag(args, flags, "customer-reference", "--filter.customer-reference");
+
+  const numberType = stringFlag(flags, "number-type");
+  if (numberType) {
+    // The current Go CLI models this filter as map[string]any, not a scalar.
+    args.push("--filter.number-type", JSON.stringify({ eq: numberType }));
+  }
+
+  addIntegerFlag(args, flags, "page-number", "--page-number", jsonOutput);
+  addIntegerFlag(args, flags, "page-size", "--page-size", jsonOutput);
+  addMappedFlag(args, flags, "sort", "--sort");
+
+  try {
+    const response = await telnyxCli(args, { format: "raw" });
+    presentNumberList("Owned phone numbers", normalizeNumberList(response), jsonOutput);
+  } catch (err) {
+    fail(errorMsg(err), jsonOutput);
+  }
+}
+
+export async function searchPhoneNumbersCommand(flags: Flags): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const country = stringFlag(flags, "country") ?? "US";
+  const args = ["available-phone-numbers", "list", "--filter.country-code", country];
+
+  addMappedFlag(args, flags, "type", "--filter.phone-number-type");
+  addMappedFlag(args, flags, "locality", "--filter.locality");
+  addMappedFlag(args, flags, "administrative-area", "--filter.administrative-area");
+
+  const areaCode = stringFlag(flags, "area-code");
+  const nationalDestinationCode = stringFlag(flags, "national-destination-code");
+  if (areaCode && nationalDestinationCode && areaCode !== nationalDestinationCode) {
+    fail("--area-code and --national-destination-code cannot specify different values", jsonOutput);
+  }
+  const destinationCode = nationalDestinationCode ?? areaCode;
+  if (destinationCode) {
+    args.push("--filter.national-destination-code", destinationCode);
+  }
+
+  const features = stringFlag(flags, "features");
+  if (features) {
+    const values = features.split(",").map((value) => value.trim()).filter(Boolean);
+    if (values.length === 0) fail("--features must contain at least one feature", jsonOutput);
+    // Current Go CLI type: InnerFlag[[]string]. It expects an array value.
+    args.push("--filter.features", JSON.stringify(values));
+  }
+
+  const pattern: JsonRecord = {};
+  const contains = stringFlag(flags, "contains");
+  const startsWith = stringFlag(flags, "starts-with");
+  const endsWith = stringFlag(flags, "ends-with");
+  if (contains) pattern.contains = contains;
+  if (startsWith) pattern.starts_with = startsWith;
+  if (endsWith) pattern.ends_with = endsWith;
+  if (Object.keys(pattern).length > 0) {
+    // Current Go CLI type: InnerFlag[map[string]any].
+    args.push("--filter.phone-number", JSON.stringify(pattern));
+  }
+
+  addIntegerFlag(args, flags, "limit", "--filter.limit", jsonOutput);
+
+  try {
+    const response = await telnyxCli(args, { format: "raw" });
+    presentNumberList("Available phone numbers", normalizeNumberList(response), jsonOutput);
+  } catch (err) {
+    fail(errorMsg(err), jsonOutput);
+  }
+}
+
+export async function buyPhoneNumberCommand(flags: Flags): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const phoneNumber = stringFlag(flags, "phone-number");
+  if (!phoneNumber) fail("--phone-number is required (E.164 format, e.g., +131****0000)", jsonOutput);
+
+  // Current Go CLI type: Flag[[]map[string]any]. A scalar --phone-number is
+  // invalid; the generated inner field must be used for a single-number order.
+  const args = ["number-orders", "create", "--phone-number.phone-number", phoneNumber];
+  addMappedFlag(args, flags, "connection-id", "--connection-id");
+  addMappedFlag(args, flags, "messaging-profile-id", "--messaging-profile-id");
+  addMappedFlag(args, flags, "billing-group-id", "--billing-group-id");
+  addMappedFlag(args, flags, "customer-reference", "--customer-reference");
+  addMappedFlag(args, flags, "bundle-id", "--phone-number.bundle-id");
+  addMappedFlag(args, flags, "requirement-group-id", "--phone-number.requirement-group-id");
+
+  try {
+    const response = await telnyxCli(args, { timeout: 120_000 });
+    const data = asRecord(asRecord(response).data ?? response);
+    const result: BuyNumberResult = {
+      order_id: stringValue(data.id),
+      status: stringValue(data.status),
+      phone_number: phoneNumber,
+    };
+
+    if (jsonOutput) {
+      outputJson(result);
+    } else {
+      printSuccess("Phone number order created!", {
+        "Phone Number": result.phone_number,
+        "Order ID": result.order_id || "(not returned)",
+        Status: result.status || "(not returned)",
+      });
+    }
+  } catch (err) {
+    fail(errorMsg(err), jsonOutput);
+  }
+}
+
+export async function lookupNumberCommand(flags: Flags): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const phoneNumber = stringFlag(flags, "phone-number");
+  const lookupType = stringFlag(flags, "type");
+  if (!phoneNumber) fail("--phone-number is required (E.164 format, e.g., +131****0000)", jsonOutput);
+  if (lookupType && lookupType !== "carrier" && lookupType !== "caller-name") {
+    fail('--type must be "carrier" or "caller-name"', jsonOutput);
+  }
+
+  const args = ["number-lookup", "retrieve", "--phone-number", phoneNumber];
+  if (lookupType) args.push("--type", lookupType);
+
+  try {
+    const response = await telnyxCli(args);
+    const data = asRecord(asRecord(response).data ?? response);
+    const result: LookupNumberResult = {
+      phone_number: stringValue(data.phone_number) || phoneNumber,
+      country_code: data.country_code ?? null,
+      national_format: data.national_format ?? null,
+      carrier: data.carrier ?? null,
+      caller_name: data.caller_name ?? null,
+    };
+
+    if (jsonOutput) {
+      outputJson(result);
+    } else {
+      const carrier = asRecord(result.carrier);
+      const callerName = asRecord(result.caller_name);
+      printSuccess("Number lookup complete!", {
+        "Phone Number": result.phone_number,
+        Country: stringValue(result.country_code) || "(not returned)",
+        "National Format": stringValue(result.national_format) || "(not returned)",
+        Carrier: stringValue(carrier.name) || "(not returned)",
+        "Line Type": stringValue(carrier.type) || "(not returned)",
+        "Caller Name": stringValue(callerName.caller_name) || "(not returned)",
+      });
+    }
+  } catch (err) {
+    fail(errorMsg(err), jsonOutput);
+  }
+}
+
+function normalizeNumberList(response: unknown): NumberListResult {
+  const envelope = asRecord(response);
+  const data = Array.isArray(envelope.data)
+    ? envelope.data.filter((item): item is JsonRecord => Boolean(item) && typeof item === "object" && !Array.isArray(item))
+    : [];
+  return {
+    count: data.length,
+    phone_numbers: data,
+    meta: asRecord(envelope.meta),
+  };
+}
+
+function presentNumberList(title: string, result: NumberListResult, jsonOutput: boolean): void {
+  if (jsonOutput) {
+    outputJson(result);
+    return;
+  }
+
+  printSuccess(`${title} retrieved!`, { Count: result.count });
+  for (const number of result.phone_numbers) {
+    const phoneNumber = stringValue(number.phone_number) || "(unknown)";
+    const details = [number.status, number.phone_number_type, number.locality]
+      .map(stringValue)
+      .filter(Boolean)
+      .join(" · ");
+    console.log(`  • ${phoneNumber}${details ? ` — ${details}` : ""}`);
+  }
+  if (result.count === 0) console.log("  (no phone numbers returned)");
+  console.log();
+}
+
+function addMappedFlag(args: string[], flags: Flags, source: string, target: string): void {
+  const value = stringFlag(flags, source);
+  if (value !== undefined) args.push(target, value);
+}
+
+function addIntegerFlag(
+  args: string[],
+  flags: Flags,
+  source: string,
+  target: string,
+  jsonOutput: boolean,
+): void {
+  const value = stringFlag(flags, source);
+  if (value === undefined) return;
+  if (!/^\d+$/.test(value) || Number(value) < 1) {
+    fail(`--${source} must be a positive integer`, jsonOutput);
+  }
+  args.push(target, value);
+}
+
+function stringFlag(flags: Flags, key: string): string | undefined {
+  const value = flags[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function asRecord(value: unknown): JsonRecord {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as JsonRecord : {};
+}
+
+function stringValue(value: unknown): string {
+  return value === undefined || value === null ? "" : String(value);
+}
+
+function fail(message: string, jsonOutput: boolean): never {
+  if (jsonOutput) outputJson({ error: message });
+  else printError(message);
+  process.exit(1);
+}
+
+function errorMsg(err: unknown): string {
+  if (err instanceof TelnyxCLIError) return err.stderr || err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/cli/src/commands/numbers.ts
+++ b/cli/src/commands/numbers.ts
@@ -155,12 +155,11 @@ export async function lookupNumberCommand(flags: Flags): Promise<void> {
   const phoneNumber = stringFlag(flags, "phone-number");
   const lookupType = stringFlag(flags, "type");
   if (!phoneNumber) fail("--phone-number is required (E.164 format, e.g., +131****0000)", jsonOutput);
-  if (lookupType && lookupType !== "carrier" && lookupType !== "caller-name") {
-    fail('--type must be "carrier" or "caller-name"', jsonOutput);
+  if (lookupType !== "carrier" && lookupType !== "caller-name") {
+    fail('--type is required and must be "carrier" or "caller-name"', jsonOutput);
   }
 
-  const args = ["number-lookup", "retrieve", "--phone-number", phoneNumber];
-  if (lookupType) args.push("--type", lookupType);
+  const args = ["number-lookup", "retrieve", "--phone-number", phoneNumber, "--type", lookupType];
 
   try {
     const response = await telnyxCli(args);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -32,6 +32,12 @@ import { callControlCommand } from "./commands/call-control.ts";
 import { callStatusCommand } from "./commands/call-status.ts";
 import { sttCommand } from "./commands/stt.ts";
 import { sttProvidersCommand } from "./commands/stt-providers.ts";
+import {
+  buyPhoneNumberCommand,
+  listPhoneNumbersCommand,
+  lookupNumberCommand,
+  searchPhoneNumbersCommand,
+} from "./commands/numbers.ts";
 import { parseFlags } from "./utils/output.ts";
 
 const HELP = `
@@ -71,6 +77,10 @@ Commands:
   call-status       Get the status of a call by call-control-id
   stt               Transcribe audio to text (speech-to-text)
   stt-providers     List available speech-to-text providers
+  list-phone-numbers List phone numbers owned by the account
+  search-phone-numbers Search available phone numbers to purchase
+  buy-phone-number  Purchase/order one phone number
+  lookup-number     Look up carrier and caller-name information
 
 Global Flags:
   --json            Output structured JSON instead of human-readable text
@@ -229,6 +239,33 @@ STT-providers Flags:
   --provider        Filter providers by name (optional)
   --service-type    Filter providers by service type (optional)
 
+Numbers Action Flags:
+  --phone-number    Phone number filter, number to buy, or E.164 number to look up
+  --country         ISO alpha-2 country code (list, search; search default: US)
+  --status          Owned-number status filter (list-phone-numbers)
+  --connection-id   Connection filter (list) or connection assignment (buy)
+  --tag             Tag filter (list-phone-numbers)
+  --source          Source filter: ported or purchased (list-phone-numbers)
+  --number-type     Number type equality filter (list-phone-numbers)
+  --page-number     Result page (list-phone-numbers)
+  --page-size       Results per page (list-phone-numbers)
+  --sort            Owned-number sort order (list-phone-numbers)
+  --type            local|toll_free|national|mobile (search); carrier|caller-name (lookup)
+  --features        Comma-separated features, e.g. sms,voice,mms (search-phone-numbers)
+  --limit           Maximum search results (search-phone-numbers)
+  --area-code       Area/national destination code (search-phone-numbers)
+  --national-destination-code Exact alias for --area-code (search-phone-numbers)
+  --locality        City/locality filter (search-phone-numbers)
+  --administrative-area State/province filter (search-phone-numbers)
+  --contains        Number pattern that must occur (search-phone-numbers)
+  --starts-with     Number pattern prefix (search-phone-numbers)
+  --ends-with       Number pattern suffix (search-phone-numbers)
+  --messaging-profile-id Messaging profile assignment (buy-phone-number)
+  --billing-group-id Billing group filter (list) or assignment (buy)
+  --customer-reference Customer reference filter (list) or value (buy)
+  --bundle-id       Bundle for the ordered number (buy-phone-number)
+  --requirement-group-id Requirement group for the ordered number (buy-phone-number)
+
 Environment:
   TELNYX_API_KEY    API key (or configure ~/.config/telnyx/config.json)
 
@@ -304,6 +341,10 @@ Examples:
   telnyx-agent stt --audio-url https://example.com/audio.mp3 --model openai/whisper-large-v3-turbo --language es --json
   telnyx-agent stt-providers --json
   telnyx-agent stt-providers --provider telnyx --service-type transcription --json
+  telnyx-agent list-phone-numbers --status active --page-size 50 --json
+  telnyx-agent search-phone-numbers --country US --area-code 312 --features sms,voice --limit 5 --json
+  telnyx-agent buy-phone-number --phone-number +131****0000 --messaging-profile-id <id> --json
+  telnyx-agent lookup-number --phone-number +131****0000 --type carrier --json
 `;
 
 const COMMANDS: Record<string, (flags: Record<string, string | boolean>) => Promise<void>> = {
@@ -337,6 +378,10 @@ const COMMANDS: Record<string, (flags: Record<string, string | boolean>) => Prom
   "call-status": callStatusCommand,
   stt: sttCommand,
   "stt-providers": sttProvidersCommand,
+  "list-phone-numbers": listPhoneNumbersCommand,
+  "search-phone-numbers": searchPhoneNumbersCommand,
+  "buy-phone-number": buyPhoneNumberCommand,
+  "lookup-number": lookupNumberCommand,
 };
 
 export async function run(argv: string[]): Promise<void> {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -250,7 +250,7 @@ Numbers Action Flags:
   --page-number     Result page (list-phone-numbers)
   --page-size       Results per page (list-phone-numbers)
   --sort            Owned-number sort order (list-phone-numbers)
-  --type            local|toll_free|national|mobile (search); carrier|caller-name (lookup)
+  --type            local|toll_free|national|mobile (search); carrier|caller-name (lookup, required)
   --features        Comma-separated features, e.g. sms,voice,mms (search-phone-numbers)
   --limit           Maximum search results (search-phone-numbers)
   --area-code       Area/national destination code (search-phone-numbers)
@@ -345,6 +345,7 @@ Examples:
   telnyx-agent search-phone-numbers --country US --area-code 312 --features sms,voice --limit 5 --json
   telnyx-agent buy-phone-number --phone-number +131****0000 --messaging-profile-id <id> --json
   telnyx-agent lookup-number --phone-number +131****0000 --type carrier --json
+  telnyx-agent lookup-number --phone-number +131****0000 --type caller-name --json
 `;
 
 const COMMANDS: Record<string, (flags: Record<string, string | boolean>) => Promise<void>> = {

--- a/cli/tests/numbers.test.ts
+++ b/cli/tests/numbers.test.ts
@@ -67,7 +67,7 @@ if (args[0] === "phone-numbers" && args[1] === "list") {
 }
 
 function runAgent(args: string[], env: NodeJS.ProcessEnv = process.env): string {
-  return execFileSync("npx", ["tsx", cliBin, ...args], {
+  return execFileSync(process.execPath, ["--import", "tsx", cliBin, ...args], {
     cwd: cliRoot,
     encoding: "utf8",
     env,
@@ -215,6 +215,29 @@ describe("Numbers action commands", () => {
     assertFlag(args, "--format", "json");
   });
 
+  it("rejects a lookup without --type before invoking telnyx", () => {
+    const fake = setupFakeTelnyx();
+
+    assert.throws(() => runAgent([
+      "lookup-number",
+      "--phone-number", "+131****0000",
+      "--json",
+    ], fake.env));
+    assert.deepEqual(loggedArgs(fake.logPath), []);
+  });
+
+  it("rejects an unsupported lookup --type before invoking telnyx", () => {
+    const fake = setupFakeTelnyx();
+
+    assert.throws(() => runAgent([
+      "lookup-number",
+      "--phone-number", "+131****0000",
+      "--type", "formatting",
+      "--json",
+    ], fake.env));
+    assert.deepEqual(loggedArgs(fake.logPath), []);
+  });
+
   it("advertises all four commands in help and capabilities", () => {
     const help = runAgent(["help"]);
     const capabilities = JSON.parse(runAgent(["capabilities", "--json"]));
@@ -226,5 +249,8 @@ describe("Numbers action commands", () => {
         `capabilities should advertise ${command}`,
       );
     }
+    assert.match(help, /carrier\|caller-name \(lookup, required\)/);
+    assert.match(help, /lookup-number .* --type carrier --json/);
+    assert.match(help, /lookup-number .* --type caller-name --json/);
   });
 });

--- a/cli/tests/numbers.test.ts
+++ b/cli/tests/numbers.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Mock-binary coverage for the direct Numbers action surface.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliRoot = join(__dirname, "..");
+const cliBin = join(cliRoot, "bin", "telnyx-agent.ts");
+
+function setupFakeTelnyx(): { logPath: string; env: NodeJS.ProcessEnv } {
+  const tempDir = mkdtempSync(join(tmpdir(), "telnyx-agent-numbers-"));
+  const binDir = join(tempDir, "bin");
+  const logPath = join(tempDir, "args.jsonl");
+  mkdirSync(binDir, { recursive: true });
+
+  const fakeTelnyx = join(binDir, "telnyx");
+  writeFileSync(
+    fakeTelnyx,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.TELNYX_FAKE_ARGS_LOG, JSON.stringify(args) + "\\n");
+function flag(name) { const index = args.indexOf(name); return index >= 0 ? args[index + 1] : undefined; }
+
+if (args[0] === "phone-numbers" && args[1] === "list") {
+  console.log(JSON.stringify({
+    data: [{ id: "pn-1", phone_number: "+131****0000", status: "active", phone_number_type: "local" }],
+    meta: { page_number: 2, page_size: 25, total_results: 1 }
+  }));
+} else if (args[0] === "available-phone-numbers" && args[1] === "list") {
+  console.log(JSON.stringify({
+    data: [{ phone_number: "+131****0001", phone_number_type: "local", locality: "Chicago" }],
+    meta: { total_results: 1 }
+  }));
+} else if (args[0] === "number-orders" && args[1] === "create") {
+  console.log(JSON.stringify({ data: { id: "order-1", status: "pending", phone_numbers_count: 1 } }));
+} else if (args[0] === "number-lookup" && args[1] === "retrieve") {
+  console.log(JSON.stringify({ data: {
+    phone_number: flag("--phone-number"),
+    country_code: "US",
+    national_format: "(312) 555-0000",
+    carrier: { name: "Example Mobile", type: "mobile" },
+    caller_name: { caller_name: "EXAMPLE" }
+  } }));
+} else {
+  console.error("unexpected fake telnyx invocation: " + args.join(" "));
+  process.exit(2);
+}
+`,
+  );
+  chmodSync(fakeTelnyx, 0o755);
+
+  return {
+    logPath,
+    env: {
+      ...process.env,
+      TELNYX_CLI_PATH: fakeTelnyx,
+      TELNYX_FAKE_ARGS_LOG: logPath,
+    },
+  };
+}
+
+function runAgent(args: string[], env: NodeJS.ProcessEnv = process.env): string {
+  return execFileSync("npx", ["tsx", cliBin, ...args], {
+    cwd: cliRoot,
+    encoding: "utf8",
+    env,
+    timeout: 30_000,
+  });
+}
+
+function loggedArgs(logPath: string): string[][] {
+  if (!existsSync(logPath)) return [];
+  const contents = readFileSync(logPath, "utf8");
+  assert.ok(contents.endsWith("\n"), "fake binary should terminate each JSON record with one newline");
+  assert.ok(!contents.endsWith("\n\n"), "fake binary should not write a blank JSONL record");
+  return contents.trimEnd().split("\n").map((line) => JSON.parse(line) as string[]);
+}
+
+function assertFlag(args: string[], flag: string, value: string): void {
+  const index = args.indexOf(flag);
+  assert.notEqual(index, -1, `expected ${flag} in ${args.join(" ")}`);
+  assert.equal(args[index + 1], value);
+}
+
+describe("Numbers action commands", () => {
+  it("lists owned numbers with current phone-numbers list filter and pagination flags", () => {
+    const fake = setupFakeTelnyx();
+    const output = runAgent([
+      "list-phone-numbers",
+      "--phone-number", "312555",
+      "--status", "active",
+      "--country", "US",
+      "--connection-id", "conn-1",
+      "--tag", "support",
+      "--source", "purchased",
+      "--number-type", "local",
+      "--page-number", "2",
+      "--page-size", "25",
+      "--json",
+    ], fake.env);
+
+    const result = JSON.parse(output);
+    assert.equal(result.count, 1);
+    assert.equal(result.phone_numbers[0].id, "pn-1");
+    assert.equal(result.meta.total_results, 1);
+
+    const [args] = loggedArgs(fake.logPath);
+    assert.deepEqual(args.slice(0, 2), ["phone-numbers", "list"]);
+    assertFlag(args, "--filter.phone-number", "312555");
+    assertFlag(args, "--filter.status", "active");
+    assertFlag(args, "--filter.country-iso-alpha2", "US");
+    assertFlag(args, "--filter.connection-id", "conn-1");
+    assertFlag(args, "--filter.tag", "support");
+    assertFlag(args, "--filter.source", "purchased");
+    assertFlag(args, "--filter.number-type", JSON.stringify({ eq: "local" }));
+    assertFlag(args, "--page-number", "2");
+    assertFlag(args, "--page-size", "25");
+    assertFlag(args, "--format", "raw");
+  });
+
+  it("searches available numbers with current nested filter flags and array/map values", () => {
+    const fake = setupFakeTelnyx();
+    const output = runAgent([
+      "search-phone-numbers",
+      "--country", "US",
+      "--type", "local",
+      "--features", "sms,voice",
+      "--area-code", "312",
+      "--locality", "Chicago",
+      "--administrative-area", "IL",
+      "--contains", "555",
+      "--starts-with", "312",
+      "--limit", "5",
+      "--json",
+    ], fake.env);
+
+    const result = JSON.parse(output);
+    assert.equal(result.count, 1);
+    assert.equal(result.phone_numbers[0].phone_number, "+131****0001");
+
+    const [args] = loggedArgs(fake.logPath);
+    assert.deepEqual(args.slice(0, 2), ["available-phone-numbers", "list"]);
+    assertFlag(args, "--filter.country-code", "US");
+    assertFlag(args, "--filter.phone-number-type", "local");
+    assertFlag(args, "--filter.features", JSON.stringify(["sms", "voice"]));
+    assertFlag(args, "--filter.national-destination-code", "312");
+    assertFlag(args, "--filter.locality", "Chicago");
+    assertFlag(args, "--filter.administrative-area", "IL");
+    assertFlag(args, "--filter.phone-number", JSON.stringify({ contains: "555", starts_with: "312" }));
+    assertFlag(args, "--filter.limit", "5");
+    assertFlag(args, "--format", "raw");
+  });
+
+  it("orders one number through number-orders create using generated inner flags", () => {
+    const fake = setupFakeTelnyx();
+    const output = runAgent([
+      "buy-phone-number",
+      "--phone-number", "+131****0001",
+      "--connection-id", "conn-1",
+      "--messaging-profile-id", "mp-1",
+      "--billing-group-id", "bg-1",
+      "--customer-reference", "agent-order",
+      "--bundle-id", "bundle-1",
+      "--requirement-group-id", "requirements-1",
+      "--json",
+    ], fake.env);
+
+    assert.deepEqual(JSON.parse(output), {
+      order_id: "order-1",
+      status: "pending",
+      phone_number: "+131****0001",
+    });
+
+    const [args] = loggedArgs(fake.logPath);
+    assert.deepEqual(args.slice(0, 2), ["number-orders", "create"]);
+    assertFlag(args, "--phone-number.phone-number", "+131****0001");
+    assert.ok(!args.includes("--phone-number"), "a scalar --phone-number is invalid for number-orders create");
+    assertFlag(args, "--connection-id", "conn-1");
+    assertFlag(args, "--messaging-profile-id", "mp-1");
+    assertFlag(args, "--billing-group-id", "bg-1");
+    assertFlag(args, "--customer-reference", "agent-order");
+    assertFlag(args, "--phone-number.bundle-id", "bundle-1");
+    assertFlag(args, "--phone-number.requirement-group-id", "requirements-1");
+    assertFlag(args, "--format", "json");
+  });
+
+  it("looks up a number through number-lookup retrieve and normalizes JSON", () => {
+    const fake = setupFakeTelnyx();
+    const output = runAgent([
+      "lookup-number",
+      "--phone-number", "+131****0000",
+      "--type", "carrier",
+      "--json",
+    ], fake.env);
+
+    assert.deepEqual(JSON.parse(output), {
+      phone_number: "+131****0000",
+      country_code: "US",
+      national_format: "(312) 555-0000",
+      carrier: { name: "Example Mobile", type: "mobile" },
+      caller_name: { caller_name: "EXAMPLE" },
+    });
+
+    const [args] = loggedArgs(fake.logPath);
+    assert.deepEqual(args.slice(0, 2), ["number-lookup", "retrieve"]);
+    assertFlag(args, "--phone-number", "+131****0000");
+    assertFlag(args, "--type", "carrier");
+    assertFlag(args, "--format", "json");
+  });
+
+  it("advertises all four commands in help and capabilities", () => {
+    const help = runAgent(["help"]);
+    const capabilities = JSON.parse(runAgent(["capabilities", "--json"]));
+
+    for (const command of ["list-phone-numbers", "search-phone-numbers", "buy-phone-number", "lookup-number"]) {
+      assert.match(help, new RegExp(command));
+      assert.ok(
+        capabilities.composite_commands.some((entry: { name: string }) => entry.name === `telnyx-agent ${command}`),
+        `capabilities should advertise ${command}`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add direct wrappers for owned-number listing, available-number search, ordering, and lookup
- use current generated Go CLI flag names and raw list envelopes
- add stable JSON outputs, help/capabilities entries, and mock-binary tests

## Verification
- `npm run typecheck`
- `npm test` (115 passed)