### PR TITLE
feat: Add AI inference actions to agent CLI

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "tsx bin/telnyx-agent.ts",
-    "test": "tsx --test tests/edge-handoff.test.ts tests/fax.test.ts tests/integration.test.ts tests/numbers.test.ts tests/setup-10dlc.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
+    "test": "tsx --test tests/ai.test.ts tests/edge-handoff.test.ts tests/fax.test.ts tests/integration.test.ts tests/numbers.test.ts tests/setup-10dlc.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
     "typecheck": "tsc --noEmit",
     "postinstall": "tsx scripts/postinstall.ts",
     "build": "npm run typecheck"

--- a/cli/src/commands/ai-chat.ts
+++ b/cli/src/commands/ai-chat.ts
@@ -1,0 +1,141 @@
+/**
+ * telnyx-agent ai-chat — OpenAI-compatible chat completion inference.
+ *
+ * This is a thin wrapper around `telnyx ai:openai:chat create-completion`.
+ * Complex values are intentionally forwarded as JSON strings so the generated
+ * Go CLI remains the source of truth for request parsing and validation.
+ */
+
+import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
+import { printSuccess, printError, outputJson } from "../utils/output.ts";
+
+const VALUE_FLAGS = [
+  "api-key-ref",
+  "best-of",
+  "frequency-penalty",
+  "guided-choice",
+  "guided-json",
+  "guided-regex",
+  "length-penalty",
+  "max-tokens",
+  "min-p",
+  "model",
+  "n",
+  "presence-penalty",
+  "response-format",
+  "seed",
+  "stop",
+  "temperature",
+  "tool",
+  "tool-choice",
+  "top-logprobs",
+  "top-p",
+] as const;
+
+const BOOLEAN_FLAGS = [
+  "early-stopping",
+  "enable-thinking",
+  "logprobs",
+  "stream",
+  "use-beam-search",
+] as const;
+
+export async function aiChatCommand(flags: Record<string, string | boolean>): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const message = flags.message;
+
+  if (typeof message !== "string" || !message) {
+    fail("--message is required as a JSON object (for example: '{\"role\":\"user\",\"content\":\"Hello\"}')", jsonOutput);
+  }
+
+  const args: string[] = [
+    "ai:openai:chat",
+    "create-completion",
+    "--message",
+    message,
+  ];
+
+  forwardValueFlags(args, flags, VALUE_FLAGS);
+  forwardBooleanFlags(args, flags, BOOLEAN_FLAGS);
+
+  try {
+    const response = await telnyxCli(args);
+
+    if (jsonOutput) {
+      // Preserve the complete OpenAI-compatible response, including tool calls,
+      // log probabilities, and usage fields that callers may depend on.
+      outputJson(response);
+      return;
+    }
+
+    const result = asObject(response);
+    const choices = Array.isArray(result.choices) ? result.choices : [];
+    const firstChoice = asObject(choices[0]);
+    const firstMessage = asObject(firstChoice.message);
+    const content = typeof firstMessage.content === "string" ? firstMessage.content : "";
+    const model = typeof result.model === "string"
+      ? result.model
+      : typeof flags.model === "string"
+        ? flags.model
+        : "(default)";
+
+    printSuccess("AI chat completion created!", {
+      Model: model,
+      Choices: choices.length,
+      Response: content || "(no text content returned)",
+    });
+  } catch (err) {
+    fail(errorMsg(err), jsonOutput);
+  }
+}
+
+function forwardValueFlags(
+  args: string[],
+  flags: Record<string, string | boolean>,
+  names: readonly string[],
+): void {
+  for (const name of names) {
+    const value = flags[name];
+    if (typeof value === "string" && value !== "") {
+      args.push(`--${name}`, value);
+    }
+  }
+}
+
+function forwardBooleanFlags(
+  args: string[],
+  flags: Record<string, string | boolean>,
+  names: readonly string[],
+): void {
+  for (const name of names) {
+    const value = flags[name];
+    if (value === true || value === "true") {
+      args.push(`--${name}`);
+    } else if (value === "false") {
+      // urfave boolean flags require the explicit false value in --flag=false
+      // form; a separate `false` argv entry is treated as an extra argument.
+      args.push(`--${name}=false`);
+    }
+  }
+}
+
+function asObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function fail(message: string, jsonOutput: boolean): never {
+  if (jsonOutput) {
+    outputJson({ error: message });
+  } else {
+    printError(message);
+  }
+  process.exit(1);
+}
+
+function errorMsg(err: unknown): string {
+  if (err instanceof TelnyxCLIError) return err.stderr || err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/cli/src/commands/ai-chat.ts
+++ b/cli/src/commands/ai-chat.ts
@@ -36,24 +36,23 @@ const BOOLEAN_FLAGS = [
   "early-stopping",
   "enable-thinking",
   "logprobs",
-  "stream",
   "use-beam-search",
 ] as const;
 
-export async function aiChatCommand(flags: Record<string, string | boolean>): Promise<void> {
+export async function aiChatCommand(
+  flags: Record<string, string | boolean>,
+  occurrences: Record<string, Array<string | boolean>> = {},
+): Promise<void> {
   const jsonOutput = flags.json === true;
-  const message = flags.message;
+  const messageValues = occurrences.message ?? (flags.message === undefined ? [] : [flags.message]);
 
-  if (typeof message !== "string" || !message) {
-    fail("--message is required as a JSON object (for example: '{\"role\":\"user\",\"content\":\"Hello\"}')", jsonOutput);
+  if (flags.stream === true || flags.stream === "true") {
+    fail("Streaming is not supported by ai-chat yet; omit --stream to request a JSON completion", jsonOutput);
   }
 
-  const args: string[] = [
-    "ai:openai:chat",
-    "create-completion",
-    "--message",
-    message,
-  ];
+  const messages = expandMessages(messageValues, jsonOutput);
+  const args: string[] = ["ai:openai:chat", "create-completion"];
+  for (const message of messages) args.push("--message", message);
 
   forwardValueFlags(args, flags, VALUE_FLAGS);
   forwardBooleanFlags(args, flags, BOOLEAN_FLAGS);
@@ -87,6 +86,36 @@ export async function aiChatCommand(flags: Record<string, string | boolean>): Pr
   } catch (err) {
     fail(errorMsg(err), jsonOutput);
   }
+}
+
+function expandMessages(values: Array<string | boolean>, jsonOutput: boolean): string[] {
+  if (values.length === 0) {
+    fail("--message is required as a JSON object (for example: '{\"role\":\"user\",\"content\":\"Hello\"}')", jsonOutput);
+  }
+
+  const messages: string[] = [];
+  for (const value of values) {
+    if (typeof value !== "string" || value === "") {
+      fail("--message requires a JSON object or an array of JSON objects", jsonOutput);
+    }
+
+    if (!value.trimStart().startsWith("[")) {
+      messages.push(value);
+      continue;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      fail("--message array must be valid JSON", jsonOutput);
+    }
+    if (!Array.isArray(parsed) || parsed.length === 0 || parsed.some((item) => !item || typeof item !== "object" || Array.isArray(item))) {
+      fail("--message array must contain at least one JSON object", jsonOutput);
+    }
+    messages.push(...parsed.map((item) => JSON.stringify(item)));
+  }
+  return messages;
 }
 
 function forwardValueFlags(

--- a/cli/src/commands/ai-embed.ts
+++ b/cli/src/commands/ai-embed.ts
@@ -1,0 +1,87 @@
+/**
+ * telnyx-agent ai-embed — OpenAI-compatible embedding inference.
+ *
+ * This is a thin wrapper around
+ * `telnyx ai:openai:embeddings create-embeddings`. The --input value is passed
+ * through unchanged: it may be plain text or a JSON array of strings.
+ */
+
+import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
+import { printSuccess, printError, outputJson } from "../utils/output.ts";
+
+const VALUE_FLAGS = ["dimensions", "encoding-format", "user"] as const;
+
+export async function aiEmbedCommand(flags: Record<string, string | boolean>): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const input = flags.input;
+  const model = flags.model;
+
+  if (typeof input !== "string" || !input) {
+    fail("--input is required (plain text or a JSON array of strings)", jsonOutput);
+  }
+  if (typeof model !== "string" || !model) {
+    fail("--model is required (use the Telnyx embedding model ID)", jsonOutput);
+  }
+
+  const args: string[] = [
+    "ai:openai:embeddings",
+    "create-embeddings",
+    "--input",
+    input,
+    "--model",
+    model,
+  ];
+
+  for (const name of VALUE_FLAGS) {
+    const value = flags[name];
+    if (typeof value === "string" && value !== "") {
+      args.push(`--${name}`, value);
+    }
+  }
+
+  try {
+    const response = await telnyxCli(args);
+
+    if (jsonOutput) {
+      // Do not unwrap `data`: in the OpenAI Embeddings response it is the
+      // actual array of embedding objects, not a Telnyx envelope.
+      outputJson(response);
+      return;
+    }
+
+    const result = asObject(response);
+    const embeddings = Array.isArray(result.data) ? result.data : [];
+    const first = asObject(embeddings[0]);
+    const firstVector = Array.isArray(first.embedding) ? first.embedding : [];
+    const responseModel = typeof result.model === "string" ? result.model : model;
+
+    printSuccess("Embeddings created!", {
+      Model: responseModel,
+      Embeddings: embeddings.length,
+      Dimensions: firstVector.length,
+    });
+  } catch (err) {
+    fail(errorMsg(err), jsonOutput);
+  }
+}
+
+function asObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function fail(message: string, jsonOutput: boolean): never {
+  if (jsonOutput) {
+    outputJson({ error: message });
+  } else {
+    printError(message);
+  }
+  process.exit(1);
+}
+
+function errorMsg(err: unknown): string {
+  if (err instanceof TelnyxCLIError) return err.stderr || err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/cli/src/commands/capabilities.ts
+++ b/cli/src/commands/capabilities.ts
@@ -21,8 +21,8 @@ const CAPABILITIES: Record<string, Capability[]> = {
     { name: "Phone Numbers", description: "Search, buy, and manage phone numbers", actions: ["list_phone_numbers", "search_phone_numbers", "buy_phone_number"] },
   ],
   "🤖 AI": [
-    { name: "Chat Completions", description: "LLM inference via Telnyx AI", actions: ["ai_chat"] },
-    { name: "Embeddings", description: "Generate text embeddings", actions: ["ai_embed"] },
+    { name: "Chat Completions", description: "LLM inference via Telnyx AI (executable with telnyx-agent ai-chat)", actions: ["ai_chat"] },
+    { name: "Embeddings", description: "Generate text embeddings (executable with telnyx-agent ai-embed)", actions: ["ai_embed"] },
     { name: "Assistants", description: "Create and manage AI voice assistants", actions: ["list_ai_assistants", "create_ai_assistant"] },
   ],
   "🔊 Text-to-Speech": [
@@ -84,6 +84,8 @@ const COMPOSITE_COMMANDS = [
   { name: "telnyx-agent setup-voice", description: "Zero to voice: creates SIP connection, buys number, assigns it" },
   { name: "telnyx-agent setup-iot", description: "Zero to IoT: lists SIMs, creates group, activates SIM" },
   { name: "telnyx-agent setup-ai", description: "Zero to AI assistant: creates assistant, buys number, wires them together" },
+  { name: "telnyx-agent ai-chat", description: "Create an OpenAI-compatible chat completion via Telnyx AI inference" },
+  { name: "telnyx-agent ai-embed", description: "Create OpenAI-compatible embeddings for text or a JSON array of texts" },
   { name: "telnyx-agent setup-wireguard", description: "Zero to VPN: creates network, WireGuard interface, peer — outputs ready-to-use WG config" },
   { name: "telnyx-edge ship", description: "Deploy an Edge Compute function with the dedicated telnyx-edge CLI (referenced by the Edge Compute guide)" },
   { name: "telnyx-agent edge-doctor", description: "Validate Edge Compute handoff prerequisites and point to the next concrete telnyx-edge steps" },

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -39,6 +39,8 @@ import {
   lookupNumberCommand,
   searchPhoneNumbersCommand,
 } from "./commands/numbers.ts";
+import { aiChatCommand } from "./commands/ai-chat.ts";
+import { aiEmbedCommand } from "./commands/ai-embed.ts";
 import { parseFlags } from "./utils/output.ts";
 
 const HELP = `
@@ -83,6 +85,8 @@ Commands:
   search-phone-numbers Search available phone numbers to purchase
   buy-phone-number  Purchase/order one phone number
   lookup-number     Look up carrier and caller-name information
+  ai-chat           Create an OpenAI-compatible chat completion
+  ai-embed          Create OpenAI-compatible text embeddings
 
 Global Flags:
   --json            Output structured JSON instead of human-readable text
@@ -285,6 +289,27 @@ Numbers Action Flags:
   --bundle-id       Bundle for the ordered number (buy-phone-number)
   --requirement-group-id Requirement group for the ordered number (buy-phone-number)
 
+AI Chat Flags:
+  --message <json>  Chat message JSON object (required; role: system|user|assistant|tool)
+  --model           Language model ID (optional; Go CLI default is Meta-Llama-3.1-8B-Instruct)
+  --max-tokens      Maximum completion tokens
+  --temperature     Sampling temperature
+  --top-p           Nucleus sampling probability
+  --stop <json>     Stop string or JSON array, passed through to the Go CLI
+  --response-format <json> OpenAI response-format object, passed through as JSON
+  --guided-choice   Constrain output to one exact choice
+  --guided-json <json> JSON schema for constrained output
+  --tool <json>     OpenAI-compatible tool object
+  --tool-choice     Tool selection: none, auto, or required
+  --stream          Request a streaming completion
+
+AI Embed Flags:
+  --input <value>   Text or JSON array of strings to embed (required)
+  --model <id>      Embedding model ID (required)
+  --dimensions      Requested embedding dimensions (model support varies)
+  --encoding-format Embedding encoding format (Go CLI default: float)
+  --user            End-user identifier for monitoring and abuse detection
+
 Environment:
   TELNYX_API_KEY    API key (or configure ~/.config/telnyx/config.json)
 
@@ -366,6 +391,10 @@ Examples:
   telnyx-agent buy-phone-number --phone-number +131****0000 --messaging-profile-id <id> --json
   telnyx-agent lookup-number --phone-number +131****0000 --type carrier --json
   telnyx-agent lookup-number --phone-number +131****0000 --type caller-name --json
+  telnyx-agent ai-chat --message '{"role":"user","content":"Hello"}' --json
+  telnyx-agent ai-chat --message '{"role":"user","content":"Return JSON"}' --response-format '{"type":"json_object"}' --json
+  telnyx-agent ai-embed --model thenlper/gte-large --input "Hello world" --json
+  telnyx-agent ai-embed --model thenlper/gte-large --input '["one","two"]' --dimensions 256 --json
 `;
 
 const COMMANDS: Record<string, (flags: Record<string, string | boolean>) => Promise<void>> = {
@@ -404,6 +433,8 @@ const COMMANDS: Record<string, (flags: Record<string, string | boolean>) => Prom
   "search-phone-numbers": searchPhoneNumbersCommand,
   "buy-phone-number": buyPhoneNumberCommand,
   "lookup-number": lookupNumberCommand,
+  "ai-chat": aiChatCommand,
+  "ai-embed": aiEmbedCommand,
 };
 
 export async function run(argv: string[]): Promise<void> {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -290,7 +290,7 @@ Numbers Action Flags:
   --requirement-group-id Requirement group for the ordered number (buy-phone-number)
 
 AI Chat Flags:
-  --message <json>  Chat message JSON object (required; role: system|user|assistant|tool)
+  --message <json>  Chat message JSON object (repeatable), or an array of message objects (required)
   --model           Language model ID (optional; Go CLI default is Meta-Llama-3.1-8B-Instruct)
   --max-tokens      Maximum completion tokens
   --temperature     Sampling temperature
@@ -301,7 +301,6 @@ AI Chat Flags:
   --guided-json <json> JSON schema for constrained output
   --tool <json>     OpenAI-compatible tool object
   --tool-choice     Tool selection: none, auto, or required
-  --stream          Request a streaming completion
 
 AI Embed Flags:
   --input <value>   Text or JSON array of strings to embed (required)
@@ -397,7 +396,10 @@ Examples:
   telnyx-agent ai-embed --model thenlper/gte-large --input '["one","two"]' --dimensions 256 --json
 `;
 
-const COMMANDS: Record<string, (flags: Record<string, string | boolean>) => Promise<void>> = {
+const COMMANDS: Record<string, (
+  flags: Record<string, string | boolean>,
+  occurrences?: Record<string, Array<string | boolean>>,
+) => Promise<void>> = {
   "setup-sms": setupSmsCommand,
   "setup-voice": setupVoiceCommand,
   "setup-iot": setupIotCommand,
@@ -438,7 +440,7 @@ const COMMANDS: Record<string, (flags: Record<string, string | boolean>) => Prom
 };
 
 export async function run(argv: string[]): Promise<void> {
-  const { command, flags } = parseFlags(argv);
+  const { command, flags, occurrences } = parseFlags(argv);
 
   if (command === "help" || command === "--help" || command === "-h" || !command) {
     console.log(HELP);
@@ -452,5 +454,5 @@ export async function run(argv: string[]): Promise<void> {
     process.exit(1);
   }
 
-  await handler(flags);
+  await handler(flags, occurrences);
 }

--- a/cli/src/utils/output.ts
+++ b/cli/src/utils/output.ts
@@ -67,9 +67,14 @@ function isSensitiveKey(key: string): boolean {
   return /(^|_)(password|passphrase|secret|token|api_key)$/i.test(key) || /^sipPassword$/i.test(key);
 }
 
-export function parseFlags(args: string[]): { command: string; flags: Record<string, string | boolean> } {
+export function parseFlags(args: string[]): {
+  command: string;
+  flags: Record<string, string | boolean>;
+  occurrences: Record<string, Array<string | boolean>>;
+} {
   const command = args[0] ?? "help";
   const flags: Record<string, string | boolean> = {};
+  const occurrences: Record<string, Array<string | boolean>> = Object.create(null);
 
   for (let i = 1; i < args.length; i++) {
     const arg = args[i];
@@ -78,12 +83,14 @@ export function parseFlags(args: string[]): { command: string; flags: Record<str
       const next = args[i + 1];
       if (next && !next.startsWith("--")) {
         flags[key] = next;
+        (occurrences[key] ??= []).push(next);
         i++;
       } else {
         flags[key] = true;
+        (occurrences[key] ??= []).push(true);
       }
     }
   }
 
-  return { command, flags };
+  return { command, flags, occurrences };
 }

--- a/cli/tests/ai.test.ts
+++ b/cli/tests/ai.test.ts
@@ -76,7 +76,7 @@ function readLoggedArgs(logPath: string): string[][] {
 
 function runCli(args: string[], env: NodeJS.ProcessEnv = process.env): { stdout: string; stderr: string; status: number } {
   try {
-    const stdout = execFileSync("npx", ["tsx", cliBin, ...args], {
+    const stdout = execFileSync(process.execPath, ["--import", "tsx", cliBin, ...args], {
       cwd: cliRoot,
       encoding: "utf8",
       env,
@@ -117,7 +117,6 @@ describe("AI inference action commands", () => {
       "--guided-json", guidedJson,
       "--tool", tool,
       "--tool-choice", "auto",
-      "--stream",
       "--json",
     ], fake.env);
 
@@ -140,8 +139,46 @@ describe("AI inference action commands", () => {
     assertFlagValue(call, "--guided-json", guidedJson);
     assertFlagValue(call, "--tool", tool);
     assertFlagValue(call, "--tool-choice", "auto");
-    assert.ok(call.includes("--stream"));
     assert.deepEqual(call.slice(-2), ["--format", "json"]);
+  });
+
+  it("ai-chat preserves repeated messages and expands a JSON message array", () => {
+    const fake = setupFakeTelnyx();
+    const system = '{"role":"system","content":"Be concise"}';
+    const user = '{"role":"user","content":"Hello"}';
+    const assistant = { role: "assistant", content: "Hi" };
+
+    const result = runCli([
+      "ai-chat",
+      "--message", system,
+      "--message", user,
+      "--message", JSON.stringify([assistant, { role: "user", content: "Continue" }]),
+      "--json",
+    ], fake.env);
+
+    assert.equal(result.status, 0, result.stderr);
+    const call = readLoggedArgs(fake.logPath)[0];
+    const messages = call.flatMap((arg, index) => arg === "--message" ? [call[index + 1]] : []);
+    assert.deepEqual(messages, [
+      system,
+      user,
+      JSON.stringify(assistant),
+      JSON.stringify({ role: "user", content: "Continue" }),
+    ]);
+  });
+
+  it("ai-chat rejects streaming locally without invoking the Go CLI", () => {
+    const fake = setupFakeTelnyx();
+    const result = runCli([
+      "ai-chat",
+      "--message", '{"role":"user","content":"Hello"}',
+      "--stream",
+      "--json",
+    ], fake.env);
+
+    assert.notEqual(result.status, 0);
+    assert.match(JSON.parse(result.stdout).error, /streaming.*not supported/i);
+    assert.deepEqual(readLoggedArgs(fake.logPath), []);
   });
 
   it("ai-chat forwards an explicit false boolean in Go CLI-compatible form", () => {
@@ -211,6 +248,7 @@ describe("AI inference action commands", () => {
     assert.match(help.stdout, /ai-chat/);
     assert.match(help.stdout, /ai-embed/);
     assert.match(help.stdout, /--message <json>/);
+    assert.doesNotMatch(help.stdout, /--stream\s+Request a streaming completion/);
     assert.match(help.stdout, /--input <value>/);
 
     const capabilities = runCli(["capabilities", "--json"]);

--- a/cli/tests/ai.test.ts
+++ b/cli/tests/ai.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Mock-binary tests for direct Telnyx AI inference actions.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliRoot = join(__dirname, "..");
+const cliBin = join(cliRoot, "bin", "telnyx-agent.ts");
+
+function setupFakeTelnyx(): { logPath: string; env: NodeJS.ProcessEnv } {
+  const tempDir = mkdtempSync(join(tmpdir(), "telnyx-agent-ai-"));
+  const binDir = join(tempDir, "bin");
+  const logPath = join(tempDir, "args.jsonl");
+  const fakeTelnyx = join(binDir, "telnyx");
+  mkdirSync(binDir, { recursive: true });
+
+  writeFileSync(
+    fakeTelnyx,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.TELNYX_FAKE_ARGS_LOG, JSON.stringify(args) + "\\n");
+
+if (args[0] === "ai:openai:chat" && args[1] === "create-completion") {
+  console.log(JSON.stringify({
+    id: "chatcmpl-123",
+    object: "chat.completion",
+    created: 1710000000,
+    model: "meta-llama/Meta-Llama-3.1-8B-Instruct",
+    choices: [{ index: 0, message: { role: "assistant", content: "Hello from Telnyx" }, finish_reason: "stop" }],
+    usage: { prompt_tokens: 8, completion_tokens: 4, total_tokens: 12 }
+  }));
+} else if (args[0] === "ai:openai:embeddings" && args[1] === "create-embeddings") {
+  console.log(JSON.stringify({
+    object: "list",
+    data: [
+      { object: "embedding", index: 0, embedding: [0.1, 0.2, 0.3] },
+      { object: "embedding", index: 1, embedding: [0.4, 0.5, 0.6] }
+    ],
+    model: "thenlper/gte-large",
+    usage: { prompt_tokens: 2, total_tokens: 2 }
+  }));
+} else {
+  console.error("unexpected command: " + args.join(" "));
+  process.exit(2);
+}
+`,
+  );
+  chmodSync(fakeTelnyx, 0o755);
+
+  return {
+    logPath,
+    env: {
+      ...process.env,
+      TELNYX_CLI_PATH: fakeTelnyx,
+      TELNYX_FAKE_ARGS_LOG: logPath,
+      TELNYX_API_KEY: "KEY_fake_test",
+    },
+  };
+}
+
+function readLoggedArgs(logPath: string): string[][] {
+  if (!existsSync(logPath)) return [];
+  return readFileSync(logPath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function runCli(args: string[], env: NodeJS.ProcessEnv = process.env): { stdout: string; stderr: string; status: number } {
+  try {
+    const stdout = execFileSync("npx", ["tsx", cliBin, ...args], {
+      cwd: cliRoot,
+      encoding: "utf8",
+      env,
+      timeout: 30000,
+    });
+    return { stdout, stderr: "", status: 0 };
+  } catch (err: any) {
+    return {
+      stdout: err.stdout?.toString() ?? "",
+      stderr: err.stderr?.toString() ?? "",
+      status: err.status ?? 1,
+    };
+  }
+}
+
+function assertFlagValue(args: string[], flag: string, expected: string): void {
+  const index = args.indexOf(flag);
+  assert.notEqual(index, -1, `expected ${flag} in ${args.join(" ")}`);
+  assert.equal(args[index + 1], expected);
+}
+
+describe("AI inference action commands", () => {
+  it("ai-chat wraps ai:openai:chat create-completion and preserves its JSON response", () => {
+    const fake = setupFakeTelnyx();
+    const message = '{"role":"user","content":"Hello"}';
+    const responseFormat = '{"type":"json_object"}';
+    const guidedJson = '{"type":"object","properties":{"answer":{"type":"string"}}}';
+    const tool = '{"type":"function","function":{"name":"lookup","parameters":{"type":"object"}}}';
+
+    const result = runCli([
+      "ai-chat",
+      "--message", message,
+      "--model", "meta-llama/Meta-Llama-3.1-8B-Instruct",
+      "--max-tokens", "128",
+      "--temperature", "0.2",
+      "--top-p", "0.9",
+      "--response-format", responseFormat,
+      "--guided-json", guidedJson,
+      "--tool", tool,
+      "--tool-choice", "auto",
+      "--stream",
+      "--json",
+    ], fake.env);
+
+    assert.equal(result.status, 0, result.stderr);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.id, "chatcmpl-123");
+    assert.equal(output.choices[0].message.content, "Hello from Telnyx");
+    assert.deepEqual(output.usage, { prompt_tokens: 8, completion_tokens: 4, total_tokens: 12 });
+
+    const calls = readLoggedArgs(fake.logPath);
+    assert.equal(calls.length, 1, "the fake binary log should contain exactly one JSON line");
+    const call = calls[0];
+    assert.deepEqual(call.slice(0, 2), ["ai:openai:chat", "create-completion"]);
+    assertFlagValue(call, "--message", message);
+    assertFlagValue(call, "--model", "meta-llama/Meta-Llama-3.1-8B-Instruct");
+    assertFlagValue(call, "--max-tokens", "128");
+    assertFlagValue(call, "--temperature", "0.2");
+    assertFlagValue(call, "--top-p", "0.9");
+    assertFlagValue(call, "--response-format", responseFormat);
+    assertFlagValue(call, "--guided-json", guidedJson);
+    assertFlagValue(call, "--tool", tool);
+    assertFlagValue(call, "--tool-choice", "auto");
+    assert.ok(call.includes("--stream"));
+    assert.deepEqual(call.slice(-2), ["--format", "json"]);
+  });
+
+  it("ai-chat forwards an explicit false boolean in Go CLI-compatible form", () => {
+    const fake = setupFakeTelnyx();
+    const result = runCli([
+      "ai-chat",
+      "--message", '{"role":"user","content":"Hi"}',
+      "--enable-thinking", "false",
+      "--json",
+    ], fake.env);
+
+    assert.equal(result.status, 0, result.stderr);
+    const call = readLoggedArgs(fake.logPath)[0];
+    assert.ok(call.includes("--enable-thinking=false"));
+    assert.ok(!call.includes("false"), "false must not be emitted as an extra positional argument");
+  });
+
+  it("ai-embed passes input JSON through and preserves top-level embedding data", () => {
+    const fake = setupFakeTelnyx();
+    const input = '["one","two"]';
+    const result = runCli([
+      "ai-embed",
+      "--input", input,
+      "--model", "thenlper/gte-large",
+      "--dimensions", "3",
+      "--encoding-format", "float",
+      "--user", "agent-test",
+      "--json",
+    ], fake.env);
+
+    assert.equal(result.status, 0, result.stderr);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.object, "list");
+    assert.equal(output.model, "thenlper/gte-large");
+    assert.equal(output.data.length, 2, "embedding data must not be unwrapped or dropped");
+    assert.deepEqual(output.data[0].embedding, [0.1, 0.2, 0.3]);
+
+    const calls = readLoggedArgs(fake.logPath);
+    assert.equal(calls.length, 1);
+    const call = calls[0];
+    assert.deepEqual(call.slice(0, 2), ["ai:openai:embeddings", "create-embeddings"]);
+    assertFlagValue(call, "--input", input);
+    assertFlagValue(call, "--model", "thenlper/gte-large");
+    assertFlagValue(call, "--dimensions", "3");
+    assertFlagValue(call, "--encoding-format", "float");
+    assertFlagValue(call, "--user", "agent-test");
+    assert.deepEqual(call.slice(-2), ["--format", "json"]);
+  });
+
+  it("validates required inference fields before invoking the Go CLI", () => {
+    for (const args of [
+      ["ai-chat", "--json"],
+      ["ai-embed", "--model", "thenlper/gte-large", "--json"],
+      ["ai-embed", "--input", "hello", "--json"],
+    ]) {
+      const fake = setupFakeTelnyx();
+      const result = runCli(args, fake.env);
+      assert.notEqual(result.status, 0, `expected ${args.join(" ")} to fail`);
+      assert.ok(JSON.parse(result.stdout).error);
+      assert.deepEqual(readLoggedArgs(fake.logPath), []);
+    }
+  });
+
+  it("wires AI inference commands into help and capabilities", () => {
+    const help = runCli(["help"]);
+    assert.equal(help.status, 0, help.stderr);
+    assert.match(help.stdout, /ai-chat/);
+    assert.match(help.stdout, /ai-embed/);
+    assert.match(help.stdout, /--message <json>/);
+    assert.match(help.stdout, /--input <value>/);
+
+    const capabilities = runCli(["capabilities", "--json"]);
+    assert.equal(capabilities.status, 0, capabilities.stderr);
+    const output = JSON.parse(capabilities.stdout);
+    const commandNames = output.composite_commands.map((command: { name: string }) => command.name);
+    assert.ok(commandNames.includes("telnyx-agent ai-chat"));
+    assert.ok(commandNames.includes("telnyx-agent ai-embed"));
+    const aiActions = output.api_capabilities["🤖 AI"].flatMap((capability: { actions: string[] }) => capability.actions);
+    assert.ok(aiActions.includes("ai_chat"));
+    assert.ok(aiActions.includes("ai_embed"));
+  });
+});

--- a/cli/tests/telnyx-cli-flags.test.ts
+++ b/cli/tests/telnyx-cli-flags.test.ts
@@ -8,6 +8,7 @@ import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from "
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { parseFlags } from "../src/utils/output.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const cliRoot = join(__dirname, "..");
@@ -78,6 +79,23 @@ function assertFlagValue(args: string[], flag: string, value: string): void {
 }
 
 describe("telnyx CLI flag compatibility", () => {
+  it("parseFlags tracks inherited flag names without breaking repeated flags", () => {
+    const parsed = parseFlags([
+      "ai-chat",
+      "--constructor", "first",
+      "--__proto__", "second",
+      "--message", "one",
+      "--message", "two",
+      "--model", "old",
+      "--model", "new",
+    ]);
+
+    assert.deepEqual(parsed.occurrences.constructor, ["first"]);
+    assert.deepEqual(parsed.occurrences.__proto__, ["second"]);
+    assert.deepEqual(parsed.occurrences.message, ["one", "two"]);
+    assert.equal(parsed.flags.model, "new");
+  });
+
   it("status uses --page-size for paginated list commands and no page-size for ai:assistants", () => {
     const fake = setupFakeTelnyx();
 


### PR DESCRIPTION
## Summary
- add `ai-chat` over the OpenAI-compatible chat completion command
- add `ai-embed` over the OpenAI-compatible embeddings command
- preserve complete JSON responses and add help/capabilities/mock tests

## Verification
- `npm run typecheck`
- `npm test` (115 passed)