### PR TITLE
chore: verify PR 87 JavaScript snake_case output

### DIFF
--- a/providers/claude/plugins/telnyx-messaging/skills/telnyx-messaging-javascript/SKILL.md
+++ b/providers/claude/plugins/telnyx-messaging/skills/telnyx-messaging-javascript/SKILL.md
@@ -96,9 +96,9 @@ Primary outbound messaging flow. Agents need exact request fields and delivery-r
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
 | `from` | string (E.164) | Yes | Sending address (+E.164 formatted phone number, alphanumeric... |
 | `text` | string | Yes | Message body (i.e., content) as a non-empty string. |
-| `messagingProfileId` | string (UUID) | No | Unique identifier for a messaging profile. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Unique identifier for a messaging profile. |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
 | ... | | | +7 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -130,10 +130,10 @@ Common sender variant that requires different request shape.
 | `from` | string (E.164) | Yes | A valid alphanumeric sender ID on the user's account. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
 | `text` | string | Yes | The message body. |
-| `messagingProfileId` | string (UUID) | Yes | The messaging profile ID to use. |
-| `webhookUrl` | string (URL) | No | Callback URL for delivery status updates. |
-| `webhookFailoverUrl` | string (URL) | No | Failover callback URL for delivery status updates. |
-| `useProfileWebhooks` | boolean | No | If true, use the messaging profile's webhook settings. |
+| `messaging_profile_id` | string (UUID) | Yes | The messaging profile ID to use. |
+| `webhook_url` | string (URL) | No | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | No | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | No | If true, use the messaging profile's webhook settings. |
 
 ```javascript
 const response = await client.messages.sendWithAlphanumericSender({
@@ -226,9 +226,9 @@ Send one MMS payload to multiple recipients.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | array[object] | Yes | A list of destinations. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +3 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -259,9 +259,9 @@ Force a long-code sending path instead of the generic send endpoint.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -289,11 +289,11 @@ Let a messaging profile or number pool choose the sender for you.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `messagingProfileId` | string (UUID) | Yes | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Yes | Unique identifier for a messaging profile. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -324,9 +324,9 @@ Force a short-code sending path when the sender must be a short code.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -355,9 +355,9 @@ Queue a message for future delivery instead of sending immediately.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `messagingProfileId` | string (UUID) | No | Unique identifier for a messaging profile. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Unique identifier for a messaging profile. |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
 | ... | | | +8 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -365,7 +365,7 @@ const response = await client.messages.schedule({
     to: '+18445550001',
     from: '+18005550101',
     text: 'Appointment reminder',
-    sendAt: '2025-07-01T15:00:00Z',
+    send_at: '2025-07-01T15:00:00Z',
 });
 
 console.log(response.data);
@@ -389,10 +389,10 @@ Send WhatsApp traffic instead of SMS/MMS.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number in +E.164 format associated with Whatsapp accou... |
 | `to` | string (E.164) | Yes | Phone number in +E.164 format |
-| `whatsappMessage` | object | Yes |  |
+| `whatsapp_message` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `messagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```javascript
 const response = await client.messages.sendWhatsapp({
@@ -424,10 +424,10 @@ Before using any operation below, read [the optional-parameters section](referen
 | Retrieve a message | `client.messages.retrieve()` | `GET /messages/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Cancel a scheduled message | `client.messages.cancelScheduled()` | `DELETE /messages/{id}` | Remove, detach, or clean up an existing resource. | `id` |
 | List alphanumeric sender IDs | `client.alphanumericSenderIDs.list()` | `GET /alphanumeric_sender_ids` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Create an alphanumeric sender ID | `client.alphanumericSenderIDs.create()` | `POST /alphanumeric_sender_ids` | Create or provision an additional resource when the core tasks do not cover this flow. | `alphanumericSenderId`, `messagingProfileId` |
+| Create an alphanumeric sender ID | `client.alphanumericSenderIDs.create()` | `POST /alphanumeric_sender_ids` | Create or provision an additional resource when the core tasks do not cover this flow. | `alphanumeric_sender_id`, `messaging_profile_id` |
 | Retrieve an alphanumeric sender ID | `client.alphanumericSenderIDs.retrieve()` | `GET /alphanumeric_sender_ids/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Delete an alphanumeric sender ID | `client.alphanumericSenderIDs.delete()` | `DELETE /alphanumeric_sender_ids/{id}` | Remove, detach, or clean up an existing resource. | `id` |
-| Retrieve group MMS messages | `client.messages.retrieveGroupMessages()` | `GET /messages/group/{message_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `messageId` |
+| Retrieve group MMS messages | `client.messages.retrieveGroupMessages()` | `GET /messages/group/{message_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `message_id` |
 | List messaging hosted numbers | `client.messagingHostedNumbers.list()` | `GET /messaging_hosted_numbers` | Inspect available resources or choose an existing resource before mutating it. | None |
 | Retrieve a messaging hosted number | `client.messagingHostedNumbers.retrieve()` | `GET /messaging_hosted_numbers/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Update a messaging hosted number | `client.messagingHostedNumbers.update()` | `PATCH /messaging_hosted_numbers/{id}` | Modify an existing resource without recreating it. | `id` |
@@ -436,11 +436,11 @@ Before using any operation below, read [the optional-parameters section](referen
 | Regenerate messaging profile secret | `client.messagingProfiles.actions.regenerateSecret()` | `POST /messaging_profiles/{id}/actions/regenerate_secret` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `id` |
 | List alphanumeric sender IDs for a messaging profile | `client.messagingProfiles.listAlphanumericSenderIDs()` | `GET /messaging_profiles/{id}/alphanumeric_sender_ids` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Get detailed messaging profile metrics | `client.messagingProfiles.retrieveMetrics()` | `GET /messaging_profiles/{id}/metrics` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
-| List Auto-Response Settings | `client.messagingProfiles.autorespConfigs.list()` | `GET /messaging_profiles/{profile_id}/autoresp_configs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profileId` |
-| Create auto-response setting | `client.messagingProfiles.autorespConfigs.create()` | `POST /messaging_profiles/{profile_id}/autoresp_configs` | Create or provision an additional resource when the core tasks do not cover this flow. | `op`, `keywords`, `countryCode`, `profileId` |
-| Get Auto-Response Setting | `client.messagingProfiles.autorespConfigs.retrieve()` | `GET /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profileId`, `autorespCfgId` |
-| Update Auto-Response Setting | `client.messagingProfiles.autorespConfigs.update()` | `PUT /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Modify an existing resource without recreating it. | `op`, `keywords`, `countryCode`, `profileId`, +1 more |
-| Delete Auto-Response Setting | `client.messagingProfiles.autorespConfigs.delete()` | `DELETE /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Remove, detach, or clean up an existing resource. | `profileId`, `autorespCfgId` |
+| List Auto-Response Settings | `client.messagingProfiles.autorespConfigs.list()` | `GET /messaging_profiles/{profile_id}/autoresp_configs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profile_id` |
+| Create auto-response setting | `client.messagingProfiles.autorespConfigs.create()` | `POST /messaging_profiles/{profile_id}/autoresp_configs` | Create or provision an additional resource when the core tasks do not cover this flow. | `op`, `keywords`, `country_code`, `profile_id` |
+| Get Auto-Response Setting | `client.messagingProfiles.autorespConfigs.retrieve()` | `GET /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profile_id`, `autoresp_cfg_id` |
+| Update Auto-Response Setting | `client.messagingProfiles.autorespConfigs.update()` | `PUT /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Modify an existing resource without recreating it. | `op`, `keywords`, `country_code`, `profile_id`, +1 more |
+| Delete Auto-Response Setting | `client.messagingProfiles.autorespConfigs.delete()` | `DELETE /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Remove, detach, or clean up an existing resource. | `profile_id`, `autoresp_cfg_id` |
 
 ### Other Webhook Events
 

--- a/providers/claude/plugins/telnyx-messaging/skills/telnyx-messaging-javascript/references/api-details.md
+++ b/providers/claude/plugins/telnyx-messaging/skills/telnyx-messaging-javascript/references/api-details.md
@@ -199,32 +199,32 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `usLongCodeFallback` | string | A US long code number to use as fallback when sending to US destinations. |
+| `us_long_code_fallback` | string | A US long code number to use as fallback when sending to US destinations. |
 
 ### Send a message — `client.messages.send()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
-| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
-| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a message using an alphanumeric sender ID — `client.messages.sendWithAlphanumericSender()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `webhookUrl` | string (URL) | Callback URL for delivery status updates. |
-| `webhookFailoverUrl` | string (URL) | Failover callback URL for delivery status updates. |
-| `useProfileWebhooks` | boolean | If true, use the messaging profile's webhook settings. |
+| `webhook_url` | string (URL) | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | If true, use the messaging profile's webhook settings. |
 
 ### Send a group MMS message — `client.messages.sendGroupMms()`
 
@@ -232,10 +232,10 @@
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 
 ### Send a long code message — `client.messages.sendLongCode()`
 
@@ -243,12 +243,12 @@
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a message using number pool — `client.messages.sendNumberPool()`
@@ -257,12 +257,12 @@
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Schedule a message — `client.messages.schedule()`
@@ -270,16 +270,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
-| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
-| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
 
 ### Send a short code message — `client.messages.sendShortCode()`
 
@@ -287,12 +287,12 @@
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a WhatsApp message — `client.messages.sendWhatsapp()`
@@ -300,17 +300,17 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `messagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messagingHostedNumbers.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `messagingProfileId` | string (UUID) | Configure the messaging profile this phone number is assigned to:
+| `messaging_profile_id` | string (UUID) | Configure the messaging profile this phone number is assigned to:
 
 * Omit thi... |
-| `messagingProduct` | string | Configure the messaging product for this number:
+| `messaging_product` | string | Configure the messaging product for this number:
 
 * Omit this field or set it... |
 | `tags` | array[string] | Tags to set on this phone number. |
@@ -319,13 +319,13 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `respText` | string |  |
+| `resp_text` | string |  |
 
 ### Update Auto-Response Setting — `client.messagingProfiles.autorespConfigs.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `respText` | string |  |
+| `resp_text` | string |  |
 
 ## Webhook Payload Fields
 

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/javascript/messaging.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/javascript/messaging.md
@@ -83,9 +83,9 @@ Primary outbound messaging flow. Agents need exact request fields and delivery-r
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
 | `from` | string (E.164) | Yes | Sending address (+E.164 formatted phone number, alphanumeric... |
 | `text` | string | Yes | Message body (i.e., content) as a non-empty string. |
-| `messagingProfileId` | string (UUID) | No | Unique identifier for a messaging profile. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Unique identifier for a messaging profile. |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
 | ... | | | +7 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -117,10 +117,10 @@ Common sender variant that requires different request shape.
 | `from` | string (E.164) | Yes | A valid alphanumeric sender ID on the user's account. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
 | `text` | string | Yes | The message body. |
-| `messagingProfileId` | string (UUID) | Yes | The messaging profile ID to use. |
-| `webhookUrl` | string (URL) | No | Callback URL for delivery status updates. |
-| `webhookFailoverUrl` | string (URL) | No | Failover callback URL for delivery status updates. |
-| `useProfileWebhooks` | boolean | No | If true, use the messaging profile's webhook settings. |
+| `messaging_profile_id` | string (UUID) | Yes | The messaging profile ID to use. |
+| `webhook_url` | string (URL) | No | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | No | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | No | If true, use the messaging profile's webhook settings. |
 
 ```javascript
 const response = await client.messages.sendWithAlphanumericSender({
@@ -213,9 +213,9 @@ Send one MMS payload to multiple recipients.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | array[object] | Yes | A list of destinations. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +3 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -246,9 +246,9 @@ Force a long-code sending path instead of the generic send endpoint.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -276,11 +276,11 @@ Let a messaging profile or number pool choose the sender for you.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `messagingProfileId` | string (UUID) | Yes | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Yes | Unique identifier for a messaging profile. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -311,9 +311,9 @@ Force a short-code sending path when the sender must be a short code.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -342,9 +342,9 @@ Queue a message for future delivery instead of sending immediately.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `messagingProfileId` | string (UUID) | No | Unique identifier for a messaging profile. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Unique identifier for a messaging profile. |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
 | ... | | | +8 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -352,7 +352,7 @@ const response = await client.messages.schedule({
     to: '+18445550001',
     from: '+18005550101',
     text: 'Appointment reminder',
-    sendAt: '2025-07-01T15:00:00Z',
+    send_at: '2025-07-01T15:00:00Z',
 });
 
 console.log(response.data);
@@ -376,10 +376,10 @@ Send WhatsApp traffic instead of SMS/MMS.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number in +E.164 format associated with Whatsapp accou... |
 | `to` | string (E.164) | Yes | Phone number in +E.164 format |
-| `whatsappMessage` | object | Yes |  |
+| `whatsapp_message` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `messagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```javascript
 const response = await client.messages.sendWhatsapp({
@@ -411,10 +411,10 @@ Before using any operation below, read the Optional Parameters section below and
 | Retrieve a message | `client.messages.retrieve()` | `GET /messages/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Cancel a scheduled message | `client.messages.cancelScheduled()` | `DELETE /messages/{id}` | Remove, detach, or clean up an existing resource. | `id` |
 | List alphanumeric sender IDs | `client.alphanumericSenderIDs.list()` | `GET /alphanumeric_sender_ids` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Create an alphanumeric sender ID | `client.alphanumericSenderIDs.create()` | `POST /alphanumeric_sender_ids` | Create or provision an additional resource when the core tasks do not cover this flow. | `alphanumericSenderId`, `messagingProfileId` |
+| Create an alphanumeric sender ID | `client.alphanumericSenderIDs.create()` | `POST /alphanumeric_sender_ids` | Create or provision an additional resource when the core tasks do not cover this flow. | `alphanumeric_sender_id`, `messaging_profile_id` |
 | Retrieve an alphanumeric sender ID | `client.alphanumericSenderIDs.retrieve()` | `GET /alphanumeric_sender_ids/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Delete an alphanumeric sender ID | `client.alphanumericSenderIDs.delete()` | `DELETE /alphanumeric_sender_ids/{id}` | Remove, detach, or clean up an existing resource. | `id` |
-| Retrieve group MMS messages | `client.messages.retrieveGroupMessages()` | `GET /messages/group/{message_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `messageId` |
+| Retrieve group MMS messages | `client.messages.retrieveGroupMessages()` | `GET /messages/group/{message_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `message_id` |
 | List messaging hosted numbers | `client.messagingHostedNumbers.list()` | `GET /messaging_hosted_numbers` | Inspect available resources or choose an existing resource before mutating it. | None |
 | Retrieve a messaging hosted number | `client.messagingHostedNumbers.retrieve()` | `GET /messaging_hosted_numbers/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Update a messaging hosted number | `client.messagingHostedNumbers.update()` | `PATCH /messaging_hosted_numbers/{id}` | Modify an existing resource without recreating it. | `id` |
@@ -423,11 +423,11 @@ Before using any operation below, read the Optional Parameters section below and
 | Regenerate messaging profile secret | `client.messagingProfiles.actions.regenerateSecret()` | `POST /messaging_profiles/{id}/actions/regenerate_secret` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `id` |
 | List alphanumeric sender IDs for a messaging profile | `client.messagingProfiles.listAlphanumericSenderIDs()` | `GET /messaging_profiles/{id}/alphanumeric_sender_ids` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Get detailed messaging profile metrics | `client.messagingProfiles.retrieveMetrics()` | `GET /messaging_profiles/{id}/metrics` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
-| List Auto-Response Settings | `client.messagingProfiles.autorespConfigs.list()` | `GET /messaging_profiles/{profile_id}/autoresp_configs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profileId` |
-| Create auto-response setting | `client.messagingProfiles.autorespConfigs.create()` | `POST /messaging_profiles/{profile_id}/autoresp_configs` | Create or provision an additional resource when the core tasks do not cover this flow. | `op`, `keywords`, `countryCode`, `profileId` |
-| Get Auto-Response Setting | `client.messagingProfiles.autorespConfigs.retrieve()` | `GET /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profileId`, `autorespCfgId` |
-| Update Auto-Response Setting | `client.messagingProfiles.autorespConfigs.update()` | `PUT /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Modify an existing resource without recreating it. | `op`, `keywords`, `countryCode`, `profileId`, +1 more |
-| Delete Auto-Response Setting | `client.messagingProfiles.autorespConfigs.delete()` | `DELETE /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Remove, detach, or clean up an existing resource. | `profileId`, `autorespCfgId` |
+| List Auto-Response Settings | `client.messagingProfiles.autorespConfigs.list()` | `GET /messaging_profiles/{profile_id}/autoresp_configs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profile_id` |
+| Create auto-response setting | `client.messagingProfiles.autorespConfigs.create()` | `POST /messaging_profiles/{profile_id}/autoresp_configs` | Create or provision an additional resource when the core tasks do not cover this flow. | `op`, `keywords`, `country_code`, `profile_id` |
+| Get Auto-Response Setting | `client.messagingProfiles.autorespConfigs.retrieve()` | `GET /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profile_id`, `autoresp_cfg_id` |
+| Update Auto-Response Setting | `client.messagingProfiles.autorespConfigs.update()` | `PUT /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Modify an existing resource without recreating it. | `op`, `keywords`, `country_code`, `profile_id`, +1 more |
+| Delete Auto-Response Setting | `client.messagingProfiles.autorespConfigs.delete()` | `DELETE /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Remove, detach, or clean up an existing resource. | `profile_id`, `autoresp_cfg_id` |
 
 ### Other Webhook Events
 
@@ -448,32 +448,32 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `usLongCodeFallback` | string | A US long code number to use as fallback when sending to US destinations. |
+| `us_long_code_fallback` | string | A US long code number to use as fallback when sending to US destinations. |
 
 ### Send a message — `client.messages.send()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
-| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
-| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a message using an alphanumeric sender ID — `client.messages.sendWithAlphanumericSender()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `webhookUrl` | string (URL) | Callback URL for delivery status updates. |
-| `webhookFailoverUrl` | string (URL) | Failover callback URL for delivery status updates. |
-| `useProfileWebhooks` | boolean | If true, use the messaging profile's webhook settings. |
+| `webhook_url` | string (URL) | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | If true, use the messaging profile's webhook settings. |
 
 ### Send a group MMS message — `client.messages.sendGroupMms()`
 
@@ -481,10 +481,10 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 
 ### Send a long code message — `client.messages.sendLongCode()`
 
@@ -492,12 +492,12 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a message using number pool — `client.messages.sendNumberPool()`
@@ -506,12 +506,12 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Schedule a message — `client.messages.schedule()`
@@ -519,16 +519,16 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
-| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
-| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
 
 ### Send a short code message — `client.messages.sendShortCode()`
 
@@ -536,12 +536,12 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a WhatsApp message — `client.messages.sendWhatsapp()`
@@ -549,17 +549,17 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `messagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messagingHostedNumbers.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `messagingProfileId` | string (UUID) | Configure the messaging profile this phone number is assigned to:
+| `messaging_profile_id` | string (UUID) | Configure the messaging profile this phone number is assigned to:
 
 * Omit thi... |
-| `messagingProduct` | string | Configure the messaging product for this number:
+| `messaging_product` | string | Configure the messaging product for this number:
 
 * Omit this field or set it... |
 | `tags` | array[string] | Tags to set on this phone number. |
@@ -568,10 +568,10 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `respText` | string |  |
+| `resp_text` | string |  |
 
 ### Update Auto-Response Setting — `client.messagingProfiles.autorespConfigs.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `respText` | string |  |
+| `resp_text` | string |  |

--- a/providers/cursor/plugin/skills/telnyx-messaging-javascript/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-javascript/SKILL.md
@@ -96,9 +96,9 @@ Primary outbound messaging flow. Agents need exact request fields and delivery-r
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
 | `from` | string (E.164) | Yes | Sending address (+E.164 formatted phone number, alphanumeric... |
 | `text` | string | Yes | Message body (i.e., content) as a non-empty string. |
-| `messagingProfileId` | string (UUID) | No | Unique identifier for a messaging profile. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Unique identifier for a messaging profile. |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
 | ... | | | +7 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -130,10 +130,10 @@ Common sender variant that requires different request shape.
 | `from` | string (E.164) | Yes | A valid alphanumeric sender ID on the user's account. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
 | `text` | string | Yes | The message body. |
-| `messagingProfileId` | string (UUID) | Yes | The messaging profile ID to use. |
-| `webhookUrl` | string (URL) | No | Callback URL for delivery status updates. |
-| `webhookFailoverUrl` | string (URL) | No | Failover callback URL for delivery status updates. |
-| `useProfileWebhooks` | boolean | No | If true, use the messaging profile's webhook settings. |
+| `messaging_profile_id` | string (UUID) | Yes | The messaging profile ID to use. |
+| `webhook_url` | string (URL) | No | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | No | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | No | If true, use the messaging profile's webhook settings. |
 
 ```javascript
 const response = await client.messages.sendWithAlphanumericSender({
@@ -226,9 +226,9 @@ Send one MMS payload to multiple recipients.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | array[object] | Yes | A list of destinations. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +3 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -259,9 +259,9 @@ Force a long-code sending path instead of the generic send endpoint.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -289,11 +289,11 @@ Let a messaging profile or number pool choose the sender for you.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `messagingProfileId` | string (UUID) | Yes | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Yes | Unique identifier for a messaging profile. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -324,9 +324,9 @@ Force a short-code sending path when the sender must be a short code.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -355,9 +355,9 @@ Queue a message for future delivery instead of sending immediately.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `messagingProfileId` | string (UUID) | No | Unique identifier for a messaging profile. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Unique identifier for a messaging profile. |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
 | ... | | | +8 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -365,7 +365,7 @@ const response = await client.messages.schedule({
     to: '+18445550001',
     from: '+18005550101',
     text: 'Appointment reminder',
-    sendAt: '2025-07-01T15:00:00Z',
+    send_at: '2025-07-01T15:00:00Z',
 });
 
 console.log(response.data);
@@ -389,10 +389,10 @@ Send WhatsApp traffic instead of SMS/MMS.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number in +E.164 format associated with Whatsapp accou... |
 | `to` | string (E.164) | Yes | Phone number in +E.164 format |
-| `whatsappMessage` | object | Yes |  |
+| `whatsapp_message` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `messagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```javascript
 const response = await client.messages.sendWhatsapp({
@@ -424,10 +424,10 @@ Before using any operation below, read [the optional-parameters section](referen
 | Retrieve a message | `client.messages.retrieve()` | `GET /messages/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Cancel a scheduled message | `client.messages.cancelScheduled()` | `DELETE /messages/{id}` | Remove, detach, or clean up an existing resource. | `id` |
 | List alphanumeric sender IDs | `client.alphanumericSenderIDs.list()` | `GET /alphanumeric_sender_ids` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Create an alphanumeric sender ID | `client.alphanumericSenderIDs.create()` | `POST /alphanumeric_sender_ids` | Create or provision an additional resource when the core tasks do not cover this flow. | `alphanumericSenderId`, `messagingProfileId` |
+| Create an alphanumeric sender ID | `client.alphanumericSenderIDs.create()` | `POST /alphanumeric_sender_ids` | Create or provision an additional resource when the core tasks do not cover this flow. | `alphanumeric_sender_id`, `messaging_profile_id` |
 | Retrieve an alphanumeric sender ID | `client.alphanumericSenderIDs.retrieve()` | `GET /alphanumeric_sender_ids/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Delete an alphanumeric sender ID | `client.alphanumericSenderIDs.delete()` | `DELETE /alphanumeric_sender_ids/{id}` | Remove, detach, or clean up an existing resource. | `id` |
-| Retrieve group MMS messages | `client.messages.retrieveGroupMessages()` | `GET /messages/group/{message_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `messageId` |
+| Retrieve group MMS messages | `client.messages.retrieveGroupMessages()` | `GET /messages/group/{message_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `message_id` |
 | List messaging hosted numbers | `client.messagingHostedNumbers.list()` | `GET /messaging_hosted_numbers` | Inspect available resources or choose an existing resource before mutating it. | None |
 | Retrieve a messaging hosted number | `client.messagingHostedNumbers.retrieve()` | `GET /messaging_hosted_numbers/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Update a messaging hosted number | `client.messagingHostedNumbers.update()` | `PATCH /messaging_hosted_numbers/{id}` | Modify an existing resource without recreating it. | `id` |
@@ -436,11 +436,11 @@ Before using any operation below, read [the optional-parameters section](referen
 | Regenerate messaging profile secret | `client.messagingProfiles.actions.regenerateSecret()` | `POST /messaging_profiles/{id}/actions/regenerate_secret` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `id` |
 | List alphanumeric sender IDs for a messaging profile | `client.messagingProfiles.listAlphanumericSenderIDs()` | `GET /messaging_profiles/{id}/alphanumeric_sender_ids` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Get detailed messaging profile metrics | `client.messagingProfiles.retrieveMetrics()` | `GET /messaging_profiles/{id}/metrics` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
-| List Auto-Response Settings | `client.messagingProfiles.autorespConfigs.list()` | `GET /messaging_profiles/{profile_id}/autoresp_configs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profileId` |
-| Create auto-response setting | `client.messagingProfiles.autorespConfigs.create()` | `POST /messaging_profiles/{profile_id}/autoresp_configs` | Create or provision an additional resource when the core tasks do not cover this flow. | `op`, `keywords`, `countryCode`, `profileId` |
-| Get Auto-Response Setting | `client.messagingProfiles.autorespConfigs.retrieve()` | `GET /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profileId`, `autorespCfgId` |
-| Update Auto-Response Setting | `client.messagingProfiles.autorespConfigs.update()` | `PUT /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Modify an existing resource without recreating it. | `op`, `keywords`, `countryCode`, `profileId`, +1 more |
-| Delete Auto-Response Setting | `client.messagingProfiles.autorespConfigs.delete()` | `DELETE /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Remove, detach, or clean up an existing resource. | `profileId`, `autorespCfgId` |
+| List Auto-Response Settings | `client.messagingProfiles.autorespConfigs.list()` | `GET /messaging_profiles/{profile_id}/autoresp_configs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profile_id` |
+| Create auto-response setting | `client.messagingProfiles.autorespConfigs.create()` | `POST /messaging_profiles/{profile_id}/autoresp_configs` | Create or provision an additional resource when the core tasks do not cover this flow. | `op`, `keywords`, `country_code`, `profile_id` |
+| Get Auto-Response Setting | `client.messagingProfiles.autorespConfigs.retrieve()` | `GET /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profile_id`, `autoresp_cfg_id` |
+| Update Auto-Response Setting | `client.messagingProfiles.autorespConfigs.update()` | `PUT /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Modify an existing resource without recreating it. | `op`, `keywords`, `country_code`, `profile_id`, +1 more |
+| Delete Auto-Response Setting | `client.messagingProfiles.autorespConfigs.delete()` | `DELETE /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Remove, detach, or clean up an existing resource. | `profile_id`, `autoresp_cfg_id` |
 
 ### Other Webhook Events
 

--- a/providers/cursor/plugin/skills/telnyx-messaging-javascript/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-javascript/references/api-details.md
@@ -199,32 +199,32 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `usLongCodeFallback` | string | A US long code number to use as fallback when sending to US destinations. |
+| `us_long_code_fallback` | string | A US long code number to use as fallback when sending to US destinations. |
 
 ### Send a message — `client.messages.send()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
-| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
-| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a message using an alphanumeric sender ID — `client.messages.sendWithAlphanumericSender()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `webhookUrl` | string (URL) | Callback URL for delivery status updates. |
-| `webhookFailoverUrl` | string (URL) | Failover callback URL for delivery status updates. |
-| `useProfileWebhooks` | boolean | If true, use the messaging profile's webhook settings. |
+| `webhook_url` | string (URL) | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | If true, use the messaging profile's webhook settings. |
 
 ### Send a group MMS message — `client.messages.sendGroupMms()`
 
@@ -232,10 +232,10 @@
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 
 ### Send a long code message — `client.messages.sendLongCode()`
 
@@ -243,12 +243,12 @@
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a message using number pool — `client.messages.sendNumberPool()`
@@ -257,12 +257,12 @@
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Schedule a message — `client.messages.schedule()`
@@ -270,16 +270,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
-| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
-| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
 
 ### Send a short code message — `client.messages.sendShortCode()`
 
@@ -287,12 +287,12 @@
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a WhatsApp message — `client.messages.sendWhatsapp()`
@@ -300,17 +300,17 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `messagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messagingHostedNumbers.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `messagingProfileId` | string (UUID) | Configure the messaging profile this phone number is assigned to:
+| `messaging_profile_id` | string (UUID) | Configure the messaging profile this phone number is assigned to:
 
 * Omit thi... |
-| `messagingProduct` | string | Configure the messaging product for this number:
+| `messaging_product` | string | Configure the messaging product for this number:
 
 * Omit this field or set it... |
 | `tags` | array[string] | Tags to set on this phone number. |
@@ -319,13 +319,13 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `respText` | string |  |
+| `resp_text` | string |  |
 
 ### Update Auto-Response Setting — `client.messagingProfiles.autorespConfigs.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `respText` | string |  |
+| `resp_text` | string |  |
 
 ## Webhook Payload Fields
 

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/messaging.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/messaging.md
@@ -83,9 +83,9 @@ Primary outbound messaging flow. Agents need exact request fields and delivery-r
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
 | `from` | string (E.164) | Yes | Sending address (+E.164 formatted phone number, alphanumeric... |
 | `text` | string | Yes | Message body (i.e., content) as a non-empty string. |
-| `messagingProfileId` | string (UUID) | No | Unique identifier for a messaging profile. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Unique identifier for a messaging profile. |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
 | ... | | | +7 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -117,10 +117,10 @@ Common sender variant that requires different request shape.
 | `from` | string (E.164) | Yes | A valid alphanumeric sender ID on the user's account. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
 | `text` | string | Yes | The message body. |
-| `messagingProfileId` | string (UUID) | Yes | The messaging profile ID to use. |
-| `webhookUrl` | string (URL) | No | Callback URL for delivery status updates. |
-| `webhookFailoverUrl` | string (URL) | No | Failover callback URL for delivery status updates. |
-| `useProfileWebhooks` | boolean | No | If true, use the messaging profile's webhook settings. |
+| `messaging_profile_id` | string (UUID) | Yes | The messaging profile ID to use. |
+| `webhook_url` | string (URL) | No | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | No | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | No | If true, use the messaging profile's webhook settings. |
 
 ```javascript
 const response = await client.messages.sendWithAlphanumericSender({
@@ -213,9 +213,9 @@ Send one MMS payload to multiple recipients.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | array[object] | Yes | A list of destinations. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +3 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -246,9 +246,9 @@ Force a long-code sending path instead of the generic send endpoint.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -276,11 +276,11 @@ Let a messaging profile or number pool choose the sender for you.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `messagingProfileId` | string (UUID) | Yes | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Yes | Unique identifier for a messaging profile. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -311,9 +311,9 @@ Force a short-code sending path when the sender must be a short code.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -342,9 +342,9 @@ Queue a message for future delivery instead of sending immediately.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `messagingProfileId` | string (UUID) | No | Unique identifier for a messaging profile. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Unique identifier for a messaging profile. |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
 | ... | | | +8 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -352,7 +352,7 @@ const response = await client.messages.schedule({
     to: '+18445550001',
     from: '+18005550101',
     text: 'Appointment reminder',
-    sendAt: '2025-07-01T15:00:00Z',
+    send_at: '2025-07-01T15:00:00Z',
 });
 
 console.log(response.data);
@@ -376,10 +376,10 @@ Send WhatsApp traffic instead of SMS/MMS.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number in +E.164 format associated with Whatsapp accou... |
 | `to` | string (E.164) | Yes | Phone number in +E.164 format |
-| `whatsappMessage` | object | Yes |  |
+| `whatsapp_message` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `messagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```javascript
 const response = await client.messages.sendWhatsapp({
@@ -411,10 +411,10 @@ Before using any operation below, read the Optional Parameters section below and
 | Retrieve a message | `client.messages.retrieve()` | `GET /messages/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Cancel a scheduled message | `client.messages.cancelScheduled()` | `DELETE /messages/{id}` | Remove, detach, or clean up an existing resource. | `id` |
 | List alphanumeric sender IDs | `client.alphanumericSenderIDs.list()` | `GET /alphanumeric_sender_ids` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Create an alphanumeric sender ID | `client.alphanumericSenderIDs.create()` | `POST /alphanumeric_sender_ids` | Create or provision an additional resource when the core tasks do not cover this flow. | `alphanumericSenderId`, `messagingProfileId` |
+| Create an alphanumeric sender ID | `client.alphanumericSenderIDs.create()` | `POST /alphanumeric_sender_ids` | Create or provision an additional resource when the core tasks do not cover this flow. | `alphanumeric_sender_id`, `messaging_profile_id` |
 | Retrieve an alphanumeric sender ID | `client.alphanumericSenderIDs.retrieve()` | `GET /alphanumeric_sender_ids/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Delete an alphanumeric sender ID | `client.alphanumericSenderIDs.delete()` | `DELETE /alphanumeric_sender_ids/{id}` | Remove, detach, or clean up an existing resource. | `id` |
-| Retrieve group MMS messages | `client.messages.retrieveGroupMessages()` | `GET /messages/group/{message_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `messageId` |
+| Retrieve group MMS messages | `client.messages.retrieveGroupMessages()` | `GET /messages/group/{message_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `message_id` |
 | List messaging hosted numbers | `client.messagingHostedNumbers.list()` | `GET /messaging_hosted_numbers` | Inspect available resources or choose an existing resource before mutating it. | None |
 | Retrieve a messaging hosted number | `client.messagingHostedNumbers.retrieve()` | `GET /messaging_hosted_numbers/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Update a messaging hosted number | `client.messagingHostedNumbers.update()` | `PATCH /messaging_hosted_numbers/{id}` | Modify an existing resource without recreating it. | `id` |
@@ -423,11 +423,11 @@ Before using any operation below, read the Optional Parameters section below and
 | Regenerate messaging profile secret | `client.messagingProfiles.actions.regenerateSecret()` | `POST /messaging_profiles/{id}/actions/regenerate_secret` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `id` |
 | List alphanumeric sender IDs for a messaging profile | `client.messagingProfiles.listAlphanumericSenderIDs()` | `GET /messaging_profiles/{id}/alphanumeric_sender_ids` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Get detailed messaging profile metrics | `client.messagingProfiles.retrieveMetrics()` | `GET /messaging_profiles/{id}/metrics` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
-| List Auto-Response Settings | `client.messagingProfiles.autorespConfigs.list()` | `GET /messaging_profiles/{profile_id}/autoresp_configs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profileId` |
-| Create auto-response setting | `client.messagingProfiles.autorespConfigs.create()` | `POST /messaging_profiles/{profile_id}/autoresp_configs` | Create or provision an additional resource when the core tasks do not cover this flow. | `op`, `keywords`, `countryCode`, `profileId` |
-| Get Auto-Response Setting | `client.messagingProfiles.autorespConfigs.retrieve()` | `GET /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profileId`, `autorespCfgId` |
-| Update Auto-Response Setting | `client.messagingProfiles.autorespConfigs.update()` | `PUT /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Modify an existing resource without recreating it. | `op`, `keywords`, `countryCode`, `profileId`, +1 more |
-| Delete Auto-Response Setting | `client.messagingProfiles.autorespConfigs.delete()` | `DELETE /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Remove, detach, or clean up an existing resource. | `profileId`, `autorespCfgId` |
+| List Auto-Response Settings | `client.messagingProfiles.autorespConfigs.list()` | `GET /messaging_profiles/{profile_id}/autoresp_configs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profile_id` |
+| Create auto-response setting | `client.messagingProfiles.autorespConfigs.create()` | `POST /messaging_profiles/{profile_id}/autoresp_configs` | Create or provision an additional resource when the core tasks do not cover this flow. | `op`, `keywords`, `country_code`, `profile_id` |
+| Get Auto-Response Setting | `client.messagingProfiles.autorespConfigs.retrieve()` | `GET /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profile_id`, `autoresp_cfg_id` |
+| Update Auto-Response Setting | `client.messagingProfiles.autorespConfigs.update()` | `PUT /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Modify an existing resource without recreating it. | `op`, `keywords`, `country_code`, `profile_id`, +1 more |
+| Delete Auto-Response Setting | `client.messagingProfiles.autorespConfigs.delete()` | `DELETE /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Remove, detach, or clean up an existing resource. | `profile_id`, `autoresp_cfg_id` |
 
 ### Other Webhook Events
 
@@ -448,32 +448,32 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `usLongCodeFallback` | string | A US long code number to use as fallback when sending to US destinations. |
+| `us_long_code_fallback` | string | A US long code number to use as fallback when sending to US destinations. |
 
 ### Send a message — `client.messages.send()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
-| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
-| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a message using an alphanumeric sender ID — `client.messages.sendWithAlphanumericSender()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `webhookUrl` | string (URL) | Callback URL for delivery status updates. |
-| `webhookFailoverUrl` | string (URL) | Failover callback URL for delivery status updates. |
-| `useProfileWebhooks` | boolean | If true, use the messaging profile's webhook settings. |
+| `webhook_url` | string (URL) | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | If true, use the messaging profile's webhook settings. |
 
 ### Send a group MMS message — `client.messages.sendGroupMms()`
 
@@ -481,10 +481,10 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 
 ### Send a long code message — `client.messages.sendLongCode()`
 
@@ -492,12 +492,12 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a message using number pool — `client.messages.sendNumberPool()`
@@ -506,12 +506,12 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Schedule a message — `client.messages.schedule()`
@@ -519,16 +519,16 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
-| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
-| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
 
 ### Send a short code message — `client.messages.sendShortCode()`
 
@@ -536,12 +536,12 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a WhatsApp message — `client.messages.sendWhatsapp()`
@@ -549,17 +549,17 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `messagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messagingHostedNumbers.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `messagingProfileId` | string (UUID) | Configure the messaging profile this phone number is assigned to:
+| `messaging_profile_id` | string (UUID) | Configure the messaging profile this phone number is assigned to:
 
 * Omit thi... |
-| `messagingProduct` | string | Configure the messaging product for this number:
+| `messaging_product` | string | Configure the messaging product for this number:
 
 * Omit this field or set it... |
 | `tags` | array[string] | Tags to set on this phone number. |
@@ -568,10 +568,10 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `respText` | string |  |
+| `resp_text` | string |  |
 
 ### Update Auto-Response Setting — `client.messagingProfiles.autorespConfigs.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `respText` | string |  |
+| `resp_text` | string |  |

--- a/skills/telnyx-messaging-javascript/SKILL.md
+++ b/skills/telnyx-messaging-javascript/SKILL.md
@@ -96,9 +96,9 @@ Primary outbound messaging flow. Agents need exact request fields and delivery-r
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
 | `from` | string (E.164) | Yes | Sending address (+E.164 formatted phone number, alphanumeric... |
 | `text` | string | Yes | Message body (i.e., content) as a non-empty string. |
-| `messagingProfileId` | string (UUID) | No | Unique identifier for a messaging profile. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Unique identifier for a messaging profile. |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
 | ... | | | +7 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -130,10 +130,10 @@ Common sender variant that requires different request shape.
 | `from` | string (E.164) | Yes | A valid alphanumeric sender ID on the user's account. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
 | `text` | string | Yes | The message body. |
-| `messagingProfileId` | string (UUID) | Yes | The messaging profile ID to use. |
-| `webhookUrl` | string (URL) | No | Callback URL for delivery status updates. |
-| `webhookFailoverUrl` | string (URL) | No | Failover callback URL for delivery status updates. |
-| `useProfileWebhooks` | boolean | No | If true, use the messaging profile's webhook settings. |
+| `messaging_profile_id` | string (UUID) | Yes | The messaging profile ID to use. |
+| `webhook_url` | string (URL) | No | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | No | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | No | If true, use the messaging profile's webhook settings. |
 
 ```javascript
 const response = await client.messages.sendWithAlphanumericSender({
@@ -226,9 +226,9 @@ Send one MMS payload to multiple recipients.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | array[object] | Yes | A list of destinations. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +3 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -259,9 +259,9 @@ Force a long-code sending path instead of the generic send endpoint.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -289,11 +289,11 @@ Let a messaging profile or number pool choose the sender for you.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `messagingProfileId` | string (UUID) | Yes | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Yes | Unique identifier for a messaging profile. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -324,9 +324,9 @@ Force a short-code sending path when the sender must be a short code.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -355,9 +355,9 @@ Queue a message for future delivery instead of sending immediately.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `messagingProfileId` | string (UUID) | No | Unique identifier for a messaging profile. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Unique identifier for a messaging profile. |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
 | ... | | | +8 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -365,7 +365,7 @@ const response = await client.messages.schedule({
     to: '+18445550001',
     from: '+18005550101',
     text: 'Appointment reminder',
-    sendAt: '2025-07-01T15:00:00Z',
+    send_at: '2025-07-01T15:00:00Z',
 });
 
 console.log(response.data);
@@ -389,10 +389,10 @@ Send WhatsApp traffic instead of SMS/MMS.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number in +E.164 format associated with Whatsapp accou... |
 | `to` | string (E.164) | Yes | Phone number in +E.164 format |
-| `whatsappMessage` | object | Yes |  |
+| `whatsapp_message` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `messagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```javascript
 const response = await client.messages.sendWhatsapp({
@@ -424,10 +424,10 @@ Before using any operation below, read [the optional-parameters section](referen
 | Retrieve a message | `client.messages.retrieve()` | `GET /messages/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Cancel a scheduled message | `client.messages.cancelScheduled()` | `DELETE /messages/{id}` | Remove, detach, or clean up an existing resource. | `id` |
 | List alphanumeric sender IDs | `client.alphanumericSenderIDs.list()` | `GET /alphanumeric_sender_ids` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Create an alphanumeric sender ID | `client.alphanumericSenderIDs.create()` | `POST /alphanumeric_sender_ids` | Create or provision an additional resource when the core tasks do not cover this flow. | `alphanumericSenderId`, `messagingProfileId` |
+| Create an alphanumeric sender ID | `client.alphanumericSenderIDs.create()` | `POST /alphanumeric_sender_ids` | Create or provision an additional resource when the core tasks do not cover this flow. | `alphanumeric_sender_id`, `messaging_profile_id` |
 | Retrieve an alphanumeric sender ID | `client.alphanumericSenderIDs.retrieve()` | `GET /alphanumeric_sender_ids/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Delete an alphanumeric sender ID | `client.alphanumericSenderIDs.delete()` | `DELETE /alphanumeric_sender_ids/{id}` | Remove, detach, or clean up an existing resource. | `id` |
-| Retrieve group MMS messages | `client.messages.retrieveGroupMessages()` | `GET /messages/group/{message_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `messageId` |
+| Retrieve group MMS messages | `client.messages.retrieveGroupMessages()` | `GET /messages/group/{message_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `message_id` |
 | List messaging hosted numbers | `client.messagingHostedNumbers.list()` | `GET /messaging_hosted_numbers` | Inspect available resources or choose an existing resource before mutating it. | None |
 | Retrieve a messaging hosted number | `client.messagingHostedNumbers.retrieve()` | `GET /messaging_hosted_numbers/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Update a messaging hosted number | `client.messagingHostedNumbers.update()` | `PATCH /messaging_hosted_numbers/{id}` | Modify an existing resource without recreating it. | `id` |
@@ -436,11 +436,11 @@ Before using any operation below, read [the optional-parameters section](referen
 | Regenerate messaging profile secret | `client.messagingProfiles.actions.regenerateSecret()` | `POST /messaging_profiles/{id}/actions/regenerate_secret` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `id` |
 | List alphanumeric sender IDs for a messaging profile | `client.messagingProfiles.listAlphanumericSenderIDs()` | `GET /messaging_profiles/{id}/alphanumeric_sender_ids` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Get detailed messaging profile metrics | `client.messagingProfiles.retrieveMetrics()` | `GET /messaging_profiles/{id}/metrics` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
-| List Auto-Response Settings | `client.messagingProfiles.autorespConfigs.list()` | `GET /messaging_profiles/{profile_id}/autoresp_configs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profileId` |
-| Create auto-response setting | `client.messagingProfiles.autorespConfigs.create()` | `POST /messaging_profiles/{profile_id}/autoresp_configs` | Create or provision an additional resource when the core tasks do not cover this flow. | `op`, `keywords`, `countryCode`, `profileId` |
-| Get Auto-Response Setting | `client.messagingProfiles.autorespConfigs.retrieve()` | `GET /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profileId`, `autorespCfgId` |
-| Update Auto-Response Setting | `client.messagingProfiles.autorespConfigs.update()` | `PUT /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Modify an existing resource without recreating it. | `op`, `keywords`, `countryCode`, `profileId`, +1 more |
-| Delete Auto-Response Setting | `client.messagingProfiles.autorespConfigs.delete()` | `DELETE /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Remove, detach, or clean up an existing resource. | `profileId`, `autorespCfgId` |
+| List Auto-Response Settings | `client.messagingProfiles.autorespConfigs.list()` | `GET /messaging_profiles/{profile_id}/autoresp_configs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profile_id` |
+| Create auto-response setting | `client.messagingProfiles.autorespConfigs.create()` | `POST /messaging_profiles/{profile_id}/autoresp_configs` | Create or provision an additional resource when the core tasks do not cover this flow. | `op`, `keywords`, `country_code`, `profile_id` |
+| Get Auto-Response Setting | `client.messagingProfiles.autorespConfigs.retrieve()` | `GET /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profile_id`, `autoresp_cfg_id` |
+| Update Auto-Response Setting | `client.messagingProfiles.autorespConfigs.update()` | `PUT /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Modify an existing resource without recreating it. | `op`, `keywords`, `country_code`, `profile_id`, +1 more |
+| Delete Auto-Response Setting | `client.messagingProfiles.autorespConfigs.delete()` | `DELETE /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Remove, detach, or clean up an existing resource. | `profile_id`, `autoresp_cfg_id` |
 
 ### Other Webhook Events
 

--- a/skills/telnyx-messaging-javascript/references/api-details.md
+++ b/skills/telnyx-messaging-javascript/references/api-details.md
@@ -199,32 +199,32 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `usLongCodeFallback` | string | A US long code number to use as fallback when sending to US destinations. |
+| `us_long_code_fallback` | string | A US long code number to use as fallback when sending to US destinations. |
 
 ### Send a message — `client.messages.send()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
-| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
-| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a message using an alphanumeric sender ID — `client.messages.sendWithAlphanumericSender()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `webhookUrl` | string (URL) | Callback URL for delivery status updates. |
-| `webhookFailoverUrl` | string (URL) | Failover callback URL for delivery status updates. |
-| `useProfileWebhooks` | boolean | If true, use the messaging profile's webhook settings. |
+| `webhook_url` | string (URL) | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | If true, use the messaging profile's webhook settings. |
 
 ### Send a group MMS message — `client.messages.sendGroupMms()`
 
@@ -232,10 +232,10 @@
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 
 ### Send a long code message — `client.messages.sendLongCode()`
 
@@ -243,12 +243,12 @@
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a message using number pool — `client.messages.sendNumberPool()`
@@ -257,12 +257,12 @@
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Schedule a message — `client.messages.schedule()`
@@ -270,16 +270,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
-| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
-| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
 
 ### Send a short code message — `client.messages.sendShortCode()`
 
@@ -287,12 +287,12 @@
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a WhatsApp message — `client.messages.sendWhatsapp()`
@@ -300,17 +300,17 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `messagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messagingHostedNumbers.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `messagingProfileId` | string (UUID) | Configure the messaging profile this phone number is assigned to:
+| `messaging_profile_id` | string (UUID) | Configure the messaging profile this phone number is assigned to:
 
 * Omit thi... |
-| `messagingProduct` | string | Configure the messaging product for this number:
+| `messaging_product` | string | Configure the messaging product for this number:
 
 * Omit this field or set it... |
 | `tags` | array[string] | Tags to set on this phone number. |
@@ -319,13 +319,13 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `respText` | string |  |
+| `resp_text` | string |  |
 
 ### Update Auto-Response Setting — `client.messagingProfiles.autorespConfigs.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `respText` | string |  |
+| `resp_text` | string |  |
 
 ## Webhook Payload Fields
 

--- a/skills/telnyx-twilio-migration/sdk-reference/javascript/messaging.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/javascript/messaging.md
@@ -83,9 +83,9 @@ Primary outbound messaging flow. Agents need exact request fields and delivery-r
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
 | `from` | string (E.164) | Yes | Sending address (+E.164 formatted phone number, alphanumeric... |
 | `text` | string | Yes | Message body (i.e., content) as a non-empty string. |
-| `messagingProfileId` | string (UUID) | No | Unique identifier for a messaging profile. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Unique identifier for a messaging profile. |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
 | ... | | | +7 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -117,10 +117,10 @@ Common sender variant that requires different request shape.
 | `from` | string (E.164) | Yes | A valid alphanumeric sender ID on the user's account. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
 | `text` | string | Yes | The message body. |
-| `messagingProfileId` | string (UUID) | Yes | The messaging profile ID to use. |
-| `webhookUrl` | string (URL) | No | Callback URL for delivery status updates. |
-| `webhookFailoverUrl` | string (URL) | No | Failover callback URL for delivery status updates. |
-| `useProfileWebhooks` | boolean | No | If true, use the messaging profile's webhook settings. |
+| `messaging_profile_id` | string (UUID) | Yes | The messaging profile ID to use. |
+| `webhook_url` | string (URL) | No | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | No | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | No | If true, use the messaging profile's webhook settings. |
 
 ```javascript
 const response = await client.messages.sendWithAlphanumericSender({
@@ -213,9 +213,9 @@ Send one MMS payload to multiple recipients.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | array[object] | Yes | A list of destinations. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +3 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -246,9 +246,9 @@ Force a long-code sending path instead of the generic send endpoint.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -276,11 +276,11 @@ Let a messaging profile or number pool choose the sender for you.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `messagingProfileId` | string (UUID) | Yes | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Yes | Unique identifier for a messaging profile. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -311,9 +311,9 @@ Force a short-code sending path when the sender must be a short code.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -342,9 +342,9 @@ Queue a message for future delivery instead of sending immediately.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `messagingProfileId` | string (UUID) | No | Unique identifier for a messaging profile. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Unique identifier for a messaging profile. |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
 | ... | | | +8 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -352,7 +352,7 @@ const response = await client.messages.schedule({
     to: '+18445550001',
     from: '+18005550101',
     text: 'Appointment reminder',
-    sendAt: '2025-07-01T15:00:00Z',
+    send_at: '2025-07-01T15:00:00Z',
 });
 
 console.log(response.data);
@@ -376,10 +376,10 @@ Send WhatsApp traffic instead of SMS/MMS.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number in +E.164 format associated with Whatsapp accou... |
 | `to` | string (E.164) | Yes | Phone number in +E.164 format |
-| `whatsappMessage` | object | Yes |  |
+| `whatsapp_message` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `messagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```javascript
 const response = await client.messages.sendWhatsapp({
@@ -411,10 +411,10 @@ Before using any operation below, read the Optional Parameters section below and
 | Retrieve a message | `client.messages.retrieve()` | `GET /messages/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Cancel a scheduled message | `client.messages.cancelScheduled()` | `DELETE /messages/{id}` | Remove, detach, or clean up an existing resource. | `id` |
 | List alphanumeric sender IDs | `client.alphanumericSenderIDs.list()` | `GET /alphanumeric_sender_ids` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Create an alphanumeric sender ID | `client.alphanumericSenderIDs.create()` | `POST /alphanumeric_sender_ids` | Create or provision an additional resource when the core tasks do not cover this flow. | `alphanumericSenderId`, `messagingProfileId` |
+| Create an alphanumeric sender ID | `client.alphanumericSenderIDs.create()` | `POST /alphanumeric_sender_ids` | Create or provision an additional resource when the core tasks do not cover this flow. | `alphanumeric_sender_id`, `messaging_profile_id` |
 | Retrieve an alphanumeric sender ID | `client.alphanumericSenderIDs.retrieve()` | `GET /alphanumeric_sender_ids/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Delete an alphanumeric sender ID | `client.alphanumericSenderIDs.delete()` | `DELETE /alphanumeric_sender_ids/{id}` | Remove, detach, or clean up an existing resource. | `id` |
-| Retrieve group MMS messages | `client.messages.retrieveGroupMessages()` | `GET /messages/group/{message_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `messageId` |
+| Retrieve group MMS messages | `client.messages.retrieveGroupMessages()` | `GET /messages/group/{message_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `message_id` |
 | List messaging hosted numbers | `client.messagingHostedNumbers.list()` | `GET /messaging_hosted_numbers` | Inspect available resources or choose an existing resource before mutating it. | None |
 | Retrieve a messaging hosted number | `client.messagingHostedNumbers.retrieve()` | `GET /messaging_hosted_numbers/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Update a messaging hosted number | `client.messagingHostedNumbers.update()` | `PATCH /messaging_hosted_numbers/{id}` | Modify an existing resource without recreating it. | `id` |
@@ -423,11 +423,11 @@ Before using any operation below, read the Optional Parameters section below and
 | Regenerate messaging profile secret | `client.messagingProfiles.actions.regenerateSecret()` | `POST /messaging_profiles/{id}/actions/regenerate_secret` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `id` |
 | List alphanumeric sender IDs for a messaging profile | `client.messagingProfiles.listAlphanumericSenderIDs()` | `GET /messaging_profiles/{id}/alphanumeric_sender_ids` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Get detailed messaging profile metrics | `client.messagingProfiles.retrieveMetrics()` | `GET /messaging_profiles/{id}/metrics` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
-| List Auto-Response Settings | `client.messagingProfiles.autorespConfigs.list()` | `GET /messaging_profiles/{profile_id}/autoresp_configs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profileId` |
-| Create auto-response setting | `client.messagingProfiles.autorespConfigs.create()` | `POST /messaging_profiles/{profile_id}/autoresp_configs` | Create or provision an additional resource when the core tasks do not cover this flow. | `op`, `keywords`, `countryCode`, `profileId` |
-| Get Auto-Response Setting | `client.messagingProfiles.autorespConfigs.retrieve()` | `GET /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profileId`, `autorespCfgId` |
-| Update Auto-Response Setting | `client.messagingProfiles.autorespConfigs.update()` | `PUT /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Modify an existing resource without recreating it. | `op`, `keywords`, `countryCode`, `profileId`, +1 more |
-| Delete Auto-Response Setting | `client.messagingProfiles.autorespConfigs.delete()` | `DELETE /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Remove, detach, or clean up an existing resource. | `profileId`, `autorespCfgId` |
+| List Auto-Response Settings | `client.messagingProfiles.autorespConfigs.list()` | `GET /messaging_profiles/{profile_id}/autoresp_configs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profile_id` |
+| Create auto-response setting | `client.messagingProfiles.autorespConfigs.create()` | `POST /messaging_profiles/{profile_id}/autoresp_configs` | Create or provision an additional resource when the core tasks do not cover this flow. | `op`, `keywords`, `country_code`, `profile_id` |
+| Get Auto-Response Setting | `client.messagingProfiles.autorespConfigs.retrieve()` | `GET /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profile_id`, `autoresp_cfg_id` |
+| Update Auto-Response Setting | `client.messagingProfiles.autorespConfigs.update()` | `PUT /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Modify an existing resource without recreating it. | `op`, `keywords`, `country_code`, `profile_id`, +1 more |
+| Delete Auto-Response Setting | `client.messagingProfiles.autorespConfigs.delete()` | `DELETE /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Remove, detach, or clean up an existing resource. | `profile_id`, `autoresp_cfg_id` |
 
 ### Other Webhook Events
 
@@ -448,32 +448,32 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `usLongCodeFallback` | string | A US long code number to use as fallback when sending to US destinations. |
+| `us_long_code_fallback` | string | A US long code number to use as fallback when sending to US destinations. |
 
 ### Send a message — `client.messages.send()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
-| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
-| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a message using an alphanumeric sender ID — `client.messages.sendWithAlphanumericSender()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `webhookUrl` | string (URL) | Callback URL for delivery status updates. |
-| `webhookFailoverUrl` | string (URL) | Failover callback URL for delivery status updates. |
-| `useProfileWebhooks` | boolean | If true, use the messaging profile's webhook settings. |
+| `webhook_url` | string (URL) | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | If true, use the messaging profile's webhook settings. |
 
 ### Send a group MMS message — `client.messages.sendGroupMms()`
 
@@ -481,10 +481,10 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 
 ### Send a long code message — `client.messages.sendLongCode()`
 
@@ -492,12 +492,12 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a message using number pool — `client.messages.sendNumberPool()`
@@ -506,12 +506,12 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Schedule a message — `client.messages.schedule()`
@@ -519,16 +519,16 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
-| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
-| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
 
 ### Send a short code message — `client.messages.sendShortCode()`
 
@@ -536,12 +536,12 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a WhatsApp message — `client.messages.sendWhatsapp()`
@@ -549,17 +549,17 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `messagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messagingHostedNumbers.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `messagingProfileId` | string (UUID) | Configure the messaging profile this phone number is assigned to:
+| `messaging_profile_id` | string (UUID) | Configure the messaging profile this phone number is assigned to:
 
 * Omit thi... |
-| `messagingProduct` | string | Configure the messaging product for this number:
+| `messaging_product` | string | Configure the messaging product for this number:
 
 * Omit this field or set it... |
 | `tags` | array[string] | Tags to set on this phone number. |
@@ -568,10 +568,10 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `respText` | string |  |
+| `resp_text` | string |  |
 
 ### Update Auto-Response Setting — `client.messagingProfiles.autorespConfigs.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `respText` | string |  |
+| `resp_text` | string |  |


### PR DESCRIPTION
## Purpose

Final downstream verification artifact for generator source PR https://github.com/team-telnyx/telnyx-ext-skills-generator/pull/87 at commit `5de64fa443e9a3271f8284f58f1b0624d215a41e`.

Downstream artifact head: `50ffdef9d8fbc34fbeb5fe698a4c27f9575c03eb`

Related issue: https://github.com/team-telnyx/ai/issues/283

## Scope

- Profile: `northstar-v2`
- Product: `messaging`
- Language: `javascript`
- Generated from the unmerged source PR branch, not generator `main`
- Rebuilt from current `team-telnyx/ai` main after the source review follow-ups

## Generated surfaces

- Canonical `telnyx-messaging-javascript` skill and `references/api-details.md`
- Claude and Cursor synchronized provider copies
- Messaging-only JavaScript SDK reference embedded in `telnyx-twilio-migration`, including Claude and Cursor copies

The generated JavaScript parameter tables, Additional Operations summaries, and request-object examples now use the exact OpenAPI/Node SDK spelling. For messaging this is snake_case, including `messaging_profile_id`, `media_urls`, `webhook_url`, and `send_at`. Method names retain JavaScript method casing.

## Changed-path audit

Exactly nine generated files changed. All are owned by the messaging × JavaScript scope above. No other products, languages, generator source, tests, or unmanaged/manual files changed. Derived twilio-migration messaging references were intentionally refreshed; adjacent manual files were preserved.

## Validation

### Source generator

- `python3.11 -m pytest -q` — `77 passed, 7 subtests passed`
- `python3.11 tests/test_northstar_v2.py` — `Ran 38 tests ... OK`
- JavaScript voice/messaging/10DLC generation verified exact request-key casing
- Python/Ruby 10DLC generation and Ruby syntax checks passed
- Generated Go 10DLC campaign-builder sample compiled against `telnyx-go/v4` v4.88.0
- Template verification, Python compilation, scoped Ruff, and `git diff --check` passed

### Downstream artifact

- Publisher dry-run from source `5de64fa443e9a3271f8284f58f1b0624d215a41e` — exactly nine expected changed files
- Added parameter-row audit — 414 rows inspected, zero camelCase additions
- Request-example audit — no `messagingProfileId:`, `mediaUrls:`, `webhookUrl:`, or `sendAt:` aliases
- Required fields present — `messaging_profile_id`, `media_urls`, `webhook_url`, `send_at`
- Canonical/provider-copy byte comparisons — passed for skill, API details, and derived messaging SDK reference
- `git diff --check` — passed
- `npm run test:guides` — 102 passed
- `npm run test:guides-api` — 29 passed

## Dependency and deployment status

This draft depends on the unmerged generator source PR above and exists to prove its final output. It is not live or deployed and should not merge before the source PR is approved and merged. After the source PR merges, refresh or confirm this artifact from generator `main` before landing it.
