### PR TITLE
feat: Add fax sending to agent CLI

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "tsx bin/telnyx-agent.ts",
-    "test": "tsx --test tests/edge-handoff.test.ts tests/integration.test.ts tests/numbers.test.ts tests/setup-10dlc.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
+    "test": "tsx --test tests/edge-handoff.test.ts tests/fax.test.ts tests/integration.test.ts tests/numbers.test.ts tests/setup-10dlc.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
     "typecheck": "tsc --noEmit",
     "postinstall": "tsx scripts/postinstall.ts",
     "build": "npm run typecheck"

--- a/cli/src/commands/capabilities.ts
+++ b/cli/src/commands/capabilities.ts
@@ -77,6 +77,7 @@ const CAPABILITIES: Record<string, Capability[]> = {
 const COMPOSITE_COMMANDS = [
   { name: "telnyx-agent setup-sms", description: "Zero to SMS: creates messaging profile, buys number, assigns it" },
   { name: "telnyx-agent send-sms", description: "Send an SMS or MMS message (pass --media-url to send MMS)" },
+  { name: "telnyx-agent fax-send", description: "Send a fax using a fax application connection and a media URL or uploaded media name" },
   { name: "telnyx-agent send-group-mms", description: "Send a group MMS to multiple recipients (--to comma-separated E.164 numbers)" },
   { name: "telnyx-agent schedule-sms", description: "Schedule an SMS for future delivery at a given ISO 8601 time" },
   { name: "telnyx-agent sms-status", description: "Check SMS delivery status, or cancel a scheduled message with --cancel" },

--- a/cli/src/commands/fax-send.ts
+++ b/cli/src/commands/fax-send.ts
@@ -30,6 +30,13 @@ const OPTIONAL_FLAGS = [
   "t38-enabled",
 ] as const;
 
+const BOOLEAN_FLAGS = new Set([
+  "monochrome",
+  "store-media",
+  "store-preview",
+  "t38-enabled",
+]);
+
 export async function faxSendCommand(flags: Record<string, string | boolean>): Promise<void> {
   const jsonOutput = flags.json === true;
   const connectionId = flags["connection-id"] as string | undefined;
@@ -52,6 +59,10 @@ export async function faxSendCommand(flags: Record<string, string | boolean>): P
     printError("--media-url and --media-name cannot be used together");
     process.exit(1);
   }
+  if (flags["media-name"] && flags["store-media"]) {
+    printError("--media-name and --store-media cannot be used together");
+    process.exit(1);
+  }
 
   const args: string[] = [
     "faxes", "create",
@@ -63,7 +74,11 @@ export async function faxSendCommand(flags: Record<string, string | boolean>): P
   for (const flag of OPTIONAL_FLAGS) {
     const value = flags[flag];
     if (typeof value === "string") {
-      args.push(`--${flag}`, value);
+      if (BOOLEAN_FLAGS.has(flag)) {
+        args.push(`--${flag}=${value}`);
+      } else {
+        args.push(`--${flag}`, value);
+      }
     } else if (value === true) {
       args.push(`--${flag}`);
     }

--- a/cli/src/commands/fax-send.ts
+++ b/cli/src/commands/fax-send.ts
@@ -1,0 +1,108 @@
+/**
+ * telnyx-agent fax-send — Send a fax.
+ *
+ * Direct wrapper over the Go telnyx CLI `faxes create` subcommand.
+ */
+
+import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
+import { printSuccess, printError, outputJson } from "../utils/output.ts";
+
+interface FaxSendResult {
+  fax_id: string;
+  status: string;
+  connection_id: string;
+  from: string;
+  to: string;
+}
+
+const OPTIONAL_FLAGS = [
+  "media-url",
+  "media-name",
+  "webhook-url",
+  "client-state",
+  "from-display-name",
+  "quality",
+  "monochrome",
+  "black-threshold",
+  "store-media",
+  "store-preview",
+  "preview-format",
+  "t38-enabled",
+] as const;
+
+export async function faxSendCommand(flags: Record<string, string | boolean>): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const connectionId = flags["connection-id"] as string | undefined;
+  const from = flags.from as string | undefined;
+  const to = flags.to as string | undefined;
+
+  if (!connectionId) {
+    printError("--connection-id is required");
+    process.exit(1);
+  }
+  if (!from) {
+    printError("--from is required (E.164 format, e.g., +131****0000)");
+    process.exit(1);
+  }
+  if (!to) {
+    printError("--to is required (E.164 format or SIP URI)");
+    process.exit(1);
+  }
+  if (flags["media-url"] && flags["media-name"]) {
+    printError("--media-url and --media-name cannot be used together");
+    process.exit(1);
+  }
+
+  const args: string[] = [
+    "faxes", "create",
+    "--connection-id", connectionId,
+    "--from", from,
+    "--to", to,
+  ];
+
+  for (const flag of OPTIONAL_FLAGS) {
+    const value = flags[flag];
+    if (typeof value === "string") {
+      args.push(`--${flag}`, value);
+    } else if (value === true) {
+      args.push(`--${flag}`);
+    }
+  }
+
+  try {
+    const res = await telnyxCli(args);
+    const data = (res?.data ?? res ?? {}) as Record<string, unknown>;
+    const result: FaxSendResult = {
+      fax_id: String(data.id ?? data.fax_id ?? ""),
+      status: String(data.status ?? "queued"),
+      connection_id: connectionId,
+      from,
+      to,
+    };
+
+    if (jsonOutput) {
+      outputJson(result);
+    } else {
+      printSuccess("Fax queued!", {
+        "Fax ID": result.fax_id,
+        Status: result.status,
+        "Connection ID": connectionId,
+        From: from,
+        To: to,
+      });
+    }
+  } catch (err) {
+    if (jsonOutput) {
+      outputJson({ error: errorMsg(err) });
+    } else {
+      printError(errorMsg(err));
+    }
+    process.exit(1);
+  }
+}
+
+function errorMsg(err: unknown): string {
+  if (err instanceof TelnyxCLIError) return err.stderr || err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -24,6 +24,7 @@ import { setupWhatsappCommand } from "./commands/setup-whatsapp.ts";
 import { whatsappSendCommand } from "./commands/whatsapp-send.ts";
 import { whatsappTemplatesCommand } from "./commands/whatsapp-templates.ts";
 import { sendSmsCommand } from "./commands/send-sms.ts";
+import { faxSendCommand } from "./commands/fax-send.ts";
 import { sendGroupMmsCommand } from "./commands/send-group-mms.ts";
 import { scheduleSmsCommand } from "./commands/schedule-sms.ts";
 import { smsStatusCommand } from "./commands/sms-status.ts";
@@ -69,6 +70,7 @@ Commands:
   whatsapp-send     Send a WhatsApp message (text or template)
   whatsapp-templates List or create WhatsApp message templates
   send-sms          Send an SMS or MMS message (--media-url sends MMS)
+  fax-send          Send a fax from a URL or uploaded media file
   send-group-mms    Send a group MMS to multiple recipients (--to comma-separated)
   schedule-sms      Schedule an SMS for future delivery (--send-at ISO 8601)
   sms-status        Check SMS delivery status, or cancel a scheduled message (--cancel)
@@ -157,6 +159,23 @@ SMS Action Flags:
   --send-at <iso8601>    Send time, ISO 8601 (schedule-sms — required, e.g., 2024-12-31T00:00:00Z)
   --id <message-id>      Message ID (sms-status — required)
   --cancel               Cancel a scheduled message instead of retrieving status (sms-status)
+
+Fax Action Flags:
+  --connection-id <id>   Fax application connection ID (fax-send, required)
+  --from <e164>          Sender number, E.164 (fax-send, required)
+  --to <e164|sip-uri>    Destination number or SIP URI (fax-send, required)
+  --media-url <url>      Public URL of the fax document (fax-send; exclusive with --media-name)
+  --media-name <name>    Previously uploaded Telnyx media name (fax-send; exclusive with --media-url)
+  --webhook-url <url>    Override webhook URL for this fax (fax-send)
+  --client-state <base64> Base64 state included in subsequent webhooks (fax-send)
+  --from-display-name <name> Caller ID display name (fax-send)
+  --quality <quality>    normal|high|very_high|ultra_light|ultra_dark (fax-send)
+  --monochrome           Enable monochrome fax output (fax-send)
+  --black-threshold <n> Black threshold percentage when monochrome is enabled (fax-send)
+  --store-media          Store fax media on a temporary URL (fax-send)
+  --store-preview        Store a fax preview on a temporary URL (fax-send)
+  --preview-format <fmt> Preview format: pdf|tiff (fax-send)
+  --t38-enabled <bool>   Enable or disable T.38 (fax-send)
 
 WhatsApp Flags:
   --waba-id <id>    WhatsApp Business Account id (setup-whatsapp, whatsapp-templates)
@@ -299,6 +318,7 @@ Examples:
   telnyx-agent whatsapp-templates --waba-id <id> --create --name promo --category MARKETING --component '[]'
   telnyx-agent send-sms --from +131****0000 --to +131****0001 --text "Hello!"
   telnyx-agent send-sms --from +131****0000 --to +131****0001 --text "See this" --media-url https://example.com/img.png --subject "Photo"
+  telnyx-agent fax-send --connection-id <id> --from +131****0000 --to +131****0001 --media-url https://example.com/document.pdf
   telnyx-agent send-group-mms --from +131****0000 --to +131****0001,+131****0002,+131****0003 --text "Group hi!"
   telnyx-agent send-group-mms --from +131****0000 --to +131****0001,+131****0002 --media-url https://example.com/cat.png
   telnyx-agent schedule-sms --from +131****0000 --to +131****0001 --text "Later" --send-at 2024-12-31T00:00:00Z
@@ -371,6 +391,7 @@ const COMMANDS: Record<string, (flags: Record<string, string | boolean>) => Prom
   "whatsapp-send": whatsappSendCommand,
   "whatsapp-templates": whatsappTemplatesCommand,
   "send-sms": sendSmsCommand,
+  "fax-send": faxSendCommand,
   "send-group-mms": sendGroupMmsCommand,
   "schedule-sms": scheduleSmsCommand,
   "sms-status": smsStatusCommand,

--- a/cli/tests/fax.test.ts
+++ b/cli/tests/fax.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Canonical mock-binary tests for telnyx-agent fax-send.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliRoot = join(__dirname, "..");
+const cliBin = join(cliRoot, "bin", "telnyx-agent.ts");
+
+function setupFakeTelnyx(): { logPath: string; env: NodeJS.ProcessEnv } {
+  const tempDir = mkdtempSync(join(tmpdir(), "telnyx-agent-fax-"));
+  const binDir = join(tempDir, "bin");
+  const logPath = join(tempDir, "args.jsonl");
+  mkdirSync(binDir, { recursive: true });
+
+  const fakeTelnyx = join(binDir, "telnyx");
+  writeFileSync(
+    fakeTelnyx,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.TELNYX_FAKE_ARGS_LOG, JSON.stringify(args) + "\\n");
+
+const command = args.slice(0, -2);
+if (command[0] === "faxes" && command[1] === "create") {
+  console.log(JSON.stringify({
+    data: {
+      id: "fax-123",
+      record_type: "fax",
+      status: "queued",
+      connection_id: "response-connection",
+      from: "+19999999999",
+      to: "+18888888888",
+      media_url: "https://api.example.test/temporary-document.pdf",
+      created_at: "2026-07-20T00:00:00Z"
+    }
+  }));
+} else {
+  console.error("unexpected command: " + command.join(" "));
+  process.exit(2);
+}
+`,
+  );
+  chmodSync(fakeTelnyx, 0o755);
+
+  return {
+    logPath,
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH}`,
+      TELNYX_CLI_PATH: fakeTelnyx,
+      TELNYX_FAKE_ARGS_LOG: logPath,
+      TELNYX_API_KEY: "KEY_fake_test",
+    },
+  };
+}
+
+function runCli(args: string[], env: NodeJS.ProcessEnv = process.env): string {
+  return execFileSync("npx", ["tsx", cliBin, ...args], {
+    cwd: cliRoot,
+    encoding: "utf8",
+    env,
+    timeout: 30000,
+  });
+}
+
+function readLoggedArgs(logPath: string): string[][] {
+  if (!existsSync(logPath)) return [];
+  return readFileSync(logPath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function expectFailure(args: string[], env: NodeJS.ProcessEnv, expected: RegExp): void {
+  try {
+    runCli(args, env);
+    assert.fail("expected fax-send to exit non-zero");
+  } catch (err: any) {
+    assert.notEqual(err?.status, 0);
+    assert.match(`${err?.stderr ?? ""}${err?.stdout ?? ""}`, expected);
+  }
+}
+
+describe("fax-send command", () => {
+  it("is a direct faxes create wrapper with stable JSON output", () => {
+    const fake = setupFakeTelnyx();
+    const output = runCli(
+      [
+        "fax-send",
+        "--connection-id", "conn-123",
+        "--from", "+131****0000",
+        "--to", "+131****0001",
+        "--media-url", "https://example.com/document.pdf",
+        "--json",
+      ],
+      fake.env,
+    );
+
+    assert.deepEqual(JSON.parse(output), {
+      fax_id: "fax-123",
+      status: "queued",
+      connection_id: "conn-123",
+      from: "+131****0000",
+      to: "+131****0001",
+    });
+    assert.deepEqual(readLoggedArgs(fake.logPath), [[
+      "faxes", "create",
+      "--connection-id", "conn-123",
+      "--from", "+131****0000",
+      "--to", "+131****0001",
+      "--media-url", "https://example.com/document.pdf",
+      "--format", "json",
+    ]]);
+  });
+
+  it("passes useful faxes create options through unchanged", () => {
+    const fake = setupFakeTelnyx();
+    runCli(
+      [
+        "fax-send",
+        "--connection-id", "conn-123",
+        "--from", "+131****0000",
+        "--to", "sip:fax@example.com",
+        "--media-name", "uploaded-document.pdf",
+        "--webhook-url", "https://example.com/fax-events",
+        "--client-state", "c3RhdGU=",
+        "--from-display-name", "Example Fax",
+        "--quality", "ultra_dark",
+        "--monochrome",
+        "--black-threshold", "90",
+        "--store-media",
+        "--store-preview",
+        "--preview-format", "pdf",
+        "--t38-enabled", "false",
+        "--json",
+      ],
+      fake.env,
+    );
+
+    assert.deepEqual(readLoggedArgs(fake.logPath)[0], [
+      "faxes", "create",
+      "--connection-id", "conn-123",
+      "--from", "+131****0000",
+      "--to", "sip:fax@example.com",
+      "--media-name", "uploaded-document.pdf",
+      "--webhook-url", "https://example.com/fax-events",
+      "--client-state", "c3RhdGU=",
+      "--from-display-name", "Example Fax",
+      "--quality", "ultra_dark",
+      "--monochrome",
+      "--black-threshold", "90",
+      "--store-media",
+      "--store-preview",
+      "--preview-format", "pdf",
+      "--t38-enabled", "false",
+      "--format", "json",
+    ]);
+  });
+
+  for (const requiredFlag of ["connection-id", "from", "to"]) {
+    it(`requires --${requiredFlag} before invoking telnyx`, () => {
+      const fake = setupFakeTelnyx();
+      const args = [
+        "fax-send",
+        "--connection-id", "conn-123",
+        "--from", "+131****0000",
+        "--to", "+131****0001",
+        "--media-url", "https://example.com/document.pdf",
+        "--json",
+      ];
+      const flagIndex = args.indexOf(`--${requiredFlag}`);
+      args.splice(flagIndex, 2);
+
+      expectFailure(args, fake.env, new RegExp(`--${requiredFlag} is required`));
+      assert.deepEqual(readLoggedArgs(fake.logPath), []);
+    });
+  }
+
+  it("rejects media-url and media-name together before invoking telnyx", () => {
+    const fake = setupFakeTelnyx();
+    expectFailure(
+      [
+        "fax-send",
+        "--connection-id", "conn-123",
+        "--from", "+131****0000",
+        "--to", "+131****0001",
+        "--media-url", "https://example.com/document.pdf",
+        "--media-name", "uploaded-document.pdf",
+        "--json",
+      ],
+      fake.env,
+      /--media-url and --media-name cannot be used together/,
+    );
+    assert.deepEqual(readLoggedArgs(fake.logPath), []);
+  });
+
+  it("is wired into help and capabilities", () => {
+    const help = runCli(["help"]);
+    assert.match(help, /fax-send\s+Send a fax/);
+    assert.match(help, /Fax Action Flags:/);
+    assert.match(help, /--connection-id <id>/);
+
+    const capabilities = JSON.parse(runCli(["capabilities", "--json"]));
+    const faxCapability = capabilities.api_capabilities["📠 Fax"][0];
+    assert.ok(faxCapability.actions.includes("send_fax"));
+    assert.ok(
+      capabilities.composite_commands.some((command: { name: string }) => command.name === "telnyx-agent fax-send"),
+      "capabilities should advertise the executable fax-send command",
+    );
+  });
+});

--- a/cli/tests/fax.test.ts
+++ b/cli/tests/fax.test.ts
@@ -134,12 +134,8 @@ describe("fax-send command", () => {
         "--client-state", "c3RhdGU=",
         "--from-display-name", "Example Fax",
         "--quality", "ultra_dark",
-        "--monochrome",
         "--black-threshold", "90",
-        "--store-media",
-        "--store-preview",
         "--preview-format", "pdf",
-        "--t38-enabled", "false",
         "--json",
       ],
       fake.env,
@@ -155,12 +151,72 @@ describe("fax-send command", () => {
       "--client-state", "c3RhdGU=",
       "--from-display-name", "Example Fax",
       "--quality", "ultra_dark",
-      "--monochrome",
       "--black-threshold", "90",
+      "--preview-format", "pdf",
+      "--format", "json",
+    ]);
+  });
+
+  it("forwards explicit false values for every fax boolean in equals form", () => {
+    const fake = setupFakeTelnyx();
+    runCli(
+      [
+        "fax-send",
+        "--connection-id", "conn-123",
+        "--from", "+131****0000",
+        "--to", "+131****0001",
+        "--media-url", "https://example.com/document.pdf",
+        "--monochrome", "false",
+        "--store-media", "false",
+        "--store-preview", "false",
+        "--t38-enabled", "false",
+        "--json",
+      ],
+      fake.env,
+    );
+
+    assert.deepEqual(readLoggedArgs(fake.logPath)[0], [
+      "faxes", "create",
+      "--connection-id", "conn-123",
+      "--from", "+131****0000",
+      "--to", "+131****0001",
+      "--media-url", "https://example.com/document.pdf",
+      "--monochrome=false",
+      "--store-media=false",
+      "--store-preview=false",
+      "--t38-enabled=false",
+      "--format", "json",
+    ]);
+  });
+
+  it("preserves bare true fax booleans", () => {
+    const fake = setupFakeTelnyx();
+    runCli(
+      [
+        "fax-send",
+        "--connection-id", "conn-123",
+        "--from", "+131****0000",
+        "--to", "+131****0001",
+        "--media-url", "https://example.com/document.pdf",
+        "--monochrome",
+        "--store-media",
+        "--store-preview",
+        "--t38-enabled",
+        "--json",
+      ],
+      fake.env,
+    );
+
+    assert.deepEqual(readLoggedArgs(fake.logPath)[0], [
+      "faxes", "create",
+      "--connection-id", "conn-123",
+      "--from", "+131****0000",
+      "--to", "+131****0001",
+      "--media-url", "https://example.com/document.pdf",
+      "--monochrome",
       "--store-media",
       "--store-preview",
-      "--preview-format", "pdf",
-      "--t38-enabled", "false",
+      "--t38-enabled",
       "--format", "json",
     ]);
   });
@@ -198,6 +254,24 @@ describe("fax-send command", () => {
       ],
       fake.env,
       /--media-url and --media-name cannot be used together/,
+    );
+    assert.deepEqual(readLoggedArgs(fake.logPath), []);
+  });
+
+  it("rejects media-name and store-media together before invoking telnyx", () => {
+    const fake = setupFakeTelnyx();
+    expectFailure(
+      [
+        "fax-send",
+        "--connection-id", "conn-123",
+        "--from", "+131****0000",
+        "--to", "+131****0001",
+        "--media-name", "uploaded-document.pdf",
+        "--store-media",
+        "--json",
+      ],
+      fake.env,
+      /--media-name and --store-media cannot be used together/,
     );
     assert.deepEqual(readLoggedArgs(fake.logPath), []);
   });


### PR DESCRIPTION
## Summary
- add `fax-send` over `faxes create`
- validate required fields and forward current media/webhook/quality/storage/T.38 flags
- add stable JSON output, help/capabilities wiring, and mock-binary tests

## Verification
- `npm run typecheck`
- `npm test` (117 passed)