### PR TITLE
feat: Add IoT SIM actions to agent CLI

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "tsx bin/telnyx-agent.ts",
-    "test": "tsx --test tests/ai.test.ts tests/edge-handoff.test.ts tests/fax.test.ts tests/integration.test.ts tests/numbers.test.ts tests/rcs.test.ts tests/setup-10dlc.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
+    "test": "tsx --test tests/ai.test.ts tests/edge-handoff.test.ts tests/fax.test.ts tests/integration.test.ts tests/iot.test.ts tests/numbers.test.ts tests/rcs.test.ts tests/setup-10dlc.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
     "typecheck": "tsc --noEmit",
     "postinstall": "tsx scripts/postinstall.ts",
     "build": "npm run typecheck"

--- a/cli/src/commands/capabilities.ts
+++ b/cli/src/commands/capabilities.ts
@@ -40,7 +40,7 @@ const CAPABILITIES: Record<string, Capability[]> = {
     { name: "Fax", description: "Send faxes programmatically", actions: ["send_fax"] },
   ],
   "📡 IoT": [
-    { name: "SIM Cards", description: "Manage IoT SIM cards and connectivity", actions: ["list_sim_cards"] },
+    { name: "SIM Cards", description: "List, inspect, enable, and disable IoT SIM cards", actions: ["list_sim_cards", "retrieve_sim_card", "enable_sim_card", "disable_sim_card"] },
   ],
   "🔍 Lookup": [
     { name: "Number Lookup", description: "Carrier and caller ID lookups", actions: ["lookup_number"] },
@@ -88,6 +88,10 @@ const COMPOSITE_COMMANDS = [
   { name: "telnyx-agent rcs-capabilities", description: "Check the RCS features available for a recipient" },
   { name: "telnyx-agent setup-voice", description: "Zero to voice: creates SIP connection, buys number, assigns it" },
   { name: "telnyx-agent setup-iot", description: "Zero to IoT: lists SIMs, creates group, activates SIM" },
+  { name: "telnyx-agent list-sim-cards", description: "List IoT SIM cards with filters and pagination" },
+  { name: "telnyx-agent retrieve-sim-card", description: "Retrieve one IoT SIM card by ID" },
+  { name: "telnyx-agent enable-sim-card", description: "Request asynchronous enablement of an IoT SIM card" },
+  { name: "telnyx-agent disable-sim-card", description: "Request asynchronous disablement of an IoT SIM card" },
   { name: "telnyx-agent setup-ai", description: "Zero to AI assistant: creates assistant, buys number, wires them together" },
   { name: "telnyx-agent ai-chat", description: "Create an OpenAI-compatible chat completion via Telnyx AI inference" },
   { name: "telnyx-agent ai-embed", description: "Create OpenAI-compatible embeddings for text or a JSON array of texts" },

--- a/cli/src/commands/sim-cards.ts
+++ b/cli/src/commands/sim-cards.ts
@@ -1,0 +1,236 @@
+/**
+ * Direct IoT SIM actions backed by the Stainless-generated Go CLI.
+ *
+ * List requests use raw output so the Go CLI returns one parseable
+ * `{ data, meta }` response instead of streaming one JSON document per SIM.
+ */
+
+import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
+import { outputJson, printError, printSuccess } from "../utils/output.ts";
+
+type Flags = Record<string, string | boolean>;
+type JsonRecord = Record<string, unknown>;
+type SimAction = "enable" | "disable";
+
+interface SimListResult {
+  count: number;
+  sim_cards: JsonRecord[];
+  meta: JsonRecord;
+}
+
+interface SimRetrieveResult {
+  sim_card_id: string;
+  sim_card: JsonRecord;
+}
+
+interface SimActionResult {
+  action_id: string;
+  sim_card_id: string;
+  action: SimAction;
+  status: string;
+}
+
+export async function listSimCardsCommand(flags: Flags): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const args = ["sim-cards", "list"];
+
+  addMappedFlag(args, flags, "iccid", "--filter.iccid");
+  addMappedFlag(args, flags, "msisdn", "--filter.msisdn");
+  addCsvFlag(args, flags, "status", "--filter.status", jsonOutput);
+  addCsvFlag(args, flags, "tags", "--filter.tags", jsonOutput);
+  addMappedFlag(args, flags, "sim-card-group-id", "--filter-sim-card-group-id");
+  addBooleanFlag(args, flags, "include-sim-card-group", jsonOutput);
+  addPositiveIntegerFlag(args, flags, "page-number", "--page-number", jsonOutput);
+  addPositiveIntegerFlag(args, flags, "page-size", "--page-size", jsonOutput);
+  addMappedFlag(args, flags, "sort", "--sort");
+
+  try {
+    const response = await telnyxCli(args, { format: "raw" });
+    presentSimList(normalizeSimList(response), jsonOutput);
+  } catch (err) {
+    fail(errorMsg(err), jsonOutput);
+  }
+}
+
+export async function retrieveSimCardCommand(flags: Flags): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const simCardId = stringFlag(flags, "id");
+  if (!simCardId) fail("--id is required (SIM card ID)", jsonOutput);
+
+  const args = ["sim-cards", "retrieve", "--id", simCardId];
+  addBooleanFlag(args, flags, "include-sim-card-group", jsonOutput);
+
+  try {
+    const response = await telnyxCli(args);
+    const simCard = asRecord(asRecord(response).data ?? response);
+    const result: SimRetrieveResult = {
+      sim_card_id: stringValue(simCard.id) || simCardId,
+      sim_card: simCard,
+    };
+
+    if (jsonOutput) {
+      outputJson(result);
+    } else {
+      printSuccess("SIM card retrieved!", {
+        "SIM Card ID": result.sim_card_id,
+        ICCID: stringValue(simCard.iccid) || "(not returned)",
+        MSISDN: stringValue(simCard.msisdn) || "(not assigned)",
+        Status: simStatus(simCard) || "(not returned)",
+      });
+    }
+  } catch (err) {
+    fail(errorMsg(err), jsonOutput);
+  }
+}
+
+export async function enableSimCardCommand(flags: Flags): Promise<void> {
+  await runSimAction("enable", flags);
+}
+
+export async function disableSimCardCommand(flags: Flags): Promise<void> {
+  await runSimAction("disable", flags);
+}
+
+async function runSimAction(action: SimAction, flags: Flags): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const simCardId = stringFlag(flags, "id");
+  if (!simCardId) fail("--id is required (SIM card ID)", jsonOutput);
+
+  try {
+    const response = await telnyxCli(["sim-cards:actions", action, "--id", simCardId]);
+    const data = asRecord(asRecord(response).data ?? response);
+    const result: SimActionResult = {
+      action_id: stringValue(data.id),
+      sim_card_id: stringValue(data.sim_card_id) || simCardId,
+      action,
+      status: stringValue(data.status) || "pending",
+    };
+
+    if (jsonOutput) {
+      outputJson(result);
+    } else {
+      printSuccess(`SIM card ${action} requested!`, {
+        "SIM Card ID": result.sim_card_id,
+        "Action ID": result.action_id || "(not returned)",
+        Action: result.action,
+        Status: result.status,
+      });
+    }
+  } catch (err) {
+    fail(errorMsg(err), jsonOutput);
+  }
+}
+
+function normalizeSimList(response: unknown): SimListResult {
+  const envelope = asRecord(response);
+  const simCards = Array.isArray(envelope.data)
+    ? envelope.data.filter(
+        (item): item is JsonRecord => Boolean(item) && typeof item === "object" && !Array.isArray(item),
+      )
+    : [];
+  return {
+    count: simCards.length,
+    sim_cards: simCards,
+    meta: asRecord(envelope.meta),
+  };
+}
+
+function presentSimList(result: SimListResult, jsonOutput: boolean): void {
+  if (jsonOutput) {
+    outputJson(result);
+    return;
+  }
+
+  printSuccess("SIM cards retrieved!", { Count: result.count });
+  for (const simCard of result.sim_cards) {
+    const id = stringValue(simCard.id) || "(unknown)";
+    const details = [simCard.iccid, simCard.msisdn, simStatus(simCard)]
+      .map(stringValue)
+      .filter(Boolean)
+      .join(" · ");
+    console.log(`  • ${id}${details ? ` — ${details}` : ""}`);
+  }
+  if (result.count === 0) console.log("  (no SIM cards returned)");
+  console.log();
+}
+
+function simStatus(simCard: JsonRecord): string {
+  const status = simCard.status;
+  if (status && typeof status === "object" && !Array.isArray(status)) {
+    return stringValue((status as JsonRecord).value);
+  }
+  return stringValue(status);
+}
+
+function addMappedFlag(args: string[], flags: Flags, source: string, target: string): void {
+  const value = stringFlag(flags, source);
+  if (value !== undefined) args.push(target, value);
+}
+
+function addCsvFlag(
+  args: string[],
+  flags: Flags,
+  source: string,
+  target: string,
+  jsonOutput: boolean,
+): void {
+  const value = stringFlag(flags, source);
+  if (value === undefined) return;
+  const values = value.split(",").map((item) => item.trim()).filter(Boolean);
+  if (values.length === 0) fail(`--${source} must contain at least one value`, jsonOutput);
+  args.push(target, JSON.stringify(values));
+}
+
+function addBooleanFlag(args: string[], flags: Flags, source: string, jsonOutput: boolean): void {
+  const value = flags[source];
+  if (value === undefined) return;
+  if (value === true) {
+    args.push(`--${source}=true`);
+    return;
+  }
+  if (value === "true" || value === "false") {
+    args.push(`--${source}=${value}`);
+    return;
+  }
+  fail(`--${source} must be true or false`, jsonOutput);
+}
+
+function addPositiveIntegerFlag(
+  args: string[],
+  flags: Flags,
+  source: string,
+  target: string,
+  jsonOutput: boolean,
+): void {
+  const value = stringFlag(flags, source);
+  if (value === undefined) return;
+  if (!/^\d+$/.test(value) || Number(value) < 1) {
+    fail(`--${source} must be a positive integer`, jsonOutput);
+  }
+  args.push(target, value);
+}
+
+function stringFlag(flags: Flags, key: string): string | undefined {
+  const value = flags[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function asRecord(value: unknown): JsonRecord {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as JsonRecord : {};
+}
+
+function stringValue(value: unknown): string {
+  return value === undefined || value === null ? "" : String(value);
+}
+
+function fail(message: string, jsonOutput: boolean): never {
+  if (jsonOutput) outputJson({ error: message });
+  else printError(message);
+  process.exit(1);
+}
+
+function errorMsg(err: unknown): string {
+  if (err instanceof TelnyxCLIError) return err.stderr || err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/cli/src/commands/sim-cards.ts
+++ b/cli/src/commands/sim-cards.ts
@@ -103,7 +103,7 @@ async function runSimAction(action: SimAction, flags: Flags): Promise<void> {
       action_id: stringValue(data.id),
       sim_card_id: stringValue(data.sim_card_id) || simCardId,
       action,
-      status: stringValue(data.status) || "pending",
+      status: simStatus(data) || "pending",
     };
 
     if (jsonOutput) {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -43,6 +43,12 @@ import {
 } from "./commands/numbers.ts";
 import { aiChatCommand } from "./commands/ai-chat.ts";
 import { aiEmbedCommand } from "./commands/ai-embed.ts";
+import {
+  disableSimCardCommand,
+  enableSimCardCommand,
+  listSimCardsCommand,
+  retrieveSimCardCommand,
+} from "./commands/sim-cards.ts";
 import { parseFlags } from "./utils/output.ts";
 
 const HELP = `
@@ -55,6 +61,10 @@ Commands:
   setup-sms         Zero to SMS: create profile, buy number, assign it
   setup-voice       Zero to voice: create connection, buy number, assign it
   setup-iot         Zero to IoT: list SIMs, create group, activate SIM
+  list-sim-cards    List IoT SIM cards with filters and pagination
+  retrieve-sim-card Retrieve one IoT SIM card by ID
+  enable-sim-card   Enable an IoT SIM card (asynchronous action)
+  disable-sim-card  Disable an IoT SIM card (asynchronous action)
   setup-ai          Zero to AI: create assistant, buy number, wire them together
   setup-wireguard   Zero to VPN: create network, WireGuard interface, peer
   setup-verify      Zero to verification: create profile, buy number
@@ -322,6 +332,18 @@ AI Embed Flags:
   --encoding-format Embedding encoding format (Go CLI default: float)
   --user            End-user identifier for monitoring and abuse detection
 
+IoT SIM Action Flags:
+  --id <sim-card-id> SIM card ID (retrieve-sim-card, enable-sim-card, disable-sim-card — required)
+  --iccid           Partial ICCID filter (list-sim-cards)
+  --msisdn          MSISDN filter (list-sim-cards)
+  --status          Comma-separated SIM statuses (list-sim-cards)
+  --tags            Comma-separated tags that all matching SIMs must have (list-sim-cards)
+  --sim-card-group-id SIM card group filter (list-sim-cards)
+  --include-sim-card-group Include the associated SIM card group (list, retrieve)
+  --page-number     Result page (list-sim-cards)
+  --page-size       Results per page (list-sim-cards)
+  --sort            Sort field; prefix with - for descending (list-sim-cards)
+
 Environment:
   TELNYX_API_KEY    API key (or configure ~/.config/telnyx/config.json)
 
@@ -409,6 +431,10 @@ Examples:
   telnyx-agent ai-chat --message '{"role":"user","content":"Return JSON"}' --response-format '{"type":"json_object"}' --json
   telnyx-agent ai-embed --model thenlper/gte-large --input "Hello world" --json
   telnyx-agent ai-embed --model thenlper/gte-large --input '["one","two"]' --dimensions 256 --json
+  telnyx-agent list-sim-cards --status enabled,disabled --page-size 25 --json
+  telnyx-agent retrieve-sim-card --id <sim-card-id> --json
+  telnyx-agent enable-sim-card --id <sim-card-id> --json
+  telnyx-agent disable-sim-card --id <sim-card-id> --json
 `;
 
 const COMMANDS: Record<string, (
@@ -454,6 +480,10 @@ const COMMANDS: Record<string, (
   "lookup-number": lookupNumberCommand,
   "ai-chat": aiChatCommand,
   "ai-embed": aiEmbedCommand,
+  "list-sim-cards": listSimCardsCommand,
+  "retrieve-sim-card": retrieveSimCardCommand,
+  "enable-sim-card": enableSimCardCommand,
+  "disable-sim-card": disableSimCardCommand,
 };
 
 export async function run(argv: string[]): Promise<void> {

--- a/cli/tests/iot.test.ts
+++ b/cli/tests/iot.test.ts
@@ -46,7 +46,9 @@ if (args[0] === "sim-cards" && args[1] === "list") {
     id: "action-" + args[1],
     sim_card_id: flag("--id"),
     action_type: args[1],
-    status: "in-progress"
+    status: process.env.TELNYX_FAKE_STRING_STATUS === "true"
+      ? "in-progress"
+      : { value: "in-progress" }
   } }));
 } else {
   console.error("unexpected fake telnyx invocation: " + args.join(" "));
@@ -153,7 +155,7 @@ describe("IoT SIM action commands", () => {
   });
 
   for (const action of ["enable", "disable"] as const) {
-    it(`${action}s a SIM card through sim-cards:actions`, () => {
+    it(`${action}s a SIM card and normalizes the documented status object`, () => {
       const fake = setupFakeTelnyx();
       const output = runAgent([`${action}-sim-card`, "--id", "sim-1", "--json"], fake.env);
 
@@ -169,7 +171,23 @@ describe("IoT SIM action commands", () => {
       assertFlag(args, "--id", "sim-1");
       assertFlag(args, "--format", "json");
     });
+
+    it(`prints the normalized ${action} status in human output`, () => {
+      const fake = setupFakeTelnyx();
+      const output = runAgent([`${action}-sim-card`, "--id", "sim-1"], fake.env);
+
+      assert.match(output, /Status\s+in-progress/);
+      assert.doesNotMatch(output, /\[object Object\]/);
+    });
   }
+
+  it("preserves compatibility with string action statuses", () => {
+    const fake = setupFakeTelnyx();
+    fake.env.TELNYX_FAKE_STRING_STATUS = "true";
+    const output = runAgent(["enable-sim-card", "--id", "sim-1", "--json"], fake.env);
+
+    assert.equal(JSON.parse(output).status, "in-progress");
+  });
 
   it("advertises all direct SIM commands in help and capabilities", () => {
     const help = runAgent(["help"]);

--- a/cli/tests/iot.test.ts
+++ b/cli/tests/iot.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Mock-binary coverage for direct IoT SIM actions.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliRoot = join(__dirname, "..");
+const cliBin = join(cliRoot, "bin", "telnyx-agent.ts");
+
+function setupFakeTelnyx(): { logPath: string; env: NodeJS.ProcessEnv } {
+  const tempDir = mkdtempSync(join(tmpdir(), "telnyx-agent-iot-"));
+  const binDir = join(tempDir, "bin");
+  const logPath = join(tempDir, "args.jsonl");
+  mkdirSync(binDir, { recursive: true });
+
+  const fakeTelnyx = join(binDir, "telnyx");
+  writeFileSync(
+    fakeTelnyx,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.TELNYX_FAKE_ARGS_LOG, JSON.stringify(args) + "\\n");
+function flag(name) { const index = args.indexOf(name); return index >= 0 ? args[index + 1] : undefined; }
+
+if (args[0] === "sim-cards" && args[1] === "list") {
+  console.log(JSON.stringify({
+    data: [{ id: "sim-1", iccid: "89310410106543789301", msisdn: "+131****6224", status: "enabled", tags: ["fleet"] }],
+    meta: { page_number: 2, page_size: 25, total_results: 1 }
+  }));
+} else if (args[0] === "sim-cards" && args[1] === "retrieve") {
+  console.log(JSON.stringify({ data: {
+    id: flag("--id"),
+    iccid: "89310410106543789301",
+    msisdn: "+131****6224",
+    status: { value: "enabled", reason: "ready" },
+    sim_card_group_id: "group-1"
+  } }));
+} else if (args[0] === "sim-cards:actions" && (args[1] === "enable" || args[1] === "disable")) {
+  console.log(JSON.stringify({ data: {
+    id: "action-" + args[1],
+    sim_card_id: flag("--id"),
+    action_type: args[1],
+    status: "in-progress"
+  } }));
+} else {
+  console.error("unexpected fake telnyx invocation: " + args.join(" "));
+  process.exit(2);
+}
+`,
+  );
+  chmodSync(fakeTelnyx, 0o755);
+
+  return {
+    logPath,
+    env: {
+      ...process.env,
+      TELNYX_CLI_PATH: fakeTelnyx,
+      TELNYX_FAKE_ARGS_LOG: logPath,
+    },
+  };
+}
+
+function runAgent(args: string[], env: NodeJS.ProcessEnv = process.env): string {
+  return execFileSync("npx", ["tsx", cliBin, ...args], {
+    cwd: cliRoot,
+    encoding: "utf8",
+    env,
+    timeout: 30_000,
+  });
+}
+
+function loggedArgs(logPath: string): string[][] {
+  if (!existsSync(logPath)) return [];
+  const contents = readFileSync(logPath, "utf8");
+  assert.ok(contents.endsWith("\n"), "fake binary should terminate its JSON record with one newline");
+  assert.ok(!contents.endsWith("\n\n"), "fake binary should not write a blank JSONL record");
+  return contents.trimEnd().split("\n").map((line) => JSON.parse(line) as string[]);
+}
+
+function assertFlag(args: string[], flag: string, value: string): void {
+  const index = args.indexOf(flag);
+  assert.notEqual(index, -1, `expected ${flag} in ${args.join(" ")}`);
+  assert.equal(args[index + 1], value);
+}
+
+describe("IoT SIM action commands", () => {
+  it("lists SIM cards with generated filter and pagination flags", () => {
+    const fake = setupFakeTelnyx();
+    const output = runAgent([
+      "list-sim-cards",
+      "--iccid", "893104",
+      "--msisdn", "+131****6224",
+      "--status", "enabled,disabled",
+      "--tags", "fleet,test",
+      "--sim-card-group-id", "group-1",
+      "--include-sim-card-group",
+      "--page-number", "2",
+      "--page-size", "25",
+      "--sort", "-created_at",
+      "--json",
+    ], fake.env);
+
+    const result = JSON.parse(output);
+    assert.equal(result.count, 1);
+    assert.equal(result.sim_cards[0].id, "sim-1");
+    assert.equal(result.meta.total_results, 1);
+
+    const [args] = loggedArgs(fake.logPath);
+    assert.deepEqual(args.slice(0, 2), ["sim-cards", "list"]);
+    assertFlag(args, "--filter.iccid", "893104");
+    assertFlag(args, "--filter.msisdn", "+131****6224");
+    assertFlag(args, "--filter.status", JSON.stringify(["enabled", "disabled"]));
+    assertFlag(args, "--filter.tags", JSON.stringify(["fleet", "test"]));
+    assertFlag(args, "--filter-sim-card-group-id", "group-1");
+    assert.ok(args.includes("--include-sim-card-group=true"));
+    assertFlag(args, "--page-number", "2");
+    assertFlag(args, "--page-size", "25");
+    assertFlag(args, "--sort", "-created_at");
+    assertFlag(args, "--format", "raw");
+  });
+
+  it("retrieves one SIM card and preserves it under a stable JSON key", () => {
+    const fake = setupFakeTelnyx();
+    const output = runAgent([
+      "retrieve-sim-card",
+      "--id", "sim-1",
+      "--include-sim-card-group", "true",
+      "--json",
+    ], fake.env);
+
+    assert.deepEqual(JSON.parse(output), {
+      sim_card_id: "sim-1",
+      sim_card: {
+        id: "sim-1",
+        iccid: "89310410106543789301",
+        msisdn: "+131****6224",
+        status: { value: "enabled", reason: "ready" },
+        sim_card_group_id: "group-1",
+      },
+    });
+
+    const [args] = loggedArgs(fake.logPath);
+    assert.deepEqual(args.slice(0, 2), ["sim-cards", "retrieve"]);
+    assertFlag(args, "--id", "sim-1");
+    assert.ok(args.includes("--include-sim-card-group=true"));
+    assertFlag(args, "--format", "json");
+  });
+
+  for (const action of ["enable", "disable"] as const) {
+    it(`${action}s a SIM card through sim-cards:actions`, () => {
+      const fake = setupFakeTelnyx();
+      const output = runAgent([`${action}-sim-card`, "--id", "sim-1", "--json"], fake.env);
+
+      assert.deepEqual(JSON.parse(output), {
+        action_id: `action-${action}`,
+        sim_card_id: "sim-1",
+        action,
+        status: "in-progress",
+      });
+
+      const [args] = loggedArgs(fake.logPath);
+      assert.deepEqual(args.slice(0, 2), ["sim-cards:actions", action]);
+      assertFlag(args, "--id", "sim-1");
+      assertFlag(args, "--format", "json");
+    });
+  }
+
+  it("advertises all direct SIM commands in help and capabilities", () => {
+    const help = runAgent(["help"]);
+    const capabilities = JSON.parse(runAgent(["capabilities", "--json"]));
+    const commands = ["list-sim-cards", "retrieve-sim-card", "enable-sim-card", "disable-sim-card"];
+
+    for (const command of commands) {
+      assert.match(help, new RegExp(command));
+      assert.ok(
+        capabilities.composite_commands.some((entry: { name: string }) => entry.name === `telnyx-agent ${command}`),
+        `capabilities should advertise ${command}`,
+      );
+    }
+
+    const iotActions = capabilities.api_capabilities["📡 IoT"][0].actions;
+    for (const action of ["list_sim_cards", "retrieve_sim_card", "enable_sim_card", "disable_sim_card"]) {
+      assert.ok(iotActions.includes(action), `IoT capabilities should include ${action}`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add direct SIM list and retrieve commands
- add direct SIM enable and disable commands
- map current generated flags and add stable JSON/help/capabilities/mock tests

## Verification
- `npm run typecheck`
- `npm test` (115 passed)