### PR TITLE
feat: Add RCS actions to agent CLI

### DIFF
--- a/agent.json
+++ b/agent.json
@@ -26,6 +26,16 @@
       "requires": ["messaging_profile", "phone_number", "10dlc_registration"]
     },
     {
+      "id": "rcs",
+      "name": "RCS Messaging",
+      "description": "Send rich business messages and check recipient RCS capabilities before choosing content or fallback behavior.",
+      "guide": "/guides/rcs-messaging.md",
+      "cli": "telnyx-agent rcs-send --agent-id AGENT_ID --messaging-profile-id PROFILE_ID --to +15559876543 --text 'Hello from RCS'",
+      "api": "POST /v2/messages/rcs",
+      "docs": "https://developers.telnyx.com/docs/messaging/messages/rcs-capabilities",
+      "requires": ["rcs_agent", "messaging_profile"]
+    },
+    {
       "id": "voice",
       "name": "Voice & Call Control",
       "description": "Programmable voice calls with real-time call control, conferencing, IVR, recording.",

--- a/cli/package.json
+++ b/cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "tsx bin/telnyx-agent.ts",
-    "test": "tsx --test tests/ai.test.ts tests/edge-handoff.test.ts tests/fax.test.ts tests/integration.test.ts tests/numbers.test.ts tests/setup-10dlc.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
+    "test": "tsx --test tests/ai.test.ts tests/edge-handoff.test.ts tests/fax.test.ts tests/integration.test.ts tests/numbers.test.ts tests/rcs.test.ts tests/setup-10dlc.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
     "typecheck": "tsc --noEmit",
     "postinstall": "tsx scripts/postinstall.ts",
     "build": "npm run typecheck"

--- a/cli/src/commands/capabilities.ts
+++ b/cli/src/commands/capabilities.ts
@@ -14,6 +14,9 @@ const CAPABILITIES: Record<string, Capability[]> = {
   "📱 Messaging": [
     { name: "SMS / MMS", description: "Send, schedule, and manage text and multimedia messages", actions: ["send_sms", "send_mms", "send_group_mms", "schedule_sms", "check_sms_status", "cancel_scheduled_sms", "list_messaging_profiles", "create_messaging_profile"] },
   ],
+  "💬 RCS": [
+    { name: "RCS Messaging", description: "Send RCS text messages and check recipient capabilities", actions: ["send_rcs_message", "check_rcs_capabilities"] },
+  ],
   "📞 Voice": [
     { name: "Call Control", description: "Make and manage voice calls via SIP connections", actions: ["make_call", "list_connections", "answer_call", "hangup_call", "transfer_call", "send_dtmf", "start_recording", "stop_recording", "start_noise_suppression", "stop_noise_suppression", "speak_tts", "bridge_calls", "refer_call", "reject_call", "get_call_status", "answering_machine_detection", "deepfake_detection", "number_masking", "from_display_name", "time_limit", "media_encryption", "transcription", "gather", "stop_gather", "start_playback", "stop_playback", "start_transcription", "stop_transcription", "pause_recording", "resume_recording", "start_forking", "stop_forking", "start_siprec", "stop_siprec", "start_streaming", "stop_streaming", "enqueue", "leave_queue", "send_sip_info", "update_client_state", "add_ai_assistant_messages", "gather_using_ai", "gather_using_audio", "gather_using_speak", "join_ai_assistant", "start_ai_assistant", "stop_ai_assistant", "start_conversation_relay", "stop_conversation_relay", "switch_supervisor_role"] },
   ],
@@ -81,6 +84,8 @@ const COMPOSITE_COMMANDS = [
   { name: "telnyx-agent send-group-mms", description: "Send a group MMS to multiple recipients (--to comma-separated E.164 numbers)" },
   { name: "telnyx-agent schedule-sms", description: "Schedule an SMS for future delivery at a given ISO 8601 time" },
   { name: "telnyx-agent sms-status", description: "Check SMS delivery status, or cancel a scheduled message with --cancel" },
+  { name: "telnyx-agent rcs-send", description: "Send a text message from an RCS agent" },
+  { name: "telnyx-agent rcs-capabilities", description: "Check the RCS features available for a recipient" },
   { name: "telnyx-agent setup-voice", description: "Zero to voice: creates SIP connection, buys number, assigns it" },
   { name: "telnyx-agent setup-iot", description: "Zero to IoT: lists SIMs, creates group, activates SIM" },
   { name: "telnyx-agent setup-ai", description: "Zero to AI assistant: creates assistant, buys number, wires them together" },

--- a/cli/src/commands/rcs-capabilities.ts
+++ b/cli/src/commands/rcs-capabilities.ts
@@ -1,0 +1,78 @@
+/**
+ * telnyx-agent rcs-capabilities — Check an RCS recipient's capabilities.
+ *
+ * Shells out to the generated Go CLI's
+ * `messaging:rcs retrieve-capabilities` action.
+ */
+
+import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
+import { printSuccess, printError, outputJson } from "../utils/output.ts";
+
+interface RcsCapabilitiesResult {
+  agent_id: string;
+  agent_name: string;
+  phone_number: string;
+  features: string[];
+}
+
+export async function rcsCapabilitiesCommand(flags: Record<string, string | boolean>): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const agentId = flags["agent-id"] as string | undefined;
+  const phoneNumber = flags["phone-number"] as string | undefined;
+
+  if (!agentId) {
+    printError("--agent-id is required");
+    process.exit(1);
+    return;
+  }
+  if (!phoneNumber) {
+    printError("--phone-number is required (E.164 format, e.g., +131****0001)");
+    process.exit(1);
+    return;
+  }
+
+  try {
+    const response = await telnyxCli([
+      "messaging:rcs", "retrieve-capabilities",
+      "--agent-id", agentId,
+      "--phone-number", phoneNumber,
+    ]);
+    const data = (response?.data ?? response) as Record<string, unknown>;
+    const result: RcsCapabilitiesResult = {
+      agent_id: String(data.agent_id ?? agentId),
+      agent_name: String(data.agent_name ?? ""),
+      phone_number: String(data.phone_number ?? phoneNumber),
+      features: Array.isArray(data.features) ? data.features.map(String) : [],
+    };
+
+    if (jsonOutput) {
+      outputJson(result);
+    } else {
+      printSuccess("RCS capabilities retrieved!", {
+        "Agent ID": result.agent_id,
+        "Agent name": result.agent_name || "—",
+        "Phone number": result.phone_number,
+        Features: result.features.length > 0 ? result.features.join(", ") : "None reported",
+      });
+    }
+  } catch (err) {
+    if (jsonOutput) {
+      outputJson({
+        agent_id: agentId,
+        agent_name: "",
+        phone_number: phoneNumber,
+        features: [],
+        error: errorMsg(err),
+      });
+    } else {
+      printError(errorMsg(err));
+    }
+    process.exit(1);
+  }
+}
+
+function errorMsg(err: unknown): string {
+  if (err instanceof TelnyxCLIError) return err.stderr || err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/cli/src/commands/rcs-capabilities.ts
+++ b/cli/src/commands/rcs-capabilities.ts
@@ -12,7 +12,9 @@ interface RcsCapabilitiesResult {
   agent_id: string;
   agent_name: string;
   phone_number: string;
-  features: string[];
+  features: string[] | null;
+  status: string;
+  rcs_enabled: boolean;
 }
 
 export async function rcsCapabilitiesCommand(flags: Record<string, string | boolean>): Promise<void> {
@@ -38,11 +40,14 @@ export async function rcsCapabilitiesCommand(flags: Record<string, string | bool
       "--phone-number", phoneNumber,
     ]);
     const data = (response?.data ?? response) as Record<string, unknown>;
+    const features = Array.isArray(data.features) ? data.features.map(String) : null;
     const result: RcsCapabilitiesResult = {
       agent_id: String(data.agent_id ?? agentId),
       agent_name: String(data.agent_name ?? ""),
       phone_number: String(data.phone_number ?? phoneNumber),
-      features: Array.isArray(data.features) ? data.features.map(String) : [],
+      features,
+      status: String(data.status ?? ""),
+      rcs_enabled: features !== null,
     };
 
     if (jsonOutput) {
@@ -52,7 +57,11 @@ export async function rcsCapabilitiesCommand(flags: Record<string, string | bool
         "Agent ID": result.agent_id,
         "Agent name": result.agent_name || "—",
         "Phone number": result.phone_number,
-        Features: result.features.length > 0 ? result.features.join(", ") : "None reported",
+        Status: result.status || "Unknown",
+        "RCS enabled": result.rcs_enabled ? "Yes" : "No",
+        Features: result.features === null
+          ? "Unavailable"
+          : result.features.length > 0 ? result.features.join(", ") : "None reported",
       });
     }
   } catch (err) {

--- a/cli/src/commands/rcs-send.ts
+++ b/cli/src/commands/rcs-send.ts
@@ -1,0 +1,108 @@
+/**
+ * telnyx-agent rcs-send — Send a text RCS message.
+ *
+ * Shells out to the generated Go CLI's `messages:rcs send` action. The agent
+ * command keeps the common text-message case simple while using the generated
+ * nested flag names verbatim.
+ */
+
+import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
+import { printSuccess, printError, outputJson } from "../utils/output.ts";
+import { deriveMessageStatus } from "../utils/message-status.ts";
+
+interface RcsSendResult {
+  message_id: string;
+  status: string;
+  type: "RCS";
+  agent_id: string;
+  messaging_profile_id: string;
+  to: string;
+}
+
+export async function rcsSendCommand(flags: Record<string, string | boolean>): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const agentId = flags["agent-id"] as string | undefined;
+  const messagingProfileId = flags["messaging-profile-id"] as string | undefined;
+  const to = flags.to as string | undefined;
+  const text = flags.text as string | undefined;
+  const ttl = flags.ttl as string | undefined;
+  const webhookUrl = flags["webhook-url"] as string | undefined;
+
+  if (!agentId) {
+    printError("--agent-id is required");
+    process.exit(1);
+    return;
+  }
+  if (!messagingProfileId) {
+    printError("--messaging-profile-id is required");
+    process.exit(1);
+    return;
+  }
+  if (!to) {
+    printError("--to is required (E.164 format, e.g., +131****0001)");
+    process.exit(1);
+    return;
+  }
+  if (!text) {
+    printError("--text is required");
+    process.exit(1);
+    return;
+  }
+
+  const args = [
+    "messages:rcs", "send",
+    "--agent-id", agentId,
+    "--agent-message.content-message", JSON.stringify({ text }),
+    "--messaging-profile-id", messagingProfileId,
+    "--to", to,
+    "--type", "RCS",
+  ];
+  if (ttl) args.push("--agent-message.ttl", ttl);
+  if (webhookUrl) args.push("--webhook-url", webhookUrl);
+
+  try {
+    const response = await telnyxCli(args);
+    const data = (response?.data ?? response) as Record<string, unknown>;
+    const result: RcsSendResult = {
+      message_id: String(data.id ?? data.message_id ?? ""),
+      status: deriveMessageStatus(data, "submitted"),
+      type: "RCS",
+      agent_id: agentId,
+      messaging_profile_id: messagingProfileId,
+      to,
+    };
+
+    if (jsonOutput) {
+      outputJson(result);
+    } else {
+      printSuccess("RCS message submitted!", {
+        "Message ID": result.message_id || "—",
+        Status: result.status,
+        "Agent ID": result.agent_id,
+        "Messaging profile ID": result.messaging_profile_id,
+        To: result.to,
+      });
+    }
+  } catch (err) {
+    if (jsonOutput) {
+      outputJson({
+        message_id: "",
+        status: "failed",
+        type: "RCS",
+        agent_id: agentId,
+        messaging_profile_id: messagingProfileId,
+        to,
+        error: errorMsg(err),
+      });
+    } else {
+      printError(errorMsg(err));
+    }
+    process.exit(1);
+  }
+}
+
+function errorMsg(err: unknown): string {
+  if (err instanceof TelnyxCLIError) return err.stderr || err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -28,6 +28,8 @@ import { faxSendCommand } from "./commands/fax-send.ts";
 import { sendGroupMmsCommand } from "./commands/send-group-mms.ts";
 import { scheduleSmsCommand } from "./commands/schedule-sms.ts";
 import { smsStatusCommand } from "./commands/sms-status.ts";
+import { rcsSendCommand } from "./commands/rcs-send.ts";
+import { rcsCapabilitiesCommand } from "./commands/rcs-capabilities.ts";
 import { callDialCommand } from "./commands/call-dial.ts";
 import { callControlCommand } from "./commands/call-control.ts";
 import { callStatusCommand } from "./commands/call-status.ts";
@@ -76,6 +78,8 @@ Commands:
   send-group-mms    Send a group MMS to multiple recipients (--to comma-separated)
   schedule-sms      Schedule an SMS for future delivery (--send-at ISO 8601)
   sms-status        Check SMS delivery status, or cancel a scheduled message (--cancel)
+  rcs-send          Send a text RCS message
+  rcs-capabilities  Check RCS capabilities for a recipient
   call-dial         Make an outbound call via Call Control
   call-control      Call Control actions (answer, hangup, transfer, dtmf, record, speak, ...)
   call-status       Get the status of a call by call-control-id
@@ -180,6 +184,15 @@ Fax Action Flags:
   --store-preview        Store a fax preview on a temporary URL (fax-send)
   --preview-format <fmt> Preview format: pdf|tiff (fax-send)
   --t38-enabled <bool>   Enable or disable T.38 (fax-send)
+
+RCS Action Flags:
+  --agent-id <id>        RCS agent ID (rcs-send, rcs-capabilities — required)
+  --messaging-profile-id <id> Messaging profile ID (rcs-send — required)
+  --to <e164>            Recipient number, E.164 (rcs-send — required)
+  --phone-number <e164>  Recipient number, E.164 (rcs-capabilities — required)
+  --text <msg>           Text content (rcs-send — required)
+  --ttl <duration>       Message lifetime ending in s, e.g. 300s (rcs-send)
+  --webhook-url <url>    Webhook for message events (rcs-send)
 
 WhatsApp Flags:
   --waba-id <id>    WhatsApp Business Account id (setup-whatsapp, whatsapp-templates)
@@ -348,6 +361,8 @@ Examples:
   telnyx-agent schedule-sms --from +131****0000 --to +131****0001 --text "Later" --send-at 2024-12-31T00:00:00Z
   telnyx-agent sms-status --id 3fa85f64-5717-4562-b3fc-2c963f66afa6
   telnyx-agent sms-status --id 3fa85f64-5717-4562-b3fc-2c963f66afa6 --cancel
+  telnyx-agent rcs-capabilities --agent-id <agent-id> --phone-number +131****0001 --json
+  telnyx-agent rcs-send --agent-id <agent-id> --messaging-profile-id <id> --to +131****0001 --text "Hello from RCS"
   telnyx-agent call-dial --connection-id <id> --from +131****0000 --to +131****1234
   telnyx-agent call-dial --connection-id <id> --from +131****0000 --to +131****1234 --answering-machine-detection --json
   telnyx-agent call-control --action hangup --call-control-id <id>
@@ -426,6 +441,8 @@ const COMMANDS: Record<string, (
   "send-group-mms": sendGroupMmsCommand,
   "schedule-sms": scheduleSmsCommand,
   "sms-status": smsStatusCommand,
+  "rcs-send": rcsSendCommand,
+  "rcs-capabilities": rcsCapabilitiesCommand,
   "call-dial": callDialCommand,
   "call-control": callControlCommand,
   "call-status": callStatusCommand,

--- a/cli/tests/rcs.test.ts
+++ b/cli/tests/rcs.test.ts
@@ -41,12 +41,13 @@ if (args[0] === "messages:rcs" && args[1] === "send") {
     to: [{ phone_number: flag("--to"), status: "queued" }]
   } }));
 } else if (args[0] === "messaging:rcs" && args[1] === "retrieve-capabilities") {
-  console.log(JSON.stringify({ data: {
+  console.log(process.env.TELNYX_FAKE_RCS_CAPABILITIES || JSON.stringify({ data: {
     agent_id: flag("--agent-id"),
     agent_name: "Example Agent",
     phone_number: flag("--phone-number"),
     record_type: "rcs.capabilities",
-    features: ["RICHCARD_STANDALONE", "ACTION_OPEN_URL"]
+    features: ["RICHCARD_STANDALONE", "ACTION_OPEN_URL"],
+    status: "Success"
   } }));
 } else {
   console.log(JSON.stringify({ data: {} }));
@@ -67,7 +68,7 @@ if (args[0] === "messages:rcs" && args[1] === "send") {
 }
 
 function runAgent(args: string[], env: NodeJS.ProcessEnv): string {
-  return execFileSync("npx", ["tsx", cliBin, ...args], {
+  return execFileSync(process.execPath, ["--import", "tsx", cliBin, ...args], {
     cwd: cliRoot,
     encoding: "utf8",
     env,
@@ -83,7 +84,7 @@ function loggedArgs(logPath: string): string[][] {
 }
 
 function expectFailure(args: string[], env: NodeJS.ProcessEnv, expected: RegExp): void {
-  const result = spawnSync("npx", ["tsx", cliBin, ...args], {
+  const result = spawnSync(process.execPath, ["--import", "tsx", cliBin, ...args], {
     cwd: cliRoot,
     encoding: "utf8",
     env,
@@ -164,6 +165,8 @@ describe("RCS action commands", () => {
       agent_name: "Example Agent",
       phone_number: "+131****0001",
       features: ["RICHCARD_STANDALONE", "ACTION_OPEN_URL"],
+      status: "Success",
+      rcs_enabled: true,
     });
     assert.deepEqual(loggedArgs(fake.logPath), [[
       "messaging:rcs", "retrieve-capabilities",
@@ -171,6 +174,66 @@ describe("RCS action commands", () => {
       "--phone-number", "+131****0001",
       "--format", "json",
     ]]);
+  });
+
+  it("rcs-capabilities preserves disabled status and null features in JSON", () => {
+    const fake = setupFakeTelnyx();
+    fake.env.TELNYX_FAKE_RCS_CAPABILITIES = JSON.stringify({ data: {
+      features: null,
+      status: "RCS is disabled or agent is not provisioned for the carrier",
+    } });
+
+    const output = runAgent([
+      "rcs-capabilities",
+      "--agent-id", "agent-123",
+      "--phone-number", "+131****0001",
+      "--json",
+    ], fake.env);
+
+    assert.deepEqual(JSON.parse(output), {
+      agent_id: "agent-123",
+      agent_name: "",
+      phone_number: "+131****0001",
+      features: null,
+      status: "RCS is disabled or agent is not provisioned for the carrier",
+      rcs_enabled: false,
+    });
+  });
+
+  it("rcs-capabilities distinguishes an empty supported feature set in human output", () => {
+    const fake = setupFakeTelnyx();
+    fake.env.TELNYX_FAKE_RCS_CAPABILITIES = JSON.stringify({ data: {
+      features: [],
+      status: "Success",
+    } });
+
+    const output = runAgent([
+      "rcs-capabilities",
+      "--agent-id", "agent-123",
+      "--phone-number", "+131****0001",
+    ], fake.env);
+
+    assert.match(output, /Status\s+Success/);
+    assert.match(output, /RCS enabled\s+Yes/);
+    assert.match(output, /Features\s+None reported/);
+  });
+
+  it("rcs-capabilities shows disabled status in human output for non-array features", () => {
+    const fake = setupFakeTelnyx();
+    fake.env.TELNYX_FAKE_RCS_CAPABILITIES = JSON.stringify({ data: {
+      features: "unavailable",
+      status: "RCS is disabled or agent is not provisioned for the carrier",
+    } });
+
+    const output = runAgent([
+      "rcs-capabilities",
+      "--agent-id", "agent-123",
+      "--phone-number", "+131****0001",
+    ], fake.env);
+
+    assert.match(output, /Status\s+RCS is disabled or agent is not provisioned for the carrier/);
+    assert.match(output, /RCS enabled\s+No/);
+    assert.match(output, /Features\s+Unavailable/);
   });
 
   it("validates required RCS flags before invoking the Go CLI", () => {

--- a/cli/tests/rcs.test.ts
+++ b/cli/tests/rcs.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Mock-backed tests for the scoped RCS agent commands.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliRoot = join(__dirname, "..");
+const cliBin = join(cliRoot, "bin", "telnyx-agent.ts");
+
+function setupFakeTelnyx(): { logPath: string; env: NodeJS.ProcessEnv } {
+  const tempDir = mkdtempSync(join(tmpdir(), "telnyx-agent-rcs-"));
+  const binDir = join(tempDir, "bin");
+  const logPath = join(tempDir, "args.jsonl");
+  mkdirSync(binDir, { recursive: true });
+
+  const fakeTelnyx = join(binDir, "telnyx");
+  writeFileSync(
+    fakeTelnyx,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.TELNYX_FAKE_ARGS_LOG, JSON.stringify(args) + "\\n");
+
+function flag(name) {
+  const index = args.indexOf(name);
+  return index >= 0 ? args[index + 1] : null;
+}
+
+if (args[0] === "messages:rcs" && args[1] === "send") {
+  console.log(JSON.stringify({ data: {
+    id: "rcs-msg-123",
+    type: "RCS",
+    messaging_profile_id: flag("--messaging-profile-id"),
+    from: { agent_id: flag("--agent-id"), agent_name: "Example Agent" },
+    to: [{ phone_number: flag("--to"), status: "queued" }]
+  } }));
+} else if (args[0] === "messaging:rcs" && args[1] === "retrieve-capabilities") {
+  console.log(JSON.stringify({ data: {
+    agent_id: flag("--agent-id"),
+    agent_name: "Example Agent",
+    phone_number: flag("--phone-number"),
+    record_type: "rcs.capabilities",
+    features: ["RICHCARD_STANDALONE", "ACTION_OPEN_URL"]
+  } }));
+} else {
+  console.log(JSON.stringify({ data: {} }));
+}
+`,
+  );
+  chmodSync(fakeTelnyx, 0o755);
+
+  return {
+    logPath,
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH}`,
+      TELNYX_CLI_PATH: fakeTelnyx,
+      TELNYX_FAKE_ARGS_LOG: logPath,
+    },
+  };
+}
+
+function runAgent(args: string[], env: NodeJS.ProcessEnv): string {
+  return execFileSync("npx", ["tsx", cliBin, ...args], {
+    cwd: cliRoot,
+    encoding: "utf8",
+    env,
+    timeout: 30000,
+  });
+}
+
+function loggedArgs(logPath: string): string[][] {
+  const raw = readFileSync(logPath, "utf8");
+  assert.ok(raw.endsWith("\n"), "fake binary log should end with one newline");
+  assert.ok(!raw.endsWith("\n\n"), "fake binary should not write a blank line");
+  return raw.trimEnd().split("\n").map((line) => JSON.parse(line));
+}
+
+function expectFailure(args: string[], env: NodeJS.ProcessEnv, expected: RegExp): void {
+  const result = spawnSync("npx", ["tsx", cliBin, ...args], {
+    cwd: cliRoot,
+    encoding: "utf8",
+    env,
+    timeout: 30000,
+  });
+  assert.notEqual(result.status, 0, "command should fail");
+  assert.match(`${result.stderr}${result.stdout}`, expected);
+}
+
+describe("RCS action commands", () => {
+  it("rcs-send maps text to the generated messages:rcs send flags and returns stable JSON", () => {
+    const fake = setupFakeTelnyx();
+    const output = runAgent([
+      "rcs-send",
+      "--agent-id", "agent-123",
+      "--messaging-profile-id", "profile-123",
+      "--to", "+131****0001",
+      "--text", "Hello RCS",
+      "--json",
+    ], fake.env);
+
+    assert.deepEqual(JSON.parse(output), {
+      message_id: "rcs-msg-123",
+      status: "queued",
+      type: "RCS",
+      agent_id: "agent-123",
+      messaging_profile_id: "profile-123",
+      to: "+131****0001",
+    });
+    assert.deepEqual(loggedArgs(fake.logPath), [[
+      "messages:rcs", "send",
+      "--agent-id", "agent-123",
+      "--agent-message.content-message", "{\"text\":\"Hello RCS\"}",
+      "--messaging-profile-id", "profile-123",
+      "--to", "+131****0001",
+      "--type", "RCS",
+      "--format", "json",
+    ]]);
+  });
+
+  it("rcs-send maps optional TTL and webhook flags to their exact generated names", () => {
+    const fake = setupFakeTelnyx();
+    runAgent([
+      "rcs-send",
+      "--agent-id", "agent-123",
+      "--messaging-profile-id", "profile-123",
+      "--to", "+131****0001",
+      "--text", "Hello RCS",
+      "--ttl", "300s",
+      "--webhook-url", "https://example.com/rcs-events",
+      "--json",
+    ], fake.env);
+
+    assert.deepEqual(loggedArgs(fake.logPath), [[
+      "messages:rcs", "send",
+      "--agent-id", "agent-123",
+      "--agent-message.content-message", "{\"text\":\"Hello RCS\"}",
+      "--messaging-profile-id", "profile-123",
+      "--to", "+131****0001",
+      "--type", "RCS",
+      "--agent-message.ttl", "300s",
+      "--webhook-url", "https://example.com/rcs-events",
+      "--format", "json",
+    ]]);
+  });
+
+  it("rcs-capabilities calls the generated recipient endpoint and returns stable JSON", () => {
+    const fake = setupFakeTelnyx();
+    const output = runAgent([
+      "rcs-capabilities",
+      "--agent-id", "agent-123",
+      "--phone-number", "+131****0001",
+      "--json",
+    ], fake.env);
+
+    assert.deepEqual(JSON.parse(output), {
+      agent_id: "agent-123",
+      agent_name: "Example Agent",
+      phone_number: "+131****0001",
+      features: ["RICHCARD_STANDALONE", "ACTION_OPEN_URL"],
+    });
+    assert.deepEqual(loggedArgs(fake.logPath), [[
+      "messaging:rcs", "retrieve-capabilities",
+      "--agent-id", "agent-123",
+      "--phone-number", "+131****0001",
+      "--format", "json",
+    ]]);
+  });
+
+  it("validates required RCS flags before invoking the Go CLI", () => {
+    const fake = setupFakeTelnyx();
+    expectFailure([
+      "rcs-send",
+      "--agent-id", "agent-123",
+      "--messaging-profile-id", "profile-123",
+      "--to", "+131****0001",
+      "--json",
+    ], fake.env, /--text is required/);
+    expectFailure([
+      "rcs-capabilities",
+      "--agent-id", "agent-123",
+      "--json",
+    ], fake.env, /--phone-number is required/);
+  });
+
+  it("wires both RCS commands into help and self-described capabilities", () => {
+    const help = runAgent(["help"], process.env);
+    assert.match(help, /rcs-send/);
+    assert.match(help, /rcs-capabilities/);
+
+    const capabilities = JSON.parse(runAgent(["capabilities", "--json"], process.env));
+    assert.deepEqual(
+      capabilities.api_capabilities["💬 RCS"][0].actions,
+      ["send_rcs_message", "check_rcs_capabilities"],
+    );
+    const commandNames = capabilities.composite_commands.map((command: { name: string }) => command.name);
+    assert.ok(commandNames.includes("telnyx-agent rcs-send"));
+    assert.ok(commandNames.includes("telnyx-agent rcs-capabilities"));
+  });
+});

--- a/guides/rcs-messaging.md
+++ b/guides/rcs-messaging.md
@@ -1,0 +1,99 @@
+# RCS Messaging
+
+> Check recipient support, then send RCS text through an approved Telnyx RCS agent.
+
+## Prerequisites
+
+- A Telnyx API key ([get one](https://telnyx.com/agent-signup.md))
+- An approved RCS agent ID
+- A messaging profile associated with the agent
+- Recipient numbers in E.164 format
+
+For the complete API surface and SDK variants, use the canonical
+[`skills/telnyx-messaging-hosted-curl/SKILL.md`](../skills/telnyx-messaging-hosted-curl/SKILL.md)
+source. Provider skill copies are generated from `skills/` and should not be edited directly.
+
+## Quick Start
+
+Check the recipient before choosing rich content or an SMS fallback:
+
+```bash
+telnyx-agent rcs-capabilities \
+  --agent-id AGENT_ID \
+  --phone-number +15559876543 \
+  --json
+```
+
+Then send a text message:
+
+```bash
+telnyx-agent rcs-send \
+  --agent-id AGENT_ID \
+  --messaging-profile-id PROFILE_ID \
+  --to +15559876543 \
+  --text "Hello from RCS"
+```
+
+## API Reference
+
+### Check recipient capabilities
+
+**`GET /v2/messaging/rcs/capabilities/{agent_id}/{phone_number}`**
+
+```bash
+curl "https://api.telnyx.com/v2/messaging/rcs/capabilities/AGENT_ID/%2B15559876543" \
+  -H "Authorization: Bearer YOUR_TELNYX_API_KEY"
+```
+
+An array in `features` means RCS is enabled, including an empty array. A null
+`features` value is different: preserve the accompanying `status`, which can
+explain that RCS is disabled or the agent is not provisioned for the carrier.
+
+### Send an RCS message
+
+**`POST /v2/messages/rcs`**
+
+```bash
+curl -X POST "https://api.telnyx.com/v2/messages/rcs" \
+  -H "Authorization: Bearer YOUR_TELNYX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agent_id": "AGENT_ID",
+    "messaging_profile_id": "PROFILE_ID",
+    "to": "+15559876543",
+    "agent_message": {"content_message": {"text": "Hello from RCS"}},
+    "type": "RCS"
+  }'
+```
+
+## Python Example
+
+```python
+import requests
+
+response = requests.get(
+    "https://api.telnyx.com/v2/messaging/rcs/capabilities/AGENT_ID/%2B15559876543",
+    headers={"Authorization": "Bearer YOUR_API_KEY"},
+)
+capabilities = response.json()["data"]
+if capabilities["features"] is None:
+    print(capabilities["status"])
+```
+
+## TypeScript Example
+
+```typescript
+const response = await fetch(
+  "https://api.telnyx.com/v2/messaging/rcs/capabilities/AGENT_ID/%2B15559876543",
+  { headers: { Authorization: `Bearer ${process.env.TELNYX_API_KEY}` } },
+);
+const { data } = await response.json();
+console.log(data.features === null ? data.status : data.features);
+```
+
+## Operational Notes
+
+- Treat `features: null` as unavailable, not as an empty supported feature set.
+- Use `GENERIC_RCS_FEATURE` for basic text only; avoid rich cards unless advertised.
+- Keep an SMS fallback path for recipients without RCS support.
+- Use `--ttl 300s` and `--webhook-url https://example.com/rcs-events` when needed.

--- a/tests/guides.test.ts
+++ b/tests/guides.test.ts
@@ -40,6 +40,21 @@ describe("agent.json validity", () => {
       );
     }
   });
+
+  it("keeps canonical RCS discovery synchronized", () => {
+    const rcs = agentJson.capabilities.find((capability: any) => capability.id === "rcs");
+    assert.ok(rcs, "agent.json missing RCS capability");
+    assert.equal(rcs.guide, "/guides/rcs-messaging.md");
+    assert.equal(rcs.api, "POST /v2/messages/rcs");
+    assert.match(rcs.cli, /telnyx-agent rcs-send/);
+
+    const guide = readFileSync(join(GUIDES_DIR, "rcs-messaging.md"), "utf-8");
+    assert.match(guide, /POST \/v2\/messages\/rcs/);
+    assert.match(guide, /GET \/v2\/messaging\/rcs\/capabilities\/\{agent_id\}\/\{phone_number\}/);
+    assert.match(guide, /telnyx-agent rcs-send/);
+    assert.match(guide, /telnyx-agent rcs-capabilities/);
+    assert.match(guide, /skills\/telnyx-messaging-hosted-curl\/SKILL\.md/);
+  });
 });
 
 describe("guide ↔ agent.json parity", () => {


### PR DESCRIPTION
## Summary
- add `rcs-send` for text RCS messages
- add `rcs-capabilities` for recipient feature detection
- map current generated flags and add stable JSON/help/capabilities/mock tests

## Verification
- `npm run typecheck`
- `npm test` (115 passed)