### PR TITLE
chore(release): bump agent CLI to 0.4.1

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@telnyx/agent-cli",
-  "version": "0.3.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@telnyx/agent-cli",
-      "version": "0.3.0",
+      "version": "0.4.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telnyx/agent-cli",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Agent-friendly CLI for Telnyx API v2 — composite setup commands that reduce multi-step workflows to a single command",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- bump `@telnyx/agent-cli` from 0.4.0 to 0.4.1
- align the CLI lockfile version with the package manifest
- prepare the merged Call Control, 10DLC, Edge, WhatsApp Verify, number, fax, AI inference, RCS, and IoT SIM changes for npm publication

## Validation
- `cd cli && npm ci`
- `cd cli && npm test` — 197 passed
- `cd cli && npm run typecheck`
- `cd cli && npm run build`
- `cd cli && npm pack --dry-run`
- `bash ./.github/bin/check-release-environment`

## Release plan
After merge, manually dispatch **Publish npm** with `package=cli`, then verify `@telnyx/agent-cli@0.4.1` on npm.

Related completed work: https://github.com/team-telnyx/ai/pulls?q=is%3Apr+is%3Amerged+290..298
