### PR TITLE
chore: refresh scoped SDK-generated skills

### DIFF
--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-assistants-curl/references/api-details.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-assistants-curl/references/api-details.md
@@ -383,6 +383,7 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |
 
 ### Update Tool
@@ -396,4 +397,5 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |

--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-assistants-go/references/api-details.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-assistants-go/references/api-details.md
@@ -383,6 +383,7 @@ dispat... |
 | `Handoff` | object |  |
 | `Invite` | object |  |
 | `Webhook` | object |  |
+| `ClientSideTool` | object |  |
 | `TimeoutMs` | integer |  |
 
 ### Update Tool — `client.AI.Tools.Update()`
@@ -396,4 +397,5 @@ dispat... |
 | `Handoff` | object |  |
 | `Invite` | object |  |
 | `Webhook` | object |  |
+| `ClientSideTool` | object |  |
 | `TimeoutMs` | integer |  |

--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-assistants-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-assistants-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.58.0</version>
+    <version>6.81.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.58.0")
+implementation("com.telnyx.sdk:telnyx:6.81.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-assistants-java/references/api-details.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-assistants-java/references/api-details.md
@@ -383,6 +383,7 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `clientSideTool` | object |  |
 | `timeoutMs` | integer |  |
 
 ### Update Tool — `client.ai().tools().update()`
@@ -396,4 +397,5 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `clientSideTool` | object |  |
 | `timeoutMs` | integer |  |

--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-assistants-javascript/SKILL.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-assistants-javascript/SKILL.md
@@ -120,8 +120,8 @@ Chat is the primary runtime path. Agents need the exact assistant method and the
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `content` | string | Yes | The message content sent by the client to the assistant |
-| `conversationId` | string (UUID) | Yes | A unique identifier for the conversation thread, used to mai... |
-| `assistantId` | string (UUID) | Yes | Unique identifier of the assistant. |
+| `conversation_id` | string (UUID) | Yes | A unique identifier for the conversation thread, used to mai... |
+| `assistant_id` | string (UUID) | Yes | Unique identifier of the assistant. |
 | `name` | string | No | The optional display name of the user sending the message |
 
 ```javascript
@@ -149,8 +149,8 @@ Test creation is the main validation path for production assistant behavior befo
 | `instructions` | string | Yes | Detailed instructions that define the test scenario and what... |
 | `rubric` | array[object] | Yes | Evaluation criteria used to assess the assistant's performan... |
 | `description` | string | No | Optional detailed description of what this test evaluates an... |
-| `telnyxConversationChannel` | object | No | The communication channel through which the test will be con... |
-| `maxDurationSeconds` | integer | No | Maximum duration in seconds that the test conversation shoul... |
+| `telnyx_conversation_channel` | object | No | The communication channel through which the test will be con... |
+| `max_duration_seconds` | integer | No | Maximum duration in seconds that the test conversation shoul... |
 | ... | | | +1 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -190,9 +190,9 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `assistantId` | string (UUID) | Yes | Unique identifier of the assistant. |
-| `callControlId` | string (UUID) | No | Filter results by call control id. |
-| `fetchDynamicVariablesFromWebhook` | boolean | No | Whether to fetch dynamic variables from the configured webho... |
+| `assistant_id` | string (UUID) | Yes | Unique identifier of the assistant. |
+| `call_control_id` | string (UUID) | No | Filter results by call control id. |
+| `fetch_dynamic_variables_from_webhook` | boolean | No | Whether to fetch dynamic variables from the configured webho... |
 | `from` | string (E.164) | No | Start of the filter range. |
 | ... | | | +1 optional params in [references/api-details.md](references/api-details.md) |
 
@@ -218,7 +218,7 @@ Create or provision an additional resource when the core tasks do not cover this
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `assistantId` | string (UUID) | Yes | Unique identifier of the assistant. |
+| `assistant_id` | string (UUID) | Yes | Unique identifier of the assistant. |
 | `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
 | `model` | string | No | ID of the model to use when `external_llm` is not set. |
@@ -270,12 +270,12 @@ Import existing assistants from an external provider instead of creating from sc
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `provider` | enum (elevenlabs, vapi, retell) | Yes | The external provider to import assistants from. |
-| `apiKeyRef` | string | Yes | Integration secret pointer that refers to the API key for th... |
-| `importIds` | array[string] | No | Optional list of assistant IDs to import from the external p... |
+| `api_key_ref` | string | Yes | Integration secret pointer that refers to the API key for th... |
+| `import_ids` | array[string] | No | Optional list of assistant IDs to import from the external p... |
 
 ```javascript
 const assistantsList = await client.ai.assistants.imports({
-  api_key_ref: 'api_key_ref',
+  api_key_ref: 'my-openai-key',
   provider: 'elevenlabs',
 });
 
@@ -316,8 +316,8 @@ Inspect available resources or choose an existing resource before mutating it.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `testSuite` | string | No | Filter tests by test suite name |
-| `telnyxConversationChannel` | string | No | Filter tests by communication channel (e.g., 'web_chat', 'sm... |
+| `test_suite` | string | No | Filter tests by test suite name |
+| `telnyx_conversation_channel` | string | No | Filter tests by communication channel (e.g., 'web_chat', 'sm... |
 | `destination` | string | No | Filter tests by destination (phone number, webhook URL, etc.... |
 | ... | | | +1 optional params in [references/api-details.md](references/api-details.md) |
 
@@ -366,8 +366,8 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `suiteName` | string | Yes | Name of the suite. |
-| `testSuiteRunId` | string (UUID) | No | Filter runs by specific suite execution batch ID |
+| `suite_name` | string | Yes | Name of the suite. |
+| `test_suite_run_id` | string (UUID) | No | Filter runs by specific suite execution batch ID |
 | `status` | string | No | Filter runs by execution status (pending, running, completed... |
 | `page` | object | No | Consolidated page parameter (deepObject style). |
 
@@ -399,46 +399,46 @@ Before using any operation below, read [the optional-parameters section](referen
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
-| Trigger test suite execution | `client.ai.assistants.tests.testSuites.runs.trigger()` | `POST /ai/assistants/tests/test-suites/{suite_name}/runs` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `suiteName` |
-| Get assistant test by ID | `client.ai.assistants.tests.retrieve()` | `GET /ai/assistants/tests/{test_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId` |
-| Update an assistant test | `client.ai.assistants.tests.update()` | `PUT /ai/assistants/tests/{test_id}` | Modify an existing resource without recreating it. | `testId` |
-| Delete an assistant test | `client.ai.assistants.tests.delete()` | `DELETE /ai/assistants/tests/{test_id}` | Remove, detach, or clean up an existing resource. | `testId` |
-| Get test run history for a specific test | `client.ai.assistants.tests.runs.list()` | `GET /ai/assistants/tests/{test_id}/runs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId` |
-| Trigger a manual test run | `client.ai.assistants.tests.runs.trigger()` | `POST /ai/assistants/tests/{test_id}/runs` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `testId` |
-| Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId`, `runId` |
-| Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistantId` |
-| Get Canary Deploy | `client.ai.assistants.canaryDeploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Create Canary Deploy | `client.ai.assistants.canaryDeploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId` |
-| Update Canary Deploy | `client.ai.assistants.canaryDeploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistantId` |
-| Delete Canary Deploy | `client.ai.assistants.canaryDeploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistantId` |
-| Assistant Sms Chat | `client.ai.assistants.sendSMS()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistantId` |
-| Clone Assistant | `client.ai.assistants.clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId` |
-| Enhance Assistant Instructions | `client.ai.assistants.instructions.enhance()` | `POST /ai/assistants/{assistant_id}/instructions/enhance` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId` |
-| List scheduled events | `client.ai.assistants.scheduledEvents.list()` | `GET /ai/assistants/{assistant_id}/scheduled_events` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Create a scheduled event | `client.ai.assistants.scheduledEvents.create()` | `POST /ai/assistants/{assistant_id}/scheduled_events` | Create or provision an additional resource when the core tasks do not cover this flow. | `telnyxConversationChannel`, `telnyxEndUserTarget`, `telnyxAgentTarget`, `scheduledAtFixedDatetime`, +1 more |
-| Get a scheduled event | `client.ai.assistants.scheduledEvents.retrieve()` | `GET /ai/assistants/{assistant_id}/scheduled_events/{event_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId`, `eventId` |
-| Delete a scheduled event | `client.ai.assistants.scheduledEvents.delete()` | `DELETE /ai/assistants/{assistant_id}/scheduled_events/{event_id}` | Remove, detach, or clean up an existing resource. | `assistantId`, `eventId` |
-| Add Assistant Tag | `client.ai.assistants.tags.add()` | `POST /ai/assistants/{assistant_id}/tags` | Create or provision an additional resource when the core tasks do not cover this flow. | `tag`, `assistantId` |
-| Remove Assistant Tag | `client.ai.assistants.tags.remove()` | `DELETE /ai/assistants/{assistant_id}/tags/{tag}` | Remove, detach, or clean up an existing resource. | `assistantId`, `tag` |
-| Get assistant texml | `client.ai.assistants.getTexml()` | `GET /ai/assistants/{assistant_id}/texml` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Add Assistant Tool | `client.ai.assistants.tools.add()` | `PUT /ai/assistants/{assistant_id}/tools/{tool_id}` | Modify an existing resource without recreating it. | `assistantId`, `toolId` |
-| Remove Assistant Tool | `client.ai.assistants.tools.remove()` | `DELETE /ai/assistants/{assistant_id}/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `assistantId`, `toolId` |
-| Test Assistant Tool | `client.ai.assistants.tools.test()` | `POST /ai/assistants/{assistant_id}/tools/{tool_id}/test` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId`, `toolId` |
-| Get all versions of an assistant | `client.ai.assistants.versions.list()` | `GET /ai/assistants/{assistant_id}/versions` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Get a specific assistant version | `client.ai.assistants.versions.retrieve()` | `GET /ai/assistants/{assistant_id}/versions/{version_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId`, `versionId` |
-| Update a specific assistant version | `client.ai.assistants.versions.update()` | `POST /ai/assistants/{assistant_id}/versions/{version_id}` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId`, `versionId` |
-| Delete a specific assistant version | `client.ai.assistants.versions.delete()` | `DELETE /ai/assistants/{assistant_id}/versions/{version_id}` | Remove, detach, or clean up an existing resource. | `assistantId`, `versionId` |
-| Promote an assistant version to main | `client.ai.assistants.versions.promote()` | `POST /ai/assistants/{assistant_id}/versions/{version_id}/promote` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId`, `versionId` |
+| Trigger test suite execution | `client.ai.assistants.tests.testSuites.runs.trigger()` | `POST /ai/assistants/tests/test-suites/{suite_name}/runs` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `suite_name` |
+| Get assistant test by ID | `client.ai.assistants.tests.retrieve()` | `GET /ai/assistants/tests/{test_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id` |
+| Update an assistant test | `client.ai.assistants.tests.update()` | `PUT /ai/assistants/tests/{test_id}` | Modify an existing resource without recreating it. | `test_id` |
+| Delete an assistant test | `client.ai.assistants.tests.delete()` | `DELETE /ai/assistants/tests/{test_id}` | Remove, detach, or clean up an existing resource. | `test_id` |
+| Get test run history for a specific test | `client.ai.assistants.tests.runs.list()` | `GET /ai/assistants/tests/{test_id}/runs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id` |
+| Trigger a manual test run | `client.ai.assistants.tests.runs.trigger()` | `POST /ai/assistants/tests/{test_id}/runs` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `test_id` |
+| Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
+| Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
+| Get Canary Deploy | `client.ai.assistants.canaryDeploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Create Canary Deploy | `client.ai.assistants.canaryDeploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | `client.ai.assistants.canaryDeploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
+| Delete Canary Deploy | `client.ai.assistants.canaryDeploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
+| Assistant Sms Chat | `client.ai.assistants.sendSMS()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistant_id` |
+| Clone Assistant | `client.ai.assistants.clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |
+| Enhance Assistant Instructions | `client.ai.assistants.instructions.enhance()` | `POST /ai/assistants/{assistant_id}/instructions/enhance` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| List scheduled events | `client.ai.assistants.scheduledEvents.list()` | `GET /ai/assistants/{assistant_id}/scheduled_events` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Create a scheduled event | `client.ai.assistants.scheduledEvents.create()` | `POST /ai/assistants/{assistant_id}/scheduled_events` | Create or provision an additional resource when the core tasks do not cover this flow. | `telnyx_conversation_channel`, `telnyx_end_user_target`, `telnyx_agent_target`, `scheduled_at_fixed_datetime`, +1 more |
+| Get a scheduled event | `client.ai.assistants.scheduledEvents.retrieve()` | `GET /ai/assistants/{assistant_id}/scheduled_events/{event_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id`, `event_id` |
+| Delete a scheduled event | `client.ai.assistants.scheduledEvents.delete()` | `DELETE /ai/assistants/{assistant_id}/scheduled_events/{event_id}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `event_id` |
+| Add Assistant Tag | `client.ai.assistants.tags.add()` | `POST /ai/assistants/{assistant_id}/tags` | Create or provision an additional resource when the core tasks do not cover this flow. | `tag`, `assistant_id` |
+| Remove Assistant Tag | `client.ai.assistants.tags.remove()` | `DELETE /ai/assistants/{assistant_id}/tags/{tag}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `tag` |
+| Get assistant texml | `client.ai.assistants.getTexml()` | `GET /ai/assistants/{assistant_id}/texml` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Add Assistant Tool | `client.ai.assistants.tools.add()` | `PUT /ai/assistants/{assistant_id}/tools/{tool_id}` | Modify an existing resource without recreating it. | `assistant_id`, `tool_id` |
+| Remove Assistant Tool | `client.ai.assistants.tools.remove()` | `DELETE /ai/assistants/{assistant_id}/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `tool_id` |
+| Test Assistant Tool | `client.ai.assistants.tools.test()` | `POST /ai/assistants/{assistant_id}/tools/{tool_id}/test` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id`, `tool_id` |
+| Get all versions of an assistant | `client.ai.assistants.versions.list()` | `GET /ai/assistants/{assistant_id}/versions` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Get a specific assistant version | `client.ai.assistants.versions.retrieve()` | `GET /ai/assistants/{assistant_id}/versions/{version_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id`, `version_id` |
+| Update a specific assistant version | `client.ai.assistants.versions.update()` | `POST /ai/assistants/{assistant_id}/versions/{version_id}` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id`, `version_id` |
+| Delete a specific assistant version | `client.ai.assistants.versions.delete()` | `DELETE /ai/assistants/{assistant_id}/versions/{version_id}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `version_id` |
+| Promote an assistant version to main | `client.ai.assistants.versions.promote()` | `POST /ai/assistants/{assistant_id}/versions/{version_id}/promote` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id`, `version_id` |
 | List MCP Servers | `client.ai.mcpServers.list()` | `GET /ai/mcp_servers` | Inspect available resources or choose an existing resource before mutating it. | None |
 | Create MCP Server | `client.ai.mcpServers.create()` | `POST /ai/mcp_servers` | Create or provision an additional resource when the core tasks do not cover this flow. | `name`, `type`, `url` |
-| Get MCP Server | `client.ai.mcpServers.retrieve()` | `GET /ai/mcp_servers/{mcp_server_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `mcpServerId` |
-| Update MCP Server | `client.ai.mcpServers.update()` | `PUT /ai/mcp_servers/{mcp_server_id}` | Modify an existing resource without recreating it. | `mcpServerId` |
-| Delete MCP Server | `client.ai.mcpServers.delete()` | `DELETE /ai/mcp_servers/{mcp_server_id}` | Remove, detach, or clean up an existing resource. | `mcpServerId` |
+| Get MCP Server | `client.ai.mcpServers.retrieve()` | `GET /ai/mcp_servers/{mcp_server_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `mcp_server_id` |
+| Update MCP Server | `client.ai.mcpServers.update()` | `PUT /ai/mcp_servers/{mcp_server_id}` | Modify an existing resource without recreating it. | `mcp_server_id` |
+| Delete MCP Server | `client.ai.mcpServers.delete()` | `DELETE /ai/mcp_servers/{mcp_server_id}` | Remove, detach, or clean up an existing resource. | `mcp_server_id` |
 | List Tools | `client.ai.tools.list()` | `GET /ai/tools` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Create Tool | `client.ai.tools.create()` | `POST /ai/tools` | Create or provision an additional resource when the core tasks do not cover this flow. | `type`, `displayName` |
-| Get Tool | `client.ai.tools.retrieve()` | `GET /ai/tools/{tool_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `toolId` |
-| Update Tool | `client.ai.tools.update()` | `PATCH /ai/tools/{tool_id}` | Modify an existing resource without recreating it. | `toolId` |
-| Delete Tool | `client.ai.tools.delete()` | `DELETE /ai/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `toolId` |
+| Create Tool | `client.ai.tools.create()` | `POST /ai/tools` | Create or provision an additional resource when the core tasks do not cover this flow. | `type`, `display_name` |
+| Get Tool | `client.ai.tools.retrieve()` | `GET /ai/tools/{tool_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `tool_id` |
+| Update Tool | `client.ai.tools.update()` | `PATCH /ai/tools/{tool_id}` | Modify an existing resource without recreating it. | `tool_id` |
+| Delete Tool | `client.ai.tools.delete()` | `DELETE /ai/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `tool_id` |
 
 ---
 

--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-assistants-javascript/references/api-details.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-assistants-javascript/references/api-details.md
@@ -169,51 +169,51 @@
 |-----------|------|-------------|
 | `model` | string | ID of the model to use when `external_llm` is not set. |
 | `tools` | array[object] | Deprecated for new integrations. |
-| `mcpServers` | array[object] | MCP servers attached to the assistant. |
-| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
-| `externalLlm` | object |  |
-| `fallbackConfig` | object |  |
-| `voiceSettings` | object |  |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
 | `transcription` | object |  |
-| `telephonySettings` | object |  |
-| `messagingSettings` | object |  |
-| `enabledFeatures` | array[object] |  |
-| `insightSettings` | object |  |
-| `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
-| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
-| `dynamicVariables` | object | Map of dynamic variables and their default values |
-| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
-| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
 | `integrations` | array[object] | Connected integrations attached to the assistant. |
-| `observabilitySettings` | object |  |
+| `observability_settings` | object |  |
 | `tags` | array[string] | Tags associated with the assistant. |
-| `postConversationSettings` | object | Configuration for post-conversation processing. |
-| `conversationFlow` | object | Conversation flow as supplied by API clients (create / update). |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+| `conversation_flow` | object | Conversation flow as supplied by API clients (create / update). |
 
 ### Import assistants from external provider — `client.ai.assistants.imports()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `importIds` | array[string] | Optional list of assistant IDs to import from the external provider. |
+| `import_ids` | array[string] | Optional list of assistant IDs to import from the external provider. |
 
 ### Create a new assistant test — `client.ai.assistants.tests.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `description` | string | Optional detailed description of what this test evaluates and its purpose. |
-| `telnyxConversationChannel` | object | The communication channel through which the test will be conducted. |
-| `maxDurationSeconds` | integer | Maximum duration in seconds that the test conversation should run before timi... |
-| `testSuite` | string | Optional test suite name to group related tests together. |
+| `telnyx_conversation_channel` | object | The communication channel through which the test will be conducted. |
+| `max_duration_seconds` | integer | Maximum duration in seconds that the test conversation should run before timi... |
+| `test_suite` | string | Optional test suite name to group related tests together. |
 
 ### Trigger test suite execution — `client.ai.assistants.tests.testSuites.runs.trigger()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `destinationVersionId` | string (UUID) | Optional assistant version ID to use for all test runs in this suite. |
+| `destination_version_id` | string (UUID) | Optional assistant version ID to use for all test runs in this suite. |
 
 ### Update an assistant test — `client.ai.assistants.tests.update()`
 
@@ -221,10 +221,10 @@
 |-----------|------|-------------|
 | `name` | string | Updated name for the assistant test. |
 | `description` | string | Updated description of the test's purpose and evaluation criteria. |
-| `telnyxConversationChannel` | enum (phone_call, web_call, sms_chat, web_chat) |  |
+| `telnyx_conversation_channel` | enum (phone_call, web_call, sms_chat, web_chat) |  |
 | `destination` | string | Updated target destination for test conversations. |
-| `maxDurationSeconds` | integer | Updated maximum test duration in seconds. |
-| `testSuite` | string | Updated test suite assignment for better organization. |
+| `max_duration_seconds` | integer | Updated maximum test duration in seconds. |
+| `test_suite` | string | Updated test suite assignment for better organization. |
 | `instructions` | string | Updated test scenario instructions and objectives. |
 | `rubric` | array[object] | Updated evaluation criteria for assessing assistant performance. |
 
@@ -232,7 +232,7 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `destinationVersionId` | string (UUID) | Optional assistant version ID to use for this test run. |
+| `destination_version_id` | string (UUID) | Optional assistant version ID to use for this test run. |
 
 ### Update an assistant — `client.ai.assistants.update()`
 
@@ -242,32 +242,32 @@
 | `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
 | `tools` | array[object] | Deprecated for new integrations. |
-| `mcpServers` | array[object] | MCP servers attached to the assistant. |
-| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
-| `externalLlm` | object |  |
-| `fallbackConfig` | object |  |
-| `voiceSettings` | object |  |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
 | `transcription` | object |  |
-| `telephonySettings` | object |  |
-| `messagingSettings` | object |  |
-| `enabledFeatures` | array[object] |  |
-| `insightSettings` | object |  |
-| `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
-| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
-| `dynamicVariables` | object | Map of dynamic variables and their default values |
-| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
-| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
 | `integrations` | array[object] | Connected integrations attached to the assistant. |
-| `observabilitySettings` | object |  |
+| `observability_settings` | object |  |
 | `tags` | array[string] | Tags associated with the assistant. |
-| `versionName` | string | Human-readable name for the assistant version. |
-| `postConversationSettings` | object | Configuration for post-conversation processing. |
-| `conversationFlow` | object | Conversation flow as supplied by API clients (create / update). |
-| `promoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+| `conversation_flow` | object | Conversation flow as supplied by API clients (create / update). |
+| `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
 
 ### Create Canary Deploy — `client.ai.assistants.canaryDeploys.create()`
 
@@ -292,14 +292,14 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `text` | string |  |
-| `conversationMetadata` | object |  |
-| `shouldCreateConversation` | boolean |  |
+| `conversation_metadata` | object |  |
+| `should_create_conversation` | boolean |  |
 
 ### Enhance Assistant Instructions — `client.ai.assistants.instructions.enhance()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `enhancementPrompt` | object | Optional guidance describing how the instructions should be enhanced. |
+| `enhancement_prompt` | object | Optional guidance describing how the instructions should be enhanced. |
 | `instructions` | object | The instructions to enhance. |
 
 ### Create a scheduled event — `client.ai.assistants.scheduledEvents.create()`
@@ -307,11 +307,11 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `text` | string | Required for sms scheduled events. |
-| `conversationMetadata` | object | Metadata associated with the conversation. |
-| `dynamicVariables` | object | A map of dynamic variable names to values. |
-| `maxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
-| `retryIntervalSecs` | integer |  |
-| `callSettings` | object | Per-call telephony overrides applied when a scheduled phone-call event
+| `conversation_metadata` | object | Metadata associated with the conversation. |
+| `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
+| `call_settings` | object | Per-call telephony overrides applied when a scheduled phone-call event
 dispat... |
 
 ### Test Assistant Tool — `client.ai.assistants.tools.test()`
@@ -319,7 +319,7 @@ dispat... |
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `arguments` | object | Key-value arguments to use for the webhook test |
-| `dynamicVariables` | object | Key-value dynamic variables to use for the webhook test |
+| `dynamic_variables` | object | Key-value dynamic variables to use for the webhook test |
 
 ### Update a specific assistant version — `client.ai.assistants.versions.update()`
 
@@ -329,38 +329,38 @@ dispat... |
 | `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
 | `tools` | array[object] | Deprecated for new integrations. |
-| `mcpServers` | array[object] | MCP servers attached to the assistant. |
-| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
-| `externalLlm` | object |  |
-| `fallbackConfig` | object |  |
-| `voiceSettings` | object |  |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
 | `transcription` | object |  |
-| `telephonySettings` | object |  |
-| `messagingSettings` | object |  |
-| `enabledFeatures` | array[object] |  |
-| `insightSettings` | object |  |
-| `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
-| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
-| `dynamicVariables` | object | Map of dynamic variables and their default values |
-| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
-| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
 | `integrations` | array[object] | Connected integrations attached to the assistant. |
-| `observabilitySettings` | object |  |
+| `observability_settings` | object |  |
 | `tags` | array[string] | Tags associated with the assistant. |
-| `versionName` | string | Human-readable name for the assistant version. |
-| `postConversationSettings` | object | Configuration for post-conversation processing. |
-| `conversationFlow` | object | Conversation flow as supplied by API clients (create / update). |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+| `conversation_flow` | object | Conversation flow as supplied by API clients (create / update). |
 
 ### Create MCP Server — `client.ai.mcpServers.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `apiKeyRef` | string |  |
-| `allowedTools` | array[string] |  |
+| `api_key_ref` | string |  |
+| `allowed_tools` | array[string] |  |
 
 ### Update MCP Server — `client.ai.mcpServers.update()`
 
@@ -370,9 +370,9 @@ dispat... |
 | `name` | string |  |
 | `type` | string |  |
 | `url` | string (URL) |  |
-| `apiKeyRef` | string |  |
-| `allowedTools` | array[string] |  |
-| `createdAt` | string (date-time) |  |
+| `api_key_ref` | string |  |
+| `allowed_tools` | array[string] |  |
+| `created_at` | string (date-time) |  |
 
 ### Create Tool — `client.ai.tools.create()`
 
@@ -383,17 +383,19 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
-| `timeoutMs` | integer |  |
+| `client_side_tool` | object |  |
+| `timeout_ms` | integer |  |
 
 ### Update Tool — `client.ai.tools.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `type` | string |  |
-| `displayName` | string |  |
+| `display_name` | string |  |
 | `function` | object |  |
 | `retrieval` | object |  |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
-| `timeoutMs` | integer |  |
+| `client_side_tool` | object |  |
+| `timeout_ms` | integer |  |

--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-assistants-python/references/api-details.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-assistants-python/references/api-details.md
@@ -383,6 +383,7 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |
 
 ### Update Tool — `client.ai.tools.update()`
@@ -396,4 +397,5 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |

--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-assistants-ruby/references/api-details.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-assistants-ruby/references/api-details.md
@@ -383,6 +383,7 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |
 
 ### Update Tool — `client.ai.tools.update()`
@@ -396,4 +397,5 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |

--- a/providers/claude/plugins/telnyx-messaging/skills/telnyx-messaging-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-messaging/skills/telnyx-messaging-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.58.0</version>
+    <version>6.81.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.58.0")
+implementation("com.telnyx.sdk:telnyx:6.81.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-messaging/skills/telnyx-messaging-javascript/SKILL.md
+++ b/providers/claude/plugins/telnyx-messaging/skills/telnyx-messaging-javascript/SKILL.md
@@ -96,9 +96,9 @@ Primary outbound messaging flow. Agents need exact request fields and delivery-r
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
 | `from` | string (E.164) | Yes | Sending address (+E.164 formatted phone number, alphanumeric... |
 | `text` | string | Yes | Message body (i.e., content) as a non-empty string. |
-| `messagingProfileId` | string (UUID) | No | Unique identifier for a messaging profile. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Unique identifier for a messaging profile. |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
 | ... | | | +7 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -130,10 +130,10 @@ Common sender variant that requires different request shape.
 | `from` | string (E.164) | Yes | A valid alphanumeric sender ID on the user's account. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
 | `text` | string | Yes | The message body. |
-| `messagingProfileId` | string (UUID) | Yes | The messaging profile ID to use. |
-| `webhookUrl` | string (URL) | No | Callback URL for delivery status updates. |
-| `webhookFailoverUrl` | string (URL) | No | Failover callback URL for delivery status updates. |
-| `useProfileWebhooks` | boolean | No | If true, use the messaging profile's webhook settings. |
+| `messaging_profile_id` | string (UUID) | Yes | The messaging profile ID to use. |
+| `webhook_url` | string (URL) | No | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | No | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | No | If true, use the messaging profile's webhook settings. |
 
 ```javascript
 const response = await client.messages.sendWithAlphanumericSender({
@@ -165,7 +165,7 @@ and `telnyx-timestamp` headers. Always verify signatures in production:
 // In your webhook handler (e.g., Express — use raw body, not parsed JSON):
 app.post('/webhooks', express.raw({ type: 'application/json' }), async (req, res) => {
   try {
-    const event = await client.webhooks.unwrap(req.body.toString(), {
+    const event = client.webhooks.unwrap(req.body.toString(), {
       headers: req.headers,
     });
     // Signature valid — event is the parsed webhook payload
@@ -226,9 +226,9 @@ Send one MMS payload to multiple recipients.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | array[object] | Yes | A list of destinations. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +3 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -259,9 +259,9 @@ Force a long-code sending path instead of the generic send endpoint.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -289,11 +289,11 @@ Let a messaging profile or number pool choose the sender for you.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `messagingProfileId` | string (UUID) | Yes | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Yes | Unique identifier for a messaging profile. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -324,9 +324,9 @@ Force a short-code sending path when the sender must be a short code.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -355,9 +355,9 @@ Queue a message for future delivery instead of sending immediately.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `messagingProfileId` | string (UUID) | No | Unique identifier for a messaging profile. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Unique identifier for a messaging profile. |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
 | ... | | | +8 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -365,7 +365,7 @@ const response = await client.messages.schedule({
     to: '+18445550001',
     from: '+18005550101',
     text: 'Appointment reminder',
-    sendAt: '2025-07-01T15:00:00Z',
+    send_at: '2025-07-01T15:00:00Z',
 });
 
 console.log(response.data);
@@ -389,10 +389,10 @@ Send WhatsApp traffic instead of SMS/MMS.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number in +E.164 format associated with Whatsapp accou... |
 | `to` | string (E.164) | Yes | Phone number in +E.164 format |
-| `whatsappMessage` | object | Yes |  |
+| `whatsapp_message` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `messagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```javascript
 const response = await client.messages.sendWhatsapp({
@@ -424,10 +424,10 @@ Before using any operation below, read [the optional-parameters section](referen
 | Retrieve a message | `client.messages.retrieve()` | `GET /messages/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Cancel a scheduled message | `client.messages.cancelScheduled()` | `DELETE /messages/{id}` | Remove, detach, or clean up an existing resource. | `id` |
 | List alphanumeric sender IDs | `client.alphanumericSenderIDs.list()` | `GET /alphanumeric_sender_ids` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Create an alphanumeric sender ID | `client.alphanumericSenderIDs.create()` | `POST /alphanumeric_sender_ids` | Create or provision an additional resource when the core tasks do not cover this flow. | `alphanumericSenderId`, `messagingProfileId` |
+| Create an alphanumeric sender ID | `client.alphanumericSenderIDs.create()` | `POST /alphanumeric_sender_ids` | Create or provision an additional resource when the core tasks do not cover this flow. | `alphanumeric_sender_id`, `messaging_profile_id` |
 | Retrieve an alphanumeric sender ID | `client.alphanumericSenderIDs.retrieve()` | `GET /alphanumeric_sender_ids/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Delete an alphanumeric sender ID | `client.alphanumericSenderIDs.delete()` | `DELETE /alphanumeric_sender_ids/{id}` | Remove, detach, or clean up an existing resource. | `id` |
-| Retrieve group MMS messages | `client.messages.retrieveGroupMessages()` | `GET /messages/group/{message_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `messageId` |
+| Retrieve group MMS messages | `client.messages.retrieveGroupMessages()` | `GET /messages/group/{message_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `message_id` |
 | List messaging hosted numbers | `client.messagingHostedNumbers.list()` | `GET /messaging_hosted_numbers` | Inspect available resources or choose an existing resource before mutating it. | None |
 | Retrieve a messaging hosted number | `client.messagingHostedNumbers.retrieve()` | `GET /messaging_hosted_numbers/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Update a messaging hosted number | `client.messagingHostedNumbers.update()` | `PATCH /messaging_hosted_numbers/{id}` | Modify an existing resource without recreating it. | `id` |
@@ -436,11 +436,11 @@ Before using any operation below, read [the optional-parameters section](referen
 | Regenerate messaging profile secret | `client.messagingProfiles.actions.regenerateSecret()` | `POST /messaging_profiles/{id}/actions/regenerate_secret` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `id` |
 | List alphanumeric sender IDs for a messaging profile | `client.messagingProfiles.listAlphanumericSenderIDs()` | `GET /messaging_profiles/{id}/alphanumeric_sender_ids` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Get detailed messaging profile metrics | `client.messagingProfiles.retrieveMetrics()` | `GET /messaging_profiles/{id}/metrics` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
-| List Auto-Response Settings | `client.messagingProfiles.autorespConfigs.list()` | `GET /messaging_profiles/{profile_id}/autoresp_configs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profileId` |
-| Create auto-response setting | `client.messagingProfiles.autorespConfigs.create()` | `POST /messaging_profiles/{profile_id}/autoresp_configs` | Create or provision an additional resource when the core tasks do not cover this flow. | `op`, `keywords`, `countryCode`, `profileId` |
-| Get Auto-Response Setting | `client.messagingProfiles.autorespConfigs.retrieve()` | `GET /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profileId`, `autorespCfgId` |
-| Update Auto-Response Setting | `client.messagingProfiles.autorespConfigs.update()` | `PUT /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Modify an existing resource without recreating it. | `op`, `keywords`, `countryCode`, `profileId`, +1 more |
-| Delete Auto-Response Setting | `client.messagingProfiles.autorespConfigs.delete()` | `DELETE /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Remove, detach, or clean up an existing resource. | `profileId`, `autorespCfgId` |
+| List Auto-Response Settings | `client.messagingProfiles.autorespConfigs.list()` | `GET /messaging_profiles/{profile_id}/autoresp_configs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profile_id` |
+| Create auto-response setting | `client.messagingProfiles.autorespConfigs.create()` | `POST /messaging_profiles/{profile_id}/autoresp_configs` | Create or provision an additional resource when the core tasks do not cover this flow. | `op`, `keywords`, `country_code`, `profile_id` |
+| Get Auto-Response Setting | `client.messagingProfiles.autorespConfigs.retrieve()` | `GET /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profile_id`, `autoresp_cfg_id` |
+| Update Auto-Response Setting | `client.messagingProfiles.autorespConfigs.update()` | `PUT /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Modify an existing resource without recreating it. | `op`, `keywords`, `country_code`, `profile_id`, +1 more |
+| Delete Auto-Response Setting | `client.messagingProfiles.autorespConfigs.delete()` | `DELETE /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Remove, detach, or clean up an existing resource. | `profile_id`, `autoresp_cfg_id` |
 
 ### Other Webhook Events
 

--- a/providers/claude/plugins/telnyx-messaging/skills/telnyx-messaging-javascript/references/api-details.md
+++ b/providers/claude/plugins/telnyx-messaging/skills/telnyx-messaging-javascript/references/api-details.md
@@ -199,32 +199,32 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `usLongCodeFallback` | string | A US long code number to use as fallback when sending to US destinations. |
+| `us_long_code_fallback` | string | A US long code number to use as fallback when sending to US destinations. |
 
 ### Send a message — `client.messages.send()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
-| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
-| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a message using an alphanumeric sender ID — `client.messages.sendWithAlphanumericSender()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `webhookUrl` | string (URL) | Callback URL for delivery status updates. |
-| `webhookFailoverUrl` | string (URL) | Failover callback URL for delivery status updates. |
-| `useProfileWebhooks` | boolean | If true, use the messaging profile's webhook settings. |
+| `webhook_url` | string (URL) | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | If true, use the messaging profile's webhook settings. |
 
 ### Send a group MMS message — `client.messages.sendGroupMms()`
 
@@ -232,10 +232,10 @@
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 
 ### Send a long code message — `client.messages.sendLongCode()`
 
@@ -243,12 +243,12 @@
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a message using number pool — `client.messages.sendNumberPool()`
@@ -257,12 +257,12 @@
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Schedule a message — `client.messages.schedule()`
@@ -270,16 +270,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
-| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
-| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
 
 ### Send a short code message — `client.messages.sendShortCode()`
 
@@ -287,12 +287,12 @@
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a WhatsApp message — `client.messages.sendWhatsapp()`
@@ -300,17 +300,17 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `messagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messagingHostedNumbers.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `messagingProfileId` | string (UUID) | Configure the messaging profile this phone number is assigned to:
+| `messaging_profile_id` | string (UUID) | Configure the messaging profile this phone number is assigned to:
 
 * Omit thi... |
-| `messagingProduct` | string | Configure the messaging product for this number:
+| `messaging_product` | string | Configure the messaging product for this number:
 
 * Omit this field or set it... |
 | `tags` | array[string] | Tags to set on this phone number. |
@@ -319,13 +319,13 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `respText` | string |  |
+| `resp_text` | string |  |
 
 ### Update Auto-Response Setting — `client.messagingProfiles.autorespConfigs.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `respText` | string |  |
+| `resp_text` | string |  |
 
 ## Webhook Payload Fields
 

--- a/providers/claude/plugins/telnyx-messaging/skills/telnyx-messaging-ruby/SKILL.md
+++ b/providers/claude/plugins/telnyx-messaging/skills/telnyx-messaging-ruby/SKILL.md
@@ -270,7 +270,7 @@ Let a messaging profile or number pool choose the sender for you.
 ```ruby
 response = client.messages.send_number_pool(
   messaging_profile_id: "abc85f64-5717-4562-b3fc-2c9600000000",
-  to: "+13125550002"
+  to: "+13125550002",
     text: "Hello from Telnyx!",
 )
 

--- a/providers/claude/plugins/telnyx-numbers/skills/telnyx-10dlc-curl/SKILL.md
+++ b/providers/claude/plugins/telnyx-numbers/skills/telnyx-10dlc-curl/SKILL.md
@@ -136,12 +136,10 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-      "brandId": "BXXX001",
+      "brandId": "BXXXXXX",
       "description": "Two-factor authentication messages",
       "usecase": "2FA",
-      "sample_messages": [
-          "Your verification code is {{code}}"
-      ]
+      "sample1": "Your verification code is {{code}}"
   }' \
   "https://api.telnyx.com/v2/10dlc/campaignBuilder"
 ```

--- a/providers/claude/plugins/telnyx-numbers/skills/telnyx-10dlc-go/SKILL.md
+++ b/providers/claude/plugins/telnyx-numbers/skills/telnyx-10dlc-go/SKILL.md
@@ -157,7 +157,7 @@ Campaign submission is the compliance-critical step that determines whether traf
 		BrandID: "BXXXXXX",
 		Description: "Two-factor authentication messages",
 		Usecase: "2FA",
-		SampleMessages: []string{"Your verification code is {{code}}"},
+		Sample1: telnyx.String("Your verification code is {{code}}"),
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/providers/claude/plugins/telnyx-numbers/skills/telnyx-10dlc-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-numbers/skills/telnyx-10dlc-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.58.0</version>
+    <version>6.81.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.58.0")
+implementation("com.telnyx.sdk:telnyx:6.81.0")
 ```
 
 ## Setup
@@ -150,7 +150,7 @@ CampaignBuilderSubmitParams params = CampaignBuilderSubmitParams.builder()
     .brandId("BXXXXXX")
     .description("Two-factor authentication messages")
     .usecase("2FA")
-    .sampleMessages(java.util.List.of("Your verification code is {{code}}"))
+    .sample1("Your verification code is {{code}}")
     .build();
 TelnyxCampaignCsp telnyxCampaignCsp = client.messaging10dlc().campaignBuilder().submit(params);
 ```

--- a/providers/claude/plugins/telnyx-numbers/skills/telnyx-10dlc-javascript/SKILL.md
+++ b/providers/claude/plugins/telnyx-numbers/skills/telnyx-10dlc-javascript/SKILL.md
@@ -145,7 +145,7 @@ const telnyxCampaignCsp = await client.messaging10dlc.campaignBuilder.submit({
   brandId: 'BXXXXXX',
   description: 'Two-factor authentication messages',
   usecase: '2FA',
-    sampleMessages: ["Your verification code is {{code}}"],
+    sample1: 'Your verification code is {{code}}',
 });
 
 console.log(telnyxCampaignCsp.brandId);
@@ -197,7 +197,7 @@ and `telnyx-timestamp` headers. Always verify signatures in production:
 // In your webhook handler (e.g., Express — use raw body, not parsed JSON):
 app.post('/webhooks', express.raw({ type: 'application/json' }), async (req, res) => {
   try {
-    const event = await client.webhooks.unwrap(req.body.toString(), {
+    const event = client.webhooks.unwrap(req.body.toString(), {
       headers: req.headers,
     });
     // Signature valid — event is the parsed webhook payload
@@ -408,7 +408,7 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get Campaign Cost | `client.messaging10dlc.campaign.usecase.getCost()` | `GET /10dlc/campaign/usecase/cost` | Inspect available resources or choose an existing resource before mutating it. | None |
 | Update campaign | `client.messaging10dlc.campaign.update()` | `PUT /10dlc/campaign/{campaignId}` | Inspect the current state of an existing campaign registration. | `campaignId` |
 | Deactivate campaign | `client.messaging10dlc.campaign.deactivate()` | `DELETE /10dlc/campaign/{campaignId}` | Inspect the current state of an existing campaign registration. | `campaignId` |
-| Submit campaign appeal for manual review | `client.messaging10dlc.campaign.submitAppeal()` | `POST /10dlc/campaign/{campaignId}/appeal` | Create or provision an additional resource when the core tasks do not cover this flow. | `appealReason`, `campaignId` |
+| Submit campaign appeal for manual review | `client.messaging10dlc.campaign.submitAppeal()` | `POST /10dlc/campaign/{campaignId}/appeal` | Create or provision an additional resource when the core tasks do not cover this flow. | `appeal_reason`, `campaignId` |
 | Get Campaign Mno Metadata | `client.messaging10dlc.campaign.getMnoMetadata()` | `GET /10dlc/campaign/{campaignId}/mnoMetadata` | Fetch the current state before updating, deleting, or making control-flow decisions. | `campaignId` |
 | Get campaign operation status | `client.messaging10dlc.campaign.getOperationStatus()` | `GET /10dlc/campaign/{campaignId}/operationStatus` | Fetch the current state before updating, deleting, or making control-flow decisions. | `campaignId` |
 | Get OSR campaign attributes | `client.messaging10dlc.campaign.osr.getAttributes()` | `GET /10dlc/campaign/{campaignId}/osr/attributes` | Fetch the current state before updating, deleting, or making control-flow decisions. | `campaignId` |

--- a/providers/claude/plugins/telnyx-numbers/skills/telnyx-10dlc-python/SKILL.md
+++ b/providers/claude/plugins/telnyx-numbers/skills/telnyx-10dlc-python/SKILL.md
@@ -143,7 +143,7 @@ telnyx_campaign_csp = client.messaging_10dlc.campaign_builder.submit(
     brand_id="BXXXXXX",
     description="Two-factor authentication messages",
     usecase="2FA",
-    sample_messages=["Your verification code is {{code}}"],
+    sample1="Your verification code is {{code}}",
 )
 print(telnyx_campaign_csp.brand_id)
 ```

--- a/providers/claude/plugins/telnyx-numbers/skills/telnyx-10dlc-ruby/SKILL.md
+++ b/providers/claude/plugins/telnyx-numbers/skills/telnyx-10dlc-ruby/SKILL.md
@@ -131,8 +131,8 @@ Campaign submission is the compliance-critical step that determines whether traf
 telnyx_campaign_csp = client.messaging_10dlc.campaign_builder.submit(
   brand_id: "BXXXXXX",
   description: "Two-factor authentication messages",
-  usecase: "2FA"
-    sample_messages: ["Your verification code is {{code}}"],
+  usecase: "2FA",
+    sample1: "Your verification code is {{code}}",
 )
 
 puts(telnyx_campaign_csp)
@@ -160,7 +160,7 @@ Messaging profile assignment is the practical handoff from registration to send-
 
 ```ruby
 response = client.messaging_10dlc.phone_number_assignment_by_profile.assign(
-  messaging_profile_id: "4001767e-ce0f-4cae-9d5f-0d5e636e7809"
+  messaging_profile_id: "4001767e-ce0f-4cae-9d5f-0d5e636e7809",
     campaign_id: "CXXX001",
 )
 

--- a/providers/claude/plugins/telnyx-numbers/skills/telnyx-numbers-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-numbers/skills/telnyx-numbers-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.58.0</version>
+    <version>6.81.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.58.0")
+implementation("com.telnyx.sdk:telnyx:6.81.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-numbers/skills/telnyx-numbers-javascript/SKILL.md
+++ b/providers/claude/plugins/telnyx-numbers/skills/telnyx-numbers-javascript/SKILL.md
@@ -109,15 +109,15 @@ Number ordering is the production provisioning step after number selection.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `phoneNumbers` | array[object] | Yes |  |
-| `connectionId` | string (UUID) | No | Identifies the connection associated with this phone number. |
-| `messagingProfileId` | string (UUID) | No | Identifies the messaging profile associated with the phone n... |
-| `billingGroupId` | string (UUID) | No | Identifies the billing group associated with the phone numbe... |
+| `phone_numbers` | array[object] | Yes |  |
+| `connection_id` | string (UUID) | No | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | No | Identifies the messaging profile associated with the phone n... |
+| `billing_group_id` | string (UUID) | No | Identifies the billing group associated with the phone numbe... |
 | ... | | | +1 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const numberOrder = await client.numberOrders.create({
-    phoneNumbers: [{"phone_number": "+18005550101"}],
+    phone_numbers: [{"phone_number": "+18005550101"}],
 });
 
 console.log(numberOrder.data);
@@ -139,7 +139,7 @@ Order status determines whether provisioning completed or additional requirement
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `numberOrderId` | string (UUID) | Yes | The number order ID. |
+| `number_order_id` | string (UUID) | Yes | The number order ID. |
 
 ```javascript
 const numberOrder = await client.numberOrders.retrieve('550e8400-e29b-41d4-a716-446655440000');
@@ -169,15 +169,15 @@ Create or provision an additional resource when the core tasks do not cover this
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `phoneNumbers` | array[object] | Yes |  |
+| `phone_numbers` | array[object] | Yes |  |
 | `status` | enum (pending, success, failure) | No | The status of the entire reservation. |
 | `id` | string (UUID) | No |  |
-| `recordType` | string | No |  |
+| `record_type` | string | No |  |
 | ... | | | +3 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const numberReservation = await client.numberReservations.create({
-    phoneNumbers: [{"phone_number": "+18005550101"}],
+    phone_numbers: [{"phone_number": "+18005550101"}],
 });
 
 console.log(numberReservation.data);
@@ -199,7 +199,7 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `numberReservationId` | string (UUID) | Yes | The number reservation ID. |
+| `number_reservation_id` | string (UUID) | Yes | The number reservation ID. |
 
 ```javascript
 const numberReservation = await client.numberReservations.retrieve('550e8400-e29b-41d4-a716-446655440000');
@@ -246,9 +246,9 @@ Create or provision an additional resource when the core tasks do not cover this
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) | No |  |
-| `requirementGroupId` | string (UUID) | No | The ID of the requirement group to associate with this advan... |
-| `countryCode` | string (ISO 3166-1 alpha-2) | No |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) | No |  |
+| `requirement_group_id` | string (UUID) | No | The ID of the requirement group to associate with this advan... |
+| `country_code` | string (ISO 3166-1 alpha-2) | No |  |
 | ... | | | +5 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -274,9 +274,9 @@ Modify an existing resource without recreating it.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `advanced-order-id` | string (UUID) | Yes | Unique identifier of the advanced order. |
-| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) | No |  |
-| `requirementGroupId` | string (UUID) | No | The ID of the requirement group to associate with this advan... |
-| `countryCode` | string (ISO 3166-1 alpha-2) | No |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) | No |  |
+| `requirement_group_id` | string (UUID) | No | The ID of the requirement group to associate with this advan... |
+| `country_code` | string (ISO 3166-1 alpha-2) | No |  |
 | ... | | | +5 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -303,7 +303,7 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `orderId` | string (UUID) | Yes | Unique identifier of the order. |
+| `order_id` | string (UUID) | Yes | Unique identifier of the order. |
 
 ```javascript
 const advancedOrder = await client.advancedOrders.retrieve('182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e');
@@ -388,38 +388,38 @@ Before using any operation below, read [the optional-parameters section](referen
 | Retrieve a comment | `client.comments.retrieve()` | `GET /comments/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Mark a comment as read | `client.comments.markAsRead()` | `PATCH /comments/{id}/read` | Modify an existing resource without recreating it. | `id` |
 | Get country coverage | `client.countryCoverage.retrieve()` | `GET /country_coverage` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Get coverage for a specific country | `client.countryCoverage.retrieveCountry()` | `GET /country_coverage/countries/{country_code}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `countryCode` |
+| Get coverage for a specific country | `client.countryCoverage.retrieveCountry()` | `GET /country_coverage/countries/{country_code}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `country_code` |
 | List customer service records | `client.customerServiceRecords.list()` | `GET /customer_service_records` | Inspect available resources or choose an existing resource before mutating it. | None |
 | Create a customer service record | `client.customerServiceRecords.create()` | `POST /customer_service_records` | Create or provision an additional resource when the core tasks do not cover this flow. | None |
 | Verify CSR phone number coverage | `client.customerServiceRecords.verifyPhoneNumberCoverage()` | `POST /customer_service_records/phone_number_coverages` | Create or provision an additional resource when the core tasks do not cover this flow. | None |
-| Get a customer service record | `client.customerServiceRecords.retrieve()` | `GET /customer_service_records/{customer_service_record_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `customerServiceRecordId` |
+| Get a customer service record | `client.customerServiceRecords.retrieve()` | `GET /customer_service_records/{customer_service_record_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `customer_service_record_id` |
 | List inexplicit number orders | `client.inexplicitNumberOrders.list()` | `GET /inexplicit_number_orders` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Create an inexplicit number order | `client.inexplicitNumberOrders.create()` | `POST /inexplicit_number_orders` | Create or provision an additional resource when the core tasks do not cover this flow. | `orderingGroups` |
+| Create an inexplicit number order | `client.inexplicitNumberOrders.create()` | `POST /inexplicit_number_orders` | Create or provision an additional resource when the core tasks do not cover this flow. | `ordering_groups` |
 | Retrieve an inexplicit number order | `client.inexplicitNumberOrders.retrieve()` | `GET /inexplicit_number_orders/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Create an inventory coverage request | `client.inventoryCoverage.list()` | `GET /inventory_coverage` | Inspect available resources or choose an existing resource before mutating it. | None |
 | List mobile network operators | `client.mobileNetworkOperators.list()` | `GET /mobile_network_operators` | Inspect available resources or choose an existing resource before mutating it. | None |
 | List network coverage locations | `client.networkCoverage.list()` | `GET /network_coverage` | Inspect available resources or choose an existing resource before mutating it. | None |
 | List number block orders | `client.numberBlockOrders.list()` | `GET /number_block_orders` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Create a number block order | `client.numberBlockOrders.create()` | `POST /number_block_orders` | Create or provision an additional resource when the core tasks do not cover this flow. | `startingNumber`, `range` |
-| Retrieve a number block order | `client.numberBlockOrders.retrieve()` | `GET /number_block_orders/{number_block_order_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `numberBlockOrderId` |
+| Create a number block order | `client.numberBlockOrders.create()` | `POST /number_block_orders` | Create or provision an additional resource when the core tasks do not cover this flow. | `starting_number`, `range` |
+| Retrieve a number block order | `client.numberBlockOrders.retrieve()` | `GET /number_block_orders/{number_block_order_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `number_block_order_id` |
 | Retrieve a list of phone numbers associated to orders | `client.numberOrderPhoneNumbers.list()` | `GET /number_order_phone_numbers` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Retrieve a single phone number within a number order. | `client.numberOrderPhoneNumbers.retrieve()` | `GET /number_order_phone_numbers/{number_order_phone_number_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `numberOrderPhoneNumberId` |
-| Update requirements for a single phone number within a number order. | `client.numberOrderPhoneNumbers.updateRequirements()` | `PATCH /number_order_phone_numbers/{number_order_phone_number_id}` | Modify an existing resource without recreating it. | `numberOrderPhoneNumberId` |
+| Retrieve a single phone number within a number order. | `client.numberOrderPhoneNumbers.retrieve()` | `GET /number_order_phone_numbers/{number_order_phone_number_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `number_order_phone_number_id` |
+| Update requirements for a single phone number within a number order. | `client.numberOrderPhoneNumbers.updateRequirements()` | `PATCH /number_order_phone_numbers/{number_order_phone_number_id}` | Modify an existing resource without recreating it. | `number_order_phone_number_id` |
 | List number orders | `client.numberOrders.list()` | `GET /number_orders` | Create or inspect provisioning orders for number purchases. | None |
-| Update a number order | `client.numberOrders.update()` | `PATCH /number_orders/{number_order_id}` | Modify an existing resource without recreating it. | `numberOrderId` |
+| Update a number order | `client.numberOrders.update()` | `PATCH /number_orders/{number_order_id}` | Modify an existing resource without recreating it. | `number_order_id` |
 | List number reservations | `client.numberReservations.list()` | `GET /number_reservations` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Extend a number reservation | `client.numberReservations.actions.extend()` | `POST /number_reservations/{number_reservation_id}/actions/extend` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `numberReservationId` |
-| Retrieve the features for a list of numbers | `client.numbersFeatures.create()` | `POST /numbers_features` | Create or provision an additional resource when the core tasks do not cover this flow. | `phoneNumbers` |
+| Extend a number reservation | `client.numberReservations.actions.extend()` | `POST /number_reservations/{number_reservation_id}/actions/extend` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `number_reservation_id` |
+| Retrieve the features for a list of numbers | `client.numbersFeatures.create()` | `POST /numbers_features` | Create or provision an additional resource when the core tasks do not cover this flow. | `phone_numbers` |
 | Lists the phone number blocks jobs | `client.phoneNumberBlocks.jobs.list()` | `GET /phone_number_blocks/jobs` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Deletes all numbers associated with a phone number block | `client.phoneNumberBlocks.jobs.deletePhoneNumberBlock()` | `POST /phone_number_blocks/jobs/delete_phone_number_block` | Create or provision an additional resource when the core tasks do not cover this flow. | `phoneNumberBlockId` |
+| Deletes all numbers associated with a phone number block | `client.phoneNumberBlocks.jobs.deletePhoneNumberBlock()` | `POST /phone_number_blocks/jobs/delete_phone_number_block` | Create or provision an additional resource when the core tasks do not cover this flow. | `phone_number_block_id` |
 | Retrieves a phone number blocks job | `client.phoneNumberBlocks.jobs.retrieve()` | `GET /phone_number_blocks/jobs/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | List sub number orders | `client.subNumberOrders.list()` | `GET /sub_number_orders` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Retrieve a sub number order | `client.subNumberOrders.retrieve()` | `GET /sub_number_orders/{sub_number_order_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `subNumberOrderId` |
-| Update a sub number order's requirements | `client.subNumberOrders.update()` | `PATCH /sub_number_orders/{sub_number_order_id}` | Modify an existing resource without recreating it. | `subNumberOrderId` |
-| Cancel a sub number order | `client.subNumberOrders.cancel()` | `PATCH /sub_number_orders/{sub_number_order_id}/cancel` | Modify an existing resource without recreating it. | `subNumberOrderId` |
+| Retrieve a sub number order | `client.subNumberOrders.retrieve()` | `GET /sub_number_orders/{sub_number_order_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `sub_number_order_id` |
+| Update a sub number order's requirements | `client.subNumberOrders.update()` | `PATCH /sub_number_orders/{sub_number_order_id}` | Modify an existing resource without recreating it. | `sub_number_order_id` |
+| Cancel a sub number order | `client.subNumberOrders.cancel()` | `PATCH /sub_number_orders/{sub_number_order_id}/cancel` | Modify an existing resource without recreating it. | `sub_number_order_id` |
 | Create a sub number orders report | `client.subNumberOrdersReport.create()` | `POST /sub_number_orders_report` | Create or provision an additional resource when the core tasks do not cover this flow. | None |
-| Retrieve a sub number orders report | `client.subNumberOrdersReport.retrieve()` | `GET /sub_number_orders_report/{report_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `reportId` |
-| Download a sub number orders report | `client.subNumberOrdersReport.download()` | `GET /sub_number_orders_report/{report_id}/download` | Fetch the current state before updating, deleting, or making control-flow decisions. | `reportId` |
+| Retrieve a sub number orders report | `client.subNumberOrdersReport.retrieve()` | `GET /sub_number_orders_report/{report_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `report_id` |
+| Download a sub number orders report | `client.subNumberOrdersReport.download()` | `GET /sub_number_orders_report/{report_id}/download` | Fetch the current state before updating, deleting, or making control-flow decisions. | `report_id` |
 
 ### Other Webhook Events
 

--- a/providers/claude/plugins/telnyx-numbers/skills/telnyx-numbers-javascript/references/api-details.md
+++ b/providers/claude/plugins/telnyx-numbers/skills/telnyx-numbers-javascript/references/api-details.md
@@ -290,27 +290,27 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `countryCode` | string (ISO 3166-1 alpha-2) |  |
+| `country_code` | string (ISO 3166-1 alpha-2) |  |
 | `comments` | string |  |
 | `quantity` | integer |  |
-| `areaCode` | string |  |
-| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `area_code` | string |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
 | `features` | array[object] |  |
-| `customerReference` | string |  |
-| `requirementGroupId` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+| `customer_reference` | string |  |
+| `requirement_group_id` | string (UUID) | The ID of the requirement group to associate with this advanced order |
 
 ### Update Advanced Order — `client.advancedOrders.updateRequirementGroup()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `countryCode` | string (ISO 3166-1 alpha-2) |  |
+| `country_code` | string (ISO 3166-1 alpha-2) |  |
 | `comments` | string |  |
 | `quantity` | integer |  |
-| `areaCode` | string |  |
-| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `area_code` | string |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
 | `features` | array[object] |  |
-| `customerReference` | string |  |
-| `requirementGroupId` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+| `customer_reference` | string |  |
+| `requirement_group_id` | string (UUID) | The ID of the requirement group to associate with this advanced order |
 
 ### Create a comment — `client.comments.create()`
 
@@ -319,89 +319,89 @@
 | `id` | string (UUID) |  |
 | `body` | string |  |
 | `commenter` | string |  |
-| `commenterType` | enum (admin, user) |  |
-| `commentRecordType` | enum (sub_number_order, requirement_group) |  |
-| `commentRecordId` | string (UUID) |  |
-| `readAt` | string (date-time) | An ISO 8901 datetime string for when the comment was read. |
-| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the comment was created. |
-| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the comment was updated. |
+| `commenter_type` | enum (admin, user) |  |
+| `comment_record_type` | enum (sub_number_order, requirement_group) |  |
+| `comment_record_id` | string (UUID) |  |
+| `read_at` | string (date-time) | An ISO 8901 datetime string for when the comment was read. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the comment was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the comment was updated. |
 
 ### Create an inexplicit number order — `client.inexplicitNumberOrders.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `connectionId` | string (UUID) | Connection id to apply to phone numbers that are purchased |
-| `messagingProfileId` | string (UUID) | Messaging profile id to apply to phone numbers that are purchased |
-| `customerReference` | string | Reference label for the customer |
-| `billingGroupId` | string (UUID) | Billing group id to apply to phone numbers that are purchased |
+| `connection_id` | string (UUID) | Connection id to apply to phone numbers that are purchased |
+| `messaging_profile_id` | string (UUID) | Messaging profile id to apply to phone numbers that are purchased |
+| `customer_reference` | string | Reference label for the customer |
+| `billing_group_id` | string (UUID) | Billing group id to apply to phone numbers that are purchased |
 
 ### Create a number block order — `client.numberBlockOrders.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `id` | string (UUID) |  |
-| `recordType` | string |  |
-| `phoneNumbersCount` | integer | The count of phone numbers in the number order. |
-| `connectionId` | string (UUID) | Identifies the connection associated with this phone number. |
-| `messagingProfileId` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `record_type` | string |  |
+| `phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `connection_id` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | Identifies the messaging profile associated with the phone number. |
 | `status` | enum (pending, success, failure) | The status of the order. |
-| `customerReference` | string | A customer reference string for customer look ups. |
-| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the number order was created. |
-| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the number order was updated. |
-| `requirementsMet` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the number order was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the number order was updated. |
+| `requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
 | `errors` | string | Errors the reservation could happen upon |
 
 ### Update requirements for a single phone number within a number order. — `client.numberOrderPhoneNumbers.updateRequirements()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `regulatoryRequirements` | array[object] |  |
+| `regulatory_requirements` | array[object] |  |
 
 ### Create a number order — `client.numberOrders.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `phoneNumbers` | array[object] |  |
-| `connectionId` | string (UUID) | Identifies the connection associated with this phone number. |
-| `messagingProfileId` | string (UUID) | Identifies the messaging profile associated with the phone number. |
-| `billingGroupId` | string (UUID) | Identifies the billing group associated with the phone number. |
-| `customerReference` | string | A customer reference string for customer look ups. |
+| `phone_numbers` | array[object] |  |
+| `connection_id` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `billing_group_id` | string (UUID) | Identifies the billing group associated with the phone number. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
 
 ### Update a number order — `client.numberOrders.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `regulatoryRequirements` | array[object] |  |
-| `customerReference` | string | A customer reference string for customer look ups. |
+| `regulatory_requirements` | array[object] |  |
+| `customer_reference` | string | A customer reference string for customer look ups. |
 
 ### Create a number reservation — `client.numberReservations.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `id` | string (UUID) |  |
-| `recordType` | string |  |
-| `phoneNumbers` | array[object] |  |
+| `record_type` | string |  |
+| `phone_numbers` | array[object] |  |
 | `status` | enum (pending, success, failure) | The status of the entire reservation. |
-| `customerReference` | string | A customer reference string for customer look ups. |
-| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the numbers reservation was created. |
-| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the number reservation was updated. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the numbers reservation was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the number reservation was updated. |
 
 ### Update a sub number order's requirements — `client.subNumberOrders.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `regulatoryRequirements` | array[object] |  |
+| `regulatory_requirements` | array[object] |  |
 
 ### Create a sub number orders report — `client.subNumberOrdersReport.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `status` | enum (pending, success, failure) | Filter by order status |
-| `countryCode` | string (ISO 3166-1 alpha-2) | Filter by country code |
-| `createdAtGt` | string (date-time) | Filter for orders created after this date |
-| `createdAtLt` | string (date-time) | Filter for orders created before this date |
-| `orderRequestId` | string (UUID) | Filter by specific order request ID |
-| `customerReference` | string | Filter by customer reference |
+| `country_code` | string (ISO 3166-1 alpha-2) | Filter by country code |
+| `created_at_gt` | string (date-time) | Filter for orders created after this date |
+| `created_at_lt` | string (date-time) | Filter for orders created before this date |
+| `order_request_id` | string (UUID) | Filter by specific order request ID |
+| `customer_reference` | string | Filter by customer reference |
 
 ## Webhook Payload Fields
 

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/curl/10dlc.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/curl/10dlc.md
@@ -123,12 +123,10 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-      "brandId": "BXXX001",
+      "brandId": "BXXXXXX",
       "description": "Two-factor authentication messages",
       "usecase": "2FA",
-      "sample_messages": [
-          "Your verification code is {{code}}"
-      ]
+      "sample1": "Your verification code is {{code}}"
   }' \
   "https://api.telnyx.com/v2/10dlc/campaignBuilder"
 ```

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/curl/ai-assistants.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/curl/ai-assistants.md
@@ -648,6 +648,7 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |
 
 ### Update Tool
@@ -661,4 +662,5 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/go/10dlc.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/go/10dlc.md
@@ -144,7 +144,7 @@ Campaign submission is the compliance-critical step that determines whether traf
 		BrandID: "BXXXXXX",
 		Description: "Two-factor authentication messages",
 		Usecase: "2FA",
-		SampleMessages: []string{"Your verification code is {{code}}"},
+		Sample1: telnyx.String("Your verification code is {{code}}"),
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/go/ai-assistants.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/go/ai-assistants.md
@@ -704,6 +704,7 @@ dispat... |
 | `Handoff` | object |  |
 | `Invite` | object |  |
 | `Webhook` | object |  |
+| `ClientSideTool` | object |  |
 | `TimeoutMs` | integer |  |
 
 ### Update Tool — `client.AI.Tools.Update()`
@@ -717,4 +718,5 @@ dispat... |
 | `Handoff` | object |  |
 | `Invite` | object |  |
 | `Webhook` | object |  |
+| `ClientSideTool` | object |  |
 | `TimeoutMs` | integer |  |

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/10dlc.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/10dlc.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.58.0</version>
+    <version>6.81.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.58.0")
+implementation("com.telnyx.sdk:telnyx:6.81.0")
 ```
 
 ## Setup
@@ -137,7 +137,7 @@ CampaignBuilderSubmitParams params = CampaignBuilderSubmitParams.builder()
     .brandId("BXXXXXX")
     .description("Two-factor authentication messages")
     .usecase("2FA")
-    .sampleMessages(java.util.List.of("Your verification code is {{code}}"))
+    .sample1("Your verification code is {{code}}")
     .build();
 TelnyxCampaignCsp telnyxCampaignCsp = client.messaging10dlc().campaignBuilder().submit(params);
 ```

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/ai-assistants.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/ai-assistants.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.58.0</version>
+    <version>6.81.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.58.0")
+implementation("com.telnyx.sdk:telnyx:6.81.0")
 ```
 
 ## Setup
@@ -669,6 +669,7 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `clientSideTool` | object |  |
 | `timeoutMs` | integer |  |
 
 ### Update Tool — `client.ai().tools().update()`
@@ -682,4 +683,5 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `clientSideTool` | object |  |
 | `timeoutMs` | integer |  |

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/messaging.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/messaging.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.58.0</version>
+    <version>6.81.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.58.0")
+implementation("com.telnyx.sdk:telnyx:6.81.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/numbers.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/numbers.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.58.0</version>
+    <version>6.81.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.58.0")
+implementation("com.telnyx.sdk:telnyx:6.81.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/voice.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/voice.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.58.0</version>
+    <version>6.81.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.58.0")
+implementation("com.telnyx.sdk:telnyx:6.81.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/javascript/10dlc.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/javascript/10dlc.md
@@ -132,7 +132,7 @@ const telnyxCampaignCsp = await client.messaging10dlc.campaignBuilder.submit({
   brandId: 'BXXXXXX',
   description: 'Two-factor authentication messages',
   usecase: '2FA',
-    sampleMessages: ["Your verification code is {{code}}"],
+    sample1: 'Your verification code is {{code}}',
 });
 
 console.log(telnyxCampaignCsp.brandId);
@@ -184,7 +184,7 @@ and `telnyx-timestamp` headers. Always verify signatures in production:
 // In your webhook handler (e.g., Express — use raw body, not parsed JSON):
 app.post('/webhooks', express.raw({ type: 'application/json' }), async (req, res) => {
   try {
-    const event = await client.webhooks.unwrap(req.body.toString(), {
+    const event = client.webhooks.unwrap(req.body.toString(), {
       headers: req.headers,
     });
     // Signature valid — event is the parsed webhook payload
@@ -395,7 +395,7 @@ Before using any operation below, read the Optional Parameters section below and
 | Get Campaign Cost | `client.messaging10dlc.campaign.usecase.getCost()` | `GET /10dlc/campaign/usecase/cost` | Inspect available resources or choose an existing resource before mutating it. | None |
 | Update campaign | `client.messaging10dlc.campaign.update()` | `PUT /10dlc/campaign/{campaignId}` | Inspect the current state of an existing campaign registration. | `campaignId` |
 | Deactivate campaign | `client.messaging10dlc.campaign.deactivate()` | `DELETE /10dlc/campaign/{campaignId}` | Inspect the current state of an existing campaign registration. | `campaignId` |
-| Submit campaign appeal for manual review | `client.messaging10dlc.campaign.submitAppeal()` | `POST /10dlc/campaign/{campaignId}/appeal` | Create or provision an additional resource when the core tasks do not cover this flow. | `appealReason`, `campaignId` |
+| Submit campaign appeal for manual review | `client.messaging10dlc.campaign.submitAppeal()` | `POST /10dlc/campaign/{campaignId}/appeal` | Create or provision an additional resource when the core tasks do not cover this flow. | `appeal_reason`, `campaignId` |
 | Get Campaign Mno Metadata | `client.messaging10dlc.campaign.getMnoMetadata()` | `GET /10dlc/campaign/{campaignId}/mnoMetadata` | Fetch the current state before updating, deleting, or making control-flow decisions. | `campaignId` |
 | Get campaign operation status | `client.messaging10dlc.campaign.getOperationStatus()` | `GET /10dlc/campaign/{campaignId}/operationStatus` | Fetch the current state before updating, deleting, or making control-flow decisions. | `campaignId` |
 | Get OSR campaign attributes | `client.messaging10dlc.campaign.osr.getAttributes()` | `GET /10dlc/campaign/{campaignId}/osr/attributes` | Fetch the current state before updating, deleting, or making control-flow decisions. | `campaignId` |

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/javascript/ai-assistants.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/javascript/ai-assistants.md
@@ -107,8 +107,8 @@ Chat is the primary runtime path. Agents need the exact assistant method and the
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `content` | string | Yes | The message content sent by the client to the assistant |
-| `conversationId` | string (UUID) | Yes | A unique identifier for the conversation thread, used to mai... |
-| `assistantId` | string (UUID) | Yes | Unique identifier of the assistant. |
+| `conversation_id` | string (UUID) | Yes | A unique identifier for the conversation thread, used to mai... |
+| `assistant_id` | string (UUID) | Yes | Unique identifier of the assistant. |
 | `name` | string | No | The optional display name of the user sending the message |
 
 ```javascript
@@ -136,8 +136,8 @@ Test creation is the main validation path for production assistant behavior befo
 | `instructions` | string | Yes | Detailed instructions that define the test scenario and what... |
 | `rubric` | array[object] | Yes | Evaluation criteria used to assess the assistant's performan... |
 | `description` | string | No | Optional detailed description of what this test evaluates an... |
-| `telnyxConversationChannel` | object | No | The communication channel through which the test will be con... |
-| `maxDurationSeconds` | integer | No | Maximum duration in seconds that the test conversation shoul... |
+| `telnyx_conversation_channel` | object | No | The communication channel through which the test will be con... |
+| `max_duration_seconds` | integer | No | Maximum duration in seconds that the test conversation shoul... |
 | ... | | | +1 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -177,9 +177,9 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `assistantId` | string (UUID) | Yes | Unique identifier of the assistant. |
-| `callControlId` | string (UUID) | No | Filter results by call control id. |
-| `fetchDynamicVariablesFromWebhook` | boolean | No | Whether to fetch dynamic variables from the configured webho... |
+| `assistant_id` | string (UUID) | Yes | Unique identifier of the assistant. |
+| `call_control_id` | string (UUID) | No | Filter results by call control id. |
+| `fetch_dynamic_variables_from_webhook` | boolean | No | Whether to fetch dynamic variables from the configured webho... |
 | `from` | string (E.164) | No | Start of the filter range. |
 | ... | | | +1 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
@@ -205,7 +205,7 @@ Create or provision an additional resource when the core tasks do not cover this
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `assistantId` | string (UUID) | Yes | Unique identifier of the assistant. |
+| `assistant_id` | string (UUID) | Yes | Unique identifier of the assistant. |
 | `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
 | `model` | string | No | ID of the model to use when `external_llm` is not set. |
@@ -257,12 +257,12 @@ Import existing assistants from an external provider instead of creating from sc
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `provider` | enum (elevenlabs, vapi, retell) | Yes | The external provider to import assistants from. |
-| `apiKeyRef` | string | Yes | Integration secret pointer that refers to the API key for th... |
-| `importIds` | array[string] | No | Optional list of assistant IDs to import from the external p... |
+| `api_key_ref` | string | Yes | Integration secret pointer that refers to the API key for th... |
+| `import_ids` | array[string] | No | Optional list of assistant IDs to import from the external p... |
 
 ```javascript
 const assistantsList = await client.ai.assistants.imports({
-  api_key_ref: 'api_key_ref',
+  api_key_ref: 'my-openai-key',
   provider: 'elevenlabs',
 });
 
@@ -303,8 +303,8 @@ Inspect available resources or choose an existing resource before mutating it.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `testSuite` | string | No | Filter tests by test suite name |
-| `telnyxConversationChannel` | string | No | Filter tests by communication channel (e.g., 'web_chat', 'sm... |
+| `test_suite` | string | No | Filter tests by test suite name |
+| `telnyx_conversation_channel` | string | No | Filter tests by communication channel (e.g., 'web_chat', 'sm... |
 | `destination` | string | No | Filter tests by destination (phone number, webhook URL, etc.... |
 | ... | | | +1 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
@@ -353,8 +353,8 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `suiteName` | string | Yes | Name of the suite. |
-| `testSuiteRunId` | string (UUID) | No | Filter runs by specific suite execution batch ID |
+| `suite_name` | string | Yes | Name of the suite. |
+| `test_suite_run_id` | string (UUID) | No | Filter runs by specific suite execution batch ID |
 | `status` | string | No | Filter runs by execution status (pending, running, completed... |
 | `page` | object | No | Consolidated page parameter (deepObject style). |
 
@@ -386,46 +386,46 @@ Before using any operation below, read the Optional Parameters section below and
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
-| Trigger test suite execution | `client.ai.assistants.tests.testSuites.runs.trigger()` | `POST /ai/assistants/tests/test-suites/{suite_name}/runs` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `suiteName` |
-| Get assistant test by ID | `client.ai.assistants.tests.retrieve()` | `GET /ai/assistants/tests/{test_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId` |
-| Update an assistant test | `client.ai.assistants.tests.update()` | `PUT /ai/assistants/tests/{test_id}` | Modify an existing resource without recreating it. | `testId` |
-| Delete an assistant test | `client.ai.assistants.tests.delete()` | `DELETE /ai/assistants/tests/{test_id}` | Remove, detach, or clean up an existing resource. | `testId` |
-| Get test run history for a specific test | `client.ai.assistants.tests.runs.list()` | `GET /ai/assistants/tests/{test_id}/runs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId` |
-| Trigger a manual test run | `client.ai.assistants.tests.runs.trigger()` | `POST /ai/assistants/tests/{test_id}/runs` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `testId` |
-| Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId`, `runId` |
-| Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistantId` |
-| Get Canary Deploy | `client.ai.assistants.canaryDeploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Create Canary Deploy | `client.ai.assistants.canaryDeploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId` |
-| Update Canary Deploy | `client.ai.assistants.canaryDeploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistantId` |
-| Delete Canary Deploy | `client.ai.assistants.canaryDeploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistantId` |
-| Assistant Sms Chat | `client.ai.assistants.sendSMS()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistantId` |
-| Clone Assistant | `client.ai.assistants.clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId` |
-| Enhance Assistant Instructions | `client.ai.assistants.instructions.enhance()` | `POST /ai/assistants/{assistant_id}/instructions/enhance` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId` |
-| List scheduled events | `client.ai.assistants.scheduledEvents.list()` | `GET /ai/assistants/{assistant_id}/scheduled_events` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Create a scheduled event | `client.ai.assistants.scheduledEvents.create()` | `POST /ai/assistants/{assistant_id}/scheduled_events` | Create or provision an additional resource when the core tasks do not cover this flow. | `telnyxConversationChannel`, `telnyxEndUserTarget`, `telnyxAgentTarget`, `scheduledAtFixedDatetime`, +1 more |
-| Get a scheduled event | `client.ai.assistants.scheduledEvents.retrieve()` | `GET /ai/assistants/{assistant_id}/scheduled_events/{event_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId`, `eventId` |
-| Delete a scheduled event | `client.ai.assistants.scheduledEvents.delete()` | `DELETE /ai/assistants/{assistant_id}/scheduled_events/{event_id}` | Remove, detach, or clean up an existing resource. | `assistantId`, `eventId` |
-| Add Assistant Tag | `client.ai.assistants.tags.add()` | `POST /ai/assistants/{assistant_id}/tags` | Create or provision an additional resource when the core tasks do not cover this flow. | `tag`, `assistantId` |
-| Remove Assistant Tag | `client.ai.assistants.tags.remove()` | `DELETE /ai/assistants/{assistant_id}/tags/{tag}` | Remove, detach, or clean up an existing resource. | `assistantId`, `tag` |
-| Get assistant texml | `client.ai.assistants.getTexml()` | `GET /ai/assistants/{assistant_id}/texml` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Add Assistant Tool | `client.ai.assistants.tools.add()` | `PUT /ai/assistants/{assistant_id}/tools/{tool_id}` | Modify an existing resource without recreating it. | `assistantId`, `toolId` |
-| Remove Assistant Tool | `client.ai.assistants.tools.remove()` | `DELETE /ai/assistants/{assistant_id}/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `assistantId`, `toolId` |
-| Test Assistant Tool | `client.ai.assistants.tools.test()` | `POST /ai/assistants/{assistant_id}/tools/{tool_id}/test` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId`, `toolId` |
-| Get all versions of an assistant | `client.ai.assistants.versions.list()` | `GET /ai/assistants/{assistant_id}/versions` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Get a specific assistant version | `client.ai.assistants.versions.retrieve()` | `GET /ai/assistants/{assistant_id}/versions/{version_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId`, `versionId` |
-| Update a specific assistant version | `client.ai.assistants.versions.update()` | `POST /ai/assistants/{assistant_id}/versions/{version_id}` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId`, `versionId` |
-| Delete a specific assistant version | `client.ai.assistants.versions.delete()` | `DELETE /ai/assistants/{assistant_id}/versions/{version_id}` | Remove, detach, or clean up an existing resource. | `assistantId`, `versionId` |
-| Promote an assistant version to main | `client.ai.assistants.versions.promote()` | `POST /ai/assistants/{assistant_id}/versions/{version_id}/promote` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId`, `versionId` |
+| Trigger test suite execution | `client.ai.assistants.tests.testSuites.runs.trigger()` | `POST /ai/assistants/tests/test-suites/{suite_name}/runs` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `suite_name` |
+| Get assistant test by ID | `client.ai.assistants.tests.retrieve()` | `GET /ai/assistants/tests/{test_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id` |
+| Update an assistant test | `client.ai.assistants.tests.update()` | `PUT /ai/assistants/tests/{test_id}` | Modify an existing resource without recreating it. | `test_id` |
+| Delete an assistant test | `client.ai.assistants.tests.delete()` | `DELETE /ai/assistants/tests/{test_id}` | Remove, detach, or clean up an existing resource. | `test_id` |
+| Get test run history for a specific test | `client.ai.assistants.tests.runs.list()` | `GET /ai/assistants/tests/{test_id}/runs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id` |
+| Trigger a manual test run | `client.ai.assistants.tests.runs.trigger()` | `POST /ai/assistants/tests/{test_id}/runs` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `test_id` |
+| Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
+| Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
+| Get Canary Deploy | `client.ai.assistants.canaryDeploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Create Canary Deploy | `client.ai.assistants.canaryDeploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | `client.ai.assistants.canaryDeploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
+| Delete Canary Deploy | `client.ai.assistants.canaryDeploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
+| Assistant Sms Chat | `client.ai.assistants.sendSMS()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistant_id` |
+| Clone Assistant | `client.ai.assistants.clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |
+| Enhance Assistant Instructions | `client.ai.assistants.instructions.enhance()` | `POST /ai/assistants/{assistant_id}/instructions/enhance` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| List scheduled events | `client.ai.assistants.scheduledEvents.list()` | `GET /ai/assistants/{assistant_id}/scheduled_events` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Create a scheduled event | `client.ai.assistants.scheduledEvents.create()` | `POST /ai/assistants/{assistant_id}/scheduled_events` | Create or provision an additional resource when the core tasks do not cover this flow. | `telnyx_conversation_channel`, `telnyx_end_user_target`, `telnyx_agent_target`, `scheduled_at_fixed_datetime`, +1 more |
+| Get a scheduled event | `client.ai.assistants.scheduledEvents.retrieve()` | `GET /ai/assistants/{assistant_id}/scheduled_events/{event_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id`, `event_id` |
+| Delete a scheduled event | `client.ai.assistants.scheduledEvents.delete()` | `DELETE /ai/assistants/{assistant_id}/scheduled_events/{event_id}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `event_id` |
+| Add Assistant Tag | `client.ai.assistants.tags.add()` | `POST /ai/assistants/{assistant_id}/tags` | Create or provision an additional resource when the core tasks do not cover this flow. | `tag`, `assistant_id` |
+| Remove Assistant Tag | `client.ai.assistants.tags.remove()` | `DELETE /ai/assistants/{assistant_id}/tags/{tag}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `tag` |
+| Get assistant texml | `client.ai.assistants.getTexml()` | `GET /ai/assistants/{assistant_id}/texml` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Add Assistant Tool | `client.ai.assistants.tools.add()` | `PUT /ai/assistants/{assistant_id}/tools/{tool_id}` | Modify an existing resource without recreating it. | `assistant_id`, `tool_id` |
+| Remove Assistant Tool | `client.ai.assistants.tools.remove()` | `DELETE /ai/assistants/{assistant_id}/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `tool_id` |
+| Test Assistant Tool | `client.ai.assistants.tools.test()` | `POST /ai/assistants/{assistant_id}/tools/{tool_id}/test` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id`, `tool_id` |
+| Get all versions of an assistant | `client.ai.assistants.versions.list()` | `GET /ai/assistants/{assistant_id}/versions` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Get a specific assistant version | `client.ai.assistants.versions.retrieve()` | `GET /ai/assistants/{assistant_id}/versions/{version_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id`, `version_id` |
+| Update a specific assistant version | `client.ai.assistants.versions.update()` | `POST /ai/assistants/{assistant_id}/versions/{version_id}` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id`, `version_id` |
+| Delete a specific assistant version | `client.ai.assistants.versions.delete()` | `DELETE /ai/assistants/{assistant_id}/versions/{version_id}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `version_id` |
+| Promote an assistant version to main | `client.ai.assistants.versions.promote()` | `POST /ai/assistants/{assistant_id}/versions/{version_id}/promote` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id`, `version_id` |
 | List MCP Servers | `client.ai.mcpServers.list()` | `GET /ai/mcp_servers` | Inspect available resources or choose an existing resource before mutating it. | None |
 | Create MCP Server | `client.ai.mcpServers.create()` | `POST /ai/mcp_servers` | Create or provision an additional resource when the core tasks do not cover this flow. | `name`, `type`, `url` |
-| Get MCP Server | `client.ai.mcpServers.retrieve()` | `GET /ai/mcp_servers/{mcp_server_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `mcpServerId` |
-| Update MCP Server | `client.ai.mcpServers.update()` | `PUT /ai/mcp_servers/{mcp_server_id}` | Modify an existing resource without recreating it. | `mcpServerId` |
-| Delete MCP Server | `client.ai.mcpServers.delete()` | `DELETE /ai/mcp_servers/{mcp_server_id}` | Remove, detach, or clean up an existing resource. | `mcpServerId` |
+| Get MCP Server | `client.ai.mcpServers.retrieve()` | `GET /ai/mcp_servers/{mcp_server_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `mcp_server_id` |
+| Update MCP Server | `client.ai.mcpServers.update()` | `PUT /ai/mcp_servers/{mcp_server_id}` | Modify an existing resource without recreating it. | `mcp_server_id` |
+| Delete MCP Server | `client.ai.mcpServers.delete()` | `DELETE /ai/mcp_servers/{mcp_server_id}` | Remove, detach, or clean up an existing resource. | `mcp_server_id` |
 | List Tools | `client.ai.tools.list()` | `GET /ai/tools` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Create Tool | `client.ai.tools.create()` | `POST /ai/tools` | Create or provision an additional resource when the core tasks do not cover this flow. | `type`, `displayName` |
-| Get Tool | `client.ai.tools.retrieve()` | `GET /ai/tools/{tool_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `toolId` |
-| Update Tool | `client.ai.tools.update()` | `PATCH /ai/tools/{tool_id}` | Modify an existing resource without recreating it. | `toolId` |
-| Delete Tool | `client.ai.tools.delete()` | `DELETE /ai/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `toolId` |
+| Create Tool | `client.ai.tools.create()` | `POST /ai/tools` | Create or provision an additional resource when the core tasks do not cover this flow. | `type`, `display_name` |
+| Get Tool | `client.ai.tools.retrieve()` | `GET /ai/tools/{tool_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `tool_id` |
+| Update Tool | `client.ai.tools.update()` | `PATCH /ai/tools/{tool_id}` | Modify an existing resource without recreating it. | `tool_id` |
+| Delete Tool | `client.ai.tools.delete()` | `DELETE /ai/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `tool_id` |
 
 ---
 
@@ -442,51 +442,51 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 |-----------|------|-------------|
 | `model` | string | ID of the model to use when `external_llm` is not set. |
 | `tools` | array[object] | Deprecated for new integrations. |
-| `mcpServers` | array[object] | MCP servers attached to the assistant. |
-| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
-| `externalLlm` | object |  |
-| `fallbackConfig` | object |  |
-| `voiceSettings` | object |  |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
 | `transcription` | object |  |
-| `telephonySettings` | object |  |
-| `messagingSettings` | object |  |
-| `enabledFeatures` | array[object] |  |
-| `insightSettings` | object |  |
-| `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
-| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
-| `dynamicVariables` | object | Map of dynamic variables and their default values |
-| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
-| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
 | `integrations` | array[object] | Connected integrations attached to the assistant. |
-| `observabilitySettings` | object |  |
+| `observability_settings` | object |  |
 | `tags` | array[string] | Tags associated with the assistant. |
-| `postConversationSettings` | object | Configuration for post-conversation processing. |
-| `conversationFlow` | object | Conversation flow as supplied by API clients (create / update). |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+| `conversation_flow` | object | Conversation flow as supplied by API clients (create / update). |
 
 ### Import assistants from external provider — `client.ai.assistants.imports()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `importIds` | array[string] | Optional list of assistant IDs to import from the external provider. |
+| `import_ids` | array[string] | Optional list of assistant IDs to import from the external provider. |
 
 ### Create a new assistant test — `client.ai.assistants.tests.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `description` | string | Optional detailed description of what this test evaluates and its purpose. |
-| `telnyxConversationChannel` | object | The communication channel through which the test will be conducted. |
-| `maxDurationSeconds` | integer | Maximum duration in seconds that the test conversation should run before timi... |
-| `testSuite` | string | Optional test suite name to group related tests together. |
+| `telnyx_conversation_channel` | object | The communication channel through which the test will be conducted. |
+| `max_duration_seconds` | integer | Maximum duration in seconds that the test conversation should run before timi... |
+| `test_suite` | string | Optional test suite name to group related tests together. |
 
 ### Trigger test suite execution — `client.ai.assistants.tests.testSuites.runs.trigger()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `destinationVersionId` | string (UUID) | Optional assistant version ID to use for all test runs in this suite. |
+| `destination_version_id` | string (UUID) | Optional assistant version ID to use for all test runs in this suite. |
 
 ### Update an assistant test — `client.ai.assistants.tests.update()`
 
@@ -494,10 +494,10 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 |-----------|------|-------------|
 | `name` | string | Updated name for the assistant test. |
 | `description` | string | Updated description of the test's purpose and evaluation criteria. |
-| `telnyxConversationChannel` | enum (phone_call, web_call, sms_chat, web_chat) |  |
+| `telnyx_conversation_channel` | enum (phone_call, web_call, sms_chat, web_chat) |  |
 | `destination` | string | Updated target destination for test conversations. |
-| `maxDurationSeconds` | integer | Updated maximum test duration in seconds. |
-| `testSuite` | string | Updated test suite assignment for better organization. |
+| `max_duration_seconds` | integer | Updated maximum test duration in seconds. |
+| `test_suite` | string | Updated test suite assignment for better organization. |
 | `instructions` | string | Updated test scenario instructions and objectives. |
 | `rubric` | array[object] | Updated evaluation criteria for assessing assistant performance. |
 
@@ -505,7 +505,7 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `destinationVersionId` | string (UUID) | Optional assistant version ID to use for this test run. |
+| `destination_version_id` | string (UUID) | Optional assistant version ID to use for this test run. |
 
 ### Update an assistant — `client.ai.assistants.update()`
 
@@ -515,32 +515,32 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 | `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
 | `tools` | array[object] | Deprecated for new integrations. |
-| `mcpServers` | array[object] | MCP servers attached to the assistant. |
-| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
-| `externalLlm` | object |  |
-| `fallbackConfig` | object |  |
-| `voiceSettings` | object |  |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
 | `transcription` | object |  |
-| `telephonySettings` | object |  |
-| `messagingSettings` | object |  |
-| `enabledFeatures` | array[object] |  |
-| `insightSettings` | object |  |
-| `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
-| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
-| `dynamicVariables` | object | Map of dynamic variables and their default values |
-| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
-| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
 | `integrations` | array[object] | Connected integrations attached to the assistant. |
-| `observabilitySettings` | object |  |
+| `observability_settings` | object |  |
 | `tags` | array[string] | Tags associated with the assistant. |
-| `versionName` | string | Human-readable name for the assistant version. |
-| `postConversationSettings` | object | Configuration for post-conversation processing. |
-| `conversationFlow` | object | Conversation flow as supplied by API clients (create / update). |
-| `promoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+| `conversation_flow` | object | Conversation flow as supplied by API clients (create / update). |
+| `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
 
 ### Create Canary Deploy — `client.ai.assistants.canaryDeploys.create()`
 
@@ -565,14 +565,14 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `text` | string |  |
-| `conversationMetadata` | object |  |
-| `shouldCreateConversation` | boolean |  |
+| `conversation_metadata` | object |  |
+| `should_create_conversation` | boolean |  |
 
 ### Enhance Assistant Instructions — `client.ai.assistants.instructions.enhance()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `enhancementPrompt` | object | Optional guidance describing how the instructions should be enhanced. |
+| `enhancement_prompt` | object | Optional guidance describing how the instructions should be enhanced. |
 | `instructions` | object | The instructions to enhance. |
 
 ### Create a scheduled event — `client.ai.assistants.scheduledEvents.create()`
@@ -580,11 +580,11 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `text` | string | Required for sms scheduled events. |
-| `conversationMetadata` | object | Metadata associated with the conversation. |
-| `dynamicVariables` | object | A map of dynamic variable names to values. |
-| `maxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
-| `retryIntervalSecs` | integer |  |
-| `callSettings` | object | Per-call telephony overrides applied when a scheduled phone-call event
+| `conversation_metadata` | object | Metadata associated with the conversation. |
+| `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
+| `call_settings` | object | Per-call telephony overrides applied when a scheduled phone-call event
 dispat... |
 
 ### Test Assistant Tool — `client.ai.assistants.tools.test()`
@@ -592,7 +592,7 @@ dispat... |
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `arguments` | object | Key-value arguments to use for the webhook test |
-| `dynamicVariables` | object | Key-value dynamic variables to use for the webhook test |
+| `dynamic_variables` | object | Key-value dynamic variables to use for the webhook test |
 
 ### Update a specific assistant version — `client.ai.assistants.versions.update()`
 
@@ -602,38 +602,38 @@ dispat... |
 | `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
 | `tools` | array[object] | Deprecated for new integrations. |
-| `mcpServers` | array[object] | MCP servers attached to the assistant. |
-| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
-| `externalLlm` | object |  |
-| `fallbackConfig` | object |  |
-| `voiceSettings` | object |  |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
 | `transcription` | object |  |
-| `telephonySettings` | object |  |
-| `messagingSettings` | object |  |
-| `enabledFeatures` | array[object] |  |
-| `insightSettings` | object |  |
-| `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
-| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
-| `dynamicVariables` | object | Map of dynamic variables and their default values |
-| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
-| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
 | `integrations` | array[object] | Connected integrations attached to the assistant. |
-| `observabilitySettings` | object |  |
+| `observability_settings` | object |  |
 | `tags` | array[string] | Tags associated with the assistant. |
-| `versionName` | string | Human-readable name for the assistant version. |
-| `postConversationSettings` | object | Configuration for post-conversation processing. |
-| `conversationFlow` | object | Conversation flow as supplied by API clients (create / update). |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+| `conversation_flow` | object | Conversation flow as supplied by API clients (create / update). |
 
 ### Create MCP Server — `client.ai.mcpServers.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `apiKeyRef` | string |  |
-| `allowedTools` | array[string] |  |
+| `api_key_ref` | string |  |
+| `allowed_tools` | array[string] |  |
 
 ### Update MCP Server — `client.ai.mcpServers.update()`
 
@@ -643,9 +643,9 @@ dispat... |
 | `name` | string |  |
 | `type` | string |  |
 | `url` | string (URL) |  |
-| `apiKeyRef` | string |  |
-| `allowedTools` | array[string] |  |
-| `createdAt` | string (date-time) |  |
+| `api_key_ref` | string |  |
+| `allowed_tools` | array[string] |  |
+| `created_at` | string (date-time) |  |
 
 ### Create Tool — `client.ai.tools.create()`
 
@@ -656,17 +656,19 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
-| `timeoutMs` | integer |  |
+| `client_side_tool` | object |  |
+| `timeout_ms` | integer |  |
 
 ### Update Tool — `client.ai.tools.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `type` | string |  |
-| `displayName` | string |  |
+| `display_name` | string |  |
 | `function` | object |  |
 | `retrieval` | object |  |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
-| `timeoutMs` | integer |  |
+| `client_side_tool` | object |  |
+| `timeout_ms` | integer |  |

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/javascript/messaging.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/javascript/messaging.md
@@ -83,9 +83,9 @@ Primary outbound messaging flow. Agents need exact request fields and delivery-r
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
 | `from` | string (E.164) | Yes | Sending address (+E.164 formatted phone number, alphanumeric... |
 | `text` | string | Yes | Message body (i.e., content) as a non-empty string. |
-| `messagingProfileId` | string (UUID) | No | Unique identifier for a messaging profile. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Unique identifier for a messaging profile. |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
 | ... | | | +7 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -117,10 +117,10 @@ Common sender variant that requires different request shape.
 | `from` | string (E.164) | Yes | A valid alphanumeric sender ID on the user's account. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
 | `text` | string | Yes | The message body. |
-| `messagingProfileId` | string (UUID) | Yes | The messaging profile ID to use. |
-| `webhookUrl` | string (URL) | No | Callback URL for delivery status updates. |
-| `webhookFailoverUrl` | string (URL) | No | Failover callback URL for delivery status updates. |
-| `useProfileWebhooks` | boolean | No | If true, use the messaging profile's webhook settings. |
+| `messaging_profile_id` | string (UUID) | Yes | The messaging profile ID to use. |
+| `webhook_url` | string (URL) | No | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | No | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | No | If true, use the messaging profile's webhook settings. |
 
 ```javascript
 const response = await client.messages.sendWithAlphanumericSender({
@@ -152,7 +152,7 @@ and `telnyx-timestamp` headers. Always verify signatures in production:
 // In your webhook handler (e.g., Express — use raw body, not parsed JSON):
 app.post('/webhooks', express.raw({ type: 'application/json' }), async (req, res) => {
   try {
-    const event = await client.webhooks.unwrap(req.body.toString(), {
+    const event = client.webhooks.unwrap(req.body.toString(), {
       headers: req.headers,
     });
     // Signature valid — event is the parsed webhook payload
@@ -213,9 +213,9 @@ Send one MMS payload to multiple recipients.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | array[object] | Yes | A list of destinations. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +3 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -246,9 +246,9 @@ Force a long-code sending path instead of the generic send endpoint.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -276,11 +276,11 @@ Let a messaging profile or number pool choose the sender for you.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `messagingProfileId` | string (UUID) | Yes | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Yes | Unique identifier for a messaging profile. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -311,9 +311,9 @@ Force a short-code sending path when the sender must be a short code.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -342,9 +342,9 @@ Queue a message for future delivery instead of sending immediately.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `messagingProfileId` | string (UUID) | No | Unique identifier for a messaging profile. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Unique identifier for a messaging profile. |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
 | ... | | | +8 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -352,7 +352,7 @@ const response = await client.messages.schedule({
     to: '+18445550001',
     from: '+18005550101',
     text: 'Appointment reminder',
-    sendAt: '2025-07-01T15:00:00Z',
+    send_at: '2025-07-01T15:00:00Z',
 });
 
 console.log(response.data);
@@ -376,10 +376,10 @@ Send WhatsApp traffic instead of SMS/MMS.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number in +E.164 format associated with Whatsapp accou... |
 | `to` | string (E.164) | Yes | Phone number in +E.164 format |
-| `whatsappMessage` | object | Yes |  |
+| `whatsapp_message` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `messagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```javascript
 const response = await client.messages.sendWhatsapp({
@@ -411,10 +411,10 @@ Before using any operation below, read the Optional Parameters section below and
 | Retrieve a message | `client.messages.retrieve()` | `GET /messages/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Cancel a scheduled message | `client.messages.cancelScheduled()` | `DELETE /messages/{id}` | Remove, detach, or clean up an existing resource. | `id` |
 | List alphanumeric sender IDs | `client.alphanumericSenderIDs.list()` | `GET /alphanumeric_sender_ids` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Create an alphanumeric sender ID | `client.alphanumericSenderIDs.create()` | `POST /alphanumeric_sender_ids` | Create or provision an additional resource when the core tasks do not cover this flow. | `alphanumericSenderId`, `messagingProfileId` |
+| Create an alphanumeric sender ID | `client.alphanumericSenderIDs.create()` | `POST /alphanumeric_sender_ids` | Create or provision an additional resource when the core tasks do not cover this flow. | `alphanumeric_sender_id`, `messaging_profile_id` |
 | Retrieve an alphanumeric sender ID | `client.alphanumericSenderIDs.retrieve()` | `GET /alphanumeric_sender_ids/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Delete an alphanumeric sender ID | `client.alphanumericSenderIDs.delete()` | `DELETE /alphanumeric_sender_ids/{id}` | Remove, detach, or clean up an existing resource. | `id` |
-| Retrieve group MMS messages | `client.messages.retrieveGroupMessages()` | `GET /messages/group/{message_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `messageId` |
+| Retrieve group MMS messages | `client.messages.retrieveGroupMessages()` | `GET /messages/group/{message_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `message_id` |
 | List messaging hosted numbers | `client.messagingHostedNumbers.list()` | `GET /messaging_hosted_numbers` | Inspect available resources or choose an existing resource before mutating it. | None |
 | Retrieve a messaging hosted number | `client.messagingHostedNumbers.retrieve()` | `GET /messaging_hosted_numbers/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Update a messaging hosted number | `client.messagingHostedNumbers.update()` | `PATCH /messaging_hosted_numbers/{id}` | Modify an existing resource without recreating it. | `id` |
@@ -423,11 +423,11 @@ Before using any operation below, read the Optional Parameters section below and
 | Regenerate messaging profile secret | `client.messagingProfiles.actions.regenerateSecret()` | `POST /messaging_profiles/{id}/actions/regenerate_secret` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `id` |
 | List alphanumeric sender IDs for a messaging profile | `client.messagingProfiles.listAlphanumericSenderIDs()` | `GET /messaging_profiles/{id}/alphanumeric_sender_ids` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Get detailed messaging profile metrics | `client.messagingProfiles.retrieveMetrics()` | `GET /messaging_profiles/{id}/metrics` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
-| List Auto-Response Settings | `client.messagingProfiles.autorespConfigs.list()` | `GET /messaging_profiles/{profile_id}/autoresp_configs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profileId` |
-| Create auto-response setting | `client.messagingProfiles.autorespConfigs.create()` | `POST /messaging_profiles/{profile_id}/autoresp_configs` | Create or provision an additional resource when the core tasks do not cover this flow. | `op`, `keywords`, `countryCode`, `profileId` |
-| Get Auto-Response Setting | `client.messagingProfiles.autorespConfigs.retrieve()` | `GET /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profileId`, `autorespCfgId` |
-| Update Auto-Response Setting | `client.messagingProfiles.autorespConfigs.update()` | `PUT /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Modify an existing resource without recreating it. | `op`, `keywords`, `countryCode`, `profileId`, +1 more |
-| Delete Auto-Response Setting | `client.messagingProfiles.autorespConfigs.delete()` | `DELETE /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Remove, detach, or clean up an existing resource. | `profileId`, `autorespCfgId` |
+| List Auto-Response Settings | `client.messagingProfiles.autorespConfigs.list()` | `GET /messaging_profiles/{profile_id}/autoresp_configs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profile_id` |
+| Create auto-response setting | `client.messagingProfiles.autorespConfigs.create()` | `POST /messaging_profiles/{profile_id}/autoresp_configs` | Create or provision an additional resource when the core tasks do not cover this flow. | `op`, `keywords`, `country_code`, `profile_id` |
+| Get Auto-Response Setting | `client.messagingProfiles.autorespConfigs.retrieve()` | `GET /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profile_id`, `autoresp_cfg_id` |
+| Update Auto-Response Setting | `client.messagingProfiles.autorespConfigs.update()` | `PUT /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Modify an existing resource without recreating it. | `op`, `keywords`, `country_code`, `profile_id`, +1 more |
+| Delete Auto-Response Setting | `client.messagingProfiles.autorespConfigs.delete()` | `DELETE /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Remove, detach, or clean up an existing resource. | `profile_id`, `autoresp_cfg_id` |
 
 ### Other Webhook Events
 
@@ -448,32 +448,32 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `usLongCodeFallback` | string | A US long code number to use as fallback when sending to US destinations. |
+| `us_long_code_fallback` | string | A US long code number to use as fallback when sending to US destinations. |
 
 ### Send a message — `client.messages.send()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
-| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
-| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a message using an alphanumeric sender ID — `client.messages.sendWithAlphanumericSender()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `webhookUrl` | string (URL) | Callback URL for delivery status updates. |
-| `webhookFailoverUrl` | string (URL) | Failover callback URL for delivery status updates. |
-| `useProfileWebhooks` | boolean | If true, use the messaging profile's webhook settings. |
+| `webhook_url` | string (URL) | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | If true, use the messaging profile's webhook settings. |
 
 ### Send a group MMS message — `client.messages.sendGroupMms()`
 
@@ -481,10 +481,10 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 
 ### Send a long code message — `client.messages.sendLongCode()`
 
@@ -492,12 +492,12 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a message using number pool — `client.messages.sendNumberPool()`
@@ -506,12 +506,12 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Schedule a message — `client.messages.schedule()`
@@ -519,16 +519,16 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
-| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
-| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
 
 ### Send a short code message — `client.messages.sendShortCode()`
 
@@ -536,12 +536,12 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a WhatsApp message — `client.messages.sendWhatsapp()`
@@ -549,17 +549,17 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `messagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messagingHostedNumbers.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `messagingProfileId` | string (UUID) | Configure the messaging profile this phone number is assigned to:
+| `messaging_profile_id` | string (UUID) | Configure the messaging profile this phone number is assigned to:
 
 * Omit thi... |
-| `messagingProduct` | string | Configure the messaging product for this number:
+| `messaging_product` | string | Configure the messaging product for this number:
 
 * Omit this field or set it... |
 | `tags` | array[string] | Tags to set on this phone number. |
@@ -568,10 +568,10 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `respText` | string |  |
+| `resp_text` | string |  |
 
 ### Update Auto-Response Setting — `client.messagingProfiles.autorespConfigs.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `respText` | string |  |
+| `resp_text` | string |  |

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/javascript/numbers.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/javascript/numbers.md
@@ -97,15 +97,15 @@ Number ordering is the production provisioning step after number selection.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `phoneNumbers` | array[object] | Yes |  |
-| `connectionId` | string (UUID) | No | Identifies the connection associated with this phone number. |
-| `messagingProfileId` | string (UUID) | No | Identifies the messaging profile associated with the phone n... |
-| `billingGroupId` | string (UUID) | No | Identifies the billing group associated with the phone numbe... |
+| `phone_numbers` | array[object] | Yes |  |
+| `connection_id` | string (UUID) | No | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | No | Identifies the messaging profile associated with the phone n... |
+| `billing_group_id` | string (UUID) | No | Identifies the billing group associated with the phone numbe... |
 | ... | | | +1 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
 const numberOrder = await client.numberOrders.create({
-    phoneNumbers: [{"phone_number": "+18005550101"}],
+    phone_numbers: [{"phone_number": "+18005550101"}],
 });
 
 console.log(numberOrder.data);
@@ -127,7 +127,7 @@ Order status determines whether provisioning completed or additional requirement
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `numberOrderId` | string (UUID) | Yes | The number order ID. |
+| `number_order_id` | string (UUID) | Yes | The number order ID. |
 
 ```javascript
 const numberOrder = await client.numberOrders.retrieve('550e8400-e29b-41d4-a716-446655440000');
@@ -157,15 +157,15 @@ Create or provision an additional resource when the core tasks do not cover this
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `phoneNumbers` | array[object] | Yes |  |
+| `phone_numbers` | array[object] | Yes |  |
 | `status` | enum (pending, success, failure) | No | The status of the entire reservation. |
 | `id` | string (UUID) | No |  |
-| `recordType` | string | No |  |
+| `record_type` | string | No |  |
 | ... | | | +3 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
 const numberReservation = await client.numberReservations.create({
-    phoneNumbers: [{"phone_number": "+18005550101"}],
+    phone_numbers: [{"phone_number": "+18005550101"}],
 });
 
 console.log(numberReservation.data);
@@ -187,7 +187,7 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `numberReservationId` | string (UUID) | Yes | The number reservation ID. |
+| `number_reservation_id` | string (UUID) | Yes | The number reservation ID. |
 
 ```javascript
 const numberReservation = await client.numberReservations.retrieve('550e8400-e29b-41d4-a716-446655440000');
@@ -234,9 +234,9 @@ Create or provision an additional resource when the core tasks do not cover this
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) | No |  |
-| `requirementGroupId` | string (UUID) | No | The ID of the requirement group to associate with this advan... |
-| `countryCode` | string (ISO 3166-1 alpha-2) | No |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) | No |  |
+| `requirement_group_id` | string (UUID) | No | The ID of the requirement group to associate with this advan... |
+| `country_code` | string (ISO 3166-1 alpha-2) | No |  |
 | ... | | | +5 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -262,9 +262,9 @@ Modify an existing resource without recreating it.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `advanced-order-id` | string (UUID) | Yes | Unique identifier of the advanced order. |
-| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) | No |  |
-| `requirementGroupId` | string (UUID) | No | The ID of the requirement group to associate with this advan... |
-| `countryCode` | string (ISO 3166-1 alpha-2) | No |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) | No |  |
+| `requirement_group_id` | string (UUID) | No | The ID of the requirement group to associate with this advan... |
+| `country_code` | string (ISO 3166-1 alpha-2) | No |  |
 | ... | | | +5 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -291,7 +291,7 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `orderId` | string (UUID) | Yes | Unique identifier of the order. |
+| `order_id` | string (UUID) | Yes | Unique identifier of the order. |
 
 ```javascript
 const advancedOrder = await client.advancedOrders.retrieve('182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e');
@@ -376,38 +376,38 @@ Before using any operation below, read the Optional Parameters section below and
 | Retrieve a comment | `client.comments.retrieve()` | `GET /comments/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Mark a comment as read | `client.comments.markAsRead()` | `PATCH /comments/{id}/read` | Modify an existing resource without recreating it. | `id` |
 | Get country coverage | `client.countryCoverage.retrieve()` | `GET /country_coverage` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Get coverage for a specific country | `client.countryCoverage.retrieveCountry()` | `GET /country_coverage/countries/{country_code}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `countryCode` |
+| Get coverage for a specific country | `client.countryCoverage.retrieveCountry()` | `GET /country_coverage/countries/{country_code}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `country_code` |
 | List customer service records | `client.customerServiceRecords.list()` | `GET /customer_service_records` | Inspect available resources or choose an existing resource before mutating it. | None |
 | Create a customer service record | `client.customerServiceRecords.create()` | `POST /customer_service_records` | Create or provision an additional resource when the core tasks do not cover this flow. | None |
 | Verify CSR phone number coverage | `client.customerServiceRecords.verifyPhoneNumberCoverage()` | `POST /customer_service_records/phone_number_coverages` | Create or provision an additional resource when the core tasks do not cover this flow. | None |
-| Get a customer service record | `client.customerServiceRecords.retrieve()` | `GET /customer_service_records/{customer_service_record_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `customerServiceRecordId` |
+| Get a customer service record | `client.customerServiceRecords.retrieve()` | `GET /customer_service_records/{customer_service_record_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `customer_service_record_id` |
 | List inexplicit number orders | `client.inexplicitNumberOrders.list()` | `GET /inexplicit_number_orders` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Create an inexplicit number order | `client.inexplicitNumberOrders.create()` | `POST /inexplicit_number_orders` | Create or provision an additional resource when the core tasks do not cover this flow. | `orderingGroups` |
+| Create an inexplicit number order | `client.inexplicitNumberOrders.create()` | `POST /inexplicit_number_orders` | Create or provision an additional resource when the core tasks do not cover this flow. | `ordering_groups` |
 | Retrieve an inexplicit number order | `client.inexplicitNumberOrders.retrieve()` | `GET /inexplicit_number_orders/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Create an inventory coverage request | `client.inventoryCoverage.list()` | `GET /inventory_coverage` | Inspect available resources or choose an existing resource before mutating it. | None |
 | List mobile network operators | `client.mobileNetworkOperators.list()` | `GET /mobile_network_operators` | Inspect available resources or choose an existing resource before mutating it. | None |
 | List network coverage locations | `client.networkCoverage.list()` | `GET /network_coverage` | Inspect available resources or choose an existing resource before mutating it. | None |
 | List number block orders | `client.numberBlockOrders.list()` | `GET /number_block_orders` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Create a number block order | `client.numberBlockOrders.create()` | `POST /number_block_orders` | Create or provision an additional resource when the core tasks do not cover this flow. | `startingNumber`, `range` |
-| Retrieve a number block order | `client.numberBlockOrders.retrieve()` | `GET /number_block_orders/{number_block_order_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `numberBlockOrderId` |
+| Create a number block order | `client.numberBlockOrders.create()` | `POST /number_block_orders` | Create or provision an additional resource when the core tasks do not cover this flow. | `starting_number`, `range` |
+| Retrieve a number block order | `client.numberBlockOrders.retrieve()` | `GET /number_block_orders/{number_block_order_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `number_block_order_id` |
 | Retrieve a list of phone numbers associated to orders | `client.numberOrderPhoneNumbers.list()` | `GET /number_order_phone_numbers` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Retrieve a single phone number within a number order. | `client.numberOrderPhoneNumbers.retrieve()` | `GET /number_order_phone_numbers/{number_order_phone_number_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `numberOrderPhoneNumberId` |
-| Update requirements for a single phone number within a number order. | `client.numberOrderPhoneNumbers.updateRequirements()` | `PATCH /number_order_phone_numbers/{number_order_phone_number_id}` | Modify an existing resource without recreating it. | `numberOrderPhoneNumberId` |
+| Retrieve a single phone number within a number order. | `client.numberOrderPhoneNumbers.retrieve()` | `GET /number_order_phone_numbers/{number_order_phone_number_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `number_order_phone_number_id` |
+| Update requirements for a single phone number within a number order. | `client.numberOrderPhoneNumbers.updateRequirements()` | `PATCH /number_order_phone_numbers/{number_order_phone_number_id}` | Modify an existing resource without recreating it. | `number_order_phone_number_id` |
 | List number orders | `client.numberOrders.list()` | `GET /number_orders` | Create or inspect provisioning orders for number purchases. | None |
-| Update a number order | `client.numberOrders.update()` | `PATCH /number_orders/{number_order_id}` | Modify an existing resource without recreating it. | `numberOrderId` |
+| Update a number order | `client.numberOrders.update()` | `PATCH /number_orders/{number_order_id}` | Modify an existing resource without recreating it. | `number_order_id` |
 | List number reservations | `client.numberReservations.list()` | `GET /number_reservations` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Extend a number reservation | `client.numberReservations.actions.extend()` | `POST /number_reservations/{number_reservation_id}/actions/extend` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `numberReservationId` |
-| Retrieve the features for a list of numbers | `client.numbersFeatures.create()` | `POST /numbers_features` | Create or provision an additional resource when the core tasks do not cover this flow. | `phoneNumbers` |
+| Extend a number reservation | `client.numberReservations.actions.extend()` | `POST /number_reservations/{number_reservation_id}/actions/extend` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `number_reservation_id` |
+| Retrieve the features for a list of numbers | `client.numbersFeatures.create()` | `POST /numbers_features` | Create or provision an additional resource when the core tasks do not cover this flow. | `phone_numbers` |
 | Lists the phone number blocks jobs | `client.phoneNumberBlocks.jobs.list()` | `GET /phone_number_blocks/jobs` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Deletes all numbers associated with a phone number block | `client.phoneNumberBlocks.jobs.deletePhoneNumberBlock()` | `POST /phone_number_blocks/jobs/delete_phone_number_block` | Create or provision an additional resource when the core tasks do not cover this flow. | `phoneNumberBlockId` |
+| Deletes all numbers associated with a phone number block | `client.phoneNumberBlocks.jobs.deletePhoneNumberBlock()` | `POST /phone_number_blocks/jobs/delete_phone_number_block` | Create or provision an additional resource when the core tasks do not cover this flow. | `phone_number_block_id` |
 | Retrieves a phone number blocks job | `client.phoneNumberBlocks.jobs.retrieve()` | `GET /phone_number_blocks/jobs/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | List sub number orders | `client.subNumberOrders.list()` | `GET /sub_number_orders` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Retrieve a sub number order | `client.subNumberOrders.retrieve()` | `GET /sub_number_orders/{sub_number_order_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `subNumberOrderId` |
-| Update a sub number order's requirements | `client.subNumberOrders.update()` | `PATCH /sub_number_orders/{sub_number_order_id}` | Modify an existing resource without recreating it. | `subNumberOrderId` |
-| Cancel a sub number order | `client.subNumberOrders.cancel()` | `PATCH /sub_number_orders/{sub_number_order_id}/cancel` | Modify an existing resource without recreating it. | `subNumberOrderId` |
+| Retrieve a sub number order | `client.subNumberOrders.retrieve()` | `GET /sub_number_orders/{sub_number_order_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `sub_number_order_id` |
+| Update a sub number order's requirements | `client.subNumberOrders.update()` | `PATCH /sub_number_orders/{sub_number_order_id}` | Modify an existing resource without recreating it. | `sub_number_order_id` |
+| Cancel a sub number order | `client.subNumberOrders.cancel()` | `PATCH /sub_number_orders/{sub_number_order_id}/cancel` | Modify an existing resource without recreating it. | `sub_number_order_id` |
 | Create a sub number orders report | `client.subNumberOrdersReport.create()` | `POST /sub_number_orders_report` | Create or provision an additional resource when the core tasks do not cover this flow. | None |
-| Retrieve a sub number orders report | `client.subNumberOrdersReport.retrieve()` | `GET /sub_number_orders_report/{report_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `reportId` |
-| Download a sub number orders report | `client.subNumberOrdersReport.download()` | `GET /sub_number_orders_report/{report_id}/download` | Fetch the current state before updating, deleting, or making control-flow decisions. | `reportId` |
+| Retrieve a sub number orders report | `client.subNumberOrdersReport.retrieve()` | `GET /sub_number_orders_report/{report_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `report_id` |
+| Download a sub number orders report | `client.subNumberOrdersReport.download()` | `GET /sub_number_orders_report/{report_id}/download` | Fetch the current state before updating, deleting, or making control-flow decisions. | `report_id` |
 
 ### Other Webhook Events
 
@@ -428,27 +428,27 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `countryCode` | string (ISO 3166-1 alpha-2) |  |
+| `country_code` | string (ISO 3166-1 alpha-2) |  |
 | `comments` | string |  |
 | `quantity` | integer |  |
-| `areaCode` | string |  |
-| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `area_code` | string |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
 | `features` | array[object] |  |
-| `customerReference` | string |  |
-| `requirementGroupId` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+| `customer_reference` | string |  |
+| `requirement_group_id` | string (UUID) | The ID of the requirement group to associate with this advanced order |
 
 ### Update Advanced Order — `client.advancedOrders.updateRequirementGroup()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `countryCode` | string (ISO 3166-1 alpha-2) |  |
+| `country_code` | string (ISO 3166-1 alpha-2) |  |
 | `comments` | string |  |
 | `quantity` | integer |  |
-| `areaCode` | string |  |
-| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `area_code` | string |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
 | `features` | array[object] |  |
-| `customerReference` | string |  |
-| `requirementGroupId` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+| `customer_reference` | string |  |
+| `requirement_group_id` | string (UUID) | The ID of the requirement group to associate with this advanced order |
 
 ### Create a comment — `client.comments.create()`
 
@@ -457,86 +457,86 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 | `id` | string (UUID) |  |
 | `body` | string |  |
 | `commenter` | string |  |
-| `commenterType` | enum (admin, user) |  |
-| `commentRecordType` | enum (sub_number_order, requirement_group) |  |
-| `commentRecordId` | string (UUID) |  |
-| `readAt` | string (date-time) | An ISO 8901 datetime string for when the comment was read. |
-| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the comment was created. |
-| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the comment was updated. |
+| `commenter_type` | enum (admin, user) |  |
+| `comment_record_type` | enum (sub_number_order, requirement_group) |  |
+| `comment_record_id` | string (UUID) |  |
+| `read_at` | string (date-time) | An ISO 8901 datetime string for when the comment was read. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the comment was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the comment was updated. |
 
 ### Create an inexplicit number order — `client.inexplicitNumberOrders.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `connectionId` | string (UUID) | Connection id to apply to phone numbers that are purchased |
-| `messagingProfileId` | string (UUID) | Messaging profile id to apply to phone numbers that are purchased |
-| `customerReference` | string | Reference label for the customer |
-| `billingGroupId` | string (UUID) | Billing group id to apply to phone numbers that are purchased |
+| `connection_id` | string (UUID) | Connection id to apply to phone numbers that are purchased |
+| `messaging_profile_id` | string (UUID) | Messaging profile id to apply to phone numbers that are purchased |
+| `customer_reference` | string | Reference label for the customer |
+| `billing_group_id` | string (UUID) | Billing group id to apply to phone numbers that are purchased |
 
 ### Create a number block order — `client.numberBlockOrders.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `id` | string (UUID) |  |
-| `recordType` | string |  |
-| `phoneNumbersCount` | integer | The count of phone numbers in the number order. |
-| `connectionId` | string (UUID) | Identifies the connection associated with this phone number. |
-| `messagingProfileId` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `record_type` | string |  |
+| `phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `connection_id` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | Identifies the messaging profile associated with the phone number. |
 | `status` | enum (pending, success, failure) | The status of the order. |
-| `customerReference` | string | A customer reference string for customer look ups. |
-| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the number order was created. |
-| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the number order was updated. |
-| `requirementsMet` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the number order was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the number order was updated. |
+| `requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
 | `errors` | string | Errors the reservation could happen upon |
 
 ### Update requirements for a single phone number within a number order. — `client.numberOrderPhoneNumbers.updateRequirements()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `regulatoryRequirements` | array[object] |  |
+| `regulatory_requirements` | array[object] |  |
 
 ### Create a number order — `client.numberOrders.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `phoneNumbers` | array[object] |  |
-| `connectionId` | string (UUID) | Identifies the connection associated with this phone number. |
-| `messagingProfileId` | string (UUID) | Identifies the messaging profile associated with the phone number. |
-| `billingGroupId` | string (UUID) | Identifies the billing group associated with the phone number. |
-| `customerReference` | string | A customer reference string for customer look ups. |
+| `phone_numbers` | array[object] |  |
+| `connection_id` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `billing_group_id` | string (UUID) | Identifies the billing group associated with the phone number. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
 
 ### Update a number order — `client.numberOrders.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `regulatoryRequirements` | array[object] |  |
-| `customerReference` | string | A customer reference string for customer look ups. |
+| `regulatory_requirements` | array[object] |  |
+| `customer_reference` | string | A customer reference string for customer look ups. |
 
 ### Create a number reservation — `client.numberReservations.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `id` | string (UUID) |  |
-| `recordType` | string |  |
-| `phoneNumbers` | array[object] |  |
+| `record_type` | string |  |
+| `phone_numbers` | array[object] |  |
 | `status` | enum (pending, success, failure) | The status of the entire reservation. |
-| `customerReference` | string | A customer reference string for customer look ups. |
-| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the numbers reservation was created. |
-| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the number reservation was updated. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the numbers reservation was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the number reservation was updated. |
 
 ### Update a sub number order's requirements — `client.subNumberOrders.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `regulatoryRequirements` | array[object] |  |
+| `regulatory_requirements` | array[object] |  |
 
 ### Create a sub number orders report — `client.subNumberOrdersReport.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `status` | enum (pending, success, failure) | Filter by order status |
-| `countryCode` | string (ISO 3166-1 alpha-2) | Filter by country code |
-| `createdAtGt` | string (date-time) | Filter for orders created after this date |
-| `createdAtLt` | string (date-time) | Filter for orders created before this date |
-| `orderRequestId` | string (UUID) | Filter by specific order request ID |
-| `customerReference` | string | Filter by customer reference |
+| `country_code` | string (ISO 3166-1 alpha-2) | Filter by country code |
+| `created_at_gt` | string (date-time) | Filter for orders created after this date |
+| `created_at_lt` | string (date-time) | Filter for orders created before this date |
+| `order_request_id` | string (UUID) | Filter by specific order request ID |
+| `customer_reference` | string | Filter by customer reference |

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/javascript/voice.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/javascript/voice.md
@@ -82,10 +82,10 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 |-----------|------|----------|-------------|
 | `to` | string (E.164) | Yes | The DID or SIP URI to dial out to. |
 | `from` | string (E.164) | Yes | The `from` number to be used as the caller id presented to t... |
-| `connectionId` | string (UUID) | Yes | The ID of the Call Control App (formerly ID of the connectio... |
-| `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
-| `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
+| `connection_id` | string (UUID) | Yes | The ID of the Call Control App (formerly ID of the connectio... |
+| `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
+| `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | ... | | | +56 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -114,10 +114,10 @@ Primary inbound call-control command.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
-| `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
+| `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
 | ... | | | +29 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -139,10 +139,10 @@ Common post-answer control path with downstream webhook implications.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `to` | string (E.164) | Yes | The DID or SIP URI to dial out to. |
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
-| `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
+| `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
 | ... | | | +35 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -167,7 +167,7 @@ and `telnyx-timestamp` headers. Always verify signatures in production:
 // In your webhook handler (e.g., Express — use raw body, not parsed JSON):
 app.post('/webhooks', express.raw({ type: 'application/json' }), async (req, res) => {
   try {
-    const event = await client.webhooks.unwrap(req.body.toString(), {
+    const event = client.webhooks.unwrap(req.body.toString(), {
       headers: req.headers,
     });
     // Signature valid — event is the parsed webhook payload
@@ -239,10 +239,10 @@ End a live call from your webhook-driven control flow.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | No | Use this field to avoid duplicate commands. |
-| `customHeaders` | array[object] | No | Custom headers to be added to the SIP BYE message. |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | No | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | No | Custom headers to be added to the SIP BYE message. |
 
 ```javascript
 const response = await client.calls.actions.hangup('v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ');
@@ -261,11 +261,11 @@ Trigger a follow-up action in an existing workflow rather than creating a new to
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `callControlId` | string (UUID) | Yes | The Call Control ID of the call you want to bridge with, can... |
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | No | Use this field to avoid duplicate commands. |
-| `videoRoomId` | string (UUID) | No | The ID of the video room you want to bridge with, can't be u... |
+| `call_control_id` | string (UUID) | Yes | The Call Control ID of the call you want to bridge with, can... |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | No | Use this field to avoid duplicate commands. |
+| `video_room_id` | string (UUID) | No | The ID of the video room you want to bridge with, can't be u... |
 | ... | | | +16 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -288,9 +288,9 @@ Trigger a follow-up action in an existing workflow rather than creating a new to
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `cause` | enum (CALL_REJECTED, USER_BUSY) | Yes | Cause for call rejection. |
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | No | Use this field to avoid duplicate commands. |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | No | Use this field to avoid duplicate commands. |
 
 ```javascript
 const response = await client.calls.actions.reject('call_control_id', { cause: 'USER_BUSY' });
@@ -309,7 +309,7 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
 
 ```javascript
 const response = await client.calls.retrieveStatus('v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ');
@@ -333,7 +333,7 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `connectionId` | string (UUID) | Yes | Telnyx connection id |
+| `connection_id` | string (UUID) | Yes | Telnyx connection id |
 | `page` | object | No | Consolidated page parameter (deepObject style). |
 
 ```javascript
@@ -397,12 +397,12 @@ Before using any operation below, read the Optional Parameters section below and
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
-| Create a call control application | `client.callControlApplications.create()` | `POST /call_control_applications` | Create or provision an additional resource when the core tasks do not cover this flow. | `applicationName`, `webhookEventUrl` |
+| Create a call control application | `client.callControlApplications.create()` | `POST /call_control_applications` | Create or provision an additional resource when the core tasks do not cover this flow. | `application_name`, `webhook_event_url` |
 | Retrieve a call control application | `client.callControlApplications.retrieve()` | `GET /call_control_applications/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
-| Update a call control application | `client.callControlApplications.update()` | `PATCH /call_control_applications/{id}` | Modify an existing resource without recreating it. | `applicationName`, `webhookEventUrl`, `id` |
+| Update a call control application | `client.callControlApplications.update()` | `PATCH /call_control_applications/{id}` | Modify an existing resource without recreating it. | `application_name`, `webhook_event_url`, `id` |
 | Delete a call control application | `client.callControlApplications.delete()` | `DELETE /call_control_applications/{id}` | Remove, detach, or clean up an existing resource. | `id` |
-| SIP Refer a call | `client.calls.actions.refer()` | `POST /calls/{call_control_id}/actions/refer` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `sipAddress`, `callControlId` |
-| Send SIP info | `client.calls.actions.sendSipInfo()` | `POST /calls/{call_control_id}/actions/send_sip_info` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `contentType`, `body`, `callControlId` |
+| SIP Refer a call | `client.calls.actions.refer()` | `POST /calls/{call_control_id}/actions/refer` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `sip_address`, `call_control_id` |
+| Send SIP info | `client.calls.actions.sendSipInfo()` | `POST /calls/{call_control_id}/actions/send_sip_info` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `content_type`, `body`, `call_control_id` |
 
 ### Other Webhook Events
 
@@ -424,233 +424,233 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `active` | boolean | Specifies whether the connection can be used. |
-| `anchorsiteOverride` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
-| `dtmfType` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
-| `firstCommandTimeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
-| `firstCommandTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `anchorsite_override` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmf_type` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `first_command_timeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `first_command_timeout_secs` | integer | Specifies how many seconds to wait before timing out a dial command. |
 | `inbound` | object |  |
 | `outbound` | object |  |
-| `webhookApiVersion` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
-| `webhookEventFailoverUrl` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
-| `webhookTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a webhook. |
-| `callCostInWebhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
-| `redactDtmfDebugLogging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+| `webhook_api_version` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhook_event_failover_url` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhook_timeout_secs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `call_cost_in_webhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `redact_dtmf_debug_logging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
 
 ### Update a call control application — `client.callControlApplications.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `callCostInWebhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `call_cost_in_webhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
 | `active` | boolean | Specifies whether the connection can be used. |
-| `anchorsiteOverride` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
-| `dtmfType` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
-| `firstCommandTimeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
-| `firstCommandTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `anchorsite_override` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmf_type` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `first_command_timeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `first_command_timeout_secs` | integer | Specifies how many seconds to wait before timing out a dial command. |
 | `tags` | array[string] | Tags assigned to the Call Control Application. |
 | `inbound` | object |  |
 | `outbound` | object |  |
-| `webhookApiVersion` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
-| `webhookEventFailoverUrl` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
-| `webhookTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a webhook. |
-| `redactDtmfDebugLogging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+| `webhook_api_version` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhook_event_failover_url` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhook_timeout_secs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `redact_dtmf_debug_logging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
 
 ### Dial — `client.calls.dial()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `assistant` | object | AI Assistant configuration. |
-| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
-| `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
 | `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
-| `audioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
-| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
-| `mediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
-| `preferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
-| `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
-| `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
-| `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
-| `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
-| `deepfakeDetection` | object | Enables deepfake detection on the call. |
-| `conferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
-| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
-| `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
-| `linkTo` | string | Use another call's control id for sharing the same call session id |
-| `bridgeIntent` | boolean | Indicates the intent to bridge this call with the call specified in link_to. |
-| `bridgeOnAnswer` | boolean | Whether to automatically bridge answered call to the call specified in link_to. |
-| `preventDoubleBridge` | boolean | Prevents bridging and hangs up the call if the target is already bridged. |
-| `parkAfterUnbridge` | string | If supplied with the value `self`, the current leg will be parked after unbri... |
-| `mediaEncryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the call. |
-| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
-| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
-| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE request. |
-| `sipTransportProtocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
-| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
-| `streamUrl` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
-| `streamTrack` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
-| `streamCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
-| `streamBidirectionalMode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
-| `streamBidirectionalCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
-| `streamBidirectionalTargetLegs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
-| `streamBidirectionalSamplingRate` | enum (8000, 16000, 22050, 24000, 48000) | Audio sampling rate. |
-| `streamEstablishBeforeCallOriginate` | boolean | Establish websocket connection before dialing the destination. |
-| `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
-| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
-| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
-| `webhookUrls` | object | A map of event types to webhook URLs. |
-| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
-| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
+| `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
+| `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
+| `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `link_to` | string | Use another call's control id for sharing the same call session id |
+| `bridge_intent` | boolean | Indicates the intent to bridge this call with the call specified in link_to. |
+| `bridge_on_answer` | boolean | Whether to automatically bridge answered call to the call specified in link_to. |
+| `prevent_double_bridge` | boolean | Prevents bridging and hangs up the call if the target is already bridged. |
+| `park_after_unbridge` | string | If supplied with the value `self`, the current leg will be parked after unbri... |
+| `media_encryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the call. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE request. |
+| `sip_transport_protocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `stream_url` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `stream_track` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `stream_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `stream_bidirectional_mode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `stream_bidirectional_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `stream_bidirectional_target_legs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `stream_bidirectional_sampling_rate` | enum (8000, 16000, 22050, 24000, 48000) | Audio sampling rate. |
+| `stream_establish_before_call_originate` | boolean | Establish websocket connection before dialing the destination. |
+| `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
-| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
-| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
-| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
-| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
-| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
-| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
-| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
-| `superviseCallControlId` | string (UUID) | The call leg which will be supervised by the new call. |
-| `supervisorRole` | enum (barge, whisper, monitor) | The role of the supervisor call. |
-| `enableDialogflow` | boolean | Enables Dialogflow for the current call. |
-| `dialogflowConfig` | object |  |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `supervise_call_control_id` | string (UUID) | The call leg which will be supervised by the new call. |
+| `supervisor_role` | enum (barge, whisper, monitor) | The role of the supervisor call. |
+| `enable_dialogflow` | boolean | Enables Dialogflow for the current call. |
+| `dialogflow_config` | object |  |
 | `transcription` | boolean | Enable transcription upon call answer. |
-| `transcriptionConfig` | object |  |
-| `sipRegion` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
-| `streamAuthToken` | string | An authentication token to be sent as part of the WebSocket connection when u... |
+| `transcription_config` | object |  |
+| `sip_region` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `stream_auth_token` | string | An authentication token to be sent as part of the WebSocket connection when u... |
 
 ### Answer call — `client.calls.actions.answer()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `assistant` | object | AI Assistant configuration. |
-| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
-| `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
-| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE response. |
-| `preferredCodecs` | enum (G722,PCMU,PCMA,G729,OPUS,VP8,H264) | The list of comma-separated codecs in a preferred order for the forked media ... |
-| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE response. |
-| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
-| `streamUrl` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
-| `streamTrack` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
-| `streamCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
-| `streamBidirectionalMode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
-| `streamBidirectionalCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
-| `streamBidirectionalTargetLegs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
-| `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
-| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
-| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE response. |
+| `preferred_codecs` | enum (G722,PCMU,PCMA,G729,OPUS,VP8,H264) | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE response. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `stream_url` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `stream_track` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `stream_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `stream_bidirectional_mode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `stream_bidirectional_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `stream_bidirectional_target_legs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
 | `transcription` | boolean | Enable transcription upon call answer. |
-| `transcriptionConfig` | object |  |
+| `transcription_config` | object |  |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
-| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
-| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
-| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
-| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
-| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
-| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
-| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
-| `webhookUrls` | object | A map of event types to webhook URLs. |
-| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
-| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
-| `deepfakeDetection` | object | Enables deepfake detection on the call. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.calls.actions.bridge()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
 | `queue` | string | The name of the queue you want to bridge with, can't be used together with ca... |
-| `videoRoomId` | string (UUID) | The ID of the video room you want to bridge with, can't be used together with... |
-| `videoRoomContext` | string | The additional parameter that will be passed to the video conference. |
-| `preventDoubleBridge` | boolean | When set to `true`, it prevents bridging if the target call is already bridge... |
-| `parkAfterUnbridge` | string | Specifies behavior after the bridge ends (i.e. |
-| `playRingtone` | boolean | Specifies whether to play a ringtone if the call you want to bridge with has ... |
+| `video_room_id` | string (UUID) | The ID of the video room you want to bridge with, can't be used together with... |
+| `video_room_context` | string | The additional parameter that will be passed to the video conference. |
+| `prevent_double_bridge` | boolean | When set to `true`, it prevents bridging if the target call is already bridge... |
+| `park_after_unbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `play_ringtone` | boolean | Specifies whether to play a ringtone if the call you want to bridge with has ... |
 | `ringtone` | enum (at, au, be, bg, br, ...) | Specifies which country ringtone to play when `play_ringtone` is set to `true`. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
-| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
-| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
-| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
-| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
-| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
-| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
-| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
-| `muteDtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
-| `holdAfterUnbridge` | boolean | Specifies behavior after the bridge ends. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `mute_dtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `hold_after_unbridge` | boolean | Specifies behavior after the bridge ends. |
 
 ### Hangup call — `client.calls.actions.hangup()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
-| `customHeaders` | array[object] | Custom headers to be added to the SIP BYE message. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP BYE message. |
 
 ### SIP Refer a call — `client.calls.actions.refer()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid execution of duplicate commands. |
-| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
-| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
-| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
-| `sipHeaders` | array[object] | SIP headers to be added to the request. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid execution of duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the request. |
 
 ### Reject a call — `client.calls.actions.reject()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
 
 ### Send SIP info — `client.calls.actions.sendSipInfo()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
 
 ### Transfer call — `client.calls.actions.transfer()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
-| `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
 | `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
-| `audioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
-| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
-| `earlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
-| `mediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
-| `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
-| `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
-| `parkAfterUnbridge` | string | Specifies behavior after the bridge ends (i.e. |
-| `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
-| `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
-| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `targetLegClientState` | string | Use this field to add state to every subsequent webhook for the new leg. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
-| `mediaEncryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the new call leg. |
-| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
-| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
-| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE. |
-| `sipTransportProtocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
-| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
-| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
-| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
-| `muteDtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
+| `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
+| `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
+| `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `park_after_unbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `target_leg_client_state` | string | Use this field to add state to every subsequent webhook for the new leg. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `media_encryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the new call leg. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE. |
+| `sip_transport_protocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `mute_dtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
-| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
-| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
-| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
-| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
-| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
-| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
-| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
-| `sipRegion` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
-| `preferredCodecs` | string | The list of comma-separated codecs in order of preference to be used during t... |
-| `webhookUrls` | object | A map of event types to webhook URLs. |
-| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
-| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `sip_region` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `preferred_codecs` | string | The list of comma-separated codecs in order of preference to be used during t... |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/python/10dlc.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/python/10dlc.md
@@ -130,7 +130,7 @@ telnyx_campaign_csp = client.messaging_10dlc.campaign_builder.submit(
     brand_id="BXXXXXX",
     description="Two-factor authentication messages",
     usecase="2FA",
-    sample_messages=["Your verification code is {{code}}"],
+    sample1="Your verification code is {{code}}",
 )
 print(telnyx_campaign_csp.brand_id)
 ```

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/python/ai-assistants.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/python/ai-assistants.md
@@ -654,6 +654,7 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |
 
 ### Update Tool — `client.ai.tools.update()`
@@ -667,4 +668,5 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/ruby/10dlc.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/ruby/10dlc.md
@@ -118,8 +118,8 @@ Campaign submission is the compliance-critical step that determines whether traf
 telnyx_campaign_csp = client.messaging_10dlc.campaign_builder.submit(
   brand_id: "BXXXXXX",
   description: "Two-factor authentication messages",
-  usecase: "2FA"
-    sample_messages: ["Your verification code is {{code}}"],
+  usecase: "2FA",
+    sample1: "Your verification code is {{code}}",
 )
 
 puts(telnyx_campaign_csp)
@@ -147,7 +147,7 @@ Messaging profile assignment is the practical handoff from registration to send-
 
 ```ruby
 response = client.messaging_10dlc.phone_number_assignment_by_profile.assign(
-  messaging_profile_id: "4001767e-ce0f-4cae-9d5f-0d5e636e7809"
+  messaging_profile_id: "4001767e-ce0f-4cae-9d5f-0d5e636e7809",
     campaign_id: "CXXX001",
 )
 

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/ruby/ai-assistants.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/ruby/ai-assistants.md
@@ -629,6 +629,7 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |
 
 ### Update Tool — `client.ai.tools.update()`
@@ -642,4 +643,5 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/ruby/messaging.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/ruby/messaging.md
@@ -257,7 +257,7 @@ Let a messaging profile or number pool choose the sender for you.
 ```ruby
 response = client.messages.send_number_pool(
   messaging_profile_id: "abc85f64-5717-4562-b3fc-2c9600000000",
-  to: "+13125550002"
+  to: "+13125550002",
     text: "Hello from Telnyx!",
 )
 

--- a/providers/claude/plugins/telnyx-voice/skills/telnyx-voice-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-voice/skills/telnyx-voice-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.58.0</version>
+    <version>6.81.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.58.0")
+implementation("com.telnyx.sdk:telnyx:6.81.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-voice/skills/telnyx-voice-javascript/SKILL.md
+++ b/providers/claude/plugins/telnyx-voice/skills/telnyx-voice-javascript/SKILL.md
@@ -95,10 +95,10 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 |-----------|------|----------|-------------|
 | `to` | string (E.164) | Yes | The DID or SIP URI to dial out to. |
 | `from` | string (E.164) | Yes | The `from` number to be used as the caller id presented to t... |
-| `connectionId` | string (UUID) | Yes | The ID of the Call Control App (formerly ID of the connectio... |
-| `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
-| `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
+| `connection_id` | string (UUID) | Yes | The ID of the Call Control App (formerly ID of the connectio... |
+| `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
+| `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | ... | | | +56 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -127,10 +127,10 @@ Primary inbound call-control command.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
-| `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
+| `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
 | ... | | | +29 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -152,10 +152,10 @@ Common post-answer control path with downstream webhook implications.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `to` | string (E.164) | Yes | The DID or SIP URI to dial out to. |
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
-| `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
+| `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
 | ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -180,7 +180,7 @@ and `telnyx-timestamp` headers. Always verify signatures in production:
 // In your webhook handler (e.g., Express — use raw body, not parsed JSON):
 app.post('/webhooks', express.raw({ type: 'application/json' }), async (req, res) => {
   try {
-    const event = await client.webhooks.unwrap(req.body.toString(), {
+    const event = client.webhooks.unwrap(req.body.toString(), {
       headers: req.headers,
     });
     // Signature valid — event is the parsed webhook payload
@@ -252,10 +252,10 @@ End a live call from your webhook-driven control flow.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | No | Use this field to avoid duplicate commands. |
-| `customHeaders` | array[object] | No | Custom headers to be added to the SIP BYE message. |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | No | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | No | Custom headers to be added to the SIP BYE message. |
 
 ```javascript
 const response = await client.calls.actions.hangup('v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ');
@@ -274,11 +274,11 @@ Trigger a follow-up action in an existing workflow rather than creating a new to
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `callControlId` | string (UUID) | Yes | The Call Control ID of the call you want to bridge with, can... |
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | No | Use this field to avoid duplicate commands. |
-| `videoRoomId` | string (UUID) | No | The ID of the video room you want to bridge with, can't be u... |
+| `call_control_id` | string (UUID) | Yes | The Call Control ID of the call you want to bridge with, can... |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | No | Use this field to avoid duplicate commands. |
+| `video_room_id` | string (UUID) | No | The ID of the video room you want to bridge with, can't be u... |
 | ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -301,9 +301,9 @@ Trigger a follow-up action in an existing workflow rather than creating a new to
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `cause` | enum (CALL_REJECTED, USER_BUSY) | Yes | Cause for call rejection. |
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | No | Use this field to avoid duplicate commands. |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | No | Use this field to avoid duplicate commands. |
 
 ```javascript
 const response = await client.calls.actions.reject('call_control_id', { cause: 'USER_BUSY' });
@@ -322,7 +322,7 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
 
 ```javascript
 const response = await client.calls.retrieveStatus('v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ');
@@ -346,7 +346,7 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `connectionId` | string (UUID) | Yes | Telnyx connection id |
+| `connection_id` | string (UUID) | Yes | Telnyx connection id |
 | `page` | object | No | Consolidated page parameter (deepObject style). |
 
 ```javascript
@@ -410,12 +410,12 @@ Before using any operation below, read [the optional-parameters section](referen
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
-| Create a call control application | `client.callControlApplications.create()` | `POST /call_control_applications` | Create or provision an additional resource when the core tasks do not cover this flow. | `applicationName`, `webhookEventUrl` |
+| Create a call control application | `client.callControlApplications.create()` | `POST /call_control_applications` | Create or provision an additional resource when the core tasks do not cover this flow. | `application_name`, `webhook_event_url` |
 | Retrieve a call control application | `client.callControlApplications.retrieve()` | `GET /call_control_applications/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
-| Update a call control application | `client.callControlApplications.update()` | `PATCH /call_control_applications/{id}` | Modify an existing resource without recreating it. | `applicationName`, `webhookEventUrl`, `id` |
+| Update a call control application | `client.callControlApplications.update()` | `PATCH /call_control_applications/{id}` | Modify an existing resource without recreating it. | `application_name`, `webhook_event_url`, `id` |
 | Delete a call control application | `client.callControlApplications.delete()` | `DELETE /call_control_applications/{id}` | Remove, detach, or clean up an existing resource. | `id` |
-| SIP Refer a call | `client.calls.actions.refer()` | `POST /calls/{call_control_id}/actions/refer` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `sipAddress`, `callControlId` |
-| Send SIP info | `client.calls.actions.sendSipInfo()` | `POST /calls/{call_control_id}/actions/send_sip_info` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `contentType`, `body`, `callControlId` |
+| SIP Refer a call | `client.calls.actions.refer()` | `POST /calls/{call_control_id}/actions/refer` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `sip_address`, `call_control_id` |
+| Send SIP info | `client.calls.actions.sendSipInfo()` | `POST /calls/{call_control_id}/actions/send_sip_info` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `content_type`, `body`, `call_control_id` |
 
 ### Other Webhook Events
 

--- a/providers/claude/plugins/telnyx-voice/skills/telnyx-voice-javascript/references/api-details.md
+++ b/providers/claude/plugins/telnyx-voice/skills/telnyx-voice-javascript/references/api-details.md
@@ -94,236 +94,236 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `active` | boolean | Specifies whether the connection can be used. |
-| `anchorsiteOverride` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
-| `dtmfType` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
-| `firstCommandTimeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
-| `firstCommandTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `anchorsite_override` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmf_type` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `first_command_timeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `first_command_timeout_secs` | integer | Specifies how many seconds to wait before timing out a dial command. |
 | `inbound` | object |  |
 | `outbound` | object |  |
-| `webhookApiVersion` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
-| `webhookEventFailoverUrl` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
-| `webhookTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a webhook. |
-| `callCostInWebhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
-| `redactDtmfDebugLogging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+| `webhook_api_version` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhook_event_failover_url` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhook_timeout_secs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `call_cost_in_webhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `redact_dtmf_debug_logging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
 
 ### Update a call control application — `client.callControlApplications.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `callCostInWebhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `call_cost_in_webhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
 | `active` | boolean | Specifies whether the connection can be used. |
-| `anchorsiteOverride` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
-| `dtmfType` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
-| `firstCommandTimeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
-| `firstCommandTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `anchorsite_override` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmf_type` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `first_command_timeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `first_command_timeout_secs` | integer | Specifies how many seconds to wait before timing out a dial command. |
 | `tags` | array[string] | Tags assigned to the Call Control Application. |
 | `inbound` | object |  |
 | `outbound` | object |  |
-| `webhookApiVersion` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
-| `webhookEventFailoverUrl` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
-| `webhookTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a webhook. |
-| `redactDtmfDebugLogging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+| `webhook_api_version` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhook_event_failover_url` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhook_timeout_secs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `redact_dtmf_debug_logging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
 
 ### Dial — `client.calls.dial()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `assistant` | object | AI Assistant configuration. |
-| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
-| `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
 | `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
-| `audioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
-| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
-| `mediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
-| `preferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
-| `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
-| `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
-| `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
-| `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
-| `deepfakeDetection` | object | Enables deepfake detection on the call. |
-| `conferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
-| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
-| `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
-| `linkTo` | string | Use another call's control id for sharing the same call session id |
-| `bridgeIntent` | boolean | Indicates the intent to bridge this call with the call specified in link_to. |
-| `bridgeOnAnswer` | boolean | Whether to automatically bridge answered call to the call specified in link_to. |
-| `preventDoubleBridge` | boolean | Prevents bridging and hangs up the call if the target is already bridged. |
-| `parkAfterUnbridge` | string | If supplied with the value `self`, the current leg will be parked after unbri... |
-| `mediaEncryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the call. |
-| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
-| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
-| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE request. |
-| `sipTransportProtocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
-| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
-| `streamUrl` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
-| `streamTrack` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
-| `streamCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
-| `streamBidirectionalMode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
-| `streamBidirectionalCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
-| `streamBidirectionalTargetLegs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
-| `streamBidirectionalSamplingRate` | enum (8000, 16000, 22050, 24000, 48000) | Audio sampling rate. |
-| `streamEstablishBeforeCallOriginate` | boolean | Establish websocket connection before dialing the destination. |
-| `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
-| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
-| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
-| `webhookUrls` | object | A map of event types to webhook URLs. |
-| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
-| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
+| `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
+| `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
+| `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `link_to` | string | Use another call's control id for sharing the same call session id |
+| `bridge_intent` | boolean | Indicates the intent to bridge this call with the call specified in link_to. |
+| `bridge_on_answer` | boolean | Whether to automatically bridge answered call to the call specified in link_to. |
+| `prevent_double_bridge` | boolean | Prevents bridging and hangs up the call if the target is already bridged. |
+| `park_after_unbridge` | string | If supplied with the value `self`, the current leg will be parked after unbri... |
+| `media_encryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the call. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE request. |
+| `sip_transport_protocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `stream_url` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `stream_track` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `stream_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `stream_bidirectional_mode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `stream_bidirectional_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `stream_bidirectional_target_legs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `stream_bidirectional_sampling_rate` | enum (8000, 16000, 22050, 24000, 48000) | Audio sampling rate. |
+| `stream_establish_before_call_originate` | boolean | Establish websocket connection before dialing the destination. |
+| `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
-| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
-| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
-| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
-| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
-| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
-| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
-| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
-| `superviseCallControlId` | string (UUID) | The call leg which will be supervised by the new call. |
-| `supervisorRole` | enum (barge, whisper, monitor) | The role of the supervisor call. |
-| `enableDialogflow` | boolean | Enables Dialogflow for the current call. |
-| `dialogflowConfig` | object |  |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `supervise_call_control_id` | string (UUID) | The call leg which will be supervised by the new call. |
+| `supervisor_role` | enum (barge, whisper, monitor) | The role of the supervisor call. |
+| `enable_dialogflow` | boolean | Enables Dialogflow for the current call. |
+| `dialogflow_config` | object |  |
 | `transcription` | boolean | Enable transcription upon call answer. |
-| `transcriptionConfig` | object |  |
-| `sipRegion` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
-| `streamAuthToken` | string | An authentication token to be sent as part of the WebSocket connection when u... |
+| `transcription_config` | object |  |
+| `sip_region` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `stream_auth_token` | string | An authentication token to be sent as part of the WebSocket connection when u... |
 
 ### Answer call — `client.calls.actions.answer()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `assistant` | object | AI Assistant configuration. |
-| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
-| `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
-| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE response. |
-| `preferredCodecs` | enum (G722,PCMU,PCMA,G729,OPUS,VP8,H264) | The list of comma-separated codecs in a preferred order for the forked media ... |
-| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE response. |
-| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
-| `streamUrl` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
-| `streamTrack` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
-| `streamCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
-| `streamBidirectionalMode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
-| `streamBidirectionalCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
-| `streamBidirectionalTargetLegs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
-| `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
-| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
-| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE response. |
+| `preferred_codecs` | enum (G722,PCMU,PCMA,G729,OPUS,VP8,H264) | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE response. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `stream_url` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `stream_track` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `stream_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `stream_bidirectional_mode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `stream_bidirectional_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `stream_bidirectional_target_legs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
 | `transcription` | boolean | Enable transcription upon call answer. |
-| `transcriptionConfig` | object |  |
+| `transcription_config` | object |  |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
-| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
-| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
-| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
-| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
-| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
-| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
-| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
-| `webhookUrls` | object | A map of event types to webhook URLs. |
-| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
-| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
-| `deepfakeDetection` | object | Enables deepfake detection on the call. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.calls.actions.bridge()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
 | `queue` | string | The name of the queue you want to bridge with, can't be used together with ca... |
-| `videoRoomId` | string (UUID) | The ID of the video room you want to bridge with, can't be used together with... |
-| `videoRoomContext` | string | The additional parameter that will be passed to the video conference. |
-| `preventDoubleBridge` | boolean | When set to `true`, it prevents bridging if the target call is already bridge... |
-| `parkAfterUnbridge` | string | Specifies behavior after the bridge ends (i.e. |
-| `playRingtone` | boolean | Specifies whether to play a ringtone if the call you want to bridge with has ... |
+| `video_room_id` | string (UUID) | The ID of the video room you want to bridge with, can't be used together with... |
+| `video_room_context` | string | The additional parameter that will be passed to the video conference. |
+| `prevent_double_bridge` | boolean | When set to `true`, it prevents bridging if the target call is already bridge... |
+| `park_after_unbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `play_ringtone` | boolean | Specifies whether to play a ringtone if the call you want to bridge with has ... |
 | `ringtone` | enum (at, au, be, bg, br, ...) | Specifies which country ringtone to play when `play_ringtone` is set to `true`. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
-| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
-| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
-| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
-| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
-| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
-| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
-| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
-| `muteDtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
-| `holdAfterUnbridge` | boolean | Specifies behavior after the bridge ends. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `mute_dtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `hold_after_unbridge` | boolean | Specifies behavior after the bridge ends. |
 
 ### Hangup call — `client.calls.actions.hangup()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
-| `customHeaders` | array[object] | Custom headers to be added to the SIP BYE message. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP BYE message. |
 
 ### SIP Refer a call — `client.calls.actions.refer()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid execution of duplicate commands. |
-| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
-| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
-| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
-| `sipHeaders` | array[object] | SIP headers to be added to the request. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid execution of duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the request. |
 
 ### Reject a call — `client.calls.actions.reject()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
 
 ### Send SIP info — `client.calls.actions.sendSipInfo()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
 
 ### Transfer call — `client.calls.actions.transfer()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
-| `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
 | `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
-| `audioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
-| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
-| `earlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
-| `mediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
-| `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
-| `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
-| `parkAfterUnbridge` | string | Specifies behavior after the bridge ends (i.e. |
-| `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
-| `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
-| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `targetLegClientState` | string | Use this field to add state to every subsequent webhook for the new leg. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
-| `mediaEncryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the new call leg. |
-| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
-| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
-| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE. |
-| `sipTransportProtocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
-| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
-| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
-| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
-| `muteDtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
+| `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
+| `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
+| `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `park_after_unbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `target_leg_client_state` | string | Use this field to add state to every subsequent webhook for the new leg. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `media_encryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the new call leg. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE. |
+| `sip_transport_protocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `mute_dtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
-| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
-| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
-| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
-| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
-| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
-| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
-| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
-| `sipRegion` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
-| `preferredCodecs` | string | The list of comma-separated codecs in order of preference to be used during t... |
-| `webhookUrls` | object | A map of event types to webhook URLs. |
-| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
-| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `sip_region` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `preferred_codecs` | string | The list of comma-separated codecs in order of preference to be used during t... |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
 
 ## Webhook Payload Fields
 

--- a/providers/cursor/plugin/skills/telnyx-10dlc-curl/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-10dlc-curl/SKILL.md
@@ -136,12 +136,10 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-      "brandId": "BXXX001",
+      "brandId": "BXXXXXX",
       "description": "Two-factor authentication messages",
       "usecase": "2FA",
-      "sample_messages": [
-          "Your verification code is {{code}}"
-      ]
+      "sample1": "Your verification code is {{code}}"
   }' \
   "https://api.telnyx.com/v2/10dlc/campaignBuilder"
 ```

--- a/providers/cursor/plugin/skills/telnyx-10dlc-go/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-10dlc-go/SKILL.md
@@ -157,7 +157,7 @@ Campaign submission is the compliance-critical step that determines whether traf
 		BrandID: "BXXXXXX",
 		Description: "Two-factor authentication messages",
 		Usecase: "2FA",
-		SampleMessages: []string{"Your verification code is {{code}}"},
+		Sample1: telnyx.String("Your verification code is {{code}}"),
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/providers/cursor/plugin/skills/telnyx-10dlc-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-10dlc-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.58.0</version>
+    <version>6.81.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.58.0")
+implementation("com.telnyx.sdk:telnyx:6.81.0")
 ```
 
 ## Setup
@@ -150,7 +150,7 @@ CampaignBuilderSubmitParams params = CampaignBuilderSubmitParams.builder()
     .brandId("BXXXXXX")
     .description("Two-factor authentication messages")
     .usecase("2FA")
-    .sampleMessages(java.util.List.of("Your verification code is {{code}}"))
+    .sample1("Your verification code is {{code}}")
     .build();
 TelnyxCampaignCsp telnyxCampaignCsp = client.messaging10dlc().campaignBuilder().submit(params);
 ```

--- a/providers/cursor/plugin/skills/telnyx-10dlc-javascript/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-10dlc-javascript/SKILL.md
@@ -145,7 +145,7 @@ const telnyxCampaignCsp = await client.messaging10dlc.campaignBuilder.submit({
   brandId: 'BXXXXXX',
   description: 'Two-factor authentication messages',
   usecase: '2FA',
-    sampleMessages: ["Your verification code is {{code}}"],
+    sample1: 'Your verification code is {{code}}',
 });
 
 console.log(telnyxCampaignCsp.brandId);
@@ -197,7 +197,7 @@ and `telnyx-timestamp` headers. Always verify signatures in production:
 // In your webhook handler (e.g., Express — use raw body, not parsed JSON):
 app.post('/webhooks', express.raw({ type: 'application/json' }), async (req, res) => {
   try {
-    const event = await client.webhooks.unwrap(req.body.toString(), {
+    const event = client.webhooks.unwrap(req.body.toString(), {
       headers: req.headers,
     });
     // Signature valid — event is the parsed webhook payload
@@ -408,7 +408,7 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get Campaign Cost | `client.messaging10dlc.campaign.usecase.getCost()` | `GET /10dlc/campaign/usecase/cost` | Inspect available resources or choose an existing resource before mutating it. | None |
 | Update campaign | `client.messaging10dlc.campaign.update()` | `PUT /10dlc/campaign/{campaignId}` | Inspect the current state of an existing campaign registration. | `campaignId` |
 | Deactivate campaign | `client.messaging10dlc.campaign.deactivate()` | `DELETE /10dlc/campaign/{campaignId}` | Inspect the current state of an existing campaign registration. | `campaignId` |
-| Submit campaign appeal for manual review | `client.messaging10dlc.campaign.submitAppeal()` | `POST /10dlc/campaign/{campaignId}/appeal` | Create or provision an additional resource when the core tasks do not cover this flow. | `appealReason`, `campaignId` |
+| Submit campaign appeal for manual review | `client.messaging10dlc.campaign.submitAppeal()` | `POST /10dlc/campaign/{campaignId}/appeal` | Create or provision an additional resource when the core tasks do not cover this flow. | `appeal_reason`, `campaignId` |
 | Get Campaign Mno Metadata | `client.messaging10dlc.campaign.getMnoMetadata()` | `GET /10dlc/campaign/{campaignId}/mnoMetadata` | Fetch the current state before updating, deleting, or making control-flow decisions. | `campaignId` |
 | Get campaign operation status | `client.messaging10dlc.campaign.getOperationStatus()` | `GET /10dlc/campaign/{campaignId}/operationStatus` | Fetch the current state before updating, deleting, or making control-flow decisions. | `campaignId` |
 | Get OSR campaign attributes | `client.messaging10dlc.campaign.osr.getAttributes()` | `GET /10dlc/campaign/{campaignId}/osr/attributes` | Fetch the current state before updating, deleting, or making control-flow decisions. | `campaignId` |

--- a/providers/cursor/plugin/skills/telnyx-10dlc-python/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-10dlc-python/SKILL.md
@@ -143,7 +143,7 @@ telnyx_campaign_csp = client.messaging_10dlc.campaign_builder.submit(
     brand_id="BXXXXXX",
     description="Two-factor authentication messages",
     usecase="2FA",
-    sample_messages=["Your verification code is {{code}}"],
+    sample1="Your verification code is {{code}}",
 )
 print(telnyx_campaign_csp.brand_id)
 ```

--- a/providers/cursor/plugin/skills/telnyx-10dlc-ruby/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-10dlc-ruby/SKILL.md
@@ -131,8 +131,8 @@ Campaign submission is the compliance-critical step that determines whether traf
 telnyx_campaign_csp = client.messaging_10dlc.campaign_builder.submit(
   brand_id: "BXXXXXX",
   description: "Two-factor authentication messages",
-  usecase: "2FA"
-    sample_messages: ["Your verification code is {{code}}"],
+  usecase: "2FA",
+    sample1: "Your verification code is {{code}}",
 )
 
 puts(telnyx_campaign_csp)
@@ -160,7 +160,7 @@ Messaging profile assignment is the practical handoff from registration to send-
 
 ```ruby
 response = client.messaging_10dlc.phone_number_assignment_by_profile.assign(
-  messaging_profile_id: "4001767e-ce0f-4cae-9d5f-0d5e636e7809"
+  messaging_profile_id: "4001767e-ce0f-4cae-9d5f-0d5e636e7809",
     campaign_id: "CXXX001",
 )
 

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-curl/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-curl/references/api-details.md
@@ -383,6 +383,7 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |
 
 ### Update Tool
@@ -396,4 +397,5 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-go/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-go/references/api-details.md
@@ -383,6 +383,7 @@ dispat... |
 | `Handoff` | object |  |
 | `Invite` | object |  |
 | `Webhook` | object |  |
+| `ClientSideTool` | object |  |
 | `TimeoutMs` | integer |  |
 
 ### Update Tool — `client.AI.Tools.Update()`
@@ -396,4 +397,5 @@ dispat... |
 | `Handoff` | object |  |
 | `Invite` | object |  |
 | `Webhook` | object |  |
+| `ClientSideTool` | object |  |
 | `TimeoutMs` | integer |  |

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.58.0</version>
+    <version>6.81.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.58.0")
+implementation("com.telnyx.sdk:telnyx:6.81.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-java/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-java/references/api-details.md
@@ -383,6 +383,7 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `clientSideTool` | object |  |
 | `timeoutMs` | integer |  |
 
 ### Update Tool — `client.ai().tools().update()`
@@ -396,4 +397,5 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `clientSideTool` | object |  |
 | `timeoutMs` | integer |  |

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-javascript/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-javascript/SKILL.md
@@ -120,8 +120,8 @@ Chat is the primary runtime path. Agents need the exact assistant method and the
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `content` | string | Yes | The message content sent by the client to the assistant |
-| `conversationId` | string (UUID) | Yes | A unique identifier for the conversation thread, used to mai... |
-| `assistantId` | string (UUID) | Yes | Unique identifier of the assistant. |
+| `conversation_id` | string (UUID) | Yes | A unique identifier for the conversation thread, used to mai... |
+| `assistant_id` | string (UUID) | Yes | Unique identifier of the assistant. |
 | `name` | string | No | The optional display name of the user sending the message |
 
 ```javascript
@@ -149,8 +149,8 @@ Test creation is the main validation path for production assistant behavior befo
 | `instructions` | string | Yes | Detailed instructions that define the test scenario and what... |
 | `rubric` | array[object] | Yes | Evaluation criteria used to assess the assistant's performan... |
 | `description` | string | No | Optional detailed description of what this test evaluates an... |
-| `telnyxConversationChannel` | object | No | The communication channel through which the test will be con... |
-| `maxDurationSeconds` | integer | No | Maximum duration in seconds that the test conversation shoul... |
+| `telnyx_conversation_channel` | object | No | The communication channel through which the test will be con... |
+| `max_duration_seconds` | integer | No | Maximum duration in seconds that the test conversation shoul... |
 | ... | | | +1 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -190,9 +190,9 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `assistantId` | string (UUID) | Yes | Unique identifier of the assistant. |
-| `callControlId` | string (UUID) | No | Filter results by call control id. |
-| `fetchDynamicVariablesFromWebhook` | boolean | No | Whether to fetch dynamic variables from the configured webho... |
+| `assistant_id` | string (UUID) | Yes | Unique identifier of the assistant. |
+| `call_control_id` | string (UUID) | No | Filter results by call control id. |
+| `fetch_dynamic_variables_from_webhook` | boolean | No | Whether to fetch dynamic variables from the configured webho... |
 | `from` | string (E.164) | No | Start of the filter range. |
 | ... | | | +1 optional params in [references/api-details.md](references/api-details.md) |
 
@@ -218,7 +218,7 @@ Create or provision an additional resource when the core tasks do not cover this
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `assistantId` | string (UUID) | Yes | Unique identifier of the assistant. |
+| `assistant_id` | string (UUID) | Yes | Unique identifier of the assistant. |
 | `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
 | `model` | string | No | ID of the model to use when `external_llm` is not set. |
@@ -270,12 +270,12 @@ Import existing assistants from an external provider instead of creating from sc
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `provider` | enum (elevenlabs, vapi, retell) | Yes | The external provider to import assistants from. |
-| `apiKeyRef` | string | Yes | Integration secret pointer that refers to the API key for th... |
-| `importIds` | array[string] | No | Optional list of assistant IDs to import from the external p... |
+| `api_key_ref` | string | Yes | Integration secret pointer that refers to the API key for th... |
+| `import_ids` | array[string] | No | Optional list of assistant IDs to import from the external p... |
 
 ```javascript
 const assistantsList = await client.ai.assistants.imports({
-  api_key_ref: 'api_key_ref',
+  api_key_ref: 'my-openai-key',
   provider: 'elevenlabs',
 });
 
@@ -316,8 +316,8 @@ Inspect available resources or choose an existing resource before mutating it.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `testSuite` | string | No | Filter tests by test suite name |
-| `telnyxConversationChannel` | string | No | Filter tests by communication channel (e.g., 'web_chat', 'sm... |
+| `test_suite` | string | No | Filter tests by test suite name |
+| `telnyx_conversation_channel` | string | No | Filter tests by communication channel (e.g., 'web_chat', 'sm... |
 | `destination` | string | No | Filter tests by destination (phone number, webhook URL, etc.... |
 | ... | | | +1 optional params in [references/api-details.md](references/api-details.md) |
 
@@ -366,8 +366,8 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `suiteName` | string | Yes | Name of the suite. |
-| `testSuiteRunId` | string (UUID) | No | Filter runs by specific suite execution batch ID |
+| `suite_name` | string | Yes | Name of the suite. |
+| `test_suite_run_id` | string (UUID) | No | Filter runs by specific suite execution batch ID |
 | `status` | string | No | Filter runs by execution status (pending, running, completed... |
 | `page` | object | No | Consolidated page parameter (deepObject style). |
 
@@ -399,46 +399,46 @@ Before using any operation below, read [the optional-parameters section](referen
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
-| Trigger test suite execution | `client.ai.assistants.tests.testSuites.runs.trigger()` | `POST /ai/assistants/tests/test-suites/{suite_name}/runs` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `suiteName` |
-| Get assistant test by ID | `client.ai.assistants.tests.retrieve()` | `GET /ai/assistants/tests/{test_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId` |
-| Update an assistant test | `client.ai.assistants.tests.update()` | `PUT /ai/assistants/tests/{test_id}` | Modify an existing resource without recreating it. | `testId` |
-| Delete an assistant test | `client.ai.assistants.tests.delete()` | `DELETE /ai/assistants/tests/{test_id}` | Remove, detach, or clean up an existing resource. | `testId` |
-| Get test run history for a specific test | `client.ai.assistants.tests.runs.list()` | `GET /ai/assistants/tests/{test_id}/runs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId` |
-| Trigger a manual test run | `client.ai.assistants.tests.runs.trigger()` | `POST /ai/assistants/tests/{test_id}/runs` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `testId` |
-| Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId`, `runId` |
-| Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistantId` |
-| Get Canary Deploy | `client.ai.assistants.canaryDeploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Create Canary Deploy | `client.ai.assistants.canaryDeploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId` |
-| Update Canary Deploy | `client.ai.assistants.canaryDeploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistantId` |
-| Delete Canary Deploy | `client.ai.assistants.canaryDeploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistantId` |
-| Assistant Sms Chat | `client.ai.assistants.sendSMS()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistantId` |
-| Clone Assistant | `client.ai.assistants.clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId` |
-| Enhance Assistant Instructions | `client.ai.assistants.instructions.enhance()` | `POST /ai/assistants/{assistant_id}/instructions/enhance` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId` |
-| List scheduled events | `client.ai.assistants.scheduledEvents.list()` | `GET /ai/assistants/{assistant_id}/scheduled_events` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Create a scheduled event | `client.ai.assistants.scheduledEvents.create()` | `POST /ai/assistants/{assistant_id}/scheduled_events` | Create or provision an additional resource when the core tasks do not cover this flow. | `telnyxConversationChannel`, `telnyxEndUserTarget`, `telnyxAgentTarget`, `scheduledAtFixedDatetime`, +1 more |
-| Get a scheduled event | `client.ai.assistants.scheduledEvents.retrieve()` | `GET /ai/assistants/{assistant_id}/scheduled_events/{event_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId`, `eventId` |
-| Delete a scheduled event | `client.ai.assistants.scheduledEvents.delete()` | `DELETE /ai/assistants/{assistant_id}/scheduled_events/{event_id}` | Remove, detach, or clean up an existing resource. | `assistantId`, `eventId` |
-| Add Assistant Tag | `client.ai.assistants.tags.add()` | `POST /ai/assistants/{assistant_id}/tags` | Create or provision an additional resource when the core tasks do not cover this flow. | `tag`, `assistantId` |
-| Remove Assistant Tag | `client.ai.assistants.tags.remove()` | `DELETE /ai/assistants/{assistant_id}/tags/{tag}` | Remove, detach, or clean up an existing resource. | `assistantId`, `tag` |
-| Get assistant texml | `client.ai.assistants.getTexml()` | `GET /ai/assistants/{assistant_id}/texml` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Add Assistant Tool | `client.ai.assistants.tools.add()` | `PUT /ai/assistants/{assistant_id}/tools/{tool_id}` | Modify an existing resource without recreating it. | `assistantId`, `toolId` |
-| Remove Assistant Tool | `client.ai.assistants.tools.remove()` | `DELETE /ai/assistants/{assistant_id}/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `assistantId`, `toolId` |
-| Test Assistant Tool | `client.ai.assistants.tools.test()` | `POST /ai/assistants/{assistant_id}/tools/{tool_id}/test` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId`, `toolId` |
-| Get all versions of an assistant | `client.ai.assistants.versions.list()` | `GET /ai/assistants/{assistant_id}/versions` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Get a specific assistant version | `client.ai.assistants.versions.retrieve()` | `GET /ai/assistants/{assistant_id}/versions/{version_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId`, `versionId` |
-| Update a specific assistant version | `client.ai.assistants.versions.update()` | `POST /ai/assistants/{assistant_id}/versions/{version_id}` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId`, `versionId` |
-| Delete a specific assistant version | `client.ai.assistants.versions.delete()` | `DELETE /ai/assistants/{assistant_id}/versions/{version_id}` | Remove, detach, or clean up an existing resource. | `assistantId`, `versionId` |
-| Promote an assistant version to main | `client.ai.assistants.versions.promote()` | `POST /ai/assistants/{assistant_id}/versions/{version_id}/promote` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId`, `versionId` |
+| Trigger test suite execution | `client.ai.assistants.tests.testSuites.runs.trigger()` | `POST /ai/assistants/tests/test-suites/{suite_name}/runs` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `suite_name` |
+| Get assistant test by ID | `client.ai.assistants.tests.retrieve()` | `GET /ai/assistants/tests/{test_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id` |
+| Update an assistant test | `client.ai.assistants.tests.update()` | `PUT /ai/assistants/tests/{test_id}` | Modify an existing resource without recreating it. | `test_id` |
+| Delete an assistant test | `client.ai.assistants.tests.delete()` | `DELETE /ai/assistants/tests/{test_id}` | Remove, detach, or clean up an existing resource. | `test_id` |
+| Get test run history for a specific test | `client.ai.assistants.tests.runs.list()` | `GET /ai/assistants/tests/{test_id}/runs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id` |
+| Trigger a manual test run | `client.ai.assistants.tests.runs.trigger()` | `POST /ai/assistants/tests/{test_id}/runs` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `test_id` |
+| Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
+| Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
+| Get Canary Deploy | `client.ai.assistants.canaryDeploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Create Canary Deploy | `client.ai.assistants.canaryDeploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | `client.ai.assistants.canaryDeploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
+| Delete Canary Deploy | `client.ai.assistants.canaryDeploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
+| Assistant Sms Chat | `client.ai.assistants.sendSMS()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistant_id` |
+| Clone Assistant | `client.ai.assistants.clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |
+| Enhance Assistant Instructions | `client.ai.assistants.instructions.enhance()` | `POST /ai/assistants/{assistant_id}/instructions/enhance` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| List scheduled events | `client.ai.assistants.scheduledEvents.list()` | `GET /ai/assistants/{assistant_id}/scheduled_events` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Create a scheduled event | `client.ai.assistants.scheduledEvents.create()` | `POST /ai/assistants/{assistant_id}/scheduled_events` | Create or provision an additional resource when the core tasks do not cover this flow. | `telnyx_conversation_channel`, `telnyx_end_user_target`, `telnyx_agent_target`, `scheduled_at_fixed_datetime`, +1 more |
+| Get a scheduled event | `client.ai.assistants.scheduledEvents.retrieve()` | `GET /ai/assistants/{assistant_id}/scheduled_events/{event_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id`, `event_id` |
+| Delete a scheduled event | `client.ai.assistants.scheduledEvents.delete()` | `DELETE /ai/assistants/{assistant_id}/scheduled_events/{event_id}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `event_id` |
+| Add Assistant Tag | `client.ai.assistants.tags.add()` | `POST /ai/assistants/{assistant_id}/tags` | Create or provision an additional resource when the core tasks do not cover this flow. | `tag`, `assistant_id` |
+| Remove Assistant Tag | `client.ai.assistants.tags.remove()` | `DELETE /ai/assistants/{assistant_id}/tags/{tag}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `tag` |
+| Get assistant texml | `client.ai.assistants.getTexml()` | `GET /ai/assistants/{assistant_id}/texml` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Add Assistant Tool | `client.ai.assistants.tools.add()` | `PUT /ai/assistants/{assistant_id}/tools/{tool_id}` | Modify an existing resource without recreating it. | `assistant_id`, `tool_id` |
+| Remove Assistant Tool | `client.ai.assistants.tools.remove()` | `DELETE /ai/assistants/{assistant_id}/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `tool_id` |
+| Test Assistant Tool | `client.ai.assistants.tools.test()` | `POST /ai/assistants/{assistant_id}/tools/{tool_id}/test` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id`, `tool_id` |
+| Get all versions of an assistant | `client.ai.assistants.versions.list()` | `GET /ai/assistants/{assistant_id}/versions` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Get a specific assistant version | `client.ai.assistants.versions.retrieve()` | `GET /ai/assistants/{assistant_id}/versions/{version_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id`, `version_id` |
+| Update a specific assistant version | `client.ai.assistants.versions.update()` | `POST /ai/assistants/{assistant_id}/versions/{version_id}` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id`, `version_id` |
+| Delete a specific assistant version | `client.ai.assistants.versions.delete()` | `DELETE /ai/assistants/{assistant_id}/versions/{version_id}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `version_id` |
+| Promote an assistant version to main | `client.ai.assistants.versions.promote()` | `POST /ai/assistants/{assistant_id}/versions/{version_id}/promote` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id`, `version_id` |
 | List MCP Servers | `client.ai.mcpServers.list()` | `GET /ai/mcp_servers` | Inspect available resources or choose an existing resource before mutating it. | None |
 | Create MCP Server | `client.ai.mcpServers.create()` | `POST /ai/mcp_servers` | Create or provision an additional resource when the core tasks do not cover this flow. | `name`, `type`, `url` |
-| Get MCP Server | `client.ai.mcpServers.retrieve()` | `GET /ai/mcp_servers/{mcp_server_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `mcpServerId` |
-| Update MCP Server | `client.ai.mcpServers.update()` | `PUT /ai/mcp_servers/{mcp_server_id}` | Modify an existing resource without recreating it. | `mcpServerId` |
-| Delete MCP Server | `client.ai.mcpServers.delete()` | `DELETE /ai/mcp_servers/{mcp_server_id}` | Remove, detach, or clean up an existing resource. | `mcpServerId` |
+| Get MCP Server | `client.ai.mcpServers.retrieve()` | `GET /ai/mcp_servers/{mcp_server_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `mcp_server_id` |
+| Update MCP Server | `client.ai.mcpServers.update()` | `PUT /ai/mcp_servers/{mcp_server_id}` | Modify an existing resource without recreating it. | `mcp_server_id` |
+| Delete MCP Server | `client.ai.mcpServers.delete()` | `DELETE /ai/mcp_servers/{mcp_server_id}` | Remove, detach, or clean up an existing resource. | `mcp_server_id` |
 | List Tools | `client.ai.tools.list()` | `GET /ai/tools` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Create Tool | `client.ai.tools.create()` | `POST /ai/tools` | Create or provision an additional resource when the core tasks do not cover this flow. | `type`, `displayName` |
-| Get Tool | `client.ai.tools.retrieve()` | `GET /ai/tools/{tool_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `toolId` |
-| Update Tool | `client.ai.tools.update()` | `PATCH /ai/tools/{tool_id}` | Modify an existing resource without recreating it. | `toolId` |
-| Delete Tool | `client.ai.tools.delete()` | `DELETE /ai/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `toolId` |
+| Create Tool | `client.ai.tools.create()` | `POST /ai/tools` | Create or provision an additional resource when the core tasks do not cover this flow. | `type`, `display_name` |
+| Get Tool | `client.ai.tools.retrieve()` | `GET /ai/tools/{tool_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `tool_id` |
+| Update Tool | `client.ai.tools.update()` | `PATCH /ai/tools/{tool_id}` | Modify an existing resource without recreating it. | `tool_id` |
+| Delete Tool | `client.ai.tools.delete()` | `DELETE /ai/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `tool_id` |
 
 ---
 

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-javascript/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-javascript/references/api-details.md
@@ -169,51 +169,51 @@
 |-----------|------|-------------|
 | `model` | string | ID of the model to use when `external_llm` is not set. |
 | `tools` | array[object] | Deprecated for new integrations. |
-| `mcpServers` | array[object] | MCP servers attached to the assistant. |
-| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
-| `externalLlm` | object |  |
-| `fallbackConfig` | object |  |
-| `voiceSettings` | object |  |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
 | `transcription` | object |  |
-| `telephonySettings` | object |  |
-| `messagingSettings` | object |  |
-| `enabledFeatures` | array[object] |  |
-| `insightSettings` | object |  |
-| `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
-| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
-| `dynamicVariables` | object | Map of dynamic variables and their default values |
-| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
-| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
 | `integrations` | array[object] | Connected integrations attached to the assistant. |
-| `observabilitySettings` | object |  |
+| `observability_settings` | object |  |
 | `tags` | array[string] | Tags associated with the assistant. |
-| `postConversationSettings` | object | Configuration for post-conversation processing. |
-| `conversationFlow` | object | Conversation flow as supplied by API clients (create / update). |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+| `conversation_flow` | object | Conversation flow as supplied by API clients (create / update). |
 
 ### Import assistants from external provider — `client.ai.assistants.imports()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `importIds` | array[string] | Optional list of assistant IDs to import from the external provider. |
+| `import_ids` | array[string] | Optional list of assistant IDs to import from the external provider. |
 
 ### Create a new assistant test — `client.ai.assistants.tests.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `description` | string | Optional detailed description of what this test evaluates and its purpose. |
-| `telnyxConversationChannel` | object | The communication channel through which the test will be conducted. |
-| `maxDurationSeconds` | integer | Maximum duration in seconds that the test conversation should run before timi... |
-| `testSuite` | string | Optional test suite name to group related tests together. |
+| `telnyx_conversation_channel` | object | The communication channel through which the test will be conducted. |
+| `max_duration_seconds` | integer | Maximum duration in seconds that the test conversation should run before timi... |
+| `test_suite` | string | Optional test suite name to group related tests together. |
 
 ### Trigger test suite execution — `client.ai.assistants.tests.testSuites.runs.trigger()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `destinationVersionId` | string (UUID) | Optional assistant version ID to use for all test runs in this suite. |
+| `destination_version_id` | string (UUID) | Optional assistant version ID to use for all test runs in this suite. |
 
 ### Update an assistant test — `client.ai.assistants.tests.update()`
 
@@ -221,10 +221,10 @@
 |-----------|------|-------------|
 | `name` | string | Updated name for the assistant test. |
 | `description` | string | Updated description of the test's purpose and evaluation criteria. |
-| `telnyxConversationChannel` | enum (phone_call, web_call, sms_chat, web_chat) |  |
+| `telnyx_conversation_channel` | enum (phone_call, web_call, sms_chat, web_chat) |  |
 | `destination` | string | Updated target destination for test conversations. |
-| `maxDurationSeconds` | integer | Updated maximum test duration in seconds. |
-| `testSuite` | string | Updated test suite assignment for better organization. |
+| `max_duration_seconds` | integer | Updated maximum test duration in seconds. |
+| `test_suite` | string | Updated test suite assignment for better organization. |
 | `instructions` | string | Updated test scenario instructions and objectives. |
 | `rubric` | array[object] | Updated evaluation criteria for assessing assistant performance. |
 
@@ -232,7 +232,7 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `destinationVersionId` | string (UUID) | Optional assistant version ID to use for this test run. |
+| `destination_version_id` | string (UUID) | Optional assistant version ID to use for this test run. |
 
 ### Update an assistant — `client.ai.assistants.update()`
 
@@ -242,32 +242,32 @@
 | `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
 | `tools` | array[object] | Deprecated for new integrations. |
-| `mcpServers` | array[object] | MCP servers attached to the assistant. |
-| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
-| `externalLlm` | object |  |
-| `fallbackConfig` | object |  |
-| `voiceSettings` | object |  |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
 | `transcription` | object |  |
-| `telephonySettings` | object |  |
-| `messagingSettings` | object |  |
-| `enabledFeatures` | array[object] |  |
-| `insightSettings` | object |  |
-| `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
-| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
-| `dynamicVariables` | object | Map of dynamic variables and their default values |
-| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
-| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
 | `integrations` | array[object] | Connected integrations attached to the assistant. |
-| `observabilitySettings` | object |  |
+| `observability_settings` | object |  |
 | `tags` | array[string] | Tags associated with the assistant. |
-| `versionName` | string | Human-readable name for the assistant version. |
-| `postConversationSettings` | object | Configuration for post-conversation processing. |
-| `conversationFlow` | object | Conversation flow as supplied by API clients (create / update). |
-| `promoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+| `conversation_flow` | object | Conversation flow as supplied by API clients (create / update). |
+| `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
 
 ### Create Canary Deploy — `client.ai.assistants.canaryDeploys.create()`
 
@@ -292,14 +292,14 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `text` | string |  |
-| `conversationMetadata` | object |  |
-| `shouldCreateConversation` | boolean |  |
+| `conversation_metadata` | object |  |
+| `should_create_conversation` | boolean |  |
 
 ### Enhance Assistant Instructions — `client.ai.assistants.instructions.enhance()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `enhancementPrompt` | object | Optional guidance describing how the instructions should be enhanced. |
+| `enhancement_prompt` | object | Optional guidance describing how the instructions should be enhanced. |
 | `instructions` | object | The instructions to enhance. |
 
 ### Create a scheduled event — `client.ai.assistants.scheduledEvents.create()`
@@ -307,11 +307,11 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `text` | string | Required for sms scheduled events. |
-| `conversationMetadata` | object | Metadata associated with the conversation. |
-| `dynamicVariables` | object | A map of dynamic variable names to values. |
-| `maxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
-| `retryIntervalSecs` | integer |  |
-| `callSettings` | object | Per-call telephony overrides applied when a scheduled phone-call event
+| `conversation_metadata` | object | Metadata associated with the conversation. |
+| `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
+| `call_settings` | object | Per-call telephony overrides applied when a scheduled phone-call event
 dispat... |
 
 ### Test Assistant Tool — `client.ai.assistants.tools.test()`
@@ -319,7 +319,7 @@ dispat... |
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `arguments` | object | Key-value arguments to use for the webhook test |
-| `dynamicVariables` | object | Key-value dynamic variables to use for the webhook test |
+| `dynamic_variables` | object | Key-value dynamic variables to use for the webhook test |
 
 ### Update a specific assistant version — `client.ai.assistants.versions.update()`
 
@@ -329,38 +329,38 @@ dispat... |
 | `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
 | `tools` | array[object] | Deprecated for new integrations. |
-| `mcpServers` | array[object] | MCP servers attached to the assistant. |
-| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
-| `externalLlm` | object |  |
-| `fallbackConfig` | object |  |
-| `voiceSettings` | object |  |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
 | `transcription` | object |  |
-| `telephonySettings` | object |  |
-| `messagingSettings` | object |  |
-| `enabledFeatures` | array[object] |  |
-| `insightSettings` | object |  |
-| `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
-| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
-| `dynamicVariables` | object | Map of dynamic variables and their default values |
-| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
-| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
 | `integrations` | array[object] | Connected integrations attached to the assistant. |
-| `observabilitySettings` | object |  |
+| `observability_settings` | object |  |
 | `tags` | array[string] | Tags associated with the assistant. |
-| `versionName` | string | Human-readable name for the assistant version. |
-| `postConversationSettings` | object | Configuration for post-conversation processing. |
-| `conversationFlow` | object | Conversation flow as supplied by API clients (create / update). |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+| `conversation_flow` | object | Conversation flow as supplied by API clients (create / update). |
 
 ### Create MCP Server — `client.ai.mcpServers.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `apiKeyRef` | string |  |
-| `allowedTools` | array[string] |  |
+| `api_key_ref` | string |  |
+| `allowed_tools` | array[string] |  |
 
 ### Update MCP Server — `client.ai.mcpServers.update()`
 
@@ -370,9 +370,9 @@ dispat... |
 | `name` | string |  |
 | `type` | string |  |
 | `url` | string (URL) |  |
-| `apiKeyRef` | string |  |
-| `allowedTools` | array[string] |  |
-| `createdAt` | string (date-time) |  |
+| `api_key_ref` | string |  |
+| `allowed_tools` | array[string] |  |
+| `created_at` | string (date-time) |  |
 
 ### Create Tool — `client.ai.tools.create()`
 
@@ -383,17 +383,19 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
-| `timeoutMs` | integer |  |
+| `client_side_tool` | object |  |
+| `timeout_ms` | integer |  |
 
 ### Update Tool — `client.ai.tools.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `type` | string |  |
-| `displayName` | string |  |
+| `display_name` | string |  |
 | `function` | object |  |
 | `retrieval` | object |  |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
-| `timeoutMs` | integer |  |
+| `client_side_tool` | object |  |
+| `timeout_ms` | integer |  |

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-python/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-python/references/api-details.md
@@ -383,6 +383,7 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |
 
 ### Update Tool — `client.ai.tools.update()`
@@ -396,4 +397,5 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-ruby/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-ruby/references/api-details.md
@@ -383,6 +383,7 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |
 
 ### Update Tool — `client.ai.tools.update()`
@@ -396,4 +397,5 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |

--- a/providers/cursor/plugin/skills/telnyx-messaging-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.58.0</version>
+    <version>6.81.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.58.0")
+implementation("com.telnyx.sdk:telnyx:6.81.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-messaging-javascript/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-javascript/SKILL.md
@@ -96,9 +96,9 @@ Primary outbound messaging flow. Agents need exact request fields and delivery-r
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
 | `from` | string (E.164) | Yes | Sending address (+E.164 formatted phone number, alphanumeric... |
 | `text` | string | Yes | Message body (i.e., content) as a non-empty string. |
-| `messagingProfileId` | string (UUID) | No | Unique identifier for a messaging profile. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Unique identifier for a messaging profile. |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
 | ... | | | +7 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -130,10 +130,10 @@ Common sender variant that requires different request shape.
 | `from` | string (E.164) | Yes | A valid alphanumeric sender ID on the user's account. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
 | `text` | string | Yes | The message body. |
-| `messagingProfileId` | string (UUID) | Yes | The messaging profile ID to use. |
-| `webhookUrl` | string (URL) | No | Callback URL for delivery status updates. |
-| `webhookFailoverUrl` | string (URL) | No | Failover callback URL for delivery status updates. |
-| `useProfileWebhooks` | boolean | No | If true, use the messaging profile's webhook settings. |
+| `messaging_profile_id` | string (UUID) | Yes | The messaging profile ID to use. |
+| `webhook_url` | string (URL) | No | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | No | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | No | If true, use the messaging profile's webhook settings. |
 
 ```javascript
 const response = await client.messages.sendWithAlphanumericSender({
@@ -165,7 +165,7 @@ and `telnyx-timestamp` headers. Always verify signatures in production:
 // In your webhook handler (e.g., Express — use raw body, not parsed JSON):
 app.post('/webhooks', express.raw({ type: 'application/json' }), async (req, res) => {
   try {
-    const event = await client.webhooks.unwrap(req.body.toString(), {
+    const event = client.webhooks.unwrap(req.body.toString(), {
       headers: req.headers,
     });
     // Signature valid — event is the parsed webhook payload
@@ -226,9 +226,9 @@ Send one MMS payload to multiple recipients.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | array[object] | Yes | A list of destinations. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +3 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -259,9 +259,9 @@ Force a long-code sending path instead of the generic send endpoint.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -289,11 +289,11 @@ Let a messaging profile or number pool choose the sender for you.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `messagingProfileId` | string (UUID) | Yes | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Yes | Unique identifier for a messaging profile. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -324,9 +324,9 @@ Force a short-code sending path when the sender must be a short code.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -355,9 +355,9 @@ Queue a message for future delivery instead of sending immediately.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `messagingProfileId` | string (UUID) | No | Unique identifier for a messaging profile. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Unique identifier for a messaging profile. |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
 | ... | | | +8 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -365,7 +365,7 @@ const response = await client.messages.schedule({
     to: '+18445550001',
     from: '+18005550101',
     text: 'Appointment reminder',
-    sendAt: '2025-07-01T15:00:00Z',
+    send_at: '2025-07-01T15:00:00Z',
 });
 
 console.log(response.data);
@@ -389,10 +389,10 @@ Send WhatsApp traffic instead of SMS/MMS.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number in +E.164 format associated with Whatsapp accou... |
 | `to` | string (E.164) | Yes | Phone number in +E.164 format |
-| `whatsappMessage` | object | Yes |  |
+| `whatsapp_message` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `messagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```javascript
 const response = await client.messages.sendWhatsapp({
@@ -424,10 +424,10 @@ Before using any operation below, read [the optional-parameters section](referen
 | Retrieve a message | `client.messages.retrieve()` | `GET /messages/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Cancel a scheduled message | `client.messages.cancelScheduled()` | `DELETE /messages/{id}` | Remove, detach, or clean up an existing resource. | `id` |
 | List alphanumeric sender IDs | `client.alphanumericSenderIDs.list()` | `GET /alphanumeric_sender_ids` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Create an alphanumeric sender ID | `client.alphanumericSenderIDs.create()` | `POST /alphanumeric_sender_ids` | Create or provision an additional resource when the core tasks do not cover this flow. | `alphanumericSenderId`, `messagingProfileId` |
+| Create an alphanumeric sender ID | `client.alphanumericSenderIDs.create()` | `POST /alphanumeric_sender_ids` | Create or provision an additional resource when the core tasks do not cover this flow. | `alphanumeric_sender_id`, `messaging_profile_id` |
 | Retrieve an alphanumeric sender ID | `client.alphanumericSenderIDs.retrieve()` | `GET /alphanumeric_sender_ids/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Delete an alphanumeric sender ID | `client.alphanumericSenderIDs.delete()` | `DELETE /alphanumeric_sender_ids/{id}` | Remove, detach, or clean up an existing resource. | `id` |
-| Retrieve group MMS messages | `client.messages.retrieveGroupMessages()` | `GET /messages/group/{message_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `messageId` |
+| Retrieve group MMS messages | `client.messages.retrieveGroupMessages()` | `GET /messages/group/{message_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `message_id` |
 | List messaging hosted numbers | `client.messagingHostedNumbers.list()` | `GET /messaging_hosted_numbers` | Inspect available resources or choose an existing resource before mutating it. | None |
 | Retrieve a messaging hosted number | `client.messagingHostedNumbers.retrieve()` | `GET /messaging_hosted_numbers/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Update a messaging hosted number | `client.messagingHostedNumbers.update()` | `PATCH /messaging_hosted_numbers/{id}` | Modify an existing resource without recreating it. | `id` |
@@ -436,11 +436,11 @@ Before using any operation below, read [the optional-parameters section](referen
 | Regenerate messaging profile secret | `client.messagingProfiles.actions.regenerateSecret()` | `POST /messaging_profiles/{id}/actions/regenerate_secret` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `id` |
 | List alphanumeric sender IDs for a messaging profile | `client.messagingProfiles.listAlphanumericSenderIDs()` | `GET /messaging_profiles/{id}/alphanumeric_sender_ids` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Get detailed messaging profile metrics | `client.messagingProfiles.retrieveMetrics()` | `GET /messaging_profiles/{id}/metrics` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
-| List Auto-Response Settings | `client.messagingProfiles.autorespConfigs.list()` | `GET /messaging_profiles/{profile_id}/autoresp_configs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profileId` |
-| Create auto-response setting | `client.messagingProfiles.autorespConfigs.create()` | `POST /messaging_profiles/{profile_id}/autoresp_configs` | Create or provision an additional resource when the core tasks do not cover this flow. | `op`, `keywords`, `countryCode`, `profileId` |
-| Get Auto-Response Setting | `client.messagingProfiles.autorespConfigs.retrieve()` | `GET /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profileId`, `autorespCfgId` |
-| Update Auto-Response Setting | `client.messagingProfiles.autorespConfigs.update()` | `PUT /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Modify an existing resource without recreating it. | `op`, `keywords`, `countryCode`, `profileId`, +1 more |
-| Delete Auto-Response Setting | `client.messagingProfiles.autorespConfigs.delete()` | `DELETE /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Remove, detach, or clean up an existing resource. | `profileId`, `autorespCfgId` |
+| List Auto-Response Settings | `client.messagingProfiles.autorespConfigs.list()` | `GET /messaging_profiles/{profile_id}/autoresp_configs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profile_id` |
+| Create auto-response setting | `client.messagingProfiles.autorespConfigs.create()` | `POST /messaging_profiles/{profile_id}/autoresp_configs` | Create or provision an additional resource when the core tasks do not cover this flow. | `op`, `keywords`, `country_code`, `profile_id` |
+| Get Auto-Response Setting | `client.messagingProfiles.autorespConfigs.retrieve()` | `GET /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profile_id`, `autoresp_cfg_id` |
+| Update Auto-Response Setting | `client.messagingProfiles.autorespConfigs.update()` | `PUT /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Modify an existing resource without recreating it. | `op`, `keywords`, `country_code`, `profile_id`, +1 more |
+| Delete Auto-Response Setting | `client.messagingProfiles.autorespConfigs.delete()` | `DELETE /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Remove, detach, or clean up an existing resource. | `profile_id`, `autoresp_cfg_id` |
 
 ### Other Webhook Events
 

--- a/providers/cursor/plugin/skills/telnyx-messaging-javascript/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-javascript/references/api-details.md
@@ -199,32 +199,32 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `usLongCodeFallback` | string | A US long code number to use as fallback when sending to US destinations. |
+| `us_long_code_fallback` | string | A US long code number to use as fallback when sending to US destinations. |
 
 ### Send a message — `client.messages.send()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
-| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
-| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a message using an alphanumeric sender ID — `client.messages.sendWithAlphanumericSender()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `webhookUrl` | string (URL) | Callback URL for delivery status updates. |
-| `webhookFailoverUrl` | string (URL) | Failover callback URL for delivery status updates. |
-| `useProfileWebhooks` | boolean | If true, use the messaging profile's webhook settings. |
+| `webhook_url` | string (URL) | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | If true, use the messaging profile's webhook settings. |
 
 ### Send a group MMS message — `client.messages.sendGroupMms()`
 
@@ -232,10 +232,10 @@
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 
 ### Send a long code message — `client.messages.sendLongCode()`
 
@@ -243,12 +243,12 @@
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a message using number pool — `client.messages.sendNumberPool()`
@@ -257,12 +257,12 @@
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Schedule a message — `client.messages.schedule()`
@@ -270,16 +270,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
-| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
-| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
 
 ### Send a short code message — `client.messages.sendShortCode()`
 
@@ -287,12 +287,12 @@
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a WhatsApp message — `client.messages.sendWhatsapp()`
@@ -300,17 +300,17 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `messagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messagingHostedNumbers.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `messagingProfileId` | string (UUID) | Configure the messaging profile this phone number is assigned to:
+| `messaging_profile_id` | string (UUID) | Configure the messaging profile this phone number is assigned to:
 
 * Omit thi... |
-| `messagingProduct` | string | Configure the messaging product for this number:
+| `messaging_product` | string | Configure the messaging product for this number:
 
 * Omit this field or set it... |
 | `tags` | array[string] | Tags to set on this phone number. |
@@ -319,13 +319,13 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `respText` | string |  |
+| `resp_text` | string |  |
 
 ### Update Auto-Response Setting — `client.messagingProfiles.autorespConfigs.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `respText` | string |  |
+| `resp_text` | string |  |
 
 ## Webhook Payload Fields
 

--- a/providers/cursor/plugin/skills/telnyx-messaging-ruby/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-ruby/SKILL.md
@@ -270,7 +270,7 @@ Let a messaging profile or number pool choose the sender for you.
 ```ruby
 response = client.messages.send_number_pool(
   messaging_profile_id: "abc85f64-5717-4562-b3fc-2c9600000000",
-  to: "+13125550002"
+  to: "+13125550002",
     text: "Hello from Telnyx!",
 )
 

--- a/providers/cursor/plugin/skills/telnyx-numbers-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-numbers-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.58.0</version>
+    <version>6.81.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.58.0")
+implementation("com.telnyx.sdk:telnyx:6.81.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-numbers-javascript/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-numbers-javascript/SKILL.md
@@ -109,15 +109,15 @@ Number ordering is the production provisioning step after number selection.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `phoneNumbers` | array[object] | Yes |  |
-| `connectionId` | string (UUID) | No | Identifies the connection associated with this phone number. |
-| `messagingProfileId` | string (UUID) | No | Identifies the messaging profile associated with the phone n... |
-| `billingGroupId` | string (UUID) | No | Identifies the billing group associated with the phone numbe... |
+| `phone_numbers` | array[object] | Yes |  |
+| `connection_id` | string (UUID) | No | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | No | Identifies the messaging profile associated with the phone n... |
+| `billing_group_id` | string (UUID) | No | Identifies the billing group associated with the phone numbe... |
 | ... | | | +1 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const numberOrder = await client.numberOrders.create({
-    phoneNumbers: [{"phone_number": "+18005550101"}],
+    phone_numbers: [{"phone_number": "+18005550101"}],
 });
 
 console.log(numberOrder.data);
@@ -139,7 +139,7 @@ Order status determines whether provisioning completed or additional requirement
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `numberOrderId` | string (UUID) | Yes | The number order ID. |
+| `number_order_id` | string (UUID) | Yes | The number order ID. |
 
 ```javascript
 const numberOrder = await client.numberOrders.retrieve('550e8400-e29b-41d4-a716-446655440000');
@@ -169,15 +169,15 @@ Create or provision an additional resource when the core tasks do not cover this
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `phoneNumbers` | array[object] | Yes |  |
+| `phone_numbers` | array[object] | Yes |  |
 | `status` | enum (pending, success, failure) | No | The status of the entire reservation. |
 | `id` | string (UUID) | No |  |
-| `recordType` | string | No |  |
+| `record_type` | string | No |  |
 | ... | | | +3 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const numberReservation = await client.numberReservations.create({
-    phoneNumbers: [{"phone_number": "+18005550101"}],
+    phone_numbers: [{"phone_number": "+18005550101"}],
 });
 
 console.log(numberReservation.data);
@@ -199,7 +199,7 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `numberReservationId` | string (UUID) | Yes | The number reservation ID. |
+| `number_reservation_id` | string (UUID) | Yes | The number reservation ID. |
 
 ```javascript
 const numberReservation = await client.numberReservations.retrieve('550e8400-e29b-41d4-a716-446655440000');
@@ -246,9 +246,9 @@ Create or provision an additional resource when the core tasks do not cover this
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) | No |  |
-| `requirementGroupId` | string (UUID) | No | The ID of the requirement group to associate with this advan... |
-| `countryCode` | string (ISO 3166-1 alpha-2) | No |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) | No |  |
+| `requirement_group_id` | string (UUID) | No | The ID of the requirement group to associate with this advan... |
+| `country_code` | string (ISO 3166-1 alpha-2) | No |  |
 | ... | | | +5 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -274,9 +274,9 @@ Modify an existing resource without recreating it.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `advanced-order-id` | string (UUID) | Yes | Unique identifier of the advanced order. |
-| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) | No |  |
-| `requirementGroupId` | string (UUID) | No | The ID of the requirement group to associate with this advan... |
-| `countryCode` | string (ISO 3166-1 alpha-2) | No |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) | No |  |
+| `requirement_group_id` | string (UUID) | No | The ID of the requirement group to associate with this advan... |
+| `country_code` | string (ISO 3166-1 alpha-2) | No |  |
 | ... | | | +5 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -303,7 +303,7 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `orderId` | string (UUID) | Yes | Unique identifier of the order. |
+| `order_id` | string (UUID) | Yes | Unique identifier of the order. |
 
 ```javascript
 const advancedOrder = await client.advancedOrders.retrieve('182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e');
@@ -388,38 +388,38 @@ Before using any operation below, read [the optional-parameters section](referen
 | Retrieve a comment | `client.comments.retrieve()` | `GET /comments/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Mark a comment as read | `client.comments.markAsRead()` | `PATCH /comments/{id}/read` | Modify an existing resource without recreating it. | `id` |
 | Get country coverage | `client.countryCoverage.retrieve()` | `GET /country_coverage` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Get coverage for a specific country | `client.countryCoverage.retrieveCountry()` | `GET /country_coverage/countries/{country_code}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `countryCode` |
+| Get coverage for a specific country | `client.countryCoverage.retrieveCountry()` | `GET /country_coverage/countries/{country_code}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `country_code` |
 | List customer service records | `client.customerServiceRecords.list()` | `GET /customer_service_records` | Inspect available resources or choose an existing resource before mutating it. | None |
 | Create a customer service record | `client.customerServiceRecords.create()` | `POST /customer_service_records` | Create or provision an additional resource when the core tasks do not cover this flow. | None |
 | Verify CSR phone number coverage | `client.customerServiceRecords.verifyPhoneNumberCoverage()` | `POST /customer_service_records/phone_number_coverages` | Create or provision an additional resource when the core tasks do not cover this flow. | None |
-| Get a customer service record | `client.customerServiceRecords.retrieve()` | `GET /customer_service_records/{customer_service_record_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `customerServiceRecordId` |
+| Get a customer service record | `client.customerServiceRecords.retrieve()` | `GET /customer_service_records/{customer_service_record_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `customer_service_record_id` |
 | List inexplicit number orders | `client.inexplicitNumberOrders.list()` | `GET /inexplicit_number_orders` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Create an inexplicit number order | `client.inexplicitNumberOrders.create()` | `POST /inexplicit_number_orders` | Create or provision an additional resource when the core tasks do not cover this flow. | `orderingGroups` |
+| Create an inexplicit number order | `client.inexplicitNumberOrders.create()` | `POST /inexplicit_number_orders` | Create or provision an additional resource when the core tasks do not cover this flow. | `ordering_groups` |
 | Retrieve an inexplicit number order | `client.inexplicitNumberOrders.retrieve()` | `GET /inexplicit_number_orders/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Create an inventory coverage request | `client.inventoryCoverage.list()` | `GET /inventory_coverage` | Inspect available resources or choose an existing resource before mutating it. | None |
 | List mobile network operators | `client.mobileNetworkOperators.list()` | `GET /mobile_network_operators` | Inspect available resources or choose an existing resource before mutating it. | None |
 | List network coverage locations | `client.networkCoverage.list()` | `GET /network_coverage` | Inspect available resources or choose an existing resource before mutating it. | None |
 | List number block orders | `client.numberBlockOrders.list()` | `GET /number_block_orders` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Create a number block order | `client.numberBlockOrders.create()` | `POST /number_block_orders` | Create or provision an additional resource when the core tasks do not cover this flow. | `startingNumber`, `range` |
-| Retrieve a number block order | `client.numberBlockOrders.retrieve()` | `GET /number_block_orders/{number_block_order_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `numberBlockOrderId` |
+| Create a number block order | `client.numberBlockOrders.create()` | `POST /number_block_orders` | Create or provision an additional resource when the core tasks do not cover this flow. | `starting_number`, `range` |
+| Retrieve a number block order | `client.numberBlockOrders.retrieve()` | `GET /number_block_orders/{number_block_order_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `number_block_order_id` |
 | Retrieve a list of phone numbers associated to orders | `client.numberOrderPhoneNumbers.list()` | `GET /number_order_phone_numbers` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Retrieve a single phone number within a number order. | `client.numberOrderPhoneNumbers.retrieve()` | `GET /number_order_phone_numbers/{number_order_phone_number_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `numberOrderPhoneNumberId` |
-| Update requirements for a single phone number within a number order. | `client.numberOrderPhoneNumbers.updateRequirements()` | `PATCH /number_order_phone_numbers/{number_order_phone_number_id}` | Modify an existing resource without recreating it. | `numberOrderPhoneNumberId` |
+| Retrieve a single phone number within a number order. | `client.numberOrderPhoneNumbers.retrieve()` | `GET /number_order_phone_numbers/{number_order_phone_number_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `number_order_phone_number_id` |
+| Update requirements for a single phone number within a number order. | `client.numberOrderPhoneNumbers.updateRequirements()` | `PATCH /number_order_phone_numbers/{number_order_phone_number_id}` | Modify an existing resource without recreating it. | `number_order_phone_number_id` |
 | List number orders | `client.numberOrders.list()` | `GET /number_orders` | Create or inspect provisioning orders for number purchases. | None |
-| Update a number order | `client.numberOrders.update()` | `PATCH /number_orders/{number_order_id}` | Modify an existing resource without recreating it. | `numberOrderId` |
+| Update a number order | `client.numberOrders.update()` | `PATCH /number_orders/{number_order_id}` | Modify an existing resource without recreating it. | `number_order_id` |
 | List number reservations | `client.numberReservations.list()` | `GET /number_reservations` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Extend a number reservation | `client.numberReservations.actions.extend()` | `POST /number_reservations/{number_reservation_id}/actions/extend` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `numberReservationId` |
-| Retrieve the features for a list of numbers | `client.numbersFeatures.create()` | `POST /numbers_features` | Create or provision an additional resource when the core tasks do not cover this flow. | `phoneNumbers` |
+| Extend a number reservation | `client.numberReservations.actions.extend()` | `POST /number_reservations/{number_reservation_id}/actions/extend` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `number_reservation_id` |
+| Retrieve the features for a list of numbers | `client.numbersFeatures.create()` | `POST /numbers_features` | Create or provision an additional resource when the core tasks do not cover this flow. | `phone_numbers` |
 | Lists the phone number blocks jobs | `client.phoneNumberBlocks.jobs.list()` | `GET /phone_number_blocks/jobs` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Deletes all numbers associated with a phone number block | `client.phoneNumberBlocks.jobs.deletePhoneNumberBlock()` | `POST /phone_number_blocks/jobs/delete_phone_number_block` | Create or provision an additional resource when the core tasks do not cover this flow. | `phoneNumberBlockId` |
+| Deletes all numbers associated with a phone number block | `client.phoneNumberBlocks.jobs.deletePhoneNumberBlock()` | `POST /phone_number_blocks/jobs/delete_phone_number_block` | Create or provision an additional resource when the core tasks do not cover this flow. | `phone_number_block_id` |
 | Retrieves a phone number blocks job | `client.phoneNumberBlocks.jobs.retrieve()` | `GET /phone_number_blocks/jobs/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | List sub number orders | `client.subNumberOrders.list()` | `GET /sub_number_orders` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Retrieve a sub number order | `client.subNumberOrders.retrieve()` | `GET /sub_number_orders/{sub_number_order_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `subNumberOrderId` |
-| Update a sub number order's requirements | `client.subNumberOrders.update()` | `PATCH /sub_number_orders/{sub_number_order_id}` | Modify an existing resource without recreating it. | `subNumberOrderId` |
-| Cancel a sub number order | `client.subNumberOrders.cancel()` | `PATCH /sub_number_orders/{sub_number_order_id}/cancel` | Modify an existing resource without recreating it. | `subNumberOrderId` |
+| Retrieve a sub number order | `client.subNumberOrders.retrieve()` | `GET /sub_number_orders/{sub_number_order_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `sub_number_order_id` |
+| Update a sub number order's requirements | `client.subNumberOrders.update()` | `PATCH /sub_number_orders/{sub_number_order_id}` | Modify an existing resource without recreating it. | `sub_number_order_id` |
+| Cancel a sub number order | `client.subNumberOrders.cancel()` | `PATCH /sub_number_orders/{sub_number_order_id}/cancel` | Modify an existing resource without recreating it. | `sub_number_order_id` |
 | Create a sub number orders report | `client.subNumberOrdersReport.create()` | `POST /sub_number_orders_report` | Create or provision an additional resource when the core tasks do not cover this flow. | None |
-| Retrieve a sub number orders report | `client.subNumberOrdersReport.retrieve()` | `GET /sub_number_orders_report/{report_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `reportId` |
-| Download a sub number orders report | `client.subNumberOrdersReport.download()` | `GET /sub_number_orders_report/{report_id}/download` | Fetch the current state before updating, deleting, or making control-flow decisions. | `reportId` |
+| Retrieve a sub number orders report | `client.subNumberOrdersReport.retrieve()` | `GET /sub_number_orders_report/{report_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `report_id` |
+| Download a sub number orders report | `client.subNumberOrdersReport.download()` | `GET /sub_number_orders_report/{report_id}/download` | Fetch the current state before updating, deleting, or making control-flow decisions. | `report_id` |
 
 ### Other Webhook Events
 

--- a/providers/cursor/plugin/skills/telnyx-numbers-javascript/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-numbers-javascript/references/api-details.md
@@ -290,27 +290,27 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `countryCode` | string (ISO 3166-1 alpha-2) |  |
+| `country_code` | string (ISO 3166-1 alpha-2) |  |
 | `comments` | string |  |
 | `quantity` | integer |  |
-| `areaCode` | string |  |
-| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `area_code` | string |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
 | `features` | array[object] |  |
-| `customerReference` | string |  |
-| `requirementGroupId` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+| `customer_reference` | string |  |
+| `requirement_group_id` | string (UUID) | The ID of the requirement group to associate with this advanced order |
 
 ### Update Advanced Order — `client.advancedOrders.updateRequirementGroup()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `countryCode` | string (ISO 3166-1 alpha-2) |  |
+| `country_code` | string (ISO 3166-1 alpha-2) |  |
 | `comments` | string |  |
 | `quantity` | integer |  |
-| `areaCode` | string |  |
-| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `area_code` | string |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
 | `features` | array[object] |  |
-| `customerReference` | string |  |
-| `requirementGroupId` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+| `customer_reference` | string |  |
+| `requirement_group_id` | string (UUID) | The ID of the requirement group to associate with this advanced order |
 
 ### Create a comment — `client.comments.create()`
 
@@ -319,89 +319,89 @@
 | `id` | string (UUID) |  |
 | `body` | string |  |
 | `commenter` | string |  |
-| `commenterType` | enum (admin, user) |  |
-| `commentRecordType` | enum (sub_number_order, requirement_group) |  |
-| `commentRecordId` | string (UUID) |  |
-| `readAt` | string (date-time) | An ISO 8901 datetime string for when the comment was read. |
-| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the comment was created. |
-| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the comment was updated. |
+| `commenter_type` | enum (admin, user) |  |
+| `comment_record_type` | enum (sub_number_order, requirement_group) |  |
+| `comment_record_id` | string (UUID) |  |
+| `read_at` | string (date-time) | An ISO 8901 datetime string for when the comment was read. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the comment was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the comment was updated. |
 
 ### Create an inexplicit number order — `client.inexplicitNumberOrders.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `connectionId` | string (UUID) | Connection id to apply to phone numbers that are purchased |
-| `messagingProfileId` | string (UUID) | Messaging profile id to apply to phone numbers that are purchased |
-| `customerReference` | string | Reference label for the customer |
-| `billingGroupId` | string (UUID) | Billing group id to apply to phone numbers that are purchased |
+| `connection_id` | string (UUID) | Connection id to apply to phone numbers that are purchased |
+| `messaging_profile_id` | string (UUID) | Messaging profile id to apply to phone numbers that are purchased |
+| `customer_reference` | string | Reference label for the customer |
+| `billing_group_id` | string (UUID) | Billing group id to apply to phone numbers that are purchased |
 
 ### Create a number block order — `client.numberBlockOrders.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `id` | string (UUID) |  |
-| `recordType` | string |  |
-| `phoneNumbersCount` | integer | The count of phone numbers in the number order. |
-| `connectionId` | string (UUID) | Identifies the connection associated with this phone number. |
-| `messagingProfileId` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `record_type` | string |  |
+| `phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `connection_id` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | Identifies the messaging profile associated with the phone number. |
 | `status` | enum (pending, success, failure) | The status of the order. |
-| `customerReference` | string | A customer reference string for customer look ups. |
-| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the number order was created. |
-| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the number order was updated. |
-| `requirementsMet` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the number order was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the number order was updated. |
+| `requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
 | `errors` | string | Errors the reservation could happen upon |
 
 ### Update requirements for a single phone number within a number order. — `client.numberOrderPhoneNumbers.updateRequirements()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `regulatoryRequirements` | array[object] |  |
+| `regulatory_requirements` | array[object] |  |
 
 ### Create a number order — `client.numberOrders.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `phoneNumbers` | array[object] |  |
-| `connectionId` | string (UUID) | Identifies the connection associated with this phone number. |
-| `messagingProfileId` | string (UUID) | Identifies the messaging profile associated with the phone number. |
-| `billingGroupId` | string (UUID) | Identifies the billing group associated with the phone number. |
-| `customerReference` | string | A customer reference string for customer look ups. |
+| `phone_numbers` | array[object] |  |
+| `connection_id` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `billing_group_id` | string (UUID) | Identifies the billing group associated with the phone number. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
 
 ### Update a number order — `client.numberOrders.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `regulatoryRequirements` | array[object] |  |
-| `customerReference` | string | A customer reference string for customer look ups. |
+| `regulatory_requirements` | array[object] |  |
+| `customer_reference` | string | A customer reference string for customer look ups. |
 
 ### Create a number reservation — `client.numberReservations.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `id` | string (UUID) |  |
-| `recordType` | string |  |
-| `phoneNumbers` | array[object] |  |
+| `record_type` | string |  |
+| `phone_numbers` | array[object] |  |
 | `status` | enum (pending, success, failure) | The status of the entire reservation. |
-| `customerReference` | string | A customer reference string for customer look ups. |
-| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the numbers reservation was created. |
-| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the number reservation was updated. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the numbers reservation was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the number reservation was updated. |
 
 ### Update a sub number order's requirements — `client.subNumberOrders.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `regulatoryRequirements` | array[object] |  |
+| `regulatory_requirements` | array[object] |  |
 
 ### Create a sub number orders report — `client.subNumberOrdersReport.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `status` | enum (pending, success, failure) | Filter by order status |
-| `countryCode` | string (ISO 3166-1 alpha-2) | Filter by country code |
-| `createdAtGt` | string (date-time) | Filter for orders created after this date |
-| `createdAtLt` | string (date-time) | Filter for orders created before this date |
-| `orderRequestId` | string (UUID) | Filter by specific order request ID |
-| `customerReference` | string | Filter by customer reference |
+| `country_code` | string (ISO 3166-1 alpha-2) | Filter by country code |
+| `created_at_gt` | string (date-time) | Filter for orders created after this date |
+| `created_at_lt` | string (date-time) | Filter for orders created before this date |
+| `order_request_id` | string (UUID) | Filter by specific order request ID |
+| `customer_reference` | string | Filter by customer reference |
 
 ## Webhook Payload Fields
 

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/curl/10dlc.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/curl/10dlc.md
@@ -123,12 +123,10 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-      "brandId": "BXXX001",
+      "brandId": "BXXXXXX",
       "description": "Two-factor authentication messages",
       "usecase": "2FA",
-      "sample_messages": [
-          "Your verification code is {{code}}"
-      ]
+      "sample1": "Your verification code is {{code}}"
   }' \
   "https://api.telnyx.com/v2/10dlc/campaignBuilder"
 ```

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/curl/ai-assistants.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/curl/ai-assistants.md
@@ -648,6 +648,7 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |
 
 ### Update Tool
@@ -661,4 +662,5 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/go/10dlc.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/go/10dlc.md
@@ -144,7 +144,7 @@ Campaign submission is the compliance-critical step that determines whether traf
 		BrandID: "BXXXXXX",
 		Description: "Two-factor authentication messages",
 		Usecase: "2FA",
-		SampleMessages: []string{"Your verification code is {{code}}"},
+		Sample1: telnyx.String("Your verification code is {{code}}"),
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/go/ai-assistants.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/go/ai-assistants.md
@@ -704,6 +704,7 @@ dispat... |
 | `Handoff` | object |  |
 | `Invite` | object |  |
 | `Webhook` | object |  |
+| `ClientSideTool` | object |  |
 | `TimeoutMs` | integer |  |
 
 ### Update Tool — `client.AI.Tools.Update()`
@@ -717,4 +718,5 @@ dispat... |
 | `Handoff` | object |  |
 | `Invite` | object |  |
 | `Webhook` | object |  |
+| `ClientSideTool` | object |  |
 | `TimeoutMs` | integer |  |

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/10dlc.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/10dlc.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.58.0</version>
+    <version>6.81.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.58.0")
+implementation("com.telnyx.sdk:telnyx:6.81.0")
 ```
 
 ## Setup
@@ -137,7 +137,7 @@ CampaignBuilderSubmitParams params = CampaignBuilderSubmitParams.builder()
     .brandId("BXXXXXX")
     .description("Two-factor authentication messages")
     .usecase("2FA")
-    .sampleMessages(java.util.List.of("Your verification code is {{code}}"))
+    .sample1("Your verification code is {{code}}")
     .build();
 TelnyxCampaignCsp telnyxCampaignCsp = client.messaging10dlc().campaignBuilder().submit(params);
 ```

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/ai-assistants.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/ai-assistants.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.58.0</version>
+    <version>6.81.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.58.0")
+implementation("com.telnyx.sdk:telnyx:6.81.0")
 ```
 
 ## Setup
@@ -669,6 +669,7 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `clientSideTool` | object |  |
 | `timeoutMs` | integer |  |
 
 ### Update Tool — `client.ai().tools().update()`
@@ -682,4 +683,5 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `clientSideTool` | object |  |
 | `timeoutMs` | integer |  |

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/messaging.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/messaging.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.58.0</version>
+    <version>6.81.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.58.0")
+implementation("com.telnyx.sdk:telnyx:6.81.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/numbers.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/numbers.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.58.0</version>
+    <version>6.81.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.58.0")
+implementation("com.telnyx.sdk:telnyx:6.81.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/voice.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/voice.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.58.0</version>
+    <version>6.81.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.58.0")
+implementation("com.telnyx.sdk:telnyx:6.81.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/10dlc.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/10dlc.md
@@ -132,7 +132,7 @@ const telnyxCampaignCsp = await client.messaging10dlc.campaignBuilder.submit({
   brandId: 'BXXXXXX',
   description: 'Two-factor authentication messages',
   usecase: '2FA',
-    sampleMessages: ["Your verification code is {{code}}"],
+    sample1: 'Your verification code is {{code}}',
 });
 
 console.log(telnyxCampaignCsp.brandId);
@@ -184,7 +184,7 @@ and `telnyx-timestamp` headers. Always verify signatures in production:
 // In your webhook handler (e.g., Express — use raw body, not parsed JSON):
 app.post('/webhooks', express.raw({ type: 'application/json' }), async (req, res) => {
   try {
-    const event = await client.webhooks.unwrap(req.body.toString(), {
+    const event = client.webhooks.unwrap(req.body.toString(), {
       headers: req.headers,
     });
     // Signature valid — event is the parsed webhook payload
@@ -395,7 +395,7 @@ Before using any operation below, read the Optional Parameters section below and
 | Get Campaign Cost | `client.messaging10dlc.campaign.usecase.getCost()` | `GET /10dlc/campaign/usecase/cost` | Inspect available resources or choose an existing resource before mutating it. | None |
 | Update campaign | `client.messaging10dlc.campaign.update()` | `PUT /10dlc/campaign/{campaignId}` | Inspect the current state of an existing campaign registration. | `campaignId` |
 | Deactivate campaign | `client.messaging10dlc.campaign.deactivate()` | `DELETE /10dlc/campaign/{campaignId}` | Inspect the current state of an existing campaign registration. | `campaignId` |
-| Submit campaign appeal for manual review | `client.messaging10dlc.campaign.submitAppeal()` | `POST /10dlc/campaign/{campaignId}/appeal` | Create or provision an additional resource when the core tasks do not cover this flow. | `appealReason`, `campaignId` |
+| Submit campaign appeal for manual review | `client.messaging10dlc.campaign.submitAppeal()` | `POST /10dlc/campaign/{campaignId}/appeal` | Create or provision an additional resource when the core tasks do not cover this flow. | `appeal_reason`, `campaignId` |
 | Get Campaign Mno Metadata | `client.messaging10dlc.campaign.getMnoMetadata()` | `GET /10dlc/campaign/{campaignId}/mnoMetadata` | Fetch the current state before updating, deleting, or making control-flow decisions. | `campaignId` |
 | Get campaign operation status | `client.messaging10dlc.campaign.getOperationStatus()` | `GET /10dlc/campaign/{campaignId}/operationStatus` | Fetch the current state before updating, deleting, or making control-flow decisions. | `campaignId` |
 | Get OSR campaign attributes | `client.messaging10dlc.campaign.osr.getAttributes()` | `GET /10dlc/campaign/{campaignId}/osr/attributes` | Fetch the current state before updating, deleting, or making control-flow decisions. | `campaignId` |

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/ai-assistants.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/ai-assistants.md
@@ -107,8 +107,8 @@ Chat is the primary runtime path. Agents need the exact assistant method and the
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `content` | string | Yes | The message content sent by the client to the assistant |
-| `conversationId` | string (UUID) | Yes | A unique identifier for the conversation thread, used to mai... |
-| `assistantId` | string (UUID) | Yes | Unique identifier of the assistant. |
+| `conversation_id` | string (UUID) | Yes | A unique identifier for the conversation thread, used to mai... |
+| `assistant_id` | string (UUID) | Yes | Unique identifier of the assistant. |
 | `name` | string | No | The optional display name of the user sending the message |
 
 ```javascript
@@ -136,8 +136,8 @@ Test creation is the main validation path for production assistant behavior befo
 | `instructions` | string | Yes | Detailed instructions that define the test scenario and what... |
 | `rubric` | array[object] | Yes | Evaluation criteria used to assess the assistant's performan... |
 | `description` | string | No | Optional detailed description of what this test evaluates an... |
-| `telnyxConversationChannel` | object | No | The communication channel through which the test will be con... |
-| `maxDurationSeconds` | integer | No | Maximum duration in seconds that the test conversation shoul... |
+| `telnyx_conversation_channel` | object | No | The communication channel through which the test will be con... |
+| `max_duration_seconds` | integer | No | Maximum duration in seconds that the test conversation shoul... |
 | ... | | | +1 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -177,9 +177,9 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `assistantId` | string (UUID) | Yes | Unique identifier of the assistant. |
-| `callControlId` | string (UUID) | No | Filter results by call control id. |
-| `fetchDynamicVariablesFromWebhook` | boolean | No | Whether to fetch dynamic variables from the configured webho... |
+| `assistant_id` | string (UUID) | Yes | Unique identifier of the assistant. |
+| `call_control_id` | string (UUID) | No | Filter results by call control id. |
+| `fetch_dynamic_variables_from_webhook` | boolean | No | Whether to fetch dynamic variables from the configured webho... |
 | `from` | string (E.164) | No | Start of the filter range. |
 | ... | | | +1 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
@@ -205,7 +205,7 @@ Create or provision an additional resource when the core tasks do not cover this
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `assistantId` | string (UUID) | Yes | Unique identifier of the assistant. |
+| `assistant_id` | string (UUID) | Yes | Unique identifier of the assistant. |
 | `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
 | `model` | string | No | ID of the model to use when `external_llm` is not set. |
@@ -257,12 +257,12 @@ Import existing assistants from an external provider instead of creating from sc
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `provider` | enum (elevenlabs, vapi, retell) | Yes | The external provider to import assistants from. |
-| `apiKeyRef` | string | Yes | Integration secret pointer that refers to the API key for th... |
-| `importIds` | array[string] | No | Optional list of assistant IDs to import from the external p... |
+| `api_key_ref` | string | Yes | Integration secret pointer that refers to the API key for th... |
+| `import_ids` | array[string] | No | Optional list of assistant IDs to import from the external p... |
 
 ```javascript
 const assistantsList = await client.ai.assistants.imports({
-  api_key_ref: 'api_key_ref',
+  api_key_ref: 'my-openai-key',
   provider: 'elevenlabs',
 });
 
@@ -303,8 +303,8 @@ Inspect available resources or choose an existing resource before mutating it.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `testSuite` | string | No | Filter tests by test suite name |
-| `telnyxConversationChannel` | string | No | Filter tests by communication channel (e.g., 'web_chat', 'sm... |
+| `test_suite` | string | No | Filter tests by test suite name |
+| `telnyx_conversation_channel` | string | No | Filter tests by communication channel (e.g., 'web_chat', 'sm... |
 | `destination` | string | No | Filter tests by destination (phone number, webhook URL, etc.... |
 | ... | | | +1 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
@@ -353,8 +353,8 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `suiteName` | string | Yes | Name of the suite. |
-| `testSuiteRunId` | string (UUID) | No | Filter runs by specific suite execution batch ID |
+| `suite_name` | string | Yes | Name of the suite. |
+| `test_suite_run_id` | string (UUID) | No | Filter runs by specific suite execution batch ID |
 | `status` | string | No | Filter runs by execution status (pending, running, completed... |
 | `page` | object | No | Consolidated page parameter (deepObject style). |
 
@@ -386,46 +386,46 @@ Before using any operation below, read the Optional Parameters section below and
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
-| Trigger test suite execution | `client.ai.assistants.tests.testSuites.runs.trigger()` | `POST /ai/assistants/tests/test-suites/{suite_name}/runs` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `suiteName` |
-| Get assistant test by ID | `client.ai.assistants.tests.retrieve()` | `GET /ai/assistants/tests/{test_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId` |
-| Update an assistant test | `client.ai.assistants.tests.update()` | `PUT /ai/assistants/tests/{test_id}` | Modify an existing resource without recreating it. | `testId` |
-| Delete an assistant test | `client.ai.assistants.tests.delete()` | `DELETE /ai/assistants/tests/{test_id}` | Remove, detach, or clean up an existing resource. | `testId` |
-| Get test run history for a specific test | `client.ai.assistants.tests.runs.list()` | `GET /ai/assistants/tests/{test_id}/runs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId` |
-| Trigger a manual test run | `client.ai.assistants.tests.runs.trigger()` | `POST /ai/assistants/tests/{test_id}/runs` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `testId` |
-| Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId`, `runId` |
-| Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistantId` |
-| Get Canary Deploy | `client.ai.assistants.canaryDeploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Create Canary Deploy | `client.ai.assistants.canaryDeploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId` |
-| Update Canary Deploy | `client.ai.assistants.canaryDeploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistantId` |
-| Delete Canary Deploy | `client.ai.assistants.canaryDeploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistantId` |
-| Assistant Sms Chat | `client.ai.assistants.sendSMS()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistantId` |
-| Clone Assistant | `client.ai.assistants.clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId` |
-| Enhance Assistant Instructions | `client.ai.assistants.instructions.enhance()` | `POST /ai/assistants/{assistant_id}/instructions/enhance` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId` |
-| List scheduled events | `client.ai.assistants.scheduledEvents.list()` | `GET /ai/assistants/{assistant_id}/scheduled_events` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Create a scheduled event | `client.ai.assistants.scheduledEvents.create()` | `POST /ai/assistants/{assistant_id}/scheduled_events` | Create or provision an additional resource when the core tasks do not cover this flow. | `telnyxConversationChannel`, `telnyxEndUserTarget`, `telnyxAgentTarget`, `scheduledAtFixedDatetime`, +1 more |
-| Get a scheduled event | `client.ai.assistants.scheduledEvents.retrieve()` | `GET /ai/assistants/{assistant_id}/scheduled_events/{event_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId`, `eventId` |
-| Delete a scheduled event | `client.ai.assistants.scheduledEvents.delete()` | `DELETE /ai/assistants/{assistant_id}/scheduled_events/{event_id}` | Remove, detach, or clean up an existing resource. | `assistantId`, `eventId` |
-| Add Assistant Tag | `client.ai.assistants.tags.add()` | `POST /ai/assistants/{assistant_id}/tags` | Create or provision an additional resource when the core tasks do not cover this flow. | `tag`, `assistantId` |
-| Remove Assistant Tag | `client.ai.assistants.tags.remove()` | `DELETE /ai/assistants/{assistant_id}/tags/{tag}` | Remove, detach, or clean up an existing resource. | `assistantId`, `tag` |
-| Get assistant texml | `client.ai.assistants.getTexml()` | `GET /ai/assistants/{assistant_id}/texml` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Add Assistant Tool | `client.ai.assistants.tools.add()` | `PUT /ai/assistants/{assistant_id}/tools/{tool_id}` | Modify an existing resource without recreating it. | `assistantId`, `toolId` |
-| Remove Assistant Tool | `client.ai.assistants.tools.remove()` | `DELETE /ai/assistants/{assistant_id}/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `assistantId`, `toolId` |
-| Test Assistant Tool | `client.ai.assistants.tools.test()` | `POST /ai/assistants/{assistant_id}/tools/{tool_id}/test` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId`, `toolId` |
-| Get all versions of an assistant | `client.ai.assistants.versions.list()` | `GET /ai/assistants/{assistant_id}/versions` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Get a specific assistant version | `client.ai.assistants.versions.retrieve()` | `GET /ai/assistants/{assistant_id}/versions/{version_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId`, `versionId` |
-| Update a specific assistant version | `client.ai.assistants.versions.update()` | `POST /ai/assistants/{assistant_id}/versions/{version_id}` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId`, `versionId` |
-| Delete a specific assistant version | `client.ai.assistants.versions.delete()` | `DELETE /ai/assistants/{assistant_id}/versions/{version_id}` | Remove, detach, or clean up an existing resource. | `assistantId`, `versionId` |
-| Promote an assistant version to main | `client.ai.assistants.versions.promote()` | `POST /ai/assistants/{assistant_id}/versions/{version_id}/promote` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId`, `versionId` |
+| Trigger test suite execution | `client.ai.assistants.tests.testSuites.runs.trigger()` | `POST /ai/assistants/tests/test-suites/{suite_name}/runs` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `suite_name` |
+| Get assistant test by ID | `client.ai.assistants.tests.retrieve()` | `GET /ai/assistants/tests/{test_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id` |
+| Update an assistant test | `client.ai.assistants.tests.update()` | `PUT /ai/assistants/tests/{test_id}` | Modify an existing resource without recreating it. | `test_id` |
+| Delete an assistant test | `client.ai.assistants.tests.delete()` | `DELETE /ai/assistants/tests/{test_id}` | Remove, detach, or clean up an existing resource. | `test_id` |
+| Get test run history for a specific test | `client.ai.assistants.tests.runs.list()` | `GET /ai/assistants/tests/{test_id}/runs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id` |
+| Trigger a manual test run | `client.ai.assistants.tests.runs.trigger()` | `POST /ai/assistants/tests/{test_id}/runs` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `test_id` |
+| Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
+| Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
+| Get Canary Deploy | `client.ai.assistants.canaryDeploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Create Canary Deploy | `client.ai.assistants.canaryDeploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | `client.ai.assistants.canaryDeploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
+| Delete Canary Deploy | `client.ai.assistants.canaryDeploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
+| Assistant Sms Chat | `client.ai.assistants.sendSMS()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistant_id` |
+| Clone Assistant | `client.ai.assistants.clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |
+| Enhance Assistant Instructions | `client.ai.assistants.instructions.enhance()` | `POST /ai/assistants/{assistant_id}/instructions/enhance` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| List scheduled events | `client.ai.assistants.scheduledEvents.list()` | `GET /ai/assistants/{assistant_id}/scheduled_events` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Create a scheduled event | `client.ai.assistants.scheduledEvents.create()` | `POST /ai/assistants/{assistant_id}/scheduled_events` | Create or provision an additional resource when the core tasks do not cover this flow. | `telnyx_conversation_channel`, `telnyx_end_user_target`, `telnyx_agent_target`, `scheduled_at_fixed_datetime`, +1 more |
+| Get a scheduled event | `client.ai.assistants.scheduledEvents.retrieve()` | `GET /ai/assistants/{assistant_id}/scheduled_events/{event_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id`, `event_id` |
+| Delete a scheduled event | `client.ai.assistants.scheduledEvents.delete()` | `DELETE /ai/assistants/{assistant_id}/scheduled_events/{event_id}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `event_id` |
+| Add Assistant Tag | `client.ai.assistants.tags.add()` | `POST /ai/assistants/{assistant_id}/tags` | Create or provision an additional resource when the core tasks do not cover this flow. | `tag`, `assistant_id` |
+| Remove Assistant Tag | `client.ai.assistants.tags.remove()` | `DELETE /ai/assistants/{assistant_id}/tags/{tag}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `tag` |
+| Get assistant texml | `client.ai.assistants.getTexml()` | `GET /ai/assistants/{assistant_id}/texml` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Add Assistant Tool | `client.ai.assistants.tools.add()` | `PUT /ai/assistants/{assistant_id}/tools/{tool_id}` | Modify an existing resource without recreating it. | `assistant_id`, `tool_id` |
+| Remove Assistant Tool | `client.ai.assistants.tools.remove()` | `DELETE /ai/assistants/{assistant_id}/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `tool_id` |
+| Test Assistant Tool | `client.ai.assistants.tools.test()` | `POST /ai/assistants/{assistant_id}/tools/{tool_id}/test` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id`, `tool_id` |
+| Get all versions of an assistant | `client.ai.assistants.versions.list()` | `GET /ai/assistants/{assistant_id}/versions` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Get a specific assistant version | `client.ai.assistants.versions.retrieve()` | `GET /ai/assistants/{assistant_id}/versions/{version_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id`, `version_id` |
+| Update a specific assistant version | `client.ai.assistants.versions.update()` | `POST /ai/assistants/{assistant_id}/versions/{version_id}` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id`, `version_id` |
+| Delete a specific assistant version | `client.ai.assistants.versions.delete()` | `DELETE /ai/assistants/{assistant_id}/versions/{version_id}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `version_id` |
+| Promote an assistant version to main | `client.ai.assistants.versions.promote()` | `POST /ai/assistants/{assistant_id}/versions/{version_id}/promote` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id`, `version_id` |
 | List MCP Servers | `client.ai.mcpServers.list()` | `GET /ai/mcp_servers` | Inspect available resources or choose an existing resource before mutating it. | None |
 | Create MCP Server | `client.ai.mcpServers.create()` | `POST /ai/mcp_servers` | Create or provision an additional resource when the core tasks do not cover this flow. | `name`, `type`, `url` |
-| Get MCP Server | `client.ai.mcpServers.retrieve()` | `GET /ai/mcp_servers/{mcp_server_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `mcpServerId` |
-| Update MCP Server | `client.ai.mcpServers.update()` | `PUT /ai/mcp_servers/{mcp_server_id}` | Modify an existing resource without recreating it. | `mcpServerId` |
-| Delete MCP Server | `client.ai.mcpServers.delete()` | `DELETE /ai/mcp_servers/{mcp_server_id}` | Remove, detach, or clean up an existing resource. | `mcpServerId` |
+| Get MCP Server | `client.ai.mcpServers.retrieve()` | `GET /ai/mcp_servers/{mcp_server_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `mcp_server_id` |
+| Update MCP Server | `client.ai.mcpServers.update()` | `PUT /ai/mcp_servers/{mcp_server_id}` | Modify an existing resource without recreating it. | `mcp_server_id` |
+| Delete MCP Server | `client.ai.mcpServers.delete()` | `DELETE /ai/mcp_servers/{mcp_server_id}` | Remove, detach, or clean up an existing resource. | `mcp_server_id` |
 | List Tools | `client.ai.tools.list()` | `GET /ai/tools` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Create Tool | `client.ai.tools.create()` | `POST /ai/tools` | Create or provision an additional resource when the core tasks do not cover this flow. | `type`, `displayName` |
-| Get Tool | `client.ai.tools.retrieve()` | `GET /ai/tools/{tool_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `toolId` |
-| Update Tool | `client.ai.tools.update()` | `PATCH /ai/tools/{tool_id}` | Modify an existing resource without recreating it. | `toolId` |
-| Delete Tool | `client.ai.tools.delete()` | `DELETE /ai/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `toolId` |
+| Create Tool | `client.ai.tools.create()` | `POST /ai/tools` | Create or provision an additional resource when the core tasks do not cover this flow. | `type`, `display_name` |
+| Get Tool | `client.ai.tools.retrieve()` | `GET /ai/tools/{tool_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `tool_id` |
+| Update Tool | `client.ai.tools.update()` | `PATCH /ai/tools/{tool_id}` | Modify an existing resource without recreating it. | `tool_id` |
+| Delete Tool | `client.ai.tools.delete()` | `DELETE /ai/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `tool_id` |
 
 ---
 
@@ -442,51 +442,51 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 |-----------|------|-------------|
 | `model` | string | ID of the model to use when `external_llm` is not set. |
 | `tools` | array[object] | Deprecated for new integrations. |
-| `mcpServers` | array[object] | MCP servers attached to the assistant. |
-| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
-| `externalLlm` | object |  |
-| `fallbackConfig` | object |  |
-| `voiceSettings` | object |  |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
 | `transcription` | object |  |
-| `telephonySettings` | object |  |
-| `messagingSettings` | object |  |
-| `enabledFeatures` | array[object] |  |
-| `insightSettings` | object |  |
-| `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
-| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
-| `dynamicVariables` | object | Map of dynamic variables and their default values |
-| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
-| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
 | `integrations` | array[object] | Connected integrations attached to the assistant. |
-| `observabilitySettings` | object |  |
+| `observability_settings` | object |  |
 | `tags` | array[string] | Tags associated with the assistant. |
-| `postConversationSettings` | object | Configuration for post-conversation processing. |
-| `conversationFlow` | object | Conversation flow as supplied by API clients (create / update). |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+| `conversation_flow` | object | Conversation flow as supplied by API clients (create / update). |
 
 ### Import assistants from external provider — `client.ai.assistants.imports()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `importIds` | array[string] | Optional list of assistant IDs to import from the external provider. |
+| `import_ids` | array[string] | Optional list of assistant IDs to import from the external provider. |
 
 ### Create a new assistant test — `client.ai.assistants.tests.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `description` | string | Optional detailed description of what this test evaluates and its purpose. |
-| `telnyxConversationChannel` | object | The communication channel through which the test will be conducted. |
-| `maxDurationSeconds` | integer | Maximum duration in seconds that the test conversation should run before timi... |
-| `testSuite` | string | Optional test suite name to group related tests together. |
+| `telnyx_conversation_channel` | object | The communication channel through which the test will be conducted. |
+| `max_duration_seconds` | integer | Maximum duration in seconds that the test conversation should run before timi... |
+| `test_suite` | string | Optional test suite name to group related tests together. |
 
 ### Trigger test suite execution — `client.ai.assistants.tests.testSuites.runs.trigger()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `destinationVersionId` | string (UUID) | Optional assistant version ID to use for all test runs in this suite. |
+| `destination_version_id` | string (UUID) | Optional assistant version ID to use for all test runs in this suite. |
 
 ### Update an assistant test — `client.ai.assistants.tests.update()`
 
@@ -494,10 +494,10 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 |-----------|------|-------------|
 | `name` | string | Updated name for the assistant test. |
 | `description` | string | Updated description of the test's purpose and evaluation criteria. |
-| `telnyxConversationChannel` | enum (phone_call, web_call, sms_chat, web_chat) |  |
+| `telnyx_conversation_channel` | enum (phone_call, web_call, sms_chat, web_chat) |  |
 | `destination` | string | Updated target destination for test conversations. |
-| `maxDurationSeconds` | integer | Updated maximum test duration in seconds. |
-| `testSuite` | string | Updated test suite assignment for better organization. |
+| `max_duration_seconds` | integer | Updated maximum test duration in seconds. |
+| `test_suite` | string | Updated test suite assignment for better organization. |
 | `instructions` | string | Updated test scenario instructions and objectives. |
 | `rubric` | array[object] | Updated evaluation criteria for assessing assistant performance. |
 
@@ -505,7 +505,7 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `destinationVersionId` | string (UUID) | Optional assistant version ID to use for this test run. |
+| `destination_version_id` | string (UUID) | Optional assistant version ID to use for this test run. |
 
 ### Update an assistant — `client.ai.assistants.update()`
 
@@ -515,32 +515,32 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 | `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
 | `tools` | array[object] | Deprecated for new integrations. |
-| `mcpServers` | array[object] | MCP servers attached to the assistant. |
-| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
-| `externalLlm` | object |  |
-| `fallbackConfig` | object |  |
-| `voiceSettings` | object |  |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
 | `transcription` | object |  |
-| `telephonySettings` | object |  |
-| `messagingSettings` | object |  |
-| `enabledFeatures` | array[object] |  |
-| `insightSettings` | object |  |
-| `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
-| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
-| `dynamicVariables` | object | Map of dynamic variables and their default values |
-| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
-| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
 | `integrations` | array[object] | Connected integrations attached to the assistant. |
-| `observabilitySettings` | object |  |
+| `observability_settings` | object |  |
 | `tags` | array[string] | Tags associated with the assistant. |
-| `versionName` | string | Human-readable name for the assistant version. |
-| `postConversationSettings` | object | Configuration for post-conversation processing. |
-| `conversationFlow` | object | Conversation flow as supplied by API clients (create / update). |
-| `promoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+| `conversation_flow` | object | Conversation flow as supplied by API clients (create / update). |
+| `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
 
 ### Create Canary Deploy — `client.ai.assistants.canaryDeploys.create()`
 
@@ -565,14 +565,14 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `text` | string |  |
-| `conversationMetadata` | object |  |
-| `shouldCreateConversation` | boolean |  |
+| `conversation_metadata` | object |  |
+| `should_create_conversation` | boolean |  |
 
 ### Enhance Assistant Instructions — `client.ai.assistants.instructions.enhance()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `enhancementPrompt` | object | Optional guidance describing how the instructions should be enhanced. |
+| `enhancement_prompt` | object | Optional guidance describing how the instructions should be enhanced. |
 | `instructions` | object | The instructions to enhance. |
 
 ### Create a scheduled event — `client.ai.assistants.scheduledEvents.create()`
@@ -580,11 +580,11 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `text` | string | Required for sms scheduled events. |
-| `conversationMetadata` | object | Metadata associated with the conversation. |
-| `dynamicVariables` | object | A map of dynamic variable names to values. |
-| `maxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
-| `retryIntervalSecs` | integer |  |
-| `callSettings` | object | Per-call telephony overrides applied when a scheduled phone-call event
+| `conversation_metadata` | object | Metadata associated with the conversation. |
+| `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
+| `call_settings` | object | Per-call telephony overrides applied when a scheduled phone-call event
 dispat... |
 
 ### Test Assistant Tool — `client.ai.assistants.tools.test()`
@@ -592,7 +592,7 @@ dispat... |
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `arguments` | object | Key-value arguments to use for the webhook test |
-| `dynamicVariables` | object | Key-value dynamic variables to use for the webhook test |
+| `dynamic_variables` | object | Key-value dynamic variables to use for the webhook test |
 
 ### Update a specific assistant version — `client.ai.assistants.versions.update()`
 
@@ -602,38 +602,38 @@ dispat... |
 | `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
 | `tools` | array[object] | Deprecated for new integrations. |
-| `mcpServers` | array[object] | MCP servers attached to the assistant. |
-| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
-| `externalLlm` | object |  |
-| `fallbackConfig` | object |  |
-| `voiceSettings` | object |  |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
 | `transcription` | object |  |
-| `telephonySettings` | object |  |
-| `messagingSettings` | object |  |
-| `enabledFeatures` | array[object] |  |
-| `insightSettings` | object |  |
-| `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
-| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
-| `dynamicVariables` | object | Map of dynamic variables and their default values |
-| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
-| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
 | `integrations` | array[object] | Connected integrations attached to the assistant. |
-| `observabilitySettings` | object |  |
+| `observability_settings` | object |  |
 | `tags` | array[string] | Tags associated with the assistant. |
-| `versionName` | string | Human-readable name for the assistant version. |
-| `postConversationSettings` | object | Configuration for post-conversation processing. |
-| `conversationFlow` | object | Conversation flow as supplied by API clients (create / update). |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+| `conversation_flow` | object | Conversation flow as supplied by API clients (create / update). |
 
 ### Create MCP Server — `client.ai.mcpServers.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `apiKeyRef` | string |  |
-| `allowedTools` | array[string] |  |
+| `api_key_ref` | string |  |
+| `allowed_tools` | array[string] |  |
 
 ### Update MCP Server — `client.ai.mcpServers.update()`
 
@@ -643,9 +643,9 @@ dispat... |
 | `name` | string |  |
 | `type` | string |  |
 | `url` | string (URL) |  |
-| `apiKeyRef` | string |  |
-| `allowedTools` | array[string] |  |
-| `createdAt` | string (date-time) |  |
+| `api_key_ref` | string |  |
+| `allowed_tools` | array[string] |  |
+| `created_at` | string (date-time) |  |
 
 ### Create Tool — `client.ai.tools.create()`
 
@@ -656,17 +656,19 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
-| `timeoutMs` | integer |  |
+| `client_side_tool` | object |  |
+| `timeout_ms` | integer |  |
 
 ### Update Tool — `client.ai.tools.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `type` | string |  |
-| `displayName` | string |  |
+| `display_name` | string |  |
 | `function` | object |  |
 | `retrieval` | object |  |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
-| `timeoutMs` | integer |  |
+| `client_side_tool` | object |  |
+| `timeout_ms` | integer |  |

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/messaging.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/messaging.md
@@ -83,9 +83,9 @@ Primary outbound messaging flow. Agents need exact request fields and delivery-r
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
 | `from` | string (E.164) | Yes | Sending address (+E.164 formatted phone number, alphanumeric... |
 | `text` | string | Yes | Message body (i.e., content) as a non-empty string. |
-| `messagingProfileId` | string (UUID) | No | Unique identifier for a messaging profile. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Unique identifier for a messaging profile. |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
 | ... | | | +7 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -117,10 +117,10 @@ Common sender variant that requires different request shape.
 | `from` | string (E.164) | Yes | A valid alphanumeric sender ID on the user's account. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
 | `text` | string | Yes | The message body. |
-| `messagingProfileId` | string (UUID) | Yes | The messaging profile ID to use. |
-| `webhookUrl` | string (URL) | No | Callback URL for delivery status updates. |
-| `webhookFailoverUrl` | string (URL) | No | Failover callback URL for delivery status updates. |
-| `useProfileWebhooks` | boolean | No | If true, use the messaging profile's webhook settings. |
+| `messaging_profile_id` | string (UUID) | Yes | The messaging profile ID to use. |
+| `webhook_url` | string (URL) | No | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | No | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | No | If true, use the messaging profile's webhook settings. |
 
 ```javascript
 const response = await client.messages.sendWithAlphanumericSender({
@@ -152,7 +152,7 @@ and `telnyx-timestamp` headers. Always verify signatures in production:
 // In your webhook handler (e.g., Express — use raw body, not parsed JSON):
 app.post('/webhooks', express.raw({ type: 'application/json' }), async (req, res) => {
   try {
-    const event = await client.webhooks.unwrap(req.body.toString(), {
+    const event = client.webhooks.unwrap(req.body.toString(), {
       headers: req.headers,
     });
     // Signature valid — event is the parsed webhook payload
@@ -213,9 +213,9 @@ Send one MMS payload to multiple recipients.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | array[object] | Yes | A list of destinations. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +3 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -246,9 +246,9 @@ Force a long-code sending path instead of the generic send endpoint.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -276,11 +276,11 @@ Let a messaging profile or number pool choose the sender for you.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `messagingProfileId` | string (UUID) | Yes | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Yes | Unique identifier for a messaging profile. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -311,9 +311,9 @@ Force a short-code sending path when the sender must be a short code.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -342,9 +342,9 @@ Queue a message for future delivery instead of sending immediately.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `messagingProfileId` | string (UUID) | No | Unique identifier for a messaging profile. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Unique identifier for a messaging profile. |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
 | ... | | | +8 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -352,7 +352,7 @@ const response = await client.messages.schedule({
     to: '+18445550001',
     from: '+18005550101',
     text: 'Appointment reminder',
-    sendAt: '2025-07-01T15:00:00Z',
+    send_at: '2025-07-01T15:00:00Z',
 });
 
 console.log(response.data);
@@ -376,10 +376,10 @@ Send WhatsApp traffic instead of SMS/MMS.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number in +E.164 format associated with Whatsapp accou... |
 | `to` | string (E.164) | Yes | Phone number in +E.164 format |
-| `whatsappMessage` | object | Yes |  |
+| `whatsapp_message` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `messagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```javascript
 const response = await client.messages.sendWhatsapp({
@@ -411,10 +411,10 @@ Before using any operation below, read the Optional Parameters section below and
 | Retrieve a message | `client.messages.retrieve()` | `GET /messages/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Cancel a scheduled message | `client.messages.cancelScheduled()` | `DELETE /messages/{id}` | Remove, detach, or clean up an existing resource. | `id` |
 | List alphanumeric sender IDs | `client.alphanumericSenderIDs.list()` | `GET /alphanumeric_sender_ids` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Create an alphanumeric sender ID | `client.alphanumericSenderIDs.create()` | `POST /alphanumeric_sender_ids` | Create or provision an additional resource when the core tasks do not cover this flow. | `alphanumericSenderId`, `messagingProfileId` |
+| Create an alphanumeric sender ID | `client.alphanumericSenderIDs.create()` | `POST /alphanumeric_sender_ids` | Create or provision an additional resource when the core tasks do not cover this flow. | `alphanumeric_sender_id`, `messaging_profile_id` |
 | Retrieve an alphanumeric sender ID | `client.alphanumericSenderIDs.retrieve()` | `GET /alphanumeric_sender_ids/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Delete an alphanumeric sender ID | `client.alphanumericSenderIDs.delete()` | `DELETE /alphanumeric_sender_ids/{id}` | Remove, detach, or clean up an existing resource. | `id` |
-| Retrieve group MMS messages | `client.messages.retrieveGroupMessages()` | `GET /messages/group/{message_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `messageId` |
+| Retrieve group MMS messages | `client.messages.retrieveGroupMessages()` | `GET /messages/group/{message_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `message_id` |
 | List messaging hosted numbers | `client.messagingHostedNumbers.list()` | `GET /messaging_hosted_numbers` | Inspect available resources or choose an existing resource before mutating it. | None |
 | Retrieve a messaging hosted number | `client.messagingHostedNumbers.retrieve()` | `GET /messaging_hosted_numbers/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Update a messaging hosted number | `client.messagingHostedNumbers.update()` | `PATCH /messaging_hosted_numbers/{id}` | Modify an existing resource without recreating it. | `id` |
@@ -423,11 +423,11 @@ Before using any operation below, read the Optional Parameters section below and
 | Regenerate messaging profile secret | `client.messagingProfiles.actions.regenerateSecret()` | `POST /messaging_profiles/{id}/actions/regenerate_secret` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `id` |
 | List alphanumeric sender IDs for a messaging profile | `client.messagingProfiles.listAlphanumericSenderIDs()` | `GET /messaging_profiles/{id}/alphanumeric_sender_ids` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Get detailed messaging profile metrics | `client.messagingProfiles.retrieveMetrics()` | `GET /messaging_profiles/{id}/metrics` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
-| List Auto-Response Settings | `client.messagingProfiles.autorespConfigs.list()` | `GET /messaging_profiles/{profile_id}/autoresp_configs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profileId` |
-| Create auto-response setting | `client.messagingProfiles.autorespConfigs.create()` | `POST /messaging_profiles/{profile_id}/autoresp_configs` | Create or provision an additional resource when the core tasks do not cover this flow. | `op`, `keywords`, `countryCode`, `profileId` |
-| Get Auto-Response Setting | `client.messagingProfiles.autorespConfigs.retrieve()` | `GET /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profileId`, `autorespCfgId` |
-| Update Auto-Response Setting | `client.messagingProfiles.autorespConfigs.update()` | `PUT /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Modify an existing resource without recreating it. | `op`, `keywords`, `countryCode`, `profileId`, +1 more |
-| Delete Auto-Response Setting | `client.messagingProfiles.autorespConfigs.delete()` | `DELETE /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Remove, detach, or clean up an existing resource. | `profileId`, `autorespCfgId` |
+| List Auto-Response Settings | `client.messagingProfiles.autorespConfigs.list()` | `GET /messaging_profiles/{profile_id}/autoresp_configs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profile_id` |
+| Create auto-response setting | `client.messagingProfiles.autorespConfigs.create()` | `POST /messaging_profiles/{profile_id}/autoresp_configs` | Create or provision an additional resource when the core tasks do not cover this flow. | `op`, `keywords`, `country_code`, `profile_id` |
+| Get Auto-Response Setting | `client.messagingProfiles.autorespConfigs.retrieve()` | `GET /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profile_id`, `autoresp_cfg_id` |
+| Update Auto-Response Setting | `client.messagingProfiles.autorespConfigs.update()` | `PUT /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Modify an existing resource without recreating it. | `op`, `keywords`, `country_code`, `profile_id`, +1 more |
+| Delete Auto-Response Setting | `client.messagingProfiles.autorespConfigs.delete()` | `DELETE /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Remove, detach, or clean up an existing resource. | `profile_id`, `autoresp_cfg_id` |
 
 ### Other Webhook Events
 
@@ -448,32 +448,32 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `usLongCodeFallback` | string | A US long code number to use as fallback when sending to US destinations. |
+| `us_long_code_fallback` | string | A US long code number to use as fallback when sending to US destinations. |
 
 ### Send a message — `client.messages.send()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
-| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
-| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a message using an alphanumeric sender ID — `client.messages.sendWithAlphanumericSender()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `webhookUrl` | string (URL) | Callback URL for delivery status updates. |
-| `webhookFailoverUrl` | string (URL) | Failover callback URL for delivery status updates. |
-| `useProfileWebhooks` | boolean | If true, use the messaging profile's webhook settings. |
+| `webhook_url` | string (URL) | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | If true, use the messaging profile's webhook settings. |
 
 ### Send a group MMS message — `client.messages.sendGroupMms()`
 
@@ -481,10 +481,10 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 
 ### Send a long code message — `client.messages.sendLongCode()`
 
@@ -492,12 +492,12 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a message using number pool — `client.messages.sendNumberPool()`
@@ -506,12 +506,12 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Schedule a message — `client.messages.schedule()`
@@ -519,16 +519,16 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
-| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
-| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
 
 ### Send a short code message — `client.messages.sendShortCode()`
 
@@ -536,12 +536,12 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a WhatsApp message — `client.messages.sendWhatsapp()`
@@ -549,17 +549,17 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `messagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messagingHostedNumbers.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `messagingProfileId` | string (UUID) | Configure the messaging profile this phone number is assigned to:
+| `messaging_profile_id` | string (UUID) | Configure the messaging profile this phone number is assigned to:
 
 * Omit thi... |
-| `messagingProduct` | string | Configure the messaging product for this number:
+| `messaging_product` | string | Configure the messaging product for this number:
 
 * Omit this field or set it... |
 | `tags` | array[string] | Tags to set on this phone number. |
@@ -568,10 +568,10 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `respText` | string |  |
+| `resp_text` | string |  |
 
 ### Update Auto-Response Setting — `client.messagingProfiles.autorespConfigs.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `respText` | string |  |
+| `resp_text` | string |  |

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/numbers.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/numbers.md
@@ -97,15 +97,15 @@ Number ordering is the production provisioning step after number selection.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `phoneNumbers` | array[object] | Yes |  |
-| `connectionId` | string (UUID) | No | Identifies the connection associated with this phone number. |
-| `messagingProfileId` | string (UUID) | No | Identifies the messaging profile associated with the phone n... |
-| `billingGroupId` | string (UUID) | No | Identifies the billing group associated with the phone numbe... |
+| `phone_numbers` | array[object] | Yes |  |
+| `connection_id` | string (UUID) | No | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | No | Identifies the messaging profile associated with the phone n... |
+| `billing_group_id` | string (UUID) | No | Identifies the billing group associated with the phone numbe... |
 | ... | | | +1 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
 const numberOrder = await client.numberOrders.create({
-    phoneNumbers: [{"phone_number": "+18005550101"}],
+    phone_numbers: [{"phone_number": "+18005550101"}],
 });
 
 console.log(numberOrder.data);
@@ -127,7 +127,7 @@ Order status determines whether provisioning completed or additional requirement
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `numberOrderId` | string (UUID) | Yes | The number order ID. |
+| `number_order_id` | string (UUID) | Yes | The number order ID. |
 
 ```javascript
 const numberOrder = await client.numberOrders.retrieve('550e8400-e29b-41d4-a716-446655440000');
@@ -157,15 +157,15 @@ Create or provision an additional resource when the core tasks do not cover this
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `phoneNumbers` | array[object] | Yes |  |
+| `phone_numbers` | array[object] | Yes |  |
 | `status` | enum (pending, success, failure) | No | The status of the entire reservation. |
 | `id` | string (UUID) | No |  |
-| `recordType` | string | No |  |
+| `record_type` | string | No |  |
 | ... | | | +3 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
 const numberReservation = await client.numberReservations.create({
-    phoneNumbers: [{"phone_number": "+18005550101"}],
+    phone_numbers: [{"phone_number": "+18005550101"}],
 });
 
 console.log(numberReservation.data);
@@ -187,7 +187,7 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `numberReservationId` | string (UUID) | Yes | The number reservation ID. |
+| `number_reservation_id` | string (UUID) | Yes | The number reservation ID. |
 
 ```javascript
 const numberReservation = await client.numberReservations.retrieve('550e8400-e29b-41d4-a716-446655440000');
@@ -234,9 +234,9 @@ Create or provision an additional resource when the core tasks do not cover this
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) | No |  |
-| `requirementGroupId` | string (UUID) | No | The ID of the requirement group to associate with this advan... |
-| `countryCode` | string (ISO 3166-1 alpha-2) | No |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) | No |  |
+| `requirement_group_id` | string (UUID) | No | The ID of the requirement group to associate with this advan... |
+| `country_code` | string (ISO 3166-1 alpha-2) | No |  |
 | ... | | | +5 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -262,9 +262,9 @@ Modify an existing resource without recreating it.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `advanced-order-id` | string (UUID) | Yes | Unique identifier of the advanced order. |
-| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) | No |  |
-| `requirementGroupId` | string (UUID) | No | The ID of the requirement group to associate with this advan... |
-| `countryCode` | string (ISO 3166-1 alpha-2) | No |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) | No |  |
+| `requirement_group_id` | string (UUID) | No | The ID of the requirement group to associate with this advan... |
+| `country_code` | string (ISO 3166-1 alpha-2) | No |  |
 | ... | | | +5 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -291,7 +291,7 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `orderId` | string (UUID) | Yes | Unique identifier of the order. |
+| `order_id` | string (UUID) | Yes | Unique identifier of the order. |
 
 ```javascript
 const advancedOrder = await client.advancedOrders.retrieve('182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e');
@@ -376,38 +376,38 @@ Before using any operation below, read the Optional Parameters section below and
 | Retrieve a comment | `client.comments.retrieve()` | `GET /comments/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Mark a comment as read | `client.comments.markAsRead()` | `PATCH /comments/{id}/read` | Modify an existing resource without recreating it. | `id` |
 | Get country coverage | `client.countryCoverage.retrieve()` | `GET /country_coverage` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Get coverage for a specific country | `client.countryCoverage.retrieveCountry()` | `GET /country_coverage/countries/{country_code}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `countryCode` |
+| Get coverage for a specific country | `client.countryCoverage.retrieveCountry()` | `GET /country_coverage/countries/{country_code}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `country_code` |
 | List customer service records | `client.customerServiceRecords.list()` | `GET /customer_service_records` | Inspect available resources or choose an existing resource before mutating it. | None |
 | Create a customer service record | `client.customerServiceRecords.create()` | `POST /customer_service_records` | Create or provision an additional resource when the core tasks do not cover this flow. | None |
 | Verify CSR phone number coverage | `client.customerServiceRecords.verifyPhoneNumberCoverage()` | `POST /customer_service_records/phone_number_coverages` | Create or provision an additional resource when the core tasks do not cover this flow. | None |
-| Get a customer service record | `client.customerServiceRecords.retrieve()` | `GET /customer_service_records/{customer_service_record_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `customerServiceRecordId` |
+| Get a customer service record | `client.customerServiceRecords.retrieve()` | `GET /customer_service_records/{customer_service_record_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `customer_service_record_id` |
 | List inexplicit number orders | `client.inexplicitNumberOrders.list()` | `GET /inexplicit_number_orders` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Create an inexplicit number order | `client.inexplicitNumberOrders.create()` | `POST /inexplicit_number_orders` | Create or provision an additional resource when the core tasks do not cover this flow. | `orderingGroups` |
+| Create an inexplicit number order | `client.inexplicitNumberOrders.create()` | `POST /inexplicit_number_orders` | Create or provision an additional resource when the core tasks do not cover this flow. | `ordering_groups` |
 | Retrieve an inexplicit number order | `client.inexplicitNumberOrders.retrieve()` | `GET /inexplicit_number_orders/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Create an inventory coverage request | `client.inventoryCoverage.list()` | `GET /inventory_coverage` | Inspect available resources or choose an existing resource before mutating it. | None |
 | List mobile network operators | `client.mobileNetworkOperators.list()` | `GET /mobile_network_operators` | Inspect available resources or choose an existing resource before mutating it. | None |
 | List network coverage locations | `client.networkCoverage.list()` | `GET /network_coverage` | Inspect available resources or choose an existing resource before mutating it. | None |
 | List number block orders | `client.numberBlockOrders.list()` | `GET /number_block_orders` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Create a number block order | `client.numberBlockOrders.create()` | `POST /number_block_orders` | Create or provision an additional resource when the core tasks do not cover this flow. | `startingNumber`, `range` |
-| Retrieve a number block order | `client.numberBlockOrders.retrieve()` | `GET /number_block_orders/{number_block_order_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `numberBlockOrderId` |
+| Create a number block order | `client.numberBlockOrders.create()` | `POST /number_block_orders` | Create or provision an additional resource when the core tasks do not cover this flow. | `starting_number`, `range` |
+| Retrieve a number block order | `client.numberBlockOrders.retrieve()` | `GET /number_block_orders/{number_block_order_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `number_block_order_id` |
 | Retrieve a list of phone numbers associated to orders | `client.numberOrderPhoneNumbers.list()` | `GET /number_order_phone_numbers` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Retrieve a single phone number within a number order. | `client.numberOrderPhoneNumbers.retrieve()` | `GET /number_order_phone_numbers/{number_order_phone_number_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `numberOrderPhoneNumberId` |
-| Update requirements for a single phone number within a number order. | `client.numberOrderPhoneNumbers.updateRequirements()` | `PATCH /number_order_phone_numbers/{number_order_phone_number_id}` | Modify an existing resource without recreating it. | `numberOrderPhoneNumberId` |
+| Retrieve a single phone number within a number order. | `client.numberOrderPhoneNumbers.retrieve()` | `GET /number_order_phone_numbers/{number_order_phone_number_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `number_order_phone_number_id` |
+| Update requirements for a single phone number within a number order. | `client.numberOrderPhoneNumbers.updateRequirements()` | `PATCH /number_order_phone_numbers/{number_order_phone_number_id}` | Modify an existing resource without recreating it. | `number_order_phone_number_id` |
 | List number orders | `client.numberOrders.list()` | `GET /number_orders` | Create or inspect provisioning orders for number purchases. | None |
-| Update a number order | `client.numberOrders.update()` | `PATCH /number_orders/{number_order_id}` | Modify an existing resource without recreating it. | `numberOrderId` |
+| Update a number order | `client.numberOrders.update()` | `PATCH /number_orders/{number_order_id}` | Modify an existing resource without recreating it. | `number_order_id` |
 | List number reservations | `client.numberReservations.list()` | `GET /number_reservations` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Extend a number reservation | `client.numberReservations.actions.extend()` | `POST /number_reservations/{number_reservation_id}/actions/extend` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `numberReservationId` |
-| Retrieve the features for a list of numbers | `client.numbersFeatures.create()` | `POST /numbers_features` | Create or provision an additional resource when the core tasks do not cover this flow. | `phoneNumbers` |
+| Extend a number reservation | `client.numberReservations.actions.extend()` | `POST /number_reservations/{number_reservation_id}/actions/extend` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `number_reservation_id` |
+| Retrieve the features for a list of numbers | `client.numbersFeatures.create()` | `POST /numbers_features` | Create or provision an additional resource when the core tasks do not cover this flow. | `phone_numbers` |
 | Lists the phone number blocks jobs | `client.phoneNumberBlocks.jobs.list()` | `GET /phone_number_blocks/jobs` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Deletes all numbers associated with a phone number block | `client.phoneNumberBlocks.jobs.deletePhoneNumberBlock()` | `POST /phone_number_blocks/jobs/delete_phone_number_block` | Create or provision an additional resource when the core tasks do not cover this flow. | `phoneNumberBlockId` |
+| Deletes all numbers associated with a phone number block | `client.phoneNumberBlocks.jobs.deletePhoneNumberBlock()` | `POST /phone_number_blocks/jobs/delete_phone_number_block` | Create or provision an additional resource when the core tasks do not cover this flow. | `phone_number_block_id` |
 | Retrieves a phone number blocks job | `client.phoneNumberBlocks.jobs.retrieve()` | `GET /phone_number_blocks/jobs/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | List sub number orders | `client.subNumberOrders.list()` | `GET /sub_number_orders` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Retrieve a sub number order | `client.subNumberOrders.retrieve()` | `GET /sub_number_orders/{sub_number_order_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `subNumberOrderId` |
-| Update a sub number order's requirements | `client.subNumberOrders.update()` | `PATCH /sub_number_orders/{sub_number_order_id}` | Modify an existing resource without recreating it. | `subNumberOrderId` |
-| Cancel a sub number order | `client.subNumberOrders.cancel()` | `PATCH /sub_number_orders/{sub_number_order_id}/cancel` | Modify an existing resource without recreating it. | `subNumberOrderId` |
+| Retrieve a sub number order | `client.subNumberOrders.retrieve()` | `GET /sub_number_orders/{sub_number_order_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `sub_number_order_id` |
+| Update a sub number order's requirements | `client.subNumberOrders.update()` | `PATCH /sub_number_orders/{sub_number_order_id}` | Modify an existing resource without recreating it. | `sub_number_order_id` |
+| Cancel a sub number order | `client.subNumberOrders.cancel()` | `PATCH /sub_number_orders/{sub_number_order_id}/cancel` | Modify an existing resource without recreating it. | `sub_number_order_id` |
 | Create a sub number orders report | `client.subNumberOrdersReport.create()` | `POST /sub_number_orders_report` | Create or provision an additional resource when the core tasks do not cover this flow. | None |
-| Retrieve a sub number orders report | `client.subNumberOrdersReport.retrieve()` | `GET /sub_number_orders_report/{report_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `reportId` |
-| Download a sub number orders report | `client.subNumberOrdersReport.download()` | `GET /sub_number_orders_report/{report_id}/download` | Fetch the current state before updating, deleting, or making control-flow decisions. | `reportId` |
+| Retrieve a sub number orders report | `client.subNumberOrdersReport.retrieve()` | `GET /sub_number_orders_report/{report_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `report_id` |
+| Download a sub number orders report | `client.subNumberOrdersReport.download()` | `GET /sub_number_orders_report/{report_id}/download` | Fetch the current state before updating, deleting, or making control-flow decisions. | `report_id` |
 
 ### Other Webhook Events
 
@@ -428,27 +428,27 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `countryCode` | string (ISO 3166-1 alpha-2) |  |
+| `country_code` | string (ISO 3166-1 alpha-2) |  |
 | `comments` | string |  |
 | `quantity` | integer |  |
-| `areaCode` | string |  |
-| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `area_code` | string |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
 | `features` | array[object] |  |
-| `customerReference` | string |  |
-| `requirementGroupId` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+| `customer_reference` | string |  |
+| `requirement_group_id` | string (UUID) | The ID of the requirement group to associate with this advanced order |
 
 ### Update Advanced Order — `client.advancedOrders.updateRequirementGroup()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `countryCode` | string (ISO 3166-1 alpha-2) |  |
+| `country_code` | string (ISO 3166-1 alpha-2) |  |
 | `comments` | string |  |
 | `quantity` | integer |  |
-| `areaCode` | string |  |
-| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `area_code` | string |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
 | `features` | array[object] |  |
-| `customerReference` | string |  |
-| `requirementGroupId` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+| `customer_reference` | string |  |
+| `requirement_group_id` | string (UUID) | The ID of the requirement group to associate with this advanced order |
 
 ### Create a comment — `client.comments.create()`
 
@@ -457,86 +457,86 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 | `id` | string (UUID) |  |
 | `body` | string |  |
 | `commenter` | string |  |
-| `commenterType` | enum (admin, user) |  |
-| `commentRecordType` | enum (sub_number_order, requirement_group) |  |
-| `commentRecordId` | string (UUID) |  |
-| `readAt` | string (date-time) | An ISO 8901 datetime string for when the comment was read. |
-| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the comment was created. |
-| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the comment was updated. |
+| `commenter_type` | enum (admin, user) |  |
+| `comment_record_type` | enum (sub_number_order, requirement_group) |  |
+| `comment_record_id` | string (UUID) |  |
+| `read_at` | string (date-time) | An ISO 8901 datetime string for when the comment was read. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the comment was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the comment was updated. |
 
 ### Create an inexplicit number order — `client.inexplicitNumberOrders.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `connectionId` | string (UUID) | Connection id to apply to phone numbers that are purchased |
-| `messagingProfileId` | string (UUID) | Messaging profile id to apply to phone numbers that are purchased |
-| `customerReference` | string | Reference label for the customer |
-| `billingGroupId` | string (UUID) | Billing group id to apply to phone numbers that are purchased |
+| `connection_id` | string (UUID) | Connection id to apply to phone numbers that are purchased |
+| `messaging_profile_id` | string (UUID) | Messaging profile id to apply to phone numbers that are purchased |
+| `customer_reference` | string | Reference label for the customer |
+| `billing_group_id` | string (UUID) | Billing group id to apply to phone numbers that are purchased |
 
 ### Create a number block order — `client.numberBlockOrders.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `id` | string (UUID) |  |
-| `recordType` | string |  |
-| `phoneNumbersCount` | integer | The count of phone numbers in the number order. |
-| `connectionId` | string (UUID) | Identifies the connection associated with this phone number. |
-| `messagingProfileId` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `record_type` | string |  |
+| `phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `connection_id` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | Identifies the messaging profile associated with the phone number. |
 | `status` | enum (pending, success, failure) | The status of the order. |
-| `customerReference` | string | A customer reference string for customer look ups. |
-| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the number order was created. |
-| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the number order was updated. |
-| `requirementsMet` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the number order was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the number order was updated. |
+| `requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
 | `errors` | string | Errors the reservation could happen upon |
 
 ### Update requirements for a single phone number within a number order. — `client.numberOrderPhoneNumbers.updateRequirements()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `regulatoryRequirements` | array[object] |  |
+| `regulatory_requirements` | array[object] |  |
 
 ### Create a number order — `client.numberOrders.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `phoneNumbers` | array[object] |  |
-| `connectionId` | string (UUID) | Identifies the connection associated with this phone number. |
-| `messagingProfileId` | string (UUID) | Identifies the messaging profile associated with the phone number. |
-| `billingGroupId` | string (UUID) | Identifies the billing group associated with the phone number. |
-| `customerReference` | string | A customer reference string for customer look ups. |
+| `phone_numbers` | array[object] |  |
+| `connection_id` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `billing_group_id` | string (UUID) | Identifies the billing group associated with the phone number. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
 
 ### Update a number order — `client.numberOrders.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `regulatoryRequirements` | array[object] |  |
-| `customerReference` | string | A customer reference string for customer look ups. |
+| `regulatory_requirements` | array[object] |  |
+| `customer_reference` | string | A customer reference string for customer look ups. |
 
 ### Create a number reservation — `client.numberReservations.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `id` | string (UUID) |  |
-| `recordType` | string |  |
-| `phoneNumbers` | array[object] |  |
+| `record_type` | string |  |
+| `phone_numbers` | array[object] |  |
 | `status` | enum (pending, success, failure) | The status of the entire reservation. |
-| `customerReference` | string | A customer reference string for customer look ups. |
-| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the numbers reservation was created. |
-| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the number reservation was updated. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the numbers reservation was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the number reservation was updated. |
 
 ### Update a sub number order's requirements — `client.subNumberOrders.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `regulatoryRequirements` | array[object] |  |
+| `regulatory_requirements` | array[object] |  |
 
 ### Create a sub number orders report — `client.subNumberOrdersReport.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `status` | enum (pending, success, failure) | Filter by order status |
-| `countryCode` | string (ISO 3166-1 alpha-2) | Filter by country code |
-| `createdAtGt` | string (date-time) | Filter for orders created after this date |
-| `createdAtLt` | string (date-time) | Filter for orders created before this date |
-| `orderRequestId` | string (UUID) | Filter by specific order request ID |
-| `customerReference` | string | Filter by customer reference |
+| `country_code` | string (ISO 3166-1 alpha-2) | Filter by country code |
+| `created_at_gt` | string (date-time) | Filter for orders created after this date |
+| `created_at_lt` | string (date-time) | Filter for orders created before this date |
+| `order_request_id` | string (UUID) | Filter by specific order request ID |
+| `customer_reference` | string | Filter by customer reference |

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/voice.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/javascript/voice.md
@@ -82,10 +82,10 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 |-----------|------|----------|-------------|
 | `to` | string (E.164) | Yes | The DID or SIP URI to dial out to. |
 | `from` | string (E.164) | Yes | The `from` number to be used as the caller id presented to t... |
-| `connectionId` | string (UUID) | Yes | The ID of the Call Control App (formerly ID of the connectio... |
-| `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
-| `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
+| `connection_id` | string (UUID) | Yes | The ID of the Call Control App (formerly ID of the connectio... |
+| `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
+| `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | ... | | | +56 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -114,10 +114,10 @@ Primary inbound call-control command.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
-| `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
+| `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
 | ... | | | +29 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -139,10 +139,10 @@ Common post-answer control path with downstream webhook implications.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `to` | string (E.164) | Yes | The DID or SIP URI to dial out to. |
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
-| `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
+| `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
 | ... | | | +35 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -167,7 +167,7 @@ and `telnyx-timestamp` headers. Always verify signatures in production:
 // In your webhook handler (e.g., Express — use raw body, not parsed JSON):
 app.post('/webhooks', express.raw({ type: 'application/json' }), async (req, res) => {
   try {
-    const event = await client.webhooks.unwrap(req.body.toString(), {
+    const event = client.webhooks.unwrap(req.body.toString(), {
       headers: req.headers,
     });
     // Signature valid — event is the parsed webhook payload
@@ -239,10 +239,10 @@ End a live call from your webhook-driven control flow.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | No | Use this field to avoid duplicate commands. |
-| `customHeaders` | array[object] | No | Custom headers to be added to the SIP BYE message. |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | No | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | No | Custom headers to be added to the SIP BYE message. |
 
 ```javascript
 const response = await client.calls.actions.hangup('v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ');
@@ -261,11 +261,11 @@ Trigger a follow-up action in an existing workflow rather than creating a new to
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `callControlId` | string (UUID) | Yes | The Call Control ID of the call you want to bridge with, can... |
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | No | Use this field to avoid duplicate commands. |
-| `videoRoomId` | string (UUID) | No | The ID of the video room you want to bridge with, can't be u... |
+| `call_control_id` | string (UUID) | Yes | The Call Control ID of the call you want to bridge with, can... |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | No | Use this field to avoid duplicate commands. |
+| `video_room_id` | string (UUID) | No | The ID of the video room you want to bridge with, can't be u... |
 | ... | | | +16 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -288,9 +288,9 @@ Trigger a follow-up action in an existing workflow rather than creating a new to
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `cause` | enum (CALL_REJECTED, USER_BUSY) | Yes | Cause for call rejection. |
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | No | Use this field to avoid duplicate commands. |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | No | Use this field to avoid duplicate commands. |
 
 ```javascript
 const response = await client.calls.actions.reject('call_control_id', { cause: 'USER_BUSY' });
@@ -309,7 +309,7 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
 
 ```javascript
 const response = await client.calls.retrieveStatus('v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ');
@@ -333,7 +333,7 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `connectionId` | string (UUID) | Yes | Telnyx connection id |
+| `connection_id` | string (UUID) | Yes | Telnyx connection id |
 | `page` | object | No | Consolidated page parameter (deepObject style). |
 
 ```javascript
@@ -397,12 +397,12 @@ Before using any operation below, read the Optional Parameters section below and
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
-| Create a call control application | `client.callControlApplications.create()` | `POST /call_control_applications` | Create or provision an additional resource when the core tasks do not cover this flow. | `applicationName`, `webhookEventUrl` |
+| Create a call control application | `client.callControlApplications.create()` | `POST /call_control_applications` | Create or provision an additional resource when the core tasks do not cover this flow. | `application_name`, `webhook_event_url` |
 | Retrieve a call control application | `client.callControlApplications.retrieve()` | `GET /call_control_applications/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
-| Update a call control application | `client.callControlApplications.update()` | `PATCH /call_control_applications/{id}` | Modify an existing resource without recreating it. | `applicationName`, `webhookEventUrl`, `id` |
+| Update a call control application | `client.callControlApplications.update()` | `PATCH /call_control_applications/{id}` | Modify an existing resource without recreating it. | `application_name`, `webhook_event_url`, `id` |
 | Delete a call control application | `client.callControlApplications.delete()` | `DELETE /call_control_applications/{id}` | Remove, detach, or clean up an existing resource. | `id` |
-| SIP Refer a call | `client.calls.actions.refer()` | `POST /calls/{call_control_id}/actions/refer` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `sipAddress`, `callControlId` |
-| Send SIP info | `client.calls.actions.sendSipInfo()` | `POST /calls/{call_control_id}/actions/send_sip_info` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `contentType`, `body`, `callControlId` |
+| SIP Refer a call | `client.calls.actions.refer()` | `POST /calls/{call_control_id}/actions/refer` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `sip_address`, `call_control_id` |
+| Send SIP info | `client.calls.actions.sendSipInfo()` | `POST /calls/{call_control_id}/actions/send_sip_info` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `content_type`, `body`, `call_control_id` |
 
 ### Other Webhook Events
 
@@ -424,233 +424,233 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `active` | boolean | Specifies whether the connection can be used. |
-| `anchorsiteOverride` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
-| `dtmfType` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
-| `firstCommandTimeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
-| `firstCommandTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `anchorsite_override` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmf_type` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `first_command_timeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `first_command_timeout_secs` | integer | Specifies how many seconds to wait before timing out a dial command. |
 | `inbound` | object |  |
 | `outbound` | object |  |
-| `webhookApiVersion` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
-| `webhookEventFailoverUrl` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
-| `webhookTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a webhook. |
-| `callCostInWebhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
-| `redactDtmfDebugLogging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+| `webhook_api_version` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhook_event_failover_url` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhook_timeout_secs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `call_cost_in_webhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `redact_dtmf_debug_logging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
 
 ### Update a call control application — `client.callControlApplications.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `callCostInWebhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `call_cost_in_webhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
 | `active` | boolean | Specifies whether the connection can be used. |
-| `anchorsiteOverride` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
-| `dtmfType` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
-| `firstCommandTimeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
-| `firstCommandTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `anchorsite_override` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmf_type` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `first_command_timeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `first_command_timeout_secs` | integer | Specifies how many seconds to wait before timing out a dial command. |
 | `tags` | array[string] | Tags assigned to the Call Control Application. |
 | `inbound` | object |  |
 | `outbound` | object |  |
-| `webhookApiVersion` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
-| `webhookEventFailoverUrl` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
-| `webhookTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a webhook. |
-| `redactDtmfDebugLogging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+| `webhook_api_version` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhook_event_failover_url` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhook_timeout_secs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `redact_dtmf_debug_logging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
 
 ### Dial — `client.calls.dial()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `assistant` | object | AI Assistant configuration. |
-| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
-| `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
 | `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
-| `audioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
-| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
-| `mediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
-| `preferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
-| `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
-| `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
-| `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
-| `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
-| `deepfakeDetection` | object | Enables deepfake detection on the call. |
-| `conferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
-| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
-| `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
-| `linkTo` | string | Use another call's control id for sharing the same call session id |
-| `bridgeIntent` | boolean | Indicates the intent to bridge this call with the call specified in link_to. |
-| `bridgeOnAnswer` | boolean | Whether to automatically bridge answered call to the call specified in link_to. |
-| `preventDoubleBridge` | boolean | Prevents bridging and hangs up the call if the target is already bridged. |
-| `parkAfterUnbridge` | string | If supplied with the value `self`, the current leg will be parked after unbri... |
-| `mediaEncryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the call. |
-| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
-| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
-| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE request. |
-| `sipTransportProtocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
-| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
-| `streamUrl` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
-| `streamTrack` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
-| `streamCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
-| `streamBidirectionalMode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
-| `streamBidirectionalCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
-| `streamBidirectionalTargetLegs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
-| `streamBidirectionalSamplingRate` | enum (8000, 16000, 22050, 24000, 48000) | Audio sampling rate. |
-| `streamEstablishBeforeCallOriginate` | boolean | Establish websocket connection before dialing the destination. |
-| `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
-| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
-| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
-| `webhookUrls` | object | A map of event types to webhook URLs. |
-| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
-| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
+| `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
+| `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
+| `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `link_to` | string | Use another call's control id for sharing the same call session id |
+| `bridge_intent` | boolean | Indicates the intent to bridge this call with the call specified in link_to. |
+| `bridge_on_answer` | boolean | Whether to automatically bridge answered call to the call specified in link_to. |
+| `prevent_double_bridge` | boolean | Prevents bridging and hangs up the call if the target is already bridged. |
+| `park_after_unbridge` | string | If supplied with the value `self`, the current leg will be parked after unbri... |
+| `media_encryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the call. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE request. |
+| `sip_transport_protocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `stream_url` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `stream_track` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `stream_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `stream_bidirectional_mode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `stream_bidirectional_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `stream_bidirectional_target_legs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `stream_bidirectional_sampling_rate` | enum (8000, 16000, 22050, 24000, 48000) | Audio sampling rate. |
+| `stream_establish_before_call_originate` | boolean | Establish websocket connection before dialing the destination. |
+| `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
-| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
-| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
-| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
-| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
-| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
-| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
-| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
-| `superviseCallControlId` | string (UUID) | The call leg which will be supervised by the new call. |
-| `supervisorRole` | enum (barge, whisper, monitor) | The role of the supervisor call. |
-| `enableDialogflow` | boolean | Enables Dialogflow for the current call. |
-| `dialogflowConfig` | object |  |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `supervise_call_control_id` | string (UUID) | The call leg which will be supervised by the new call. |
+| `supervisor_role` | enum (barge, whisper, monitor) | The role of the supervisor call. |
+| `enable_dialogflow` | boolean | Enables Dialogflow for the current call. |
+| `dialogflow_config` | object |  |
 | `transcription` | boolean | Enable transcription upon call answer. |
-| `transcriptionConfig` | object |  |
-| `sipRegion` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
-| `streamAuthToken` | string | An authentication token to be sent as part of the WebSocket connection when u... |
+| `transcription_config` | object |  |
+| `sip_region` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `stream_auth_token` | string | An authentication token to be sent as part of the WebSocket connection when u... |
 
 ### Answer call — `client.calls.actions.answer()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `assistant` | object | AI Assistant configuration. |
-| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
-| `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
-| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE response. |
-| `preferredCodecs` | enum (G722,PCMU,PCMA,G729,OPUS,VP8,H264) | The list of comma-separated codecs in a preferred order for the forked media ... |
-| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE response. |
-| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
-| `streamUrl` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
-| `streamTrack` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
-| `streamCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
-| `streamBidirectionalMode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
-| `streamBidirectionalCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
-| `streamBidirectionalTargetLegs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
-| `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
-| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
-| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE response. |
+| `preferred_codecs` | enum (G722,PCMU,PCMA,G729,OPUS,VP8,H264) | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE response. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `stream_url` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `stream_track` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `stream_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `stream_bidirectional_mode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `stream_bidirectional_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `stream_bidirectional_target_legs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
 | `transcription` | boolean | Enable transcription upon call answer. |
-| `transcriptionConfig` | object |  |
+| `transcription_config` | object |  |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
-| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
-| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
-| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
-| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
-| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
-| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
-| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
-| `webhookUrls` | object | A map of event types to webhook URLs. |
-| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
-| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
-| `deepfakeDetection` | object | Enables deepfake detection on the call. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.calls.actions.bridge()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
 | `queue` | string | The name of the queue you want to bridge with, can't be used together with ca... |
-| `videoRoomId` | string (UUID) | The ID of the video room you want to bridge with, can't be used together with... |
-| `videoRoomContext` | string | The additional parameter that will be passed to the video conference. |
-| `preventDoubleBridge` | boolean | When set to `true`, it prevents bridging if the target call is already bridge... |
-| `parkAfterUnbridge` | string | Specifies behavior after the bridge ends (i.e. |
-| `playRingtone` | boolean | Specifies whether to play a ringtone if the call you want to bridge with has ... |
+| `video_room_id` | string (UUID) | The ID of the video room you want to bridge with, can't be used together with... |
+| `video_room_context` | string | The additional parameter that will be passed to the video conference. |
+| `prevent_double_bridge` | boolean | When set to `true`, it prevents bridging if the target call is already bridge... |
+| `park_after_unbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `play_ringtone` | boolean | Specifies whether to play a ringtone if the call you want to bridge with has ... |
 | `ringtone` | enum (at, au, be, bg, br, ...) | Specifies which country ringtone to play when `play_ringtone` is set to `true`. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
-| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
-| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
-| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
-| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
-| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
-| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
-| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
-| `muteDtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
-| `holdAfterUnbridge` | boolean | Specifies behavior after the bridge ends. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `mute_dtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `hold_after_unbridge` | boolean | Specifies behavior after the bridge ends. |
 
 ### Hangup call — `client.calls.actions.hangup()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
-| `customHeaders` | array[object] | Custom headers to be added to the SIP BYE message. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP BYE message. |
 
 ### SIP Refer a call — `client.calls.actions.refer()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid execution of duplicate commands. |
-| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
-| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
-| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
-| `sipHeaders` | array[object] | SIP headers to be added to the request. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid execution of duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the request. |
 
 ### Reject a call — `client.calls.actions.reject()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
 
 ### Send SIP info — `client.calls.actions.sendSipInfo()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
 
 ### Transfer call — `client.calls.actions.transfer()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
-| `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
 | `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
-| `audioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
-| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
-| `earlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
-| `mediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
-| `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
-| `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
-| `parkAfterUnbridge` | string | Specifies behavior after the bridge ends (i.e. |
-| `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
-| `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
-| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `targetLegClientState` | string | Use this field to add state to every subsequent webhook for the new leg. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
-| `mediaEncryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the new call leg. |
-| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
-| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
-| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE. |
-| `sipTransportProtocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
-| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
-| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
-| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
-| `muteDtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
+| `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
+| `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
+| `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `park_after_unbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `target_leg_client_state` | string | Use this field to add state to every subsequent webhook for the new leg. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `media_encryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the new call leg. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE. |
+| `sip_transport_protocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `mute_dtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
-| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
-| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
-| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
-| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
-| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
-| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
-| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
-| `sipRegion` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
-| `preferredCodecs` | string | The list of comma-separated codecs in order of preference to be used during t... |
-| `webhookUrls` | object | A map of event types to webhook URLs. |
-| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
-| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `sip_region` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `preferred_codecs` | string | The list of comma-separated codecs in order of preference to be used during t... |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/python/10dlc.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/python/10dlc.md
@@ -130,7 +130,7 @@ telnyx_campaign_csp = client.messaging_10dlc.campaign_builder.submit(
     brand_id="BXXXXXX",
     description="Two-factor authentication messages",
     usecase="2FA",
-    sample_messages=["Your verification code is {{code}}"],
+    sample1="Your verification code is {{code}}",
 )
 print(telnyx_campaign_csp.brand_id)
 ```

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/python/ai-assistants.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/python/ai-assistants.md
@@ -654,6 +654,7 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |
 
 ### Update Tool — `client.ai.tools.update()`
@@ -667,4 +668,5 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/ruby/10dlc.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/ruby/10dlc.md
@@ -118,8 +118,8 @@ Campaign submission is the compliance-critical step that determines whether traf
 telnyx_campaign_csp = client.messaging_10dlc.campaign_builder.submit(
   brand_id: "BXXXXXX",
   description: "Two-factor authentication messages",
-  usecase: "2FA"
-    sample_messages: ["Your verification code is {{code}}"],
+  usecase: "2FA",
+    sample1: "Your verification code is {{code}}",
 )
 
 puts(telnyx_campaign_csp)
@@ -147,7 +147,7 @@ Messaging profile assignment is the practical handoff from registration to send-
 
 ```ruby
 response = client.messaging_10dlc.phone_number_assignment_by_profile.assign(
-  messaging_profile_id: "4001767e-ce0f-4cae-9d5f-0d5e636e7809"
+  messaging_profile_id: "4001767e-ce0f-4cae-9d5f-0d5e636e7809",
     campaign_id: "CXXX001",
 )
 

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/ruby/ai-assistants.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/ruby/ai-assistants.md
@@ -629,6 +629,7 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |
 
 ### Update Tool — `client.ai.tools.update()`
@@ -642,4 +643,5 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/ruby/messaging.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/ruby/messaging.md
@@ -257,7 +257,7 @@ Let a messaging profile or number pool choose the sender for you.
 ```ruby
 response = client.messages.send_number_pool(
   messaging_profile_id: "abc85f64-5717-4562-b3fc-2c9600000000",
-  to: "+13125550002"
+  to: "+13125550002",
     text: "Hello from Telnyx!",
 )
 

--- a/providers/cursor/plugin/skills/telnyx-voice-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.58.0</version>
+    <version>6.81.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.58.0")
+implementation("com.telnyx.sdk:telnyx:6.81.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-voice-javascript/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-javascript/SKILL.md
@@ -95,10 +95,10 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 |-----------|------|----------|-------------|
 | `to` | string (E.164) | Yes | The DID or SIP URI to dial out to. |
 | `from` | string (E.164) | Yes | The `from` number to be used as the caller id presented to t... |
-| `connectionId` | string (UUID) | Yes | The ID of the Call Control App (formerly ID of the connectio... |
-| `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
-| `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
+| `connection_id` | string (UUID) | Yes | The ID of the Call Control App (formerly ID of the connectio... |
+| `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
+| `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | ... | | | +56 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -127,10 +127,10 @@ Primary inbound call-control command.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
-| `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
+| `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
 | ... | | | +29 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -152,10 +152,10 @@ Common post-answer control path with downstream webhook implications.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `to` | string (E.164) | Yes | The DID or SIP URI to dial out to. |
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
-| `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
+| `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
 | ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -180,7 +180,7 @@ and `telnyx-timestamp` headers. Always verify signatures in production:
 // In your webhook handler (e.g., Express — use raw body, not parsed JSON):
 app.post('/webhooks', express.raw({ type: 'application/json' }), async (req, res) => {
   try {
-    const event = await client.webhooks.unwrap(req.body.toString(), {
+    const event = client.webhooks.unwrap(req.body.toString(), {
       headers: req.headers,
     });
     // Signature valid — event is the parsed webhook payload
@@ -252,10 +252,10 @@ End a live call from your webhook-driven control flow.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | No | Use this field to avoid duplicate commands. |
-| `customHeaders` | array[object] | No | Custom headers to be added to the SIP BYE message. |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | No | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | No | Custom headers to be added to the SIP BYE message. |
 
 ```javascript
 const response = await client.calls.actions.hangup('v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ');
@@ -274,11 +274,11 @@ Trigger a follow-up action in an existing workflow rather than creating a new to
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `callControlId` | string (UUID) | Yes | The Call Control ID of the call you want to bridge with, can... |
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | No | Use this field to avoid duplicate commands. |
-| `videoRoomId` | string (UUID) | No | The ID of the video room you want to bridge with, can't be u... |
+| `call_control_id` | string (UUID) | Yes | The Call Control ID of the call you want to bridge with, can... |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | No | Use this field to avoid duplicate commands. |
+| `video_room_id` | string (UUID) | No | The ID of the video room you want to bridge with, can't be u... |
 | ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -301,9 +301,9 @@ Trigger a follow-up action in an existing workflow rather than creating a new to
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `cause` | enum (CALL_REJECTED, USER_BUSY) | Yes | Cause for call rejection. |
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | No | Use this field to avoid duplicate commands. |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | No | Use this field to avoid duplicate commands. |
 
 ```javascript
 const response = await client.calls.actions.reject('call_control_id', { cause: 'USER_BUSY' });
@@ -322,7 +322,7 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
 
 ```javascript
 const response = await client.calls.retrieveStatus('v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ');
@@ -346,7 +346,7 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `connectionId` | string (UUID) | Yes | Telnyx connection id |
+| `connection_id` | string (UUID) | Yes | Telnyx connection id |
 | `page` | object | No | Consolidated page parameter (deepObject style). |
 
 ```javascript
@@ -410,12 +410,12 @@ Before using any operation below, read [the optional-parameters section](referen
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
-| Create a call control application | `client.callControlApplications.create()` | `POST /call_control_applications` | Create or provision an additional resource when the core tasks do not cover this flow. | `applicationName`, `webhookEventUrl` |
+| Create a call control application | `client.callControlApplications.create()` | `POST /call_control_applications` | Create or provision an additional resource when the core tasks do not cover this flow. | `application_name`, `webhook_event_url` |
 | Retrieve a call control application | `client.callControlApplications.retrieve()` | `GET /call_control_applications/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
-| Update a call control application | `client.callControlApplications.update()` | `PATCH /call_control_applications/{id}` | Modify an existing resource without recreating it. | `applicationName`, `webhookEventUrl`, `id` |
+| Update a call control application | `client.callControlApplications.update()` | `PATCH /call_control_applications/{id}` | Modify an existing resource without recreating it. | `application_name`, `webhook_event_url`, `id` |
 | Delete a call control application | `client.callControlApplications.delete()` | `DELETE /call_control_applications/{id}` | Remove, detach, or clean up an existing resource. | `id` |
-| SIP Refer a call | `client.calls.actions.refer()` | `POST /calls/{call_control_id}/actions/refer` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `sipAddress`, `callControlId` |
-| Send SIP info | `client.calls.actions.sendSipInfo()` | `POST /calls/{call_control_id}/actions/send_sip_info` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `contentType`, `body`, `callControlId` |
+| SIP Refer a call | `client.calls.actions.refer()` | `POST /calls/{call_control_id}/actions/refer` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `sip_address`, `call_control_id` |
+| Send SIP info | `client.calls.actions.sendSipInfo()` | `POST /calls/{call_control_id}/actions/send_sip_info` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `content_type`, `body`, `call_control_id` |
 
 ### Other Webhook Events
 

--- a/providers/cursor/plugin/skills/telnyx-voice-javascript/references/api-details.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-javascript/references/api-details.md
@@ -94,236 +94,236 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `active` | boolean | Specifies whether the connection can be used. |
-| `anchorsiteOverride` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
-| `dtmfType` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
-| `firstCommandTimeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
-| `firstCommandTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `anchorsite_override` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmf_type` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `first_command_timeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `first_command_timeout_secs` | integer | Specifies how many seconds to wait before timing out a dial command. |
 | `inbound` | object |  |
 | `outbound` | object |  |
-| `webhookApiVersion` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
-| `webhookEventFailoverUrl` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
-| `webhookTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a webhook. |
-| `callCostInWebhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
-| `redactDtmfDebugLogging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+| `webhook_api_version` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhook_event_failover_url` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhook_timeout_secs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `call_cost_in_webhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `redact_dtmf_debug_logging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
 
 ### Update a call control application — `client.callControlApplications.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `callCostInWebhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `call_cost_in_webhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
 | `active` | boolean | Specifies whether the connection can be used. |
-| `anchorsiteOverride` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
-| `dtmfType` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
-| `firstCommandTimeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
-| `firstCommandTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `anchorsite_override` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmf_type` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `first_command_timeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `first_command_timeout_secs` | integer | Specifies how many seconds to wait before timing out a dial command. |
 | `tags` | array[string] | Tags assigned to the Call Control Application. |
 | `inbound` | object |  |
 | `outbound` | object |  |
-| `webhookApiVersion` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
-| `webhookEventFailoverUrl` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
-| `webhookTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a webhook. |
-| `redactDtmfDebugLogging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+| `webhook_api_version` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhook_event_failover_url` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhook_timeout_secs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `redact_dtmf_debug_logging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
 
 ### Dial — `client.calls.dial()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `assistant` | object | AI Assistant configuration. |
-| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
-| `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
 | `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
-| `audioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
-| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
-| `mediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
-| `preferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
-| `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
-| `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
-| `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
-| `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
-| `deepfakeDetection` | object | Enables deepfake detection on the call. |
-| `conferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
-| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
-| `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
-| `linkTo` | string | Use another call's control id for sharing the same call session id |
-| `bridgeIntent` | boolean | Indicates the intent to bridge this call with the call specified in link_to. |
-| `bridgeOnAnswer` | boolean | Whether to automatically bridge answered call to the call specified in link_to. |
-| `preventDoubleBridge` | boolean | Prevents bridging and hangs up the call if the target is already bridged. |
-| `parkAfterUnbridge` | string | If supplied with the value `self`, the current leg will be parked after unbri... |
-| `mediaEncryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the call. |
-| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
-| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
-| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE request. |
-| `sipTransportProtocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
-| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
-| `streamUrl` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
-| `streamTrack` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
-| `streamCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
-| `streamBidirectionalMode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
-| `streamBidirectionalCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
-| `streamBidirectionalTargetLegs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
-| `streamBidirectionalSamplingRate` | enum (8000, 16000, 22050, 24000, 48000) | Audio sampling rate. |
-| `streamEstablishBeforeCallOriginate` | boolean | Establish websocket connection before dialing the destination. |
-| `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
-| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
-| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
-| `webhookUrls` | object | A map of event types to webhook URLs. |
-| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
-| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
+| `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
+| `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
+| `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `link_to` | string | Use another call's control id for sharing the same call session id |
+| `bridge_intent` | boolean | Indicates the intent to bridge this call with the call specified in link_to. |
+| `bridge_on_answer` | boolean | Whether to automatically bridge answered call to the call specified in link_to. |
+| `prevent_double_bridge` | boolean | Prevents bridging and hangs up the call if the target is already bridged. |
+| `park_after_unbridge` | string | If supplied with the value `self`, the current leg will be parked after unbri... |
+| `media_encryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the call. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE request. |
+| `sip_transport_protocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `stream_url` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `stream_track` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `stream_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `stream_bidirectional_mode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `stream_bidirectional_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `stream_bidirectional_target_legs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `stream_bidirectional_sampling_rate` | enum (8000, 16000, 22050, 24000, 48000) | Audio sampling rate. |
+| `stream_establish_before_call_originate` | boolean | Establish websocket connection before dialing the destination. |
+| `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
-| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
-| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
-| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
-| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
-| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
-| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
-| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
-| `superviseCallControlId` | string (UUID) | The call leg which will be supervised by the new call. |
-| `supervisorRole` | enum (barge, whisper, monitor) | The role of the supervisor call. |
-| `enableDialogflow` | boolean | Enables Dialogflow for the current call. |
-| `dialogflowConfig` | object |  |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `supervise_call_control_id` | string (UUID) | The call leg which will be supervised by the new call. |
+| `supervisor_role` | enum (barge, whisper, monitor) | The role of the supervisor call. |
+| `enable_dialogflow` | boolean | Enables Dialogflow for the current call. |
+| `dialogflow_config` | object |  |
 | `transcription` | boolean | Enable transcription upon call answer. |
-| `transcriptionConfig` | object |  |
-| `sipRegion` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
-| `streamAuthToken` | string | An authentication token to be sent as part of the WebSocket connection when u... |
+| `transcription_config` | object |  |
+| `sip_region` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `stream_auth_token` | string | An authentication token to be sent as part of the WebSocket connection when u... |
 
 ### Answer call — `client.calls.actions.answer()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `assistant` | object | AI Assistant configuration. |
-| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
-| `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
-| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE response. |
-| `preferredCodecs` | enum (G722,PCMU,PCMA,G729,OPUS,VP8,H264) | The list of comma-separated codecs in a preferred order for the forked media ... |
-| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE response. |
-| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
-| `streamUrl` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
-| `streamTrack` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
-| `streamCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
-| `streamBidirectionalMode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
-| `streamBidirectionalCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
-| `streamBidirectionalTargetLegs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
-| `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
-| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
-| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE response. |
+| `preferred_codecs` | enum (G722,PCMU,PCMA,G729,OPUS,VP8,H264) | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE response. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `stream_url` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `stream_track` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `stream_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `stream_bidirectional_mode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `stream_bidirectional_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `stream_bidirectional_target_legs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
 | `transcription` | boolean | Enable transcription upon call answer. |
-| `transcriptionConfig` | object |  |
+| `transcription_config` | object |  |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
-| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
-| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
-| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
-| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
-| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
-| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
-| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
-| `webhookUrls` | object | A map of event types to webhook URLs. |
-| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
-| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
-| `deepfakeDetection` | object | Enables deepfake detection on the call. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.calls.actions.bridge()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
 | `queue` | string | The name of the queue you want to bridge with, can't be used together with ca... |
-| `videoRoomId` | string (UUID) | The ID of the video room you want to bridge with, can't be used together with... |
-| `videoRoomContext` | string | The additional parameter that will be passed to the video conference. |
-| `preventDoubleBridge` | boolean | When set to `true`, it prevents bridging if the target call is already bridge... |
-| `parkAfterUnbridge` | string | Specifies behavior after the bridge ends (i.e. |
-| `playRingtone` | boolean | Specifies whether to play a ringtone if the call you want to bridge with has ... |
+| `video_room_id` | string (UUID) | The ID of the video room you want to bridge with, can't be used together with... |
+| `video_room_context` | string | The additional parameter that will be passed to the video conference. |
+| `prevent_double_bridge` | boolean | When set to `true`, it prevents bridging if the target call is already bridge... |
+| `park_after_unbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `play_ringtone` | boolean | Specifies whether to play a ringtone if the call you want to bridge with has ... |
 | `ringtone` | enum (at, au, be, bg, br, ...) | Specifies which country ringtone to play when `play_ringtone` is set to `true`. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
-| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
-| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
-| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
-| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
-| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
-| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
-| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
-| `muteDtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
-| `holdAfterUnbridge` | boolean | Specifies behavior after the bridge ends. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `mute_dtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `hold_after_unbridge` | boolean | Specifies behavior after the bridge ends. |
 
 ### Hangup call — `client.calls.actions.hangup()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
-| `customHeaders` | array[object] | Custom headers to be added to the SIP BYE message. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP BYE message. |
 
 ### SIP Refer a call — `client.calls.actions.refer()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid execution of duplicate commands. |
-| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
-| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
-| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
-| `sipHeaders` | array[object] | SIP headers to be added to the request. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid execution of duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the request. |
 
 ### Reject a call — `client.calls.actions.reject()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
 
 ### Send SIP info — `client.calls.actions.sendSipInfo()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
 
 ### Transfer call — `client.calls.actions.transfer()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
-| `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
 | `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
-| `audioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
-| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
-| `earlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
-| `mediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
-| `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
-| `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
-| `parkAfterUnbridge` | string | Specifies behavior after the bridge ends (i.e. |
-| `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
-| `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
-| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `targetLegClientState` | string | Use this field to add state to every subsequent webhook for the new leg. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
-| `mediaEncryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the new call leg. |
-| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
-| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
-| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE. |
-| `sipTransportProtocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
-| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
-| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
-| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
-| `muteDtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
+| `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
+| `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
+| `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `park_after_unbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `target_leg_client_state` | string | Use this field to add state to every subsequent webhook for the new leg. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `media_encryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the new call leg. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE. |
+| `sip_transport_protocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `mute_dtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
-| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
-| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
-| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
-| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
-| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
-| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
-| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
-| `sipRegion` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
-| `preferredCodecs` | string | The list of comma-separated codecs in order of preference to be used during t... |
-| `webhookUrls` | object | A map of event types to webhook URLs. |
-| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
-| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `sip_region` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `preferred_codecs` | string | The list of comma-separated codecs in order of preference to be used during t... |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
 
 ## Webhook Payload Fields
 

--- a/skills/telnyx-10dlc-curl/SKILL.md
+++ b/skills/telnyx-10dlc-curl/SKILL.md
@@ -136,12 +136,10 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-      "brandId": "BXXX001",
+      "brandId": "BXXXXXX",
       "description": "Two-factor authentication messages",
       "usecase": "2FA",
-      "sample_messages": [
-          "Your verification code is {{code}}"
-      ]
+      "sample1": "Your verification code is {{code}}"
   }' \
   "https://api.telnyx.com/v2/10dlc/campaignBuilder"
 ```

--- a/skills/telnyx-10dlc-go/SKILL.md
+++ b/skills/telnyx-10dlc-go/SKILL.md
@@ -157,7 +157,7 @@ Campaign submission is the compliance-critical step that determines whether traf
 		BrandID: "BXXXXXX",
 		Description: "Two-factor authentication messages",
 		Usecase: "2FA",
-		SampleMessages: []string{"Your verification code is {{code}}"},
+		Sample1: telnyx.String("Your verification code is {{code}}"),
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/skills/telnyx-10dlc-java/SKILL.md
+++ b/skills/telnyx-10dlc-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.58.0</version>
+    <version>6.81.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.58.0")
+implementation("com.telnyx.sdk:telnyx:6.81.0")
 ```
 
 ## Setup
@@ -150,7 +150,7 @@ CampaignBuilderSubmitParams params = CampaignBuilderSubmitParams.builder()
     .brandId("BXXXXXX")
     .description("Two-factor authentication messages")
     .usecase("2FA")
-    .sampleMessages(java.util.List.of("Your verification code is {{code}}"))
+    .sample1("Your verification code is {{code}}")
     .build();
 TelnyxCampaignCsp telnyxCampaignCsp = client.messaging10dlc().campaignBuilder().submit(params);
 ```

--- a/skills/telnyx-10dlc-javascript/SKILL.md
+++ b/skills/telnyx-10dlc-javascript/SKILL.md
@@ -145,7 +145,7 @@ const telnyxCampaignCsp = await client.messaging10dlc.campaignBuilder.submit({
   brandId: 'BXXXXXX',
   description: 'Two-factor authentication messages',
   usecase: '2FA',
-    sampleMessages: ["Your verification code is {{code}}"],
+    sample1: 'Your verification code is {{code}}',
 });
 
 console.log(telnyxCampaignCsp.brandId);
@@ -197,7 +197,7 @@ and `telnyx-timestamp` headers. Always verify signatures in production:
 // In your webhook handler (e.g., Express — use raw body, not parsed JSON):
 app.post('/webhooks', express.raw({ type: 'application/json' }), async (req, res) => {
   try {
-    const event = await client.webhooks.unwrap(req.body.toString(), {
+    const event = client.webhooks.unwrap(req.body.toString(), {
       headers: req.headers,
     });
     // Signature valid — event is the parsed webhook payload
@@ -408,7 +408,7 @@ Before using any operation below, read [the optional-parameters section](referen
 | Get Campaign Cost | `client.messaging10dlc.campaign.usecase.getCost()` | `GET /10dlc/campaign/usecase/cost` | Inspect available resources or choose an existing resource before mutating it. | None |
 | Update campaign | `client.messaging10dlc.campaign.update()` | `PUT /10dlc/campaign/{campaignId}` | Inspect the current state of an existing campaign registration. | `campaignId` |
 | Deactivate campaign | `client.messaging10dlc.campaign.deactivate()` | `DELETE /10dlc/campaign/{campaignId}` | Inspect the current state of an existing campaign registration. | `campaignId` |
-| Submit campaign appeal for manual review | `client.messaging10dlc.campaign.submitAppeal()` | `POST /10dlc/campaign/{campaignId}/appeal` | Create or provision an additional resource when the core tasks do not cover this flow. | `appealReason`, `campaignId` |
+| Submit campaign appeal for manual review | `client.messaging10dlc.campaign.submitAppeal()` | `POST /10dlc/campaign/{campaignId}/appeal` | Create or provision an additional resource when the core tasks do not cover this flow. | `appeal_reason`, `campaignId` |
 | Get Campaign Mno Metadata | `client.messaging10dlc.campaign.getMnoMetadata()` | `GET /10dlc/campaign/{campaignId}/mnoMetadata` | Fetch the current state before updating, deleting, or making control-flow decisions. | `campaignId` |
 | Get campaign operation status | `client.messaging10dlc.campaign.getOperationStatus()` | `GET /10dlc/campaign/{campaignId}/operationStatus` | Fetch the current state before updating, deleting, or making control-flow decisions. | `campaignId` |
 | Get OSR campaign attributes | `client.messaging10dlc.campaign.osr.getAttributes()` | `GET /10dlc/campaign/{campaignId}/osr/attributes` | Fetch the current state before updating, deleting, or making control-flow decisions. | `campaignId` |

--- a/skills/telnyx-10dlc-python/SKILL.md
+++ b/skills/telnyx-10dlc-python/SKILL.md
@@ -143,7 +143,7 @@ telnyx_campaign_csp = client.messaging_10dlc.campaign_builder.submit(
     brand_id="BXXXXXX",
     description="Two-factor authentication messages",
     usecase="2FA",
-    sample_messages=["Your verification code is {{code}}"],
+    sample1="Your verification code is {{code}}",
 )
 print(telnyx_campaign_csp.brand_id)
 ```

--- a/skills/telnyx-10dlc-ruby/SKILL.md
+++ b/skills/telnyx-10dlc-ruby/SKILL.md
@@ -131,8 +131,8 @@ Campaign submission is the compliance-critical step that determines whether traf
 telnyx_campaign_csp = client.messaging_10dlc.campaign_builder.submit(
   brand_id: "BXXXXXX",
   description: "Two-factor authentication messages",
-  usecase: "2FA"
-    sample_messages: ["Your verification code is {{code}}"],
+  usecase: "2FA",
+    sample1: "Your verification code is {{code}}",
 )
 
 puts(telnyx_campaign_csp)
@@ -160,7 +160,7 @@ Messaging profile assignment is the practical handoff from registration to send-
 
 ```ruby
 response = client.messaging_10dlc.phone_number_assignment_by_profile.assign(
-  messaging_profile_id: "4001767e-ce0f-4cae-9d5f-0d5e636e7809"
+  messaging_profile_id: "4001767e-ce0f-4cae-9d5f-0d5e636e7809",
     campaign_id: "CXXX001",
 )
 

--- a/skills/telnyx-ai-assistants-curl/references/api-details.md
+++ b/skills/telnyx-ai-assistants-curl/references/api-details.md
@@ -383,6 +383,7 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |
 
 ### Update Tool
@@ -396,4 +397,5 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |

--- a/skills/telnyx-ai-assistants-go/references/api-details.md
+++ b/skills/telnyx-ai-assistants-go/references/api-details.md
@@ -383,6 +383,7 @@ dispat... |
 | `Handoff` | object |  |
 | `Invite` | object |  |
 | `Webhook` | object |  |
+| `ClientSideTool` | object |  |
 | `TimeoutMs` | integer |  |
 
 ### Update Tool — `client.AI.Tools.Update()`
@@ -396,4 +397,5 @@ dispat... |
 | `Handoff` | object |  |
 | `Invite` | object |  |
 | `Webhook` | object |  |
+| `ClientSideTool` | object |  |
 | `TimeoutMs` | integer |  |

--- a/skills/telnyx-ai-assistants-java/SKILL.md
+++ b/skills/telnyx-ai-assistants-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.58.0</version>
+    <version>6.81.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.58.0")
+implementation("com.telnyx.sdk:telnyx:6.81.0")
 ```
 
 ## Setup

--- a/skills/telnyx-ai-assistants-java/references/api-details.md
+++ b/skills/telnyx-ai-assistants-java/references/api-details.md
@@ -383,6 +383,7 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `clientSideTool` | object |  |
 | `timeoutMs` | integer |  |
 
 ### Update Tool — `client.ai().tools().update()`
@@ -396,4 +397,5 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `clientSideTool` | object |  |
 | `timeoutMs` | integer |  |

--- a/skills/telnyx-ai-assistants-javascript/SKILL.md
+++ b/skills/telnyx-ai-assistants-javascript/SKILL.md
@@ -120,8 +120,8 @@ Chat is the primary runtime path. Agents need the exact assistant method and the
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `content` | string | Yes | The message content sent by the client to the assistant |
-| `conversationId` | string (UUID) | Yes | A unique identifier for the conversation thread, used to mai... |
-| `assistantId` | string (UUID) | Yes | Unique identifier of the assistant. |
+| `conversation_id` | string (UUID) | Yes | A unique identifier for the conversation thread, used to mai... |
+| `assistant_id` | string (UUID) | Yes | Unique identifier of the assistant. |
 | `name` | string | No | The optional display name of the user sending the message |
 
 ```javascript
@@ -149,8 +149,8 @@ Test creation is the main validation path for production assistant behavior befo
 | `instructions` | string | Yes | Detailed instructions that define the test scenario and what... |
 | `rubric` | array[object] | Yes | Evaluation criteria used to assess the assistant's performan... |
 | `description` | string | No | Optional detailed description of what this test evaluates an... |
-| `telnyxConversationChannel` | object | No | The communication channel through which the test will be con... |
-| `maxDurationSeconds` | integer | No | Maximum duration in seconds that the test conversation shoul... |
+| `telnyx_conversation_channel` | object | No | The communication channel through which the test will be con... |
+| `max_duration_seconds` | integer | No | Maximum duration in seconds that the test conversation shoul... |
 | ... | | | +1 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -190,9 +190,9 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `assistantId` | string (UUID) | Yes | Unique identifier of the assistant. |
-| `callControlId` | string (UUID) | No | Filter results by call control id. |
-| `fetchDynamicVariablesFromWebhook` | boolean | No | Whether to fetch dynamic variables from the configured webho... |
+| `assistant_id` | string (UUID) | Yes | Unique identifier of the assistant. |
+| `call_control_id` | string (UUID) | No | Filter results by call control id. |
+| `fetch_dynamic_variables_from_webhook` | boolean | No | Whether to fetch dynamic variables from the configured webho... |
 | `from` | string (E.164) | No | Start of the filter range. |
 | ... | | | +1 optional params in [references/api-details.md](references/api-details.md) |
 
@@ -218,7 +218,7 @@ Create or provision an additional resource when the core tasks do not cover this
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `assistantId` | string (UUID) | Yes | Unique identifier of the assistant. |
+| `assistant_id` | string (UUID) | Yes | Unique identifier of the assistant. |
 | `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
 | `model` | string | No | ID of the model to use when `external_llm` is not set. |
@@ -270,12 +270,12 @@ Import existing assistants from an external provider instead of creating from sc
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `provider` | enum (elevenlabs, vapi, retell) | Yes | The external provider to import assistants from. |
-| `apiKeyRef` | string | Yes | Integration secret pointer that refers to the API key for th... |
-| `importIds` | array[string] | No | Optional list of assistant IDs to import from the external p... |
+| `api_key_ref` | string | Yes | Integration secret pointer that refers to the API key for th... |
+| `import_ids` | array[string] | No | Optional list of assistant IDs to import from the external p... |
 
 ```javascript
 const assistantsList = await client.ai.assistants.imports({
-  api_key_ref: 'api_key_ref',
+  api_key_ref: 'my-openai-key',
   provider: 'elevenlabs',
 });
 
@@ -316,8 +316,8 @@ Inspect available resources or choose an existing resource before mutating it.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `testSuite` | string | No | Filter tests by test suite name |
-| `telnyxConversationChannel` | string | No | Filter tests by communication channel (e.g., 'web_chat', 'sm... |
+| `test_suite` | string | No | Filter tests by test suite name |
+| `telnyx_conversation_channel` | string | No | Filter tests by communication channel (e.g., 'web_chat', 'sm... |
 | `destination` | string | No | Filter tests by destination (phone number, webhook URL, etc.... |
 | ... | | | +1 optional params in [references/api-details.md](references/api-details.md) |
 
@@ -366,8 +366,8 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `suiteName` | string | Yes | Name of the suite. |
-| `testSuiteRunId` | string (UUID) | No | Filter runs by specific suite execution batch ID |
+| `suite_name` | string | Yes | Name of the suite. |
+| `test_suite_run_id` | string (UUID) | No | Filter runs by specific suite execution batch ID |
 | `status` | string | No | Filter runs by execution status (pending, running, completed... |
 | `page` | object | No | Consolidated page parameter (deepObject style). |
 
@@ -399,46 +399,46 @@ Before using any operation below, read [the optional-parameters section](referen
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
-| Trigger test suite execution | `client.ai.assistants.tests.testSuites.runs.trigger()` | `POST /ai/assistants/tests/test-suites/{suite_name}/runs` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `suiteName` |
-| Get assistant test by ID | `client.ai.assistants.tests.retrieve()` | `GET /ai/assistants/tests/{test_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId` |
-| Update an assistant test | `client.ai.assistants.tests.update()` | `PUT /ai/assistants/tests/{test_id}` | Modify an existing resource without recreating it. | `testId` |
-| Delete an assistant test | `client.ai.assistants.tests.delete()` | `DELETE /ai/assistants/tests/{test_id}` | Remove, detach, or clean up an existing resource. | `testId` |
-| Get test run history for a specific test | `client.ai.assistants.tests.runs.list()` | `GET /ai/assistants/tests/{test_id}/runs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId` |
-| Trigger a manual test run | `client.ai.assistants.tests.runs.trigger()` | `POST /ai/assistants/tests/{test_id}/runs` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `testId` |
-| Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId`, `runId` |
-| Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistantId` |
-| Get Canary Deploy | `client.ai.assistants.canaryDeploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Create Canary Deploy | `client.ai.assistants.canaryDeploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId` |
-| Update Canary Deploy | `client.ai.assistants.canaryDeploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistantId` |
-| Delete Canary Deploy | `client.ai.assistants.canaryDeploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistantId` |
-| Assistant Sms Chat | `client.ai.assistants.sendSMS()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistantId` |
-| Clone Assistant | `client.ai.assistants.clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId` |
-| Enhance Assistant Instructions | `client.ai.assistants.instructions.enhance()` | `POST /ai/assistants/{assistant_id}/instructions/enhance` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId` |
-| List scheduled events | `client.ai.assistants.scheduledEvents.list()` | `GET /ai/assistants/{assistant_id}/scheduled_events` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Create a scheduled event | `client.ai.assistants.scheduledEvents.create()` | `POST /ai/assistants/{assistant_id}/scheduled_events` | Create or provision an additional resource when the core tasks do not cover this flow. | `telnyxConversationChannel`, `telnyxEndUserTarget`, `telnyxAgentTarget`, `scheduledAtFixedDatetime`, +1 more |
-| Get a scheduled event | `client.ai.assistants.scheduledEvents.retrieve()` | `GET /ai/assistants/{assistant_id}/scheduled_events/{event_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId`, `eventId` |
-| Delete a scheduled event | `client.ai.assistants.scheduledEvents.delete()` | `DELETE /ai/assistants/{assistant_id}/scheduled_events/{event_id}` | Remove, detach, or clean up an existing resource. | `assistantId`, `eventId` |
-| Add Assistant Tag | `client.ai.assistants.tags.add()` | `POST /ai/assistants/{assistant_id}/tags` | Create or provision an additional resource when the core tasks do not cover this flow. | `tag`, `assistantId` |
-| Remove Assistant Tag | `client.ai.assistants.tags.remove()` | `DELETE /ai/assistants/{assistant_id}/tags/{tag}` | Remove, detach, or clean up an existing resource. | `assistantId`, `tag` |
-| Get assistant texml | `client.ai.assistants.getTexml()` | `GET /ai/assistants/{assistant_id}/texml` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Add Assistant Tool | `client.ai.assistants.tools.add()` | `PUT /ai/assistants/{assistant_id}/tools/{tool_id}` | Modify an existing resource without recreating it. | `assistantId`, `toolId` |
-| Remove Assistant Tool | `client.ai.assistants.tools.remove()` | `DELETE /ai/assistants/{assistant_id}/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `assistantId`, `toolId` |
-| Test Assistant Tool | `client.ai.assistants.tools.test()` | `POST /ai/assistants/{assistant_id}/tools/{tool_id}/test` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId`, `toolId` |
-| Get all versions of an assistant | `client.ai.assistants.versions.list()` | `GET /ai/assistants/{assistant_id}/versions` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Get a specific assistant version | `client.ai.assistants.versions.retrieve()` | `GET /ai/assistants/{assistant_id}/versions/{version_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId`, `versionId` |
-| Update a specific assistant version | `client.ai.assistants.versions.update()` | `POST /ai/assistants/{assistant_id}/versions/{version_id}` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId`, `versionId` |
-| Delete a specific assistant version | `client.ai.assistants.versions.delete()` | `DELETE /ai/assistants/{assistant_id}/versions/{version_id}` | Remove, detach, or clean up an existing resource. | `assistantId`, `versionId` |
-| Promote an assistant version to main | `client.ai.assistants.versions.promote()` | `POST /ai/assistants/{assistant_id}/versions/{version_id}/promote` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId`, `versionId` |
+| Trigger test suite execution | `client.ai.assistants.tests.testSuites.runs.trigger()` | `POST /ai/assistants/tests/test-suites/{suite_name}/runs` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `suite_name` |
+| Get assistant test by ID | `client.ai.assistants.tests.retrieve()` | `GET /ai/assistants/tests/{test_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id` |
+| Update an assistant test | `client.ai.assistants.tests.update()` | `PUT /ai/assistants/tests/{test_id}` | Modify an existing resource without recreating it. | `test_id` |
+| Delete an assistant test | `client.ai.assistants.tests.delete()` | `DELETE /ai/assistants/tests/{test_id}` | Remove, detach, or clean up an existing resource. | `test_id` |
+| Get test run history for a specific test | `client.ai.assistants.tests.runs.list()` | `GET /ai/assistants/tests/{test_id}/runs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id` |
+| Trigger a manual test run | `client.ai.assistants.tests.runs.trigger()` | `POST /ai/assistants/tests/{test_id}/runs` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `test_id` |
+| Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
+| Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
+| Get Canary Deploy | `client.ai.assistants.canaryDeploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Create Canary Deploy | `client.ai.assistants.canaryDeploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | `client.ai.assistants.canaryDeploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
+| Delete Canary Deploy | `client.ai.assistants.canaryDeploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
+| Assistant Sms Chat | `client.ai.assistants.sendSMS()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistant_id` |
+| Clone Assistant | `client.ai.assistants.clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |
+| Enhance Assistant Instructions | `client.ai.assistants.instructions.enhance()` | `POST /ai/assistants/{assistant_id}/instructions/enhance` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| List scheduled events | `client.ai.assistants.scheduledEvents.list()` | `GET /ai/assistants/{assistant_id}/scheduled_events` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Create a scheduled event | `client.ai.assistants.scheduledEvents.create()` | `POST /ai/assistants/{assistant_id}/scheduled_events` | Create or provision an additional resource when the core tasks do not cover this flow. | `telnyx_conversation_channel`, `telnyx_end_user_target`, `telnyx_agent_target`, `scheduled_at_fixed_datetime`, +1 more |
+| Get a scheduled event | `client.ai.assistants.scheduledEvents.retrieve()` | `GET /ai/assistants/{assistant_id}/scheduled_events/{event_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id`, `event_id` |
+| Delete a scheduled event | `client.ai.assistants.scheduledEvents.delete()` | `DELETE /ai/assistants/{assistant_id}/scheduled_events/{event_id}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `event_id` |
+| Add Assistant Tag | `client.ai.assistants.tags.add()` | `POST /ai/assistants/{assistant_id}/tags` | Create or provision an additional resource when the core tasks do not cover this flow. | `tag`, `assistant_id` |
+| Remove Assistant Tag | `client.ai.assistants.tags.remove()` | `DELETE /ai/assistants/{assistant_id}/tags/{tag}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `tag` |
+| Get assistant texml | `client.ai.assistants.getTexml()` | `GET /ai/assistants/{assistant_id}/texml` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Add Assistant Tool | `client.ai.assistants.tools.add()` | `PUT /ai/assistants/{assistant_id}/tools/{tool_id}` | Modify an existing resource without recreating it. | `assistant_id`, `tool_id` |
+| Remove Assistant Tool | `client.ai.assistants.tools.remove()` | `DELETE /ai/assistants/{assistant_id}/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `tool_id` |
+| Test Assistant Tool | `client.ai.assistants.tools.test()` | `POST /ai/assistants/{assistant_id}/tools/{tool_id}/test` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id`, `tool_id` |
+| Get all versions of an assistant | `client.ai.assistants.versions.list()` | `GET /ai/assistants/{assistant_id}/versions` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Get a specific assistant version | `client.ai.assistants.versions.retrieve()` | `GET /ai/assistants/{assistant_id}/versions/{version_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id`, `version_id` |
+| Update a specific assistant version | `client.ai.assistants.versions.update()` | `POST /ai/assistants/{assistant_id}/versions/{version_id}` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id`, `version_id` |
+| Delete a specific assistant version | `client.ai.assistants.versions.delete()` | `DELETE /ai/assistants/{assistant_id}/versions/{version_id}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `version_id` |
+| Promote an assistant version to main | `client.ai.assistants.versions.promote()` | `POST /ai/assistants/{assistant_id}/versions/{version_id}/promote` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id`, `version_id` |
 | List MCP Servers | `client.ai.mcpServers.list()` | `GET /ai/mcp_servers` | Inspect available resources or choose an existing resource before mutating it. | None |
 | Create MCP Server | `client.ai.mcpServers.create()` | `POST /ai/mcp_servers` | Create or provision an additional resource when the core tasks do not cover this flow. | `name`, `type`, `url` |
-| Get MCP Server | `client.ai.mcpServers.retrieve()` | `GET /ai/mcp_servers/{mcp_server_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `mcpServerId` |
-| Update MCP Server | `client.ai.mcpServers.update()` | `PUT /ai/mcp_servers/{mcp_server_id}` | Modify an existing resource without recreating it. | `mcpServerId` |
-| Delete MCP Server | `client.ai.mcpServers.delete()` | `DELETE /ai/mcp_servers/{mcp_server_id}` | Remove, detach, or clean up an existing resource. | `mcpServerId` |
+| Get MCP Server | `client.ai.mcpServers.retrieve()` | `GET /ai/mcp_servers/{mcp_server_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `mcp_server_id` |
+| Update MCP Server | `client.ai.mcpServers.update()` | `PUT /ai/mcp_servers/{mcp_server_id}` | Modify an existing resource without recreating it. | `mcp_server_id` |
+| Delete MCP Server | `client.ai.mcpServers.delete()` | `DELETE /ai/mcp_servers/{mcp_server_id}` | Remove, detach, or clean up an existing resource. | `mcp_server_id` |
 | List Tools | `client.ai.tools.list()` | `GET /ai/tools` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Create Tool | `client.ai.tools.create()` | `POST /ai/tools` | Create or provision an additional resource when the core tasks do not cover this flow. | `type`, `displayName` |
-| Get Tool | `client.ai.tools.retrieve()` | `GET /ai/tools/{tool_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `toolId` |
-| Update Tool | `client.ai.tools.update()` | `PATCH /ai/tools/{tool_id}` | Modify an existing resource without recreating it. | `toolId` |
-| Delete Tool | `client.ai.tools.delete()` | `DELETE /ai/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `toolId` |
+| Create Tool | `client.ai.tools.create()` | `POST /ai/tools` | Create or provision an additional resource when the core tasks do not cover this flow. | `type`, `display_name` |
+| Get Tool | `client.ai.tools.retrieve()` | `GET /ai/tools/{tool_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `tool_id` |
+| Update Tool | `client.ai.tools.update()` | `PATCH /ai/tools/{tool_id}` | Modify an existing resource without recreating it. | `tool_id` |
+| Delete Tool | `client.ai.tools.delete()` | `DELETE /ai/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `tool_id` |
 
 ---
 

--- a/skills/telnyx-ai-assistants-javascript/references/api-details.md
+++ b/skills/telnyx-ai-assistants-javascript/references/api-details.md
@@ -169,51 +169,51 @@
 |-----------|------|-------------|
 | `model` | string | ID of the model to use when `external_llm` is not set. |
 | `tools` | array[object] | Deprecated for new integrations. |
-| `mcpServers` | array[object] | MCP servers attached to the assistant. |
-| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
-| `externalLlm` | object |  |
-| `fallbackConfig` | object |  |
-| `voiceSettings` | object |  |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
 | `transcription` | object |  |
-| `telephonySettings` | object |  |
-| `messagingSettings` | object |  |
-| `enabledFeatures` | array[object] |  |
-| `insightSettings` | object |  |
-| `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
-| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
-| `dynamicVariables` | object | Map of dynamic variables and their default values |
-| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
-| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
 | `integrations` | array[object] | Connected integrations attached to the assistant. |
-| `observabilitySettings` | object |  |
+| `observability_settings` | object |  |
 | `tags` | array[string] | Tags associated with the assistant. |
-| `postConversationSettings` | object | Configuration for post-conversation processing. |
-| `conversationFlow` | object | Conversation flow as supplied by API clients (create / update). |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+| `conversation_flow` | object | Conversation flow as supplied by API clients (create / update). |
 
 ### Import assistants from external provider — `client.ai.assistants.imports()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `importIds` | array[string] | Optional list of assistant IDs to import from the external provider. |
+| `import_ids` | array[string] | Optional list of assistant IDs to import from the external provider. |
 
 ### Create a new assistant test — `client.ai.assistants.tests.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `description` | string | Optional detailed description of what this test evaluates and its purpose. |
-| `telnyxConversationChannel` | object | The communication channel through which the test will be conducted. |
-| `maxDurationSeconds` | integer | Maximum duration in seconds that the test conversation should run before timi... |
-| `testSuite` | string | Optional test suite name to group related tests together. |
+| `telnyx_conversation_channel` | object | The communication channel through which the test will be conducted. |
+| `max_duration_seconds` | integer | Maximum duration in seconds that the test conversation should run before timi... |
+| `test_suite` | string | Optional test suite name to group related tests together. |
 
 ### Trigger test suite execution — `client.ai.assistants.tests.testSuites.runs.trigger()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `destinationVersionId` | string (UUID) | Optional assistant version ID to use for all test runs in this suite. |
+| `destination_version_id` | string (UUID) | Optional assistant version ID to use for all test runs in this suite. |
 
 ### Update an assistant test — `client.ai.assistants.tests.update()`
 
@@ -221,10 +221,10 @@
 |-----------|------|-------------|
 | `name` | string | Updated name for the assistant test. |
 | `description` | string | Updated description of the test's purpose and evaluation criteria. |
-| `telnyxConversationChannel` | enum (phone_call, web_call, sms_chat, web_chat) |  |
+| `telnyx_conversation_channel` | enum (phone_call, web_call, sms_chat, web_chat) |  |
 | `destination` | string | Updated target destination for test conversations. |
-| `maxDurationSeconds` | integer | Updated maximum test duration in seconds. |
-| `testSuite` | string | Updated test suite assignment for better organization. |
+| `max_duration_seconds` | integer | Updated maximum test duration in seconds. |
+| `test_suite` | string | Updated test suite assignment for better organization. |
 | `instructions` | string | Updated test scenario instructions and objectives. |
 | `rubric` | array[object] | Updated evaluation criteria for assessing assistant performance. |
 
@@ -232,7 +232,7 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `destinationVersionId` | string (UUID) | Optional assistant version ID to use for this test run. |
+| `destination_version_id` | string (UUID) | Optional assistant version ID to use for this test run. |
 
 ### Update an assistant — `client.ai.assistants.update()`
 
@@ -242,32 +242,32 @@
 | `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
 | `tools` | array[object] | Deprecated for new integrations. |
-| `mcpServers` | array[object] | MCP servers attached to the assistant. |
-| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
-| `externalLlm` | object |  |
-| `fallbackConfig` | object |  |
-| `voiceSettings` | object |  |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
 | `transcription` | object |  |
-| `telephonySettings` | object |  |
-| `messagingSettings` | object |  |
-| `enabledFeatures` | array[object] |  |
-| `insightSettings` | object |  |
-| `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
-| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
-| `dynamicVariables` | object | Map of dynamic variables and their default values |
-| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
-| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
 | `integrations` | array[object] | Connected integrations attached to the assistant. |
-| `observabilitySettings` | object |  |
+| `observability_settings` | object |  |
 | `tags` | array[string] | Tags associated with the assistant. |
-| `versionName` | string | Human-readable name for the assistant version. |
-| `postConversationSettings` | object | Configuration for post-conversation processing. |
-| `conversationFlow` | object | Conversation flow as supplied by API clients (create / update). |
-| `promoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+| `conversation_flow` | object | Conversation flow as supplied by API clients (create / update). |
+| `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
 
 ### Create Canary Deploy — `client.ai.assistants.canaryDeploys.create()`
 
@@ -292,14 +292,14 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `text` | string |  |
-| `conversationMetadata` | object |  |
-| `shouldCreateConversation` | boolean |  |
+| `conversation_metadata` | object |  |
+| `should_create_conversation` | boolean |  |
 
 ### Enhance Assistant Instructions — `client.ai.assistants.instructions.enhance()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `enhancementPrompt` | object | Optional guidance describing how the instructions should be enhanced. |
+| `enhancement_prompt` | object | Optional guidance describing how the instructions should be enhanced. |
 | `instructions` | object | The instructions to enhance. |
 
 ### Create a scheduled event — `client.ai.assistants.scheduledEvents.create()`
@@ -307,11 +307,11 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `text` | string | Required for sms scheduled events. |
-| `conversationMetadata` | object | Metadata associated with the conversation. |
-| `dynamicVariables` | object | A map of dynamic variable names to values. |
-| `maxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
-| `retryIntervalSecs` | integer |  |
-| `callSettings` | object | Per-call telephony overrides applied when a scheduled phone-call event
+| `conversation_metadata` | object | Metadata associated with the conversation. |
+| `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
+| `call_settings` | object | Per-call telephony overrides applied when a scheduled phone-call event
 dispat... |
 
 ### Test Assistant Tool — `client.ai.assistants.tools.test()`
@@ -319,7 +319,7 @@ dispat... |
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `arguments` | object | Key-value arguments to use for the webhook test |
-| `dynamicVariables` | object | Key-value dynamic variables to use for the webhook test |
+| `dynamic_variables` | object | Key-value dynamic variables to use for the webhook test |
 
 ### Update a specific assistant version — `client.ai.assistants.versions.update()`
 
@@ -329,38 +329,38 @@ dispat... |
 | `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
 | `tools` | array[object] | Deprecated for new integrations. |
-| `mcpServers` | array[object] | MCP servers attached to the assistant. |
-| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
-| `externalLlm` | object |  |
-| `fallbackConfig` | object |  |
-| `voiceSettings` | object |  |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
 | `transcription` | object |  |
-| `telephonySettings` | object |  |
-| `messagingSettings` | object |  |
-| `enabledFeatures` | array[object] |  |
-| `insightSettings` | object |  |
-| `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
-| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
-| `dynamicVariables` | object | Map of dynamic variables and their default values |
-| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
-| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
 | `integrations` | array[object] | Connected integrations attached to the assistant. |
-| `observabilitySettings` | object |  |
+| `observability_settings` | object |  |
 | `tags` | array[string] | Tags associated with the assistant. |
-| `versionName` | string | Human-readable name for the assistant version. |
-| `postConversationSettings` | object | Configuration for post-conversation processing. |
-| `conversationFlow` | object | Conversation flow as supplied by API clients (create / update). |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+| `conversation_flow` | object | Conversation flow as supplied by API clients (create / update). |
 
 ### Create MCP Server — `client.ai.mcpServers.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `apiKeyRef` | string |  |
-| `allowedTools` | array[string] |  |
+| `api_key_ref` | string |  |
+| `allowed_tools` | array[string] |  |
 
 ### Update MCP Server — `client.ai.mcpServers.update()`
 
@@ -370,9 +370,9 @@ dispat... |
 | `name` | string |  |
 | `type` | string |  |
 | `url` | string (URL) |  |
-| `apiKeyRef` | string |  |
-| `allowedTools` | array[string] |  |
-| `createdAt` | string (date-time) |  |
+| `api_key_ref` | string |  |
+| `allowed_tools` | array[string] |  |
+| `created_at` | string (date-time) |  |
 
 ### Create Tool — `client.ai.tools.create()`
 
@@ -383,17 +383,19 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
-| `timeoutMs` | integer |  |
+| `client_side_tool` | object |  |
+| `timeout_ms` | integer |  |
 
 ### Update Tool — `client.ai.tools.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `type` | string |  |
-| `displayName` | string |  |
+| `display_name` | string |  |
 | `function` | object |  |
 | `retrieval` | object |  |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
-| `timeoutMs` | integer |  |
+| `client_side_tool` | object |  |
+| `timeout_ms` | integer |  |

--- a/skills/telnyx-ai-assistants-python/references/api-details.md
+++ b/skills/telnyx-ai-assistants-python/references/api-details.md
@@ -383,6 +383,7 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |
 
 ### Update Tool — `client.ai.tools.update()`
@@ -396,4 +397,5 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |

--- a/skills/telnyx-ai-assistants-ruby/references/api-details.md
+++ b/skills/telnyx-ai-assistants-ruby/references/api-details.md
@@ -383,6 +383,7 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |
 
 ### Update Tool — `client.ai.tools.update()`
@@ -396,4 +397,5 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |

--- a/skills/telnyx-messaging-java/SKILL.md
+++ b/skills/telnyx-messaging-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.58.0</version>
+    <version>6.81.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.58.0")
+implementation("com.telnyx.sdk:telnyx:6.81.0")
 ```
 
 ## Setup

--- a/skills/telnyx-messaging-javascript/SKILL.md
+++ b/skills/telnyx-messaging-javascript/SKILL.md
@@ -96,9 +96,9 @@ Primary outbound messaging flow. Agents need exact request fields and delivery-r
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
 | `from` | string (E.164) | Yes | Sending address (+E.164 formatted phone number, alphanumeric... |
 | `text` | string | Yes | Message body (i.e., content) as a non-empty string. |
-| `messagingProfileId` | string (UUID) | No | Unique identifier for a messaging profile. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Unique identifier for a messaging profile. |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
 | ... | | | +7 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -130,10 +130,10 @@ Common sender variant that requires different request shape.
 | `from` | string (E.164) | Yes | A valid alphanumeric sender ID on the user's account. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
 | `text` | string | Yes | The message body. |
-| `messagingProfileId` | string (UUID) | Yes | The messaging profile ID to use. |
-| `webhookUrl` | string (URL) | No | Callback URL for delivery status updates. |
-| `webhookFailoverUrl` | string (URL) | No | Failover callback URL for delivery status updates. |
-| `useProfileWebhooks` | boolean | No | If true, use the messaging profile's webhook settings. |
+| `messaging_profile_id` | string (UUID) | Yes | The messaging profile ID to use. |
+| `webhook_url` | string (URL) | No | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | No | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | No | If true, use the messaging profile's webhook settings. |
 
 ```javascript
 const response = await client.messages.sendWithAlphanumericSender({
@@ -165,7 +165,7 @@ and `telnyx-timestamp` headers. Always verify signatures in production:
 // In your webhook handler (e.g., Express — use raw body, not parsed JSON):
 app.post('/webhooks', express.raw({ type: 'application/json' }), async (req, res) => {
   try {
-    const event = await client.webhooks.unwrap(req.body.toString(), {
+    const event = client.webhooks.unwrap(req.body.toString(), {
       headers: req.headers,
     });
     // Signature valid — event is the parsed webhook payload
@@ -226,9 +226,9 @@ Send one MMS payload to multiple recipients.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | array[object] | Yes | A list of destinations. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +3 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -259,9 +259,9 @@ Force a long-code sending path instead of the generic send endpoint.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -289,11 +289,11 @@ Let a messaging profile or number pool choose the sender for you.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `messagingProfileId` | string (UUID) | Yes | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Yes | Unique identifier for a messaging profile. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -324,9 +324,9 @@ Force a short-code sending path when the sender must be a short code.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -355,9 +355,9 @@ Queue a message for future delivery instead of sending immediately.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `messagingProfileId` | string (UUID) | No | Unique identifier for a messaging profile. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Unique identifier for a messaging profile. |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
 | ... | | | +8 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -365,7 +365,7 @@ const response = await client.messages.schedule({
     to: '+18445550001',
     from: '+18005550101',
     text: 'Appointment reminder',
-    sendAt: '2025-07-01T15:00:00Z',
+    send_at: '2025-07-01T15:00:00Z',
 });
 
 console.log(response.data);
@@ -389,10 +389,10 @@ Send WhatsApp traffic instead of SMS/MMS.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number in +E.164 format associated with Whatsapp accou... |
 | `to` | string (E.164) | Yes | Phone number in +E.164 format |
-| `whatsappMessage` | object | Yes |  |
+| `whatsapp_message` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `messagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```javascript
 const response = await client.messages.sendWhatsapp({
@@ -424,10 +424,10 @@ Before using any operation below, read [the optional-parameters section](referen
 | Retrieve a message | `client.messages.retrieve()` | `GET /messages/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Cancel a scheduled message | `client.messages.cancelScheduled()` | `DELETE /messages/{id}` | Remove, detach, or clean up an existing resource. | `id` |
 | List alphanumeric sender IDs | `client.alphanumericSenderIDs.list()` | `GET /alphanumeric_sender_ids` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Create an alphanumeric sender ID | `client.alphanumericSenderIDs.create()` | `POST /alphanumeric_sender_ids` | Create or provision an additional resource when the core tasks do not cover this flow. | `alphanumericSenderId`, `messagingProfileId` |
+| Create an alphanumeric sender ID | `client.alphanumericSenderIDs.create()` | `POST /alphanumeric_sender_ids` | Create or provision an additional resource when the core tasks do not cover this flow. | `alphanumeric_sender_id`, `messaging_profile_id` |
 | Retrieve an alphanumeric sender ID | `client.alphanumericSenderIDs.retrieve()` | `GET /alphanumeric_sender_ids/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Delete an alphanumeric sender ID | `client.alphanumericSenderIDs.delete()` | `DELETE /alphanumeric_sender_ids/{id}` | Remove, detach, or clean up an existing resource. | `id` |
-| Retrieve group MMS messages | `client.messages.retrieveGroupMessages()` | `GET /messages/group/{message_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `messageId` |
+| Retrieve group MMS messages | `client.messages.retrieveGroupMessages()` | `GET /messages/group/{message_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `message_id` |
 | List messaging hosted numbers | `client.messagingHostedNumbers.list()` | `GET /messaging_hosted_numbers` | Inspect available resources or choose an existing resource before mutating it. | None |
 | Retrieve a messaging hosted number | `client.messagingHostedNumbers.retrieve()` | `GET /messaging_hosted_numbers/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Update a messaging hosted number | `client.messagingHostedNumbers.update()` | `PATCH /messaging_hosted_numbers/{id}` | Modify an existing resource without recreating it. | `id` |
@@ -436,11 +436,11 @@ Before using any operation below, read [the optional-parameters section](referen
 | Regenerate messaging profile secret | `client.messagingProfiles.actions.regenerateSecret()` | `POST /messaging_profiles/{id}/actions/regenerate_secret` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `id` |
 | List alphanumeric sender IDs for a messaging profile | `client.messagingProfiles.listAlphanumericSenderIDs()` | `GET /messaging_profiles/{id}/alphanumeric_sender_ids` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Get detailed messaging profile metrics | `client.messagingProfiles.retrieveMetrics()` | `GET /messaging_profiles/{id}/metrics` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
-| List Auto-Response Settings | `client.messagingProfiles.autorespConfigs.list()` | `GET /messaging_profiles/{profile_id}/autoresp_configs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profileId` |
-| Create auto-response setting | `client.messagingProfiles.autorespConfigs.create()` | `POST /messaging_profiles/{profile_id}/autoresp_configs` | Create or provision an additional resource when the core tasks do not cover this flow. | `op`, `keywords`, `countryCode`, `profileId` |
-| Get Auto-Response Setting | `client.messagingProfiles.autorespConfigs.retrieve()` | `GET /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profileId`, `autorespCfgId` |
-| Update Auto-Response Setting | `client.messagingProfiles.autorespConfigs.update()` | `PUT /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Modify an existing resource without recreating it. | `op`, `keywords`, `countryCode`, `profileId`, +1 more |
-| Delete Auto-Response Setting | `client.messagingProfiles.autorespConfigs.delete()` | `DELETE /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Remove, detach, or clean up an existing resource. | `profileId`, `autorespCfgId` |
+| List Auto-Response Settings | `client.messagingProfiles.autorespConfigs.list()` | `GET /messaging_profiles/{profile_id}/autoresp_configs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profile_id` |
+| Create auto-response setting | `client.messagingProfiles.autorespConfigs.create()` | `POST /messaging_profiles/{profile_id}/autoresp_configs` | Create or provision an additional resource when the core tasks do not cover this flow. | `op`, `keywords`, `country_code`, `profile_id` |
+| Get Auto-Response Setting | `client.messagingProfiles.autorespConfigs.retrieve()` | `GET /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profile_id`, `autoresp_cfg_id` |
+| Update Auto-Response Setting | `client.messagingProfiles.autorespConfigs.update()` | `PUT /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Modify an existing resource without recreating it. | `op`, `keywords`, `country_code`, `profile_id`, +1 more |
+| Delete Auto-Response Setting | `client.messagingProfiles.autorespConfigs.delete()` | `DELETE /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Remove, detach, or clean up an existing resource. | `profile_id`, `autoresp_cfg_id` |
 
 ### Other Webhook Events
 

--- a/skills/telnyx-messaging-javascript/references/api-details.md
+++ b/skills/telnyx-messaging-javascript/references/api-details.md
@@ -199,32 +199,32 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `usLongCodeFallback` | string | A US long code number to use as fallback when sending to US destinations. |
+| `us_long_code_fallback` | string | A US long code number to use as fallback when sending to US destinations. |
 
 ### Send a message — `client.messages.send()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
-| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
-| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a message using an alphanumeric sender ID — `client.messages.sendWithAlphanumericSender()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `webhookUrl` | string (URL) | Callback URL for delivery status updates. |
-| `webhookFailoverUrl` | string (URL) | Failover callback URL for delivery status updates. |
-| `useProfileWebhooks` | boolean | If true, use the messaging profile's webhook settings. |
+| `webhook_url` | string (URL) | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | If true, use the messaging profile's webhook settings. |
 
 ### Send a group MMS message — `client.messages.sendGroupMms()`
 
@@ -232,10 +232,10 @@
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 
 ### Send a long code message — `client.messages.sendLongCode()`
 
@@ -243,12 +243,12 @@
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a message using number pool — `client.messages.sendNumberPool()`
@@ -257,12 +257,12 @@
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Schedule a message — `client.messages.schedule()`
@@ -270,16 +270,16 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
-| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
-| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
 
 ### Send a short code message — `client.messages.sendShortCode()`
 
@@ -287,12 +287,12 @@
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a WhatsApp message — `client.messages.sendWhatsapp()`
@@ -300,17 +300,17 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `messagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messagingHostedNumbers.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `messagingProfileId` | string (UUID) | Configure the messaging profile this phone number is assigned to:
+| `messaging_profile_id` | string (UUID) | Configure the messaging profile this phone number is assigned to:
 
 * Omit thi... |
-| `messagingProduct` | string | Configure the messaging product for this number:
+| `messaging_product` | string | Configure the messaging product for this number:
 
 * Omit this field or set it... |
 | `tags` | array[string] | Tags to set on this phone number. |
@@ -319,13 +319,13 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `respText` | string |  |
+| `resp_text` | string |  |
 
 ### Update Auto-Response Setting — `client.messagingProfiles.autorespConfigs.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `respText` | string |  |
+| `resp_text` | string |  |
 
 ## Webhook Payload Fields
 

--- a/skills/telnyx-messaging-ruby/SKILL.md
+++ b/skills/telnyx-messaging-ruby/SKILL.md
@@ -270,7 +270,7 @@ Let a messaging profile or number pool choose the sender for you.
 ```ruby
 response = client.messages.send_number_pool(
   messaging_profile_id: "abc85f64-5717-4562-b3fc-2c9600000000",
-  to: "+13125550002"
+  to: "+13125550002",
     text: "Hello from Telnyx!",
 )
 

--- a/skills/telnyx-numbers-java/SKILL.md
+++ b/skills/telnyx-numbers-java/SKILL.md
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.58.0</version>
+    <version>6.81.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.58.0")
+implementation("com.telnyx.sdk:telnyx:6.81.0")
 ```
 
 ## Setup

--- a/skills/telnyx-numbers-javascript/SKILL.md
+++ b/skills/telnyx-numbers-javascript/SKILL.md
@@ -109,15 +109,15 @@ Number ordering is the production provisioning step after number selection.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `phoneNumbers` | array[object] | Yes |  |
-| `connectionId` | string (UUID) | No | Identifies the connection associated with this phone number. |
-| `messagingProfileId` | string (UUID) | No | Identifies the messaging profile associated with the phone n... |
-| `billingGroupId` | string (UUID) | No | Identifies the billing group associated with the phone numbe... |
+| `phone_numbers` | array[object] | Yes |  |
+| `connection_id` | string (UUID) | No | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | No | Identifies the messaging profile associated with the phone n... |
+| `billing_group_id` | string (UUID) | No | Identifies the billing group associated with the phone numbe... |
 | ... | | | +1 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const numberOrder = await client.numberOrders.create({
-    phoneNumbers: [{"phone_number": "+18005550101"}],
+    phone_numbers: [{"phone_number": "+18005550101"}],
 });
 
 console.log(numberOrder.data);
@@ -139,7 +139,7 @@ Order status determines whether provisioning completed or additional requirement
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `numberOrderId` | string (UUID) | Yes | The number order ID. |
+| `number_order_id` | string (UUID) | Yes | The number order ID. |
 
 ```javascript
 const numberOrder = await client.numberOrders.retrieve('550e8400-e29b-41d4-a716-446655440000');
@@ -169,15 +169,15 @@ Create or provision an additional resource when the core tasks do not cover this
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `phoneNumbers` | array[object] | Yes |  |
+| `phone_numbers` | array[object] | Yes |  |
 | `status` | enum (pending, success, failure) | No | The status of the entire reservation. |
 | `id` | string (UUID) | No |  |
-| `recordType` | string | No |  |
+| `record_type` | string | No |  |
 | ... | | | +3 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
 const numberReservation = await client.numberReservations.create({
-    phoneNumbers: [{"phone_number": "+18005550101"}],
+    phone_numbers: [{"phone_number": "+18005550101"}],
 });
 
 console.log(numberReservation.data);
@@ -199,7 +199,7 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `numberReservationId` | string (UUID) | Yes | The number reservation ID. |
+| `number_reservation_id` | string (UUID) | Yes | The number reservation ID. |
 
 ```javascript
 const numberReservation = await client.numberReservations.retrieve('550e8400-e29b-41d4-a716-446655440000');
@@ -246,9 +246,9 @@ Create or provision an additional resource when the core tasks do not cover this
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) | No |  |
-| `requirementGroupId` | string (UUID) | No | The ID of the requirement group to associate with this advan... |
-| `countryCode` | string (ISO 3166-1 alpha-2) | No |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) | No |  |
+| `requirement_group_id` | string (UUID) | No | The ID of the requirement group to associate with this advan... |
+| `country_code` | string (ISO 3166-1 alpha-2) | No |  |
 | ... | | | +5 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -274,9 +274,9 @@ Modify an existing resource without recreating it.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `advanced-order-id` | string (UUID) | Yes | Unique identifier of the advanced order. |
-| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) | No |  |
-| `requirementGroupId` | string (UUID) | No | The ID of the requirement group to associate with this advan... |
-| `countryCode` | string (ISO 3166-1 alpha-2) | No |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) | No |  |
+| `requirement_group_id` | string (UUID) | No | The ID of the requirement group to associate with this advan... |
+| `country_code` | string (ISO 3166-1 alpha-2) | No |  |
 | ... | | | +5 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -303,7 +303,7 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `orderId` | string (UUID) | Yes | Unique identifier of the order. |
+| `order_id` | string (UUID) | Yes | Unique identifier of the order. |
 
 ```javascript
 const advancedOrder = await client.advancedOrders.retrieve('182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e');
@@ -388,38 +388,38 @@ Before using any operation below, read [the optional-parameters section](referen
 | Retrieve a comment | `client.comments.retrieve()` | `GET /comments/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Mark a comment as read | `client.comments.markAsRead()` | `PATCH /comments/{id}/read` | Modify an existing resource without recreating it. | `id` |
 | Get country coverage | `client.countryCoverage.retrieve()` | `GET /country_coverage` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Get coverage for a specific country | `client.countryCoverage.retrieveCountry()` | `GET /country_coverage/countries/{country_code}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `countryCode` |
+| Get coverage for a specific country | `client.countryCoverage.retrieveCountry()` | `GET /country_coverage/countries/{country_code}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `country_code` |
 | List customer service records | `client.customerServiceRecords.list()` | `GET /customer_service_records` | Inspect available resources or choose an existing resource before mutating it. | None |
 | Create a customer service record | `client.customerServiceRecords.create()` | `POST /customer_service_records` | Create or provision an additional resource when the core tasks do not cover this flow. | None |
 | Verify CSR phone number coverage | `client.customerServiceRecords.verifyPhoneNumberCoverage()` | `POST /customer_service_records/phone_number_coverages` | Create or provision an additional resource when the core tasks do not cover this flow. | None |
-| Get a customer service record | `client.customerServiceRecords.retrieve()` | `GET /customer_service_records/{customer_service_record_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `customerServiceRecordId` |
+| Get a customer service record | `client.customerServiceRecords.retrieve()` | `GET /customer_service_records/{customer_service_record_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `customer_service_record_id` |
 | List inexplicit number orders | `client.inexplicitNumberOrders.list()` | `GET /inexplicit_number_orders` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Create an inexplicit number order | `client.inexplicitNumberOrders.create()` | `POST /inexplicit_number_orders` | Create or provision an additional resource when the core tasks do not cover this flow. | `orderingGroups` |
+| Create an inexplicit number order | `client.inexplicitNumberOrders.create()` | `POST /inexplicit_number_orders` | Create or provision an additional resource when the core tasks do not cover this flow. | `ordering_groups` |
 | Retrieve an inexplicit number order | `client.inexplicitNumberOrders.retrieve()` | `GET /inexplicit_number_orders/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Create an inventory coverage request | `client.inventoryCoverage.list()` | `GET /inventory_coverage` | Inspect available resources or choose an existing resource before mutating it. | None |
 | List mobile network operators | `client.mobileNetworkOperators.list()` | `GET /mobile_network_operators` | Inspect available resources or choose an existing resource before mutating it. | None |
 | List network coverage locations | `client.networkCoverage.list()` | `GET /network_coverage` | Inspect available resources or choose an existing resource before mutating it. | None |
 | List number block orders | `client.numberBlockOrders.list()` | `GET /number_block_orders` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Create a number block order | `client.numberBlockOrders.create()` | `POST /number_block_orders` | Create or provision an additional resource when the core tasks do not cover this flow. | `startingNumber`, `range` |
-| Retrieve a number block order | `client.numberBlockOrders.retrieve()` | `GET /number_block_orders/{number_block_order_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `numberBlockOrderId` |
+| Create a number block order | `client.numberBlockOrders.create()` | `POST /number_block_orders` | Create or provision an additional resource when the core tasks do not cover this flow. | `starting_number`, `range` |
+| Retrieve a number block order | `client.numberBlockOrders.retrieve()` | `GET /number_block_orders/{number_block_order_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `number_block_order_id` |
 | Retrieve a list of phone numbers associated to orders | `client.numberOrderPhoneNumbers.list()` | `GET /number_order_phone_numbers` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Retrieve a single phone number within a number order. | `client.numberOrderPhoneNumbers.retrieve()` | `GET /number_order_phone_numbers/{number_order_phone_number_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `numberOrderPhoneNumberId` |
-| Update requirements for a single phone number within a number order. | `client.numberOrderPhoneNumbers.updateRequirements()` | `PATCH /number_order_phone_numbers/{number_order_phone_number_id}` | Modify an existing resource without recreating it. | `numberOrderPhoneNumberId` |
+| Retrieve a single phone number within a number order. | `client.numberOrderPhoneNumbers.retrieve()` | `GET /number_order_phone_numbers/{number_order_phone_number_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `number_order_phone_number_id` |
+| Update requirements for a single phone number within a number order. | `client.numberOrderPhoneNumbers.updateRequirements()` | `PATCH /number_order_phone_numbers/{number_order_phone_number_id}` | Modify an existing resource without recreating it. | `number_order_phone_number_id` |
 | List number orders | `client.numberOrders.list()` | `GET /number_orders` | Create or inspect provisioning orders for number purchases. | None |
-| Update a number order | `client.numberOrders.update()` | `PATCH /number_orders/{number_order_id}` | Modify an existing resource without recreating it. | `numberOrderId` |
+| Update a number order | `client.numberOrders.update()` | `PATCH /number_orders/{number_order_id}` | Modify an existing resource without recreating it. | `number_order_id` |
 | List number reservations | `client.numberReservations.list()` | `GET /number_reservations` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Extend a number reservation | `client.numberReservations.actions.extend()` | `POST /number_reservations/{number_reservation_id}/actions/extend` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `numberReservationId` |
-| Retrieve the features for a list of numbers | `client.numbersFeatures.create()` | `POST /numbers_features` | Create or provision an additional resource when the core tasks do not cover this flow. | `phoneNumbers` |
+| Extend a number reservation | `client.numberReservations.actions.extend()` | `POST /number_reservations/{number_reservation_id}/actions/extend` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `number_reservation_id` |
+| Retrieve the features for a list of numbers | `client.numbersFeatures.create()` | `POST /numbers_features` | Create or provision an additional resource when the core tasks do not cover this flow. | `phone_numbers` |
 | Lists the phone number blocks jobs | `client.phoneNumberBlocks.jobs.list()` | `GET /phone_number_blocks/jobs` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Deletes all numbers associated with a phone number block | `client.phoneNumberBlocks.jobs.deletePhoneNumberBlock()` | `POST /phone_number_blocks/jobs/delete_phone_number_block` | Create or provision an additional resource when the core tasks do not cover this flow. | `phoneNumberBlockId` |
+| Deletes all numbers associated with a phone number block | `client.phoneNumberBlocks.jobs.deletePhoneNumberBlock()` | `POST /phone_number_blocks/jobs/delete_phone_number_block` | Create or provision an additional resource when the core tasks do not cover this flow. | `phone_number_block_id` |
 | Retrieves a phone number blocks job | `client.phoneNumberBlocks.jobs.retrieve()` | `GET /phone_number_blocks/jobs/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | List sub number orders | `client.subNumberOrders.list()` | `GET /sub_number_orders` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Retrieve a sub number order | `client.subNumberOrders.retrieve()` | `GET /sub_number_orders/{sub_number_order_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `subNumberOrderId` |
-| Update a sub number order's requirements | `client.subNumberOrders.update()` | `PATCH /sub_number_orders/{sub_number_order_id}` | Modify an existing resource without recreating it. | `subNumberOrderId` |
-| Cancel a sub number order | `client.subNumberOrders.cancel()` | `PATCH /sub_number_orders/{sub_number_order_id}/cancel` | Modify an existing resource without recreating it. | `subNumberOrderId` |
+| Retrieve a sub number order | `client.subNumberOrders.retrieve()` | `GET /sub_number_orders/{sub_number_order_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `sub_number_order_id` |
+| Update a sub number order's requirements | `client.subNumberOrders.update()` | `PATCH /sub_number_orders/{sub_number_order_id}` | Modify an existing resource without recreating it. | `sub_number_order_id` |
+| Cancel a sub number order | `client.subNumberOrders.cancel()` | `PATCH /sub_number_orders/{sub_number_order_id}/cancel` | Modify an existing resource without recreating it. | `sub_number_order_id` |
 | Create a sub number orders report | `client.subNumberOrdersReport.create()` | `POST /sub_number_orders_report` | Create or provision an additional resource when the core tasks do not cover this flow. | None |
-| Retrieve a sub number orders report | `client.subNumberOrdersReport.retrieve()` | `GET /sub_number_orders_report/{report_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `reportId` |
-| Download a sub number orders report | `client.subNumberOrdersReport.download()` | `GET /sub_number_orders_report/{report_id}/download` | Fetch the current state before updating, deleting, or making control-flow decisions. | `reportId` |
+| Retrieve a sub number orders report | `client.subNumberOrdersReport.retrieve()` | `GET /sub_number_orders_report/{report_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `report_id` |
+| Download a sub number orders report | `client.subNumberOrdersReport.download()` | `GET /sub_number_orders_report/{report_id}/download` | Fetch the current state before updating, deleting, or making control-flow decisions. | `report_id` |
 
 ### Other Webhook Events
 

--- a/skills/telnyx-numbers-javascript/references/api-details.md
+++ b/skills/telnyx-numbers-javascript/references/api-details.md
@@ -290,27 +290,27 @@
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `countryCode` | string (ISO 3166-1 alpha-2) |  |
+| `country_code` | string (ISO 3166-1 alpha-2) |  |
 | `comments` | string |  |
 | `quantity` | integer |  |
-| `areaCode` | string |  |
-| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `area_code` | string |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
 | `features` | array[object] |  |
-| `customerReference` | string |  |
-| `requirementGroupId` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+| `customer_reference` | string |  |
+| `requirement_group_id` | string (UUID) | The ID of the requirement group to associate with this advanced order |
 
 ### Update Advanced Order — `client.advancedOrders.updateRequirementGroup()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `countryCode` | string (ISO 3166-1 alpha-2) |  |
+| `country_code` | string (ISO 3166-1 alpha-2) |  |
 | `comments` | string |  |
 | `quantity` | integer |  |
-| `areaCode` | string |  |
-| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `area_code` | string |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
 | `features` | array[object] |  |
-| `customerReference` | string |  |
-| `requirementGroupId` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+| `customer_reference` | string |  |
+| `requirement_group_id` | string (UUID) | The ID of the requirement group to associate with this advanced order |
 
 ### Create a comment — `client.comments.create()`
 
@@ -319,89 +319,89 @@
 | `id` | string (UUID) |  |
 | `body` | string |  |
 | `commenter` | string |  |
-| `commenterType` | enum (admin, user) |  |
-| `commentRecordType` | enum (sub_number_order, requirement_group) |  |
-| `commentRecordId` | string (UUID) |  |
-| `readAt` | string (date-time) | An ISO 8901 datetime string for when the comment was read. |
-| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the comment was created. |
-| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the comment was updated. |
+| `commenter_type` | enum (admin, user) |  |
+| `comment_record_type` | enum (sub_number_order, requirement_group) |  |
+| `comment_record_id` | string (UUID) |  |
+| `read_at` | string (date-time) | An ISO 8901 datetime string for when the comment was read. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the comment was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the comment was updated. |
 
 ### Create an inexplicit number order — `client.inexplicitNumberOrders.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `connectionId` | string (UUID) | Connection id to apply to phone numbers that are purchased |
-| `messagingProfileId` | string (UUID) | Messaging profile id to apply to phone numbers that are purchased |
-| `customerReference` | string | Reference label for the customer |
-| `billingGroupId` | string (UUID) | Billing group id to apply to phone numbers that are purchased |
+| `connection_id` | string (UUID) | Connection id to apply to phone numbers that are purchased |
+| `messaging_profile_id` | string (UUID) | Messaging profile id to apply to phone numbers that are purchased |
+| `customer_reference` | string | Reference label for the customer |
+| `billing_group_id` | string (UUID) | Billing group id to apply to phone numbers that are purchased |
 
 ### Create a number block order — `client.numberBlockOrders.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `id` | string (UUID) |  |
-| `recordType` | string |  |
-| `phoneNumbersCount` | integer | The count of phone numbers in the number order. |
-| `connectionId` | string (UUID) | Identifies the connection associated with this phone number. |
-| `messagingProfileId` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `record_type` | string |  |
+| `phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `connection_id` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | Identifies the messaging profile associated with the phone number. |
 | `status` | enum (pending, success, failure) | The status of the order. |
-| `customerReference` | string | A customer reference string for customer look ups. |
-| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the number order was created. |
-| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the number order was updated. |
-| `requirementsMet` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the number order was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the number order was updated. |
+| `requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
 | `errors` | string | Errors the reservation could happen upon |
 
 ### Update requirements for a single phone number within a number order. — `client.numberOrderPhoneNumbers.updateRequirements()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `regulatoryRequirements` | array[object] |  |
+| `regulatory_requirements` | array[object] |  |
 
 ### Create a number order — `client.numberOrders.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `phoneNumbers` | array[object] |  |
-| `connectionId` | string (UUID) | Identifies the connection associated with this phone number. |
-| `messagingProfileId` | string (UUID) | Identifies the messaging profile associated with the phone number. |
-| `billingGroupId` | string (UUID) | Identifies the billing group associated with the phone number. |
-| `customerReference` | string | A customer reference string for customer look ups. |
+| `phone_numbers` | array[object] |  |
+| `connection_id` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `billing_group_id` | string (UUID) | Identifies the billing group associated with the phone number. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
 
 ### Update a number order — `client.numberOrders.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `regulatoryRequirements` | array[object] |  |
-| `customerReference` | string | A customer reference string for customer look ups. |
+| `regulatory_requirements` | array[object] |  |
+| `customer_reference` | string | A customer reference string for customer look ups. |
 
 ### Create a number reservation — `client.numberReservations.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `id` | string (UUID) |  |
-| `recordType` | string |  |
-| `phoneNumbers` | array[object] |  |
+| `record_type` | string |  |
+| `phone_numbers` | array[object] |  |
 | `status` | enum (pending, success, failure) | The status of the entire reservation. |
-| `customerReference` | string | A customer reference string for customer look ups. |
-| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the numbers reservation was created. |
-| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the number reservation was updated. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the numbers reservation was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the number reservation was updated. |
 
 ### Update a sub number order's requirements — `client.subNumberOrders.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `regulatoryRequirements` | array[object] |  |
+| `regulatory_requirements` | array[object] |  |
 
 ### Create a sub number orders report — `client.subNumberOrdersReport.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `status` | enum (pending, success, failure) | Filter by order status |
-| `countryCode` | string (ISO 3166-1 alpha-2) | Filter by country code |
-| `createdAtGt` | string (date-time) | Filter for orders created after this date |
-| `createdAtLt` | string (date-time) | Filter for orders created before this date |
-| `orderRequestId` | string (UUID) | Filter by specific order request ID |
-| `customerReference` | string | Filter by customer reference |
+| `country_code` | string (ISO 3166-1 alpha-2) | Filter by country code |
+| `created_at_gt` | string (date-time) | Filter for orders created after this date |
+| `created_at_lt` | string (date-time) | Filter for orders created before this date |
+| `order_request_id` | string (UUID) | Filter by specific order request ID |
+| `customer_reference` | string | Filter by customer reference |
 
 ## Webhook Payload Fields
 

--- a/skills/telnyx-twilio-migration/sdk-reference/curl/10dlc.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/curl/10dlc.md
@@ -123,12 +123,10 @@ curl \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-      "brandId": "BXXX001",
+      "brandId": "BXXXXXX",
       "description": "Two-factor authentication messages",
       "usecase": "2FA",
-      "sample_messages": [
-          "Your verification code is {{code}}"
-      ]
+      "sample1": "Your verification code is {{code}}"
   }' \
   "https://api.telnyx.com/v2/10dlc/campaignBuilder"
 ```

--- a/skills/telnyx-twilio-migration/sdk-reference/curl/ai-assistants.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/curl/ai-assistants.md
@@ -648,6 +648,7 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |
 
 ### Update Tool
@@ -661,4 +662,5 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |

--- a/skills/telnyx-twilio-migration/sdk-reference/go/10dlc.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/go/10dlc.md
@@ -144,7 +144,7 @@ Campaign submission is the compliance-critical step that determines whether traf
 		BrandID: "BXXXXXX",
 		Description: "Two-factor authentication messages",
 		Usecase: "2FA",
-		SampleMessages: []string{"Your verification code is {{code}}"},
+		Sample1: telnyx.String("Your verification code is {{code}}"),
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/skills/telnyx-twilio-migration/sdk-reference/go/ai-assistants.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/go/ai-assistants.md
@@ -704,6 +704,7 @@ dispat... |
 | `Handoff` | object |  |
 | `Invite` | object |  |
 | `Webhook` | object |  |
+| `ClientSideTool` | object |  |
 | `TimeoutMs` | integer |  |
 
 ### Update Tool — `client.AI.Tools.Update()`
@@ -717,4 +718,5 @@ dispat... |
 | `Handoff` | object |  |
 | `Invite` | object |  |
 | `Webhook` | object |  |
+| `ClientSideTool` | object |  |
 | `TimeoutMs` | integer |  |

--- a/skills/telnyx-twilio-migration/sdk-reference/java/10dlc.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/10dlc.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.58.0</version>
+    <version>6.81.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.58.0")
+implementation("com.telnyx.sdk:telnyx:6.81.0")
 ```
 
 ## Setup
@@ -137,7 +137,7 @@ CampaignBuilderSubmitParams params = CampaignBuilderSubmitParams.builder()
     .brandId("BXXXXXX")
     .description("Two-factor authentication messages")
     .usecase("2FA")
-    .sampleMessages(java.util.List.of("Your verification code is {{code}}"))
+    .sample1("Your verification code is {{code}}")
     .build();
 TelnyxCampaignCsp telnyxCampaignCsp = client.messaging10dlc().campaignBuilder().submit(params);
 ```

--- a/skills/telnyx-twilio-migration/sdk-reference/java/ai-assistants.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/ai-assistants.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.58.0</version>
+    <version>6.81.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.58.0")
+implementation("com.telnyx.sdk:telnyx:6.81.0")
 ```
 
 ## Setup
@@ -669,6 +669,7 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `clientSideTool` | object |  |
 | `timeoutMs` | integer |  |
 
 ### Update Tool — `client.ai().tools().update()`
@@ -682,4 +683,5 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `clientSideTool` | object |  |
 | `timeoutMs` | integer |  |

--- a/skills/telnyx-twilio-migration/sdk-reference/java/messaging.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/messaging.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.58.0</version>
+    <version>6.81.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.58.0")
+implementation("com.telnyx.sdk:telnyx:6.81.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/numbers.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/numbers.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.58.0</version>
+    <version>6.81.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.58.0")
+implementation("com.telnyx.sdk:telnyx:6.81.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/voice.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/voice.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.58.0</version>
+    <version>6.81.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.58.0")
+implementation("com.telnyx.sdk:telnyx:6.81.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/javascript/10dlc.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/javascript/10dlc.md
@@ -132,7 +132,7 @@ const telnyxCampaignCsp = await client.messaging10dlc.campaignBuilder.submit({
   brandId: 'BXXXXXX',
   description: 'Two-factor authentication messages',
   usecase: '2FA',
-    sampleMessages: ["Your verification code is {{code}}"],
+    sample1: 'Your verification code is {{code}}',
 });
 
 console.log(telnyxCampaignCsp.brandId);
@@ -184,7 +184,7 @@ and `telnyx-timestamp` headers. Always verify signatures in production:
 // In your webhook handler (e.g., Express — use raw body, not parsed JSON):
 app.post('/webhooks', express.raw({ type: 'application/json' }), async (req, res) => {
   try {
-    const event = await client.webhooks.unwrap(req.body.toString(), {
+    const event = client.webhooks.unwrap(req.body.toString(), {
       headers: req.headers,
     });
     // Signature valid — event is the parsed webhook payload
@@ -395,7 +395,7 @@ Before using any operation below, read the Optional Parameters section below and
 | Get Campaign Cost | `client.messaging10dlc.campaign.usecase.getCost()` | `GET /10dlc/campaign/usecase/cost` | Inspect available resources or choose an existing resource before mutating it. | None |
 | Update campaign | `client.messaging10dlc.campaign.update()` | `PUT /10dlc/campaign/{campaignId}` | Inspect the current state of an existing campaign registration. | `campaignId` |
 | Deactivate campaign | `client.messaging10dlc.campaign.deactivate()` | `DELETE /10dlc/campaign/{campaignId}` | Inspect the current state of an existing campaign registration. | `campaignId` |
-| Submit campaign appeal for manual review | `client.messaging10dlc.campaign.submitAppeal()` | `POST /10dlc/campaign/{campaignId}/appeal` | Create or provision an additional resource when the core tasks do not cover this flow. | `appealReason`, `campaignId` |
+| Submit campaign appeal for manual review | `client.messaging10dlc.campaign.submitAppeal()` | `POST /10dlc/campaign/{campaignId}/appeal` | Create or provision an additional resource when the core tasks do not cover this flow. | `appeal_reason`, `campaignId` |
 | Get Campaign Mno Metadata | `client.messaging10dlc.campaign.getMnoMetadata()` | `GET /10dlc/campaign/{campaignId}/mnoMetadata` | Fetch the current state before updating, deleting, or making control-flow decisions. | `campaignId` |
 | Get campaign operation status | `client.messaging10dlc.campaign.getOperationStatus()` | `GET /10dlc/campaign/{campaignId}/operationStatus` | Fetch the current state before updating, deleting, or making control-flow decisions. | `campaignId` |
 | Get OSR campaign attributes | `client.messaging10dlc.campaign.osr.getAttributes()` | `GET /10dlc/campaign/{campaignId}/osr/attributes` | Fetch the current state before updating, deleting, or making control-flow decisions. | `campaignId` |

--- a/skills/telnyx-twilio-migration/sdk-reference/javascript/ai-assistants.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/javascript/ai-assistants.md
@@ -107,8 +107,8 @@ Chat is the primary runtime path. Agents need the exact assistant method and the
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `content` | string | Yes | The message content sent by the client to the assistant |
-| `conversationId` | string (UUID) | Yes | A unique identifier for the conversation thread, used to mai... |
-| `assistantId` | string (UUID) | Yes | Unique identifier of the assistant. |
+| `conversation_id` | string (UUID) | Yes | A unique identifier for the conversation thread, used to mai... |
+| `assistant_id` | string (UUID) | Yes | Unique identifier of the assistant. |
 | `name` | string | No | The optional display name of the user sending the message |
 
 ```javascript
@@ -136,8 +136,8 @@ Test creation is the main validation path for production assistant behavior befo
 | `instructions` | string | Yes | Detailed instructions that define the test scenario and what... |
 | `rubric` | array[object] | Yes | Evaluation criteria used to assess the assistant's performan... |
 | `description` | string | No | Optional detailed description of what this test evaluates an... |
-| `telnyxConversationChannel` | object | No | The communication channel through which the test will be con... |
-| `maxDurationSeconds` | integer | No | Maximum duration in seconds that the test conversation shoul... |
+| `telnyx_conversation_channel` | object | No | The communication channel through which the test will be con... |
+| `max_duration_seconds` | integer | No | Maximum duration in seconds that the test conversation shoul... |
 | ... | | | +1 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -177,9 +177,9 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `assistantId` | string (UUID) | Yes | Unique identifier of the assistant. |
-| `callControlId` | string (UUID) | No | Filter results by call control id. |
-| `fetchDynamicVariablesFromWebhook` | boolean | No | Whether to fetch dynamic variables from the configured webho... |
+| `assistant_id` | string (UUID) | Yes | Unique identifier of the assistant. |
+| `call_control_id` | string (UUID) | No | Filter results by call control id. |
+| `fetch_dynamic_variables_from_webhook` | boolean | No | Whether to fetch dynamic variables from the configured webho... |
 | `from` | string (E.164) | No | Start of the filter range. |
 | ... | | | +1 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
@@ -205,7 +205,7 @@ Create or provision an additional resource when the core tasks do not cover this
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `assistantId` | string (UUID) | Yes | Unique identifier of the assistant. |
+| `assistant_id` | string (UUID) | Yes | Unique identifier of the assistant. |
 | `tags` | array[string] | No | Tags associated with the assistant. |
 | `name` | string | No |  |
 | `model` | string | No | ID of the model to use when `external_llm` is not set. |
@@ -257,12 +257,12 @@ Import existing assistants from an external provider instead of creating from sc
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `provider` | enum (elevenlabs, vapi, retell) | Yes | The external provider to import assistants from. |
-| `apiKeyRef` | string | Yes | Integration secret pointer that refers to the API key for th... |
-| `importIds` | array[string] | No | Optional list of assistant IDs to import from the external p... |
+| `api_key_ref` | string | Yes | Integration secret pointer that refers to the API key for th... |
+| `import_ids` | array[string] | No | Optional list of assistant IDs to import from the external p... |
 
 ```javascript
 const assistantsList = await client.ai.assistants.imports({
-  api_key_ref: 'api_key_ref',
+  api_key_ref: 'my-openai-key',
   provider: 'elevenlabs',
 });
 
@@ -303,8 +303,8 @@ Inspect available resources or choose an existing resource before mutating it.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `testSuite` | string | No | Filter tests by test suite name |
-| `telnyxConversationChannel` | string | No | Filter tests by communication channel (e.g., 'web_chat', 'sm... |
+| `test_suite` | string | No | Filter tests by test suite name |
+| `telnyx_conversation_channel` | string | No | Filter tests by communication channel (e.g., 'web_chat', 'sm... |
 | `destination` | string | No | Filter tests by destination (phone number, webhook URL, etc.... |
 | ... | | | +1 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
@@ -353,8 +353,8 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `suiteName` | string | Yes | Name of the suite. |
-| `testSuiteRunId` | string (UUID) | No | Filter runs by specific suite execution batch ID |
+| `suite_name` | string | Yes | Name of the suite. |
+| `test_suite_run_id` | string (UUID) | No | Filter runs by specific suite execution batch ID |
 | `status` | string | No | Filter runs by execution status (pending, running, completed... |
 | `page` | object | No | Consolidated page parameter (deepObject style). |
 
@@ -386,46 +386,46 @@ Before using any operation below, read the Optional Parameters section below and
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
-| Trigger test suite execution | `client.ai.assistants.tests.testSuites.runs.trigger()` | `POST /ai/assistants/tests/test-suites/{suite_name}/runs` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `suiteName` |
-| Get assistant test by ID | `client.ai.assistants.tests.retrieve()` | `GET /ai/assistants/tests/{test_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId` |
-| Update an assistant test | `client.ai.assistants.tests.update()` | `PUT /ai/assistants/tests/{test_id}` | Modify an existing resource without recreating it. | `testId` |
-| Delete an assistant test | `client.ai.assistants.tests.delete()` | `DELETE /ai/assistants/tests/{test_id}` | Remove, detach, or clean up an existing resource. | `testId` |
-| Get test run history for a specific test | `client.ai.assistants.tests.runs.list()` | `GET /ai/assistants/tests/{test_id}/runs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId` |
-| Trigger a manual test run | `client.ai.assistants.tests.runs.trigger()` | `POST /ai/assistants/tests/{test_id}/runs` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `testId` |
-| Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `testId`, `runId` |
-| Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistantId` |
-| Get Canary Deploy | `client.ai.assistants.canaryDeploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Create Canary Deploy | `client.ai.assistants.canaryDeploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId` |
-| Update Canary Deploy | `client.ai.assistants.canaryDeploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistantId` |
-| Delete Canary Deploy | `client.ai.assistants.canaryDeploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistantId` |
-| Assistant Sms Chat | `client.ai.assistants.sendSMS()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistantId` |
-| Clone Assistant | `client.ai.assistants.clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId` |
-| Enhance Assistant Instructions | `client.ai.assistants.instructions.enhance()` | `POST /ai/assistants/{assistant_id}/instructions/enhance` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId` |
-| List scheduled events | `client.ai.assistants.scheduledEvents.list()` | `GET /ai/assistants/{assistant_id}/scheduled_events` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Create a scheduled event | `client.ai.assistants.scheduledEvents.create()` | `POST /ai/assistants/{assistant_id}/scheduled_events` | Create or provision an additional resource when the core tasks do not cover this flow. | `telnyxConversationChannel`, `telnyxEndUserTarget`, `telnyxAgentTarget`, `scheduledAtFixedDatetime`, +1 more |
-| Get a scheduled event | `client.ai.assistants.scheduledEvents.retrieve()` | `GET /ai/assistants/{assistant_id}/scheduled_events/{event_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId`, `eventId` |
-| Delete a scheduled event | `client.ai.assistants.scheduledEvents.delete()` | `DELETE /ai/assistants/{assistant_id}/scheduled_events/{event_id}` | Remove, detach, or clean up an existing resource. | `assistantId`, `eventId` |
-| Add Assistant Tag | `client.ai.assistants.tags.add()` | `POST /ai/assistants/{assistant_id}/tags` | Create or provision an additional resource when the core tasks do not cover this flow. | `tag`, `assistantId` |
-| Remove Assistant Tag | `client.ai.assistants.tags.remove()` | `DELETE /ai/assistants/{assistant_id}/tags/{tag}` | Remove, detach, or clean up an existing resource. | `assistantId`, `tag` |
-| Get assistant texml | `client.ai.assistants.getTexml()` | `GET /ai/assistants/{assistant_id}/texml` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Add Assistant Tool | `client.ai.assistants.tools.add()` | `PUT /ai/assistants/{assistant_id}/tools/{tool_id}` | Modify an existing resource without recreating it. | `assistantId`, `toolId` |
-| Remove Assistant Tool | `client.ai.assistants.tools.remove()` | `DELETE /ai/assistants/{assistant_id}/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `assistantId`, `toolId` |
-| Test Assistant Tool | `client.ai.assistants.tools.test()` | `POST /ai/assistants/{assistant_id}/tools/{tool_id}/test` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId`, `toolId` |
-| Get all versions of an assistant | `client.ai.assistants.versions.list()` | `GET /ai/assistants/{assistant_id}/versions` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId` |
-| Get a specific assistant version | `client.ai.assistants.versions.retrieve()` | `GET /ai/assistants/{assistant_id}/versions/{version_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistantId`, `versionId` |
-| Update a specific assistant version | `client.ai.assistants.versions.update()` | `POST /ai/assistants/{assistant_id}/versions/{version_id}` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistantId`, `versionId` |
-| Delete a specific assistant version | `client.ai.assistants.versions.delete()` | `DELETE /ai/assistants/{assistant_id}/versions/{version_id}` | Remove, detach, or clean up an existing resource. | `assistantId`, `versionId` |
-| Promote an assistant version to main | `client.ai.assistants.versions.promote()` | `POST /ai/assistants/{assistant_id}/versions/{version_id}/promote` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistantId`, `versionId` |
+| Trigger test suite execution | `client.ai.assistants.tests.testSuites.runs.trigger()` | `POST /ai/assistants/tests/test-suites/{suite_name}/runs` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `suite_name` |
+| Get assistant test by ID | `client.ai.assistants.tests.retrieve()` | `GET /ai/assistants/tests/{test_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id` |
+| Update an assistant test | `client.ai.assistants.tests.update()` | `PUT /ai/assistants/tests/{test_id}` | Modify an existing resource without recreating it. | `test_id` |
+| Delete an assistant test | `client.ai.assistants.tests.delete()` | `DELETE /ai/assistants/tests/{test_id}` | Remove, detach, or clean up an existing resource. | `test_id` |
+| Get test run history for a specific test | `client.ai.assistants.tests.runs.list()` | `GET /ai/assistants/tests/{test_id}/runs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id` |
+| Trigger a manual test run | `client.ai.assistants.tests.runs.trigger()` | `POST /ai/assistants/tests/{test_id}/runs` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `test_id` |
+| Get specific test run details | `client.ai.assistants.tests.runs.retrieve()` | `GET /ai/assistants/tests/{test_id}/runs/{run_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `test_id`, `run_id` |
+| Delete an assistant | `client.ai.assistants.delete()` | `DELETE /ai/assistants/{assistant_id}` | Remove, detach, or clean up an existing resource. | `assistant_id` |
+| Get Canary Deploy | `client.ai.assistants.canaryDeploys.retrieve()` | `GET /ai/assistants/{assistant_id}/canary-deploys` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Create Canary Deploy | `client.ai.assistants.canaryDeploys.create()` | `POST /ai/assistants/{assistant_id}/canary-deploys` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| Update Canary Deploy | `client.ai.assistants.canaryDeploys.update()` | `PUT /ai/assistants/{assistant_id}/canary-deploys` | Modify an existing resource without recreating it. | `assistant_id` |
+| Delete Canary Deploy | `client.ai.assistants.canaryDeploys.delete()` | `DELETE /ai/assistants/{assistant_id}/canary-deploys` | Remove, detach, or clean up an existing resource. | `assistant_id` |
+| Assistant Sms Chat | `client.ai.assistants.sendSMS()` | `POST /ai/assistants/{assistant_id}/chat/sms` | Run assistant chat over SMS instead of direct API chat. | `from`, `to`, `assistant_id` |
+| Clone Assistant | `client.ai.assistants.clone()` | `POST /ai/assistants/{assistant_id}/clone` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id` |
+| Enhance Assistant Instructions | `client.ai.assistants.instructions.enhance()` | `POST /ai/assistants/{assistant_id}/instructions/enhance` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id` |
+| List scheduled events | `client.ai.assistants.scheduledEvents.list()` | `GET /ai/assistants/{assistant_id}/scheduled_events` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Create a scheduled event | `client.ai.assistants.scheduledEvents.create()` | `POST /ai/assistants/{assistant_id}/scheduled_events` | Create or provision an additional resource when the core tasks do not cover this flow. | `telnyx_conversation_channel`, `telnyx_end_user_target`, `telnyx_agent_target`, `scheduled_at_fixed_datetime`, +1 more |
+| Get a scheduled event | `client.ai.assistants.scheduledEvents.retrieve()` | `GET /ai/assistants/{assistant_id}/scheduled_events/{event_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id`, `event_id` |
+| Delete a scheduled event | `client.ai.assistants.scheduledEvents.delete()` | `DELETE /ai/assistants/{assistant_id}/scheduled_events/{event_id}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `event_id` |
+| Add Assistant Tag | `client.ai.assistants.tags.add()` | `POST /ai/assistants/{assistant_id}/tags` | Create or provision an additional resource when the core tasks do not cover this flow. | `tag`, `assistant_id` |
+| Remove Assistant Tag | `client.ai.assistants.tags.remove()` | `DELETE /ai/assistants/{assistant_id}/tags/{tag}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `tag` |
+| Get assistant texml | `client.ai.assistants.getTexml()` | `GET /ai/assistants/{assistant_id}/texml` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Add Assistant Tool | `client.ai.assistants.tools.add()` | `PUT /ai/assistants/{assistant_id}/tools/{tool_id}` | Modify an existing resource without recreating it. | `assistant_id`, `tool_id` |
+| Remove Assistant Tool | `client.ai.assistants.tools.remove()` | `DELETE /ai/assistants/{assistant_id}/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `tool_id` |
+| Test Assistant Tool | `client.ai.assistants.tools.test()` | `POST /ai/assistants/{assistant_id}/tools/{tool_id}/test` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id`, `tool_id` |
+| Get all versions of an assistant | `client.ai.assistants.versions.list()` | `GET /ai/assistants/{assistant_id}/versions` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id` |
+| Get a specific assistant version | `client.ai.assistants.versions.retrieve()` | `GET /ai/assistants/{assistant_id}/versions/{version_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `assistant_id`, `version_id` |
+| Update a specific assistant version | `client.ai.assistants.versions.update()` | `POST /ai/assistants/{assistant_id}/versions/{version_id}` | Create or provision an additional resource when the core tasks do not cover this flow. | `assistant_id`, `version_id` |
+| Delete a specific assistant version | `client.ai.assistants.versions.delete()` | `DELETE /ai/assistants/{assistant_id}/versions/{version_id}` | Remove, detach, or clean up an existing resource. | `assistant_id`, `version_id` |
+| Promote an assistant version to main | `client.ai.assistants.versions.promote()` | `POST /ai/assistants/{assistant_id}/versions/{version_id}/promote` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `assistant_id`, `version_id` |
 | List MCP Servers | `client.ai.mcpServers.list()` | `GET /ai/mcp_servers` | Inspect available resources or choose an existing resource before mutating it. | None |
 | Create MCP Server | `client.ai.mcpServers.create()` | `POST /ai/mcp_servers` | Create or provision an additional resource when the core tasks do not cover this flow. | `name`, `type`, `url` |
-| Get MCP Server | `client.ai.mcpServers.retrieve()` | `GET /ai/mcp_servers/{mcp_server_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `mcpServerId` |
-| Update MCP Server | `client.ai.mcpServers.update()` | `PUT /ai/mcp_servers/{mcp_server_id}` | Modify an existing resource without recreating it. | `mcpServerId` |
-| Delete MCP Server | `client.ai.mcpServers.delete()` | `DELETE /ai/mcp_servers/{mcp_server_id}` | Remove, detach, or clean up an existing resource. | `mcpServerId` |
+| Get MCP Server | `client.ai.mcpServers.retrieve()` | `GET /ai/mcp_servers/{mcp_server_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `mcp_server_id` |
+| Update MCP Server | `client.ai.mcpServers.update()` | `PUT /ai/mcp_servers/{mcp_server_id}` | Modify an existing resource without recreating it. | `mcp_server_id` |
+| Delete MCP Server | `client.ai.mcpServers.delete()` | `DELETE /ai/mcp_servers/{mcp_server_id}` | Remove, detach, or clean up an existing resource. | `mcp_server_id` |
 | List Tools | `client.ai.tools.list()` | `GET /ai/tools` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Create Tool | `client.ai.tools.create()` | `POST /ai/tools` | Create or provision an additional resource when the core tasks do not cover this flow. | `type`, `displayName` |
-| Get Tool | `client.ai.tools.retrieve()` | `GET /ai/tools/{tool_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `toolId` |
-| Update Tool | `client.ai.tools.update()` | `PATCH /ai/tools/{tool_id}` | Modify an existing resource without recreating it. | `toolId` |
-| Delete Tool | `client.ai.tools.delete()` | `DELETE /ai/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `toolId` |
+| Create Tool | `client.ai.tools.create()` | `POST /ai/tools` | Create or provision an additional resource when the core tasks do not cover this flow. | `type`, `display_name` |
+| Get Tool | `client.ai.tools.retrieve()` | `GET /ai/tools/{tool_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `tool_id` |
+| Update Tool | `client.ai.tools.update()` | `PATCH /ai/tools/{tool_id}` | Modify an existing resource without recreating it. | `tool_id` |
+| Delete Tool | `client.ai.tools.delete()` | `DELETE /ai/tools/{tool_id}` | Remove, detach, or clean up an existing resource. | `tool_id` |
 
 ---
 
@@ -442,51 +442,51 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 |-----------|------|-------------|
 | `model` | string | ID of the model to use when `external_llm` is not set. |
 | `tools` | array[object] | Deprecated for new integrations. |
-| `mcpServers` | array[object] | MCP servers attached to the assistant. |
-| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
-| `externalLlm` | object |  |
-| `fallbackConfig` | object |  |
-| `voiceSettings` | object |  |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
 | `transcription` | object |  |
-| `telephonySettings` | object |  |
-| `messagingSettings` | object |  |
-| `enabledFeatures` | array[object] |  |
-| `insightSettings` | object |  |
-| `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
-| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
-| `dynamicVariables` | object | Map of dynamic variables and their default values |
-| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
-| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
 | `integrations` | array[object] | Connected integrations attached to the assistant. |
-| `observabilitySettings` | object |  |
+| `observability_settings` | object |  |
 | `tags` | array[string] | Tags associated with the assistant. |
-| `postConversationSettings` | object | Configuration for post-conversation processing. |
-| `conversationFlow` | object | Conversation flow as supplied by API clients (create / update). |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+| `conversation_flow` | object | Conversation flow as supplied by API clients (create / update). |
 
 ### Import assistants from external provider — `client.ai.assistants.imports()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `importIds` | array[string] | Optional list of assistant IDs to import from the external provider. |
+| `import_ids` | array[string] | Optional list of assistant IDs to import from the external provider. |
 
 ### Create a new assistant test — `client.ai.assistants.tests.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `description` | string | Optional detailed description of what this test evaluates and its purpose. |
-| `telnyxConversationChannel` | object | The communication channel through which the test will be conducted. |
-| `maxDurationSeconds` | integer | Maximum duration in seconds that the test conversation should run before timi... |
-| `testSuite` | string | Optional test suite name to group related tests together. |
+| `telnyx_conversation_channel` | object | The communication channel through which the test will be conducted. |
+| `max_duration_seconds` | integer | Maximum duration in seconds that the test conversation should run before timi... |
+| `test_suite` | string | Optional test suite name to group related tests together. |
 
 ### Trigger test suite execution — `client.ai.assistants.tests.testSuites.runs.trigger()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `destinationVersionId` | string (UUID) | Optional assistant version ID to use for all test runs in this suite. |
+| `destination_version_id` | string (UUID) | Optional assistant version ID to use for all test runs in this suite. |
 
 ### Update an assistant test — `client.ai.assistants.tests.update()`
 
@@ -494,10 +494,10 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 |-----------|------|-------------|
 | `name` | string | Updated name for the assistant test. |
 | `description` | string | Updated description of the test's purpose and evaluation criteria. |
-| `telnyxConversationChannel` | enum (phone_call, web_call, sms_chat, web_chat) |  |
+| `telnyx_conversation_channel` | enum (phone_call, web_call, sms_chat, web_chat) |  |
 | `destination` | string | Updated target destination for test conversations. |
-| `maxDurationSeconds` | integer | Updated maximum test duration in seconds. |
-| `testSuite` | string | Updated test suite assignment for better organization. |
+| `max_duration_seconds` | integer | Updated maximum test duration in seconds. |
+| `test_suite` | string | Updated test suite assignment for better organization. |
 | `instructions` | string | Updated test scenario instructions and objectives. |
 | `rubric` | array[object] | Updated evaluation criteria for assessing assistant performance. |
 
@@ -505,7 +505,7 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `destinationVersionId` | string (UUID) | Optional assistant version ID to use for this test run. |
+| `destination_version_id` | string (UUID) | Optional assistant version ID to use for this test run. |
 
 ### Update an assistant — `client.ai.assistants.update()`
 
@@ -515,32 +515,32 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 | `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
 | `tools` | array[object] | Deprecated for new integrations. |
-| `mcpServers` | array[object] | MCP servers attached to the assistant. |
-| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
-| `externalLlm` | object |  |
-| `fallbackConfig` | object |  |
-| `voiceSettings` | object |  |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
 | `transcription` | object |  |
-| `telephonySettings` | object |  |
-| `messagingSettings` | object |  |
-| `enabledFeatures` | array[object] |  |
-| `insightSettings` | object |  |
-| `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
-| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
-| `dynamicVariables` | object | Map of dynamic variables and their default values |
-| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
-| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
 | `integrations` | array[object] | Connected integrations attached to the assistant. |
-| `observabilitySettings` | object |  |
+| `observability_settings` | object |  |
 | `tags` | array[string] | Tags associated with the assistant. |
-| `versionName` | string | Human-readable name for the assistant version. |
-| `postConversationSettings` | object | Configuration for post-conversation processing. |
-| `conversationFlow` | object | Conversation flow as supplied by API clients (create / update). |
-| `promoteToMain` | boolean | Indicates whether the assistant should be promoted to the main version. |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+| `conversation_flow` | object | Conversation flow as supplied by API clients (create / update). |
+| `promote_to_main` | boolean | Indicates whether the assistant should be promoted to the main version. |
 
 ### Create Canary Deploy — `client.ai.assistants.canaryDeploys.create()`
 
@@ -565,14 +565,14 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `text` | string |  |
-| `conversationMetadata` | object |  |
-| `shouldCreateConversation` | boolean |  |
+| `conversation_metadata` | object |  |
+| `should_create_conversation` | boolean |  |
 
 ### Enhance Assistant Instructions — `client.ai.assistants.instructions.enhance()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `enhancementPrompt` | object | Optional guidance describing how the instructions should be enhanced. |
+| `enhancement_prompt` | object | Optional guidance describing how the instructions should be enhanced. |
 | `instructions` | object | The instructions to enhance. |
 
 ### Create a scheduled event — `client.ai.assistants.scheduledEvents.create()`
@@ -580,11 +580,11 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `text` | string | Required for sms scheduled events. |
-| `conversationMetadata` | object | Metadata associated with the conversation. |
-| `dynamicVariables` | object | A map of dynamic variable names to values. |
-| `maxRetriesClientErrors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
-| `retryIntervalSecs` | integer |  |
-| `callSettings` | object | Per-call telephony overrides applied when a scheduled phone-call event
+| `conversation_metadata` | object | Metadata associated with the conversation. |
+| `dynamic_variables` | object | A map of dynamic variable names to values. |
+| `max_retries_client_errors` | integer | Configure number of retries on client errors: busy, no-answer, failed, cancel... |
+| `retry_interval_secs` | integer |  |
+| `call_settings` | object | Per-call telephony overrides applied when a scheduled phone-call event
 dispat... |
 
 ### Test Assistant Tool — `client.ai.assistants.tools.test()`
@@ -592,7 +592,7 @@ dispat... |
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `arguments` | object | Key-value arguments to use for the webhook test |
-| `dynamicVariables` | object | Key-value dynamic variables to use for the webhook test |
+| `dynamic_variables` | object | Key-value dynamic variables to use for the webhook test |
 
 ### Update a specific assistant version — `client.ai.assistants.versions.update()`
 
@@ -602,38 +602,38 @@ dispat... |
 | `model` | string | ID of the model to use when `external_llm` is not set. |
 | `instructions` | string | System instructions for the assistant. |
 | `tools` | array[object] | Deprecated for new integrations. |
-| `mcpServers` | array[object] | MCP servers attached to the assistant. |
-| `toolIds` | array[string] | IDs of shared tools to attach to the assistant. |
+| `mcp_servers` | array[object] | MCP servers attached to the assistant. |
+| `tool_ids` | array[string] | IDs of shared tools to attach to the assistant. |
 | `description` | string |  |
 | `greeting` | string | Text that the assistant will use to start the conversation. |
-| `llmApiKeyRef` | string | This is only needed when using third-party inference providers selected by `m... |
-| `externalLlm` | object |  |
-| `fallbackConfig` | object |  |
-| `voiceSettings` | object |  |
+| `llm_api_key_ref` | string | This is only needed when using third-party inference providers selected by `m... |
+| `external_llm` | object |  |
+| `fallback_config` | object |  |
+| `voice_settings` | object |  |
 | `transcription` | object |  |
-| `telephonySettings` | object |  |
-| `messagingSettings` | object |  |
-| `enabledFeatures` | array[object] |  |
-| `insightSettings` | object |  |
-| `privacySettings` | object |  |
-| `dynamicVariablesWebhookUrl` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
-| `dynamicVariablesWebhookTimeoutMs` | integer | Timeout in milliseconds for the dynamic variables webhook. |
-| `dynamicVariables` | object | Map of dynamic variables and their default values |
-| `widgetSettings` | object | Configuration settings for the assistant's web widget. |
-| `interruptionSettings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
+| `telephony_settings` | object |  |
+| `messaging_settings` | object |  |
+| `enabled_features` | array[object] |  |
+| `insight_settings` | object |  |
+| `privacy_settings` | object |  |
+| `dynamic_variables_webhook_url` | string (URL) | If `dynamic_variables_webhook_url` is set, Telnyx sends a POST request to thi... |
+| `dynamic_variables_webhook_timeout_ms` | integer | Timeout in milliseconds for the dynamic variables webhook. |
+| `dynamic_variables` | object | Map of dynamic variables and their default values |
+| `widget_settings` | object | Configuration settings for the assistant's web widget. |
+| `interruption_settings` | object | Settings for interruptions and how the assistant decides the user has finishe... |
 | `integrations` | array[object] | Connected integrations attached to the assistant. |
-| `observabilitySettings` | object |  |
+| `observability_settings` | object |  |
 | `tags` | array[string] | Tags associated with the assistant. |
-| `versionName` | string | Human-readable name for the assistant version. |
-| `postConversationSettings` | object | Configuration for post-conversation processing. |
-| `conversationFlow` | object | Conversation flow as supplied by API clients (create / update). |
+| `version_name` | string | Human-readable name for the assistant version. |
+| `post_conversation_settings` | object | Configuration for post-conversation processing. |
+| `conversation_flow` | object | Conversation flow as supplied by API clients (create / update). |
 
 ### Create MCP Server — `client.ai.mcpServers.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `apiKeyRef` | string |  |
-| `allowedTools` | array[string] |  |
+| `api_key_ref` | string |  |
+| `allowed_tools` | array[string] |  |
 
 ### Update MCP Server — `client.ai.mcpServers.update()`
 
@@ -643,9 +643,9 @@ dispat... |
 | `name` | string |  |
 | `type` | string |  |
 | `url` | string (URL) |  |
-| `apiKeyRef` | string |  |
-| `allowedTools` | array[string] |  |
-| `createdAt` | string (date-time) |  |
+| `api_key_ref` | string |  |
+| `allowed_tools` | array[string] |  |
+| `created_at` | string (date-time) |  |
 
 ### Create Tool — `client.ai.tools.create()`
 
@@ -656,17 +656,19 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
-| `timeoutMs` | integer |  |
+| `client_side_tool` | object |  |
+| `timeout_ms` | integer |  |
 
 ### Update Tool — `client.ai.tools.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `type` | string |  |
-| `displayName` | string |  |
+| `display_name` | string |  |
 | `function` | object |  |
 | `retrieval` | object |  |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
-| `timeoutMs` | integer |  |
+| `client_side_tool` | object |  |
+| `timeout_ms` | integer |  |

--- a/skills/telnyx-twilio-migration/sdk-reference/javascript/messaging.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/javascript/messaging.md
@@ -83,9 +83,9 @@ Primary outbound messaging flow. Agents need exact request fields and delivery-r
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
 | `from` | string (E.164) | Yes | Sending address (+E.164 formatted phone number, alphanumeric... |
 | `text` | string | Yes | Message body (i.e., content) as a non-empty string. |
-| `messagingProfileId` | string (UUID) | No | Unique identifier for a messaging profile. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Unique identifier for a messaging profile. |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
 | ... | | | +7 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -117,10 +117,10 @@ Common sender variant that requires different request shape.
 | `from` | string (E.164) | Yes | A valid alphanumeric sender ID on the user's account. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
 | `text` | string | Yes | The message body. |
-| `messagingProfileId` | string (UUID) | Yes | The messaging profile ID to use. |
-| `webhookUrl` | string (URL) | No | Callback URL for delivery status updates. |
-| `webhookFailoverUrl` | string (URL) | No | Failover callback URL for delivery status updates. |
-| `useProfileWebhooks` | boolean | No | If true, use the messaging profile's webhook settings. |
+| `messaging_profile_id` | string (UUID) | Yes | The messaging profile ID to use. |
+| `webhook_url` | string (URL) | No | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | No | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | No | If true, use the messaging profile's webhook settings. |
 
 ```javascript
 const response = await client.messages.sendWithAlphanumericSender({
@@ -152,7 +152,7 @@ and `telnyx-timestamp` headers. Always verify signatures in production:
 // In your webhook handler (e.g., Express — use raw body, not parsed JSON):
 app.post('/webhooks', express.raw({ type: 'application/json' }), async (req, res) => {
   try {
-    const event = await client.webhooks.unwrap(req.body.toString(), {
+    const event = client.webhooks.unwrap(req.body.toString(), {
       headers: req.headers,
     });
     // Signature valid — event is the parsed webhook payload
@@ -213,9 +213,9 @@ Send one MMS payload to multiple recipients.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | array[object] | Yes | A list of destinations. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +3 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -246,9 +246,9 @@ Force a long-code sending path instead of the generic send endpoint.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -276,11 +276,11 @@ Let a messaging profile or number pool choose the sender for you.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `messagingProfileId` | string (UUID) | Yes | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Yes | Unique identifier for a messaging profile. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -311,9 +311,9 @@ Force a short-code sending path when the sender must be a short code.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number, in +E.164 format, used to send the message. |
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | No | The failover URL where webhooks related to this message will... |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | No | The failover URL where webhooks related to this message will... |
 | ... | | | +6 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -342,9 +342,9 @@ Queue a message for future delivery instead of sending immediately.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `to` | string (E.164) | Yes | Receiving address (+E.164 formatted phone number or short co... |
-| `messagingProfileId` | string (UUID) | No | Unique identifier for a messaging profile. |
-| `mediaUrls` | array[string] | No | A list of media URLs. |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Unique identifier for a messaging profile. |
+| `media_urls` | array[string] | No | A list of media URLs. |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
 | ... | | | +8 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -352,7 +352,7 @@ const response = await client.messages.schedule({
     to: '+18445550001',
     from: '+18005550101',
     text: 'Appointment reminder',
-    sendAt: '2025-07-01T15:00:00Z',
+    send_at: '2025-07-01T15:00:00Z',
 });
 
 console.log(response.data);
@@ -376,10 +376,10 @@ Send WhatsApp traffic instead of SMS/MMS.
 |-----------|------|----------|-------------|
 | `from` | string (E.164) | Yes | Phone number in +E.164 format associated with Whatsapp accou... |
 | `to` | string (E.164) | Yes | Phone number in +E.164 format |
-| `whatsappMessage` | object | Yes |  |
+| `whatsapp_message` | object | Yes |  |
 | `type` | enum (WHATSAPP) | No | Message type - must be set to "WHATSAPP" |
-| `webhookUrl` | string (URL) | No | The URL where webhooks related to this message will be sent. |
-| `messagingProfileId` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
+| `webhook_url` | string (URL) | No | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | No | Messaging profile ID - required if the 'from' number is not ... |
 
 ```javascript
 const response = await client.messages.sendWhatsapp({
@@ -411,10 +411,10 @@ Before using any operation below, read the Optional Parameters section below and
 | Retrieve a message | `client.messages.retrieve()` | `GET /messages/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Cancel a scheduled message | `client.messages.cancelScheduled()` | `DELETE /messages/{id}` | Remove, detach, or clean up an existing resource. | `id` |
 | List alphanumeric sender IDs | `client.alphanumericSenderIDs.list()` | `GET /alphanumeric_sender_ids` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Create an alphanumeric sender ID | `client.alphanumericSenderIDs.create()` | `POST /alphanumeric_sender_ids` | Create or provision an additional resource when the core tasks do not cover this flow. | `alphanumericSenderId`, `messagingProfileId` |
+| Create an alphanumeric sender ID | `client.alphanumericSenderIDs.create()` | `POST /alphanumeric_sender_ids` | Create or provision an additional resource when the core tasks do not cover this flow. | `alphanumeric_sender_id`, `messaging_profile_id` |
 | Retrieve an alphanumeric sender ID | `client.alphanumericSenderIDs.retrieve()` | `GET /alphanumeric_sender_ids/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Delete an alphanumeric sender ID | `client.alphanumericSenderIDs.delete()` | `DELETE /alphanumeric_sender_ids/{id}` | Remove, detach, or clean up an existing resource. | `id` |
-| Retrieve group MMS messages | `client.messages.retrieveGroupMessages()` | `GET /messages/group/{message_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `messageId` |
+| Retrieve group MMS messages | `client.messages.retrieveGroupMessages()` | `GET /messages/group/{message_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `message_id` |
 | List messaging hosted numbers | `client.messagingHostedNumbers.list()` | `GET /messaging_hosted_numbers` | Inspect available resources or choose an existing resource before mutating it. | None |
 | Retrieve a messaging hosted number | `client.messagingHostedNumbers.retrieve()` | `GET /messaging_hosted_numbers/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Update a messaging hosted number | `client.messagingHostedNumbers.update()` | `PATCH /messaging_hosted_numbers/{id}` | Modify an existing resource without recreating it. | `id` |
@@ -423,11 +423,11 @@ Before using any operation below, read the Optional Parameters section below and
 | Regenerate messaging profile secret | `client.messagingProfiles.actions.regenerateSecret()` | `POST /messaging_profiles/{id}/actions/regenerate_secret` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `id` |
 | List alphanumeric sender IDs for a messaging profile | `client.messagingProfiles.listAlphanumericSenderIDs()` | `GET /messaging_profiles/{id}/alphanumeric_sender_ids` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Get detailed messaging profile metrics | `client.messagingProfiles.retrieveMetrics()` | `GET /messaging_profiles/{id}/metrics` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
-| List Auto-Response Settings | `client.messagingProfiles.autorespConfigs.list()` | `GET /messaging_profiles/{profile_id}/autoresp_configs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profileId` |
-| Create auto-response setting | `client.messagingProfiles.autorespConfigs.create()` | `POST /messaging_profiles/{profile_id}/autoresp_configs` | Create or provision an additional resource when the core tasks do not cover this flow. | `op`, `keywords`, `countryCode`, `profileId` |
-| Get Auto-Response Setting | `client.messagingProfiles.autorespConfigs.retrieve()` | `GET /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profileId`, `autorespCfgId` |
-| Update Auto-Response Setting | `client.messagingProfiles.autorespConfigs.update()` | `PUT /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Modify an existing resource without recreating it. | `op`, `keywords`, `countryCode`, `profileId`, +1 more |
-| Delete Auto-Response Setting | `client.messagingProfiles.autorespConfigs.delete()` | `DELETE /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Remove, detach, or clean up an existing resource. | `profileId`, `autorespCfgId` |
+| List Auto-Response Settings | `client.messagingProfiles.autorespConfigs.list()` | `GET /messaging_profiles/{profile_id}/autoresp_configs` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profile_id` |
+| Create auto-response setting | `client.messagingProfiles.autorespConfigs.create()` | `POST /messaging_profiles/{profile_id}/autoresp_configs` | Create or provision an additional resource when the core tasks do not cover this flow. | `op`, `keywords`, `country_code`, `profile_id` |
+| Get Auto-Response Setting | `client.messagingProfiles.autorespConfigs.retrieve()` | `GET /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `profile_id`, `autoresp_cfg_id` |
+| Update Auto-Response Setting | `client.messagingProfiles.autorespConfigs.update()` | `PUT /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Modify an existing resource without recreating it. | `op`, `keywords`, `country_code`, `profile_id`, +1 more |
+| Delete Auto-Response Setting | `client.messagingProfiles.autorespConfigs.delete()` | `DELETE /messaging_profiles/{profile_id}/autoresp_configs/{autoresp_cfg_id}` | Remove, detach, or clean up an existing resource. | `profile_id`, `autoresp_cfg_id` |
 
 ### Other Webhook Events
 
@@ -448,32 +448,32 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `usLongCodeFallback` | string | A US long code number to use as fallback when sending to US destinations. |
+| `us_long_code_fallback` | string | A US long code number to use as fallback when sending to US destinations. |
 
 ### Send a message — `client.messages.send()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
-| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
-| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a message using an alphanumeric sender ID — `client.messages.sendWithAlphanumericSender()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `webhookUrl` | string (URL) | Callback URL for delivery status updates. |
-| `webhookFailoverUrl` | string (URL) | Failover callback URL for delivery status updates. |
-| `useProfileWebhooks` | boolean | If true, use the messaging profile's webhook settings. |
+| `webhook_url` | string (URL) | Callback URL for delivery status updates. |
+| `webhook_failover_url` | string (URL) | Failover callback URL for delivery status updates. |
+| `use_profile_webhooks` | boolean | If true, use the messaging profile's webhook settings. |
 
 ### Send a group MMS message — `client.messages.sendGroupMms()`
 
@@ -481,10 +481,10 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 
 ### Send a long code message — `client.messages.sendLongCode()`
 
@@ -492,12 +492,12 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a message using number pool — `client.messages.sendNumberPool()`
@@ -506,12 +506,12 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Schedule a message — `client.messages.schedule()`
@@ -519,16 +519,16 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `from` | string (E.164) | Sending address (+E.164 formatted phone number, alphanumeric sender ID, or sh... |
-| `messagingProfileId` | string (UUID) | Unique identifier for a messaging profile. |
+| `messaging_profile_id` | string (UUID) | Unique identifier for a messaging profile. |
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
-| `sendAt` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `send_at` | string (date-time) | ISO 8601 formatted date indicating when to send the message - accurate up til... |
 
 ### Send a short code message — `client.messages.sendShortCode()`
 
@@ -536,12 +536,12 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 |-----------|------|-------------|
 | `text` | string | Message body (i.e., content) as a non-empty string. |
 | `subject` | string | Subject of multimedia message |
-| `mediaUrls` | array[string] | A list of media URLs. |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `webhookFailoverUrl` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
-| `useProfileWebhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
+| `media_urls` | array[string] | A list of media URLs. |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `webhook_failover_url` | string (URL) | The failover URL where webhooks related to this message will be sent if sendi... |
+| `use_profile_webhooks` | boolean | If the profile this number is associated with has webhooks, use them for deli... |
 | `type` | enum (SMS, MMS) | The protocol for sending the message, either SMS or MMS. |
-| `autoDetect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
+| `auto_detect` | boolean | Automatically detect if an SMS message is unusually long and exceeds a recomm... |
 | `encoding` | enum (auto, gsm7, ucs2) | Encoding to use for the message. |
 
 ### Send a WhatsApp message — `client.messages.sendWhatsapp()`
@@ -549,17 +549,17 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `type` | enum (WHATSAPP) | Message type - must be set to "WHATSAPP" |
-| `webhookUrl` | string (URL) | The URL where webhooks related to this message will be sent. |
-| `messagingProfileId` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
+| `webhook_url` | string (URL) | The URL where webhooks related to this message will be sent. |
+| `messaging_profile_id` | string (UUID) | Messaging profile ID - required if the 'from' number is not SMS-enabled |
 
 ### Update a messaging hosted number — `client.messagingHostedNumbers.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `messagingProfileId` | string (UUID) | Configure the messaging profile this phone number is assigned to:
+| `messaging_profile_id` | string (UUID) | Configure the messaging profile this phone number is assigned to:
 
 * Omit thi... |
-| `messagingProduct` | string | Configure the messaging product for this number:
+| `messaging_product` | string | Configure the messaging product for this number:
 
 * Omit this field or set it... |
 | `tags` | array[string] | Tags to set on this phone number. |
@@ -568,10 +568,10 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `respText` | string |  |
+| `resp_text` | string |  |
 
 ### Update Auto-Response Setting — `client.messagingProfiles.autorespConfigs.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `respText` | string |  |
+| `resp_text` | string |  |

--- a/skills/telnyx-twilio-migration/sdk-reference/javascript/numbers.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/javascript/numbers.md
@@ -97,15 +97,15 @@ Number ordering is the production provisioning step after number selection.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `phoneNumbers` | array[object] | Yes |  |
-| `connectionId` | string (UUID) | No | Identifies the connection associated with this phone number. |
-| `messagingProfileId` | string (UUID) | No | Identifies the messaging profile associated with the phone n... |
-| `billingGroupId` | string (UUID) | No | Identifies the billing group associated with the phone numbe... |
+| `phone_numbers` | array[object] | Yes |  |
+| `connection_id` | string (UUID) | No | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | No | Identifies the messaging profile associated with the phone n... |
+| `billing_group_id` | string (UUID) | No | Identifies the billing group associated with the phone numbe... |
 | ... | | | +1 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
 const numberOrder = await client.numberOrders.create({
-    phoneNumbers: [{"phone_number": "+18005550101"}],
+    phone_numbers: [{"phone_number": "+18005550101"}],
 });
 
 console.log(numberOrder.data);
@@ -127,7 +127,7 @@ Order status determines whether provisioning completed or additional requirement
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `numberOrderId` | string (UUID) | Yes | The number order ID. |
+| `number_order_id` | string (UUID) | Yes | The number order ID. |
 
 ```javascript
 const numberOrder = await client.numberOrders.retrieve('550e8400-e29b-41d4-a716-446655440000');
@@ -157,15 +157,15 @@ Create or provision an additional resource when the core tasks do not cover this
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `phoneNumbers` | array[object] | Yes |  |
+| `phone_numbers` | array[object] | Yes |  |
 | `status` | enum (pending, success, failure) | No | The status of the entire reservation. |
 | `id` | string (UUID) | No |  |
-| `recordType` | string | No |  |
+| `record_type` | string | No |  |
 | ... | | | +3 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
 const numberReservation = await client.numberReservations.create({
-    phoneNumbers: [{"phone_number": "+18005550101"}],
+    phone_numbers: [{"phone_number": "+18005550101"}],
 });
 
 console.log(numberReservation.data);
@@ -187,7 +187,7 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `numberReservationId` | string (UUID) | Yes | The number reservation ID. |
+| `number_reservation_id` | string (UUID) | Yes | The number reservation ID. |
 
 ```javascript
 const numberReservation = await client.numberReservations.retrieve('550e8400-e29b-41d4-a716-446655440000');
@@ -234,9 +234,9 @@ Create or provision an additional resource when the core tasks do not cover this
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) | No |  |
-| `requirementGroupId` | string (UUID) | No | The ID of the requirement group to associate with this advan... |
-| `countryCode` | string (ISO 3166-1 alpha-2) | No |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) | No |  |
+| `requirement_group_id` | string (UUID) | No | The ID of the requirement group to associate with this advan... |
+| `country_code` | string (ISO 3166-1 alpha-2) | No |  |
 | ... | | | +5 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -262,9 +262,9 @@ Modify an existing resource without recreating it.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `advanced-order-id` | string (UUID) | Yes | Unique identifier of the advanced order. |
-| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) | No |  |
-| `requirementGroupId` | string (UUID) | No | The ID of the requirement group to associate with this advan... |
-| `countryCode` | string (ISO 3166-1 alpha-2) | No |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) | No |  |
+| `requirement_group_id` | string (UUID) | No | The ID of the requirement group to associate with this advan... |
+| `country_code` | string (ISO 3166-1 alpha-2) | No |  |
 | ... | | | +5 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -291,7 +291,7 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `orderId` | string (UUID) | Yes | Unique identifier of the order. |
+| `order_id` | string (UUID) | Yes | Unique identifier of the order. |
 
 ```javascript
 const advancedOrder = await client.advancedOrders.retrieve('182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e');
@@ -376,38 +376,38 @@ Before using any operation below, read the Optional Parameters section below and
 | Retrieve a comment | `client.comments.retrieve()` | `GET /comments/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Mark a comment as read | `client.comments.markAsRead()` | `PATCH /comments/{id}/read` | Modify an existing resource without recreating it. | `id` |
 | Get country coverage | `client.countryCoverage.retrieve()` | `GET /country_coverage` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Get coverage for a specific country | `client.countryCoverage.retrieveCountry()` | `GET /country_coverage/countries/{country_code}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `countryCode` |
+| Get coverage for a specific country | `client.countryCoverage.retrieveCountry()` | `GET /country_coverage/countries/{country_code}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `country_code` |
 | List customer service records | `client.customerServiceRecords.list()` | `GET /customer_service_records` | Inspect available resources or choose an existing resource before mutating it. | None |
 | Create a customer service record | `client.customerServiceRecords.create()` | `POST /customer_service_records` | Create or provision an additional resource when the core tasks do not cover this flow. | None |
 | Verify CSR phone number coverage | `client.customerServiceRecords.verifyPhoneNumberCoverage()` | `POST /customer_service_records/phone_number_coverages` | Create or provision an additional resource when the core tasks do not cover this flow. | None |
-| Get a customer service record | `client.customerServiceRecords.retrieve()` | `GET /customer_service_records/{customer_service_record_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `customerServiceRecordId` |
+| Get a customer service record | `client.customerServiceRecords.retrieve()` | `GET /customer_service_records/{customer_service_record_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `customer_service_record_id` |
 | List inexplicit number orders | `client.inexplicitNumberOrders.list()` | `GET /inexplicit_number_orders` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Create an inexplicit number order | `client.inexplicitNumberOrders.create()` | `POST /inexplicit_number_orders` | Create or provision an additional resource when the core tasks do not cover this flow. | `orderingGroups` |
+| Create an inexplicit number order | `client.inexplicitNumberOrders.create()` | `POST /inexplicit_number_orders` | Create or provision an additional resource when the core tasks do not cover this flow. | `ordering_groups` |
 | Retrieve an inexplicit number order | `client.inexplicitNumberOrders.retrieve()` | `GET /inexplicit_number_orders/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | Create an inventory coverage request | `client.inventoryCoverage.list()` | `GET /inventory_coverage` | Inspect available resources or choose an existing resource before mutating it. | None |
 | List mobile network operators | `client.mobileNetworkOperators.list()` | `GET /mobile_network_operators` | Inspect available resources or choose an existing resource before mutating it. | None |
 | List network coverage locations | `client.networkCoverage.list()` | `GET /network_coverage` | Inspect available resources or choose an existing resource before mutating it. | None |
 | List number block orders | `client.numberBlockOrders.list()` | `GET /number_block_orders` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Create a number block order | `client.numberBlockOrders.create()` | `POST /number_block_orders` | Create or provision an additional resource when the core tasks do not cover this flow. | `startingNumber`, `range` |
-| Retrieve a number block order | `client.numberBlockOrders.retrieve()` | `GET /number_block_orders/{number_block_order_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `numberBlockOrderId` |
+| Create a number block order | `client.numberBlockOrders.create()` | `POST /number_block_orders` | Create or provision an additional resource when the core tasks do not cover this flow. | `starting_number`, `range` |
+| Retrieve a number block order | `client.numberBlockOrders.retrieve()` | `GET /number_block_orders/{number_block_order_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `number_block_order_id` |
 | Retrieve a list of phone numbers associated to orders | `client.numberOrderPhoneNumbers.list()` | `GET /number_order_phone_numbers` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Retrieve a single phone number within a number order. | `client.numberOrderPhoneNumbers.retrieve()` | `GET /number_order_phone_numbers/{number_order_phone_number_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `numberOrderPhoneNumberId` |
-| Update requirements for a single phone number within a number order. | `client.numberOrderPhoneNumbers.updateRequirements()` | `PATCH /number_order_phone_numbers/{number_order_phone_number_id}` | Modify an existing resource without recreating it. | `numberOrderPhoneNumberId` |
+| Retrieve a single phone number within a number order. | `client.numberOrderPhoneNumbers.retrieve()` | `GET /number_order_phone_numbers/{number_order_phone_number_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `number_order_phone_number_id` |
+| Update requirements for a single phone number within a number order. | `client.numberOrderPhoneNumbers.updateRequirements()` | `PATCH /number_order_phone_numbers/{number_order_phone_number_id}` | Modify an existing resource without recreating it. | `number_order_phone_number_id` |
 | List number orders | `client.numberOrders.list()` | `GET /number_orders` | Create or inspect provisioning orders for number purchases. | None |
-| Update a number order | `client.numberOrders.update()` | `PATCH /number_orders/{number_order_id}` | Modify an existing resource without recreating it. | `numberOrderId` |
+| Update a number order | `client.numberOrders.update()` | `PATCH /number_orders/{number_order_id}` | Modify an existing resource without recreating it. | `number_order_id` |
 | List number reservations | `client.numberReservations.list()` | `GET /number_reservations` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Extend a number reservation | `client.numberReservations.actions.extend()` | `POST /number_reservations/{number_reservation_id}/actions/extend` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `numberReservationId` |
-| Retrieve the features for a list of numbers | `client.numbersFeatures.create()` | `POST /numbers_features` | Create or provision an additional resource when the core tasks do not cover this flow. | `phoneNumbers` |
+| Extend a number reservation | `client.numberReservations.actions.extend()` | `POST /number_reservations/{number_reservation_id}/actions/extend` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `number_reservation_id` |
+| Retrieve the features for a list of numbers | `client.numbersFeatures.create()` | `POST /numbers_features` | Create or provision an additional resource when the core tasks do not cover this flow. | `phone_numbers` |
 | Lists the phone number blocks jobs | `client.phoneNumberBlocks.jobs.list()` | `GET /phone_number_blocks/jobs` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Deletes all numbers associated with a phone number block | `client.phoneNumberBlocks.jobs.deletePhoneNumberBlock()` | `POST /phone_number_blocks/jobs/delete_phone_number_block` | Create or provision an additional resource when the core tasks do not cover this flow. | `phoneNumberBlockId` |
+| Deletes all numbers associated with a phone number block | `client.phoneNumberBlocks.jobs.deletePhoneNumberBlock()` | `POST /phone_number_blocks/jobs/delete_phone_number_block` | Create or provision an additional resource when the core tasks do not cover this flow. | `phone_number_block_id` |
 | Retrieves a phone number blocks job | `client.phoneNumberBlocks.jobs.retrieve()` | `GET /phone_number_blocks/jobs/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
 | List sub number orders | `client.subNumberOrders.list()` | `GET /sub_number_orders` | Inspect available resources or choose an existing resource before mutating it. | None |
-| Retrieve a sub number order | `client.subNumberOrders.retrieve()` | `GET /sub_number_orders/{sub_number_order_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `subNumberOrderId` |
-| Update a sub number order's requirements | `client.subNumberOrders.update()` | `PATCH /sub_number_orders/{sub_number_order_id}` | Modify an existing resource without recreating it. | `subNumberOrderId` |
-| Cancel a sub number order | `client.subNumberOrders.cancel()` | `PATCH /sub_number_orders/{sub_number_order_id}/cancel` | Modify an existing resource without recreating it. | `subNumberOrderId` |
+| Retrieve a sub number order | `client.subNumberOrders.retrieve()` | `GET /sub_number_orders/{sub_number_order_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `sub_number_order_id` |
+| Update a sub number order's requirements | `client.subNumberOrders.update()` | `PATCH /sub_number_orders/{sub_number_order_id}` | Modify an existing resource without recreating it. | `sub_number_order_id` |
+| Cancel a sub number order | `client.subNumberOrders.cancel()` | `PATCH /sub_number_orders/{sub_number_order_id}/cancel` | Modify an existing resource without recreating it. | `sub_number_order_id` |
 | Create a sub number orders report | `client.subNumberOrdersReport.create()` | `POST /sub_number_orders_report` | Create or provision an additional resource when the core tasks do not cover this flow. | None |
-| Retrieve a sub number orders report | `client.subNumberOrdersReport.retrieve()` | `GET /sub_number_orders_report/{report_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `reportId` |
-| Download a sub number orders report | `client.subNumberOrdersReport.download()` | `GET /sub_number_orders_report/{report_id}/download` | Fetch the current state before updating, deleting, or making control-flow decisions. | `reportId` |
+| Retrieve a sub number orders report | `client.subNumberOrdersReport.retrieve()` | `GET /sub_number_orders_report/{report_id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `report_id` |
+| Download a sub number orders report | `client.subNumberOrdersReport.download()` | `GET /sub_number_orders_report/{report_id}/download` | Fetch the current state before updating, deleting, or making control-flow decisions. | `report_id` |
 
 ### Other Webhook Events
 
@@ -428,27 +428,27 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `countryCode` | string (ISO 3166-1 alpha-2) |  |
+| `country_code` | string (ISO 3166-1 alpha-2) |  |
 | `comments` | string |  |
 | `quantity` | integer |  |
-| `areaCode` | string |  |
-| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `area_code` | string |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
 | `features` | array[object] |  |
-| `customerReference` | string |  |
-| `requirementGroupId` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+| `customer_reference` | string |  |
+| `requirement_group_id` | string (UUID) | The ID of the requirement group to associate with this advanced order |
 
 ### Update Advanced Order — `client.advancedOrders.updateRequirementGroup()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `countryCode` | string (ISO 3166-1 alpha-2) |  |
+| `country_code` | string (ISO 3166-1 alpha-2) |  |
 | `comments` | string |  |
 | `quantity` | integer |  |
-| `areaCode` | string |  |
-| `phoneNumberType` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
+| `area_code` | string |  |
+| `phone_number_type` | enum (local, mobile, toll_free, shared_cost, national, ...) |  |
 | `features` | array[object] |  |
-| `customerReference` | string |  |
-| `requirementGroupId` | string (UUID) | The ID of the requirement group to associate with this advanced order |
+| `customer_reference` | string |  |
+| `requirement_group_id` | string (UUID) | The ID of the requirement group to associate with this advanced order |
 
 ### Create a comment — `client.comments.create()`
 
@@ -457,86 +457,86 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 | `id` | string (UUID) |  |
 | `body` | string |  |
 | `commenter` | string |  |
-| `commenterType` | enum (admin, user) |  |
-| `commentRecordType` | enum (sub_number_order, requirement_group) |  |
-| `commentRecordId` | string (UUID) |  |
-| `readAt` | string (date-time) | An ISO 8901 datetime string for when the comment was read. |
-| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the comment was created. |
-| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the comment was updated. |
+| `commenter_type` | enum (admin, user) |  |
+| `comment_record_type` | enum (sub_number_order, requirement_group) |  |
+| `comment_record_id` | string (UUID) |  |
+| `read_at` | string (date-time) | An ISO 8901 datetime string for when the comment was read. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the comment was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the comment was updated. |
 
 ### Create an inexplicit number order — `client.inexplicitNumberOrders.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `connectionId` | string (UUID) | Connection id to apply to phone numbers that are purchased |
-| `messagingProfileId` | string (UUID) | Messaging profile id to apply to phone numbers that are purchased |
-| `customerReference` | string | Reference label for the customer |
-| `billingGroupId` | string (UUID) | Billing group id to apply to phone numbers that are purchased |
+| `connection_id` | string (UUID) | Connection id to apply to phone numbers that are purchased |
+| `messaging_profile_id` | string (UUID) | Messaging profile id to apply to phone numbers that are purchased |
+| `customer_reference` | string | Reference label for the customer |
+| `billing_group_id` | string (UUID) | Billing group id to apply to phone numbers that are purchased |
 
 ### Create a number block order — `client.numberBlockOrders.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `id` | string (UUID) |  |
-| `recordType` | string |  |
-| `phoneNumbersCount` | integer | The count of phone numbers in the number order. |
-| `connectionId` | string (UUID) | Identifies the connection associated with this phone number. |
-| `messagingProfileId` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `record_type` | string |  |
+| `phone_numbers_count` | integer | The count of phone numbers in the number order. |
+| `connection_id` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | Identifies the messaging profile associated with the phone number. |
 | `status` | enum (pending, success, failure) | The status of the order. |
-| `customerReference` | string | A customer reference string for customer look ups. |
-| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the number order was created. |
-| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the number order was updated. |
-| `requirementsMet` | boolean | True if all requirements are met for every phone number, false otherwise. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the number order was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the number order was updated. |
+| `requirements_met` | boolean | True if all requirements are met for every phone number, false otherwise. |
 | `errors` | string | Errors the reservation could happen upon |
 
 ### Update requirements for a single phone number within a number order. — `client.numberOrderPhoneNumbers.updateRequirements()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `regulatoryRequirements` | array[object] |  |
+| `regulatory_requirements` | array[object] |  |
 
 ### Create a number order — `client.numberOrders.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `phoneNumbers` | array[object] |  |
-| `connectionId` | string (UUID) | Identifies the connection associated with this phone number. |
-| `messagingProfileId` | string (UUID) | Identifies the messaging profile associated with the phone number. |
-| `billingGroupId` | string (UUID) | Identifies the billing group associated with the phone number. |
-| `customerReference` | string | A customer reference string for customer look ups. |
+| `phone_numbers` | array[object] |  |
+| `connection_id` | string (UUID) | Identifies the connection associated with this phone number. |
+| `messaging_profile_id` | string (UUID) | Identifies the messaging profile associated with the phone number. |
+| `billing_group_id` | string (UUID) | Identifies the billing group associated with the phone number. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
 
 ### Update a number order — `client.numberOrders.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `regulatoryRequirements` | array[object] |  |
-| `customerReference` | string | A customer reference string for customer look ups. |
+| `regulatory_requirements` | array[object] |  |
+| `customer_reference` | string | A customer reference string for customer look ups. |
 
 ### Create a number reservation — `client.numberReservations.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `id` | string (UUID) |  |
-| `recordType` | string |  |
-| `phoneNumbers` | array[object] |  |
+| `record_type` | string |  |
+| `phone_numbers` | array[object] |  |
 | `status` | enum (pending, success, failure) | The status of the entire reservation. |
-| `customerReference` | string | A customer reference string for customer look ups. |
-| `createdAt` | string (date-time) | An ISO 8901 datetime string denoting when the numbers reservation was created. |
-| `updatedAt` | string (date-time) | An ISO 8901 datetime string for when the number reservation was updated. |
+| `customer_reference` | string | A customer reference string for customer look ups. |
+| `created_at` | string (date-time) | An ISO 8901 datetime string denoting when the numbers reservation was created. |
+| `updated_at` | string (date-time) | An ISO 8901 datetime string for when the number reservation was updated. |
 
 ### Update a sub number order's requirements — `client.subNumberOrders.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `regulatoryRequirements` | array[object] |  |
+| `regulatory_requirements` | array[object] |  |
 
 ### Create a sub number orders report — `client.subNumberOrdersReport.create()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `status` | enum (pending, success, failure) | Filter by order status |
-| `countryCode` | string (ISO 3166-1 alpha-2) | Filter by country code |
-| `createdAtGt` | string (date-time) | Filter for orders created after this date |
-| `createdAtLt` | string (date-time) | Filter for orders created before this date |
-| `orderRequestId` | string (UUID) | Filter by specific order request ID |
-| `customerReference` | string | Filter by customer reference |
+| `country_code` | string (ISO 3166-1 alpha-2) | Filter by country code |
+| `created_at_gt` | string (date-time) | Filter for orders created after this date |
+| `created_at_lt` | string (date-time) | Filter for orders created before this date |
+| `order_request_id` | string (UUID) | Filter by specific order request ID |
+| `customer_reference` | string | Filter by customer reference |

--- a/skills/telnyx-twilio-migration/sdk-reference/javascript/voice.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/javascript/voice.md
@@ -82,10 +82,10 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 |-----------|------|----------|-------------|
 | `to` | string (E.164) | Yes | The DID or SIP URI to dial out to. |
 | `from` | string (E.164) | Yes | The `from` number to be used as the caller id presented to t... |
-| `connectionId` | string (UUID) | Yes | The ID of the Call Control App (formerly ID of the connectio... |
-| `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
-| `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
+| `connection_id` | string (UUID) | Yes | The ID of the Call Control App (formerly ID of the connectio... |
+| `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
+| `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | ... | | | +56 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -114,10 +114,10 @@ Primary inbound call-control command.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
-| `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
+| `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
 | ... | | | +29 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -139,10 +139,10 @@ Common post-answer control path with downstream webhook implications.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `to` | string (E.164) | Yes | The DID or SIP URI to dial out to. |
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
-| `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
+| `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
 | ... | | | +35 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -167,7 +167,7 @@ and `telnyx-timestamp` headers. Always verify signatures in production:
 // In your webhook handler (e.g., Express — use raw body, not parsed JSON):
 app.post('/webhooks', express.raw({ type: 'application/json' }), async (req, res) => {
   try {
-    const event = await client.webhooks.unwrap(req.body.toString(), {
+    const event = client.webhooks.unwrap(req.body.toString(), {
       headers: req.headers,
     });
     // Signature valid — event is the parsed webhook payload
@@ -239,10 +239,10 @@ End a live call from your webhook-driven control flow.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | No | Use this field to avoid duplicate commands. |
-| `customHeaders` | array[object] | No | Custom headers to be added to the SIP BYE message. |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | No | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | No | Custom headers to be added to the SIP BYE message. |
 
 ```javascript
 const response = await client.calls.actions.hangup('v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ');
@@ -261,11 +261,11 @@ Trigger a follow-up action in an existing workflow rather than creating a new to
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `callControlId` | string (UUID) | Yes | The Call Control ID of the call you want to bridge with, can... |
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | No | Use this field to avoid duplicate commands. |
-| `videoRoomId` | string (UUID) | No | The ID of the video room you want to bridge with, can't be u... |
+| `call_control_id` | string (UUID) | Yes | The Call Control ID of the call you want to bridge with, can... |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | No | Use this field to avoid duplicate commands. |
+| `video_room_id` | string (UUID) | No | The ID of the video room you want to bridge with, can't be u... |
 | ... | | | +16 optional params in the Optional Parameters section below and the shared SDK API Details reference |
 
 ```javascript
@@ -288,9 +288,9 @@ Trigger a follow-up action in an existing workflow rather than creating a new to
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `cause` | enum (CALL_REJECTED, USER_BUSY) | Yes | Cause for call rejection. |
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | No | Use this field to avoid duplicate commands. |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | No | Use this field to avoid duplicate commands. |
 
 ```javascript
 const response = await client.calls.actions.reject('call_control_id', { cause: 'USER_BUSY' });
@@ -309,7 +309,7 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
 
 ```javascript
 const response = await client.calls.retrieveStatus('v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ');
@@ -333,7 +333,7 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `connectionId` | string (UUID) | Yes | Telnyx connection id |
+| `connection_id` | string (UUID) | Yes | Telnyx connection id |
 | `page` | object | No | Consolidated page parameter (deepObject style). |
 
 ```javascript
@@ -397,12 +397,12 @@ Before using any operation below, read the Optional Parameters section below and
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
-| Create a call control application | `client.callControlApplications.create()` | `POST /call_control_applications` | Create or provision an additional resource when the core tasks do not cover this flow. | `applicationName`, `webhookEventUrl` |
+| Create a call control application | `client.callControlApplications.create()` | `POST /call_control_applications` | Create or provision an additional resource when the core tasks do not cover this flow. | `application_name`, `webhook_event_url` |
 | Retrieve a call control application | `client.callControlApplications.retrieve()` | `GET /call_control_applications/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
-| Update a call control application | `client.callControlApplications.update()` | `PATCH /call_control_applications/{id}` | Modify an existing resource without recreating it. | `applicationName`, `webhookEventUrl`, `id` |
+| Update a call control application | `client.callControlApplications.update()` | `PATCH /call_control_applications/{id}` | Modify an existing resource without recreating it. | `application_name`, `webhook_event_url`, `id` |
 | Delete a call control application | `client.callControlApplications.delete()` | `DELETE /call_control_applications/{id}` | Remove, detach, or clean up an existing resource. | `id` |
-| SIP Refer a call | `client.calls.actions.refer()` | `POST /calls/{call_control_id}/actions/refer` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `sipAddress`, `callControlId` |
-| Send SIP info | `client.calls.actions.sendSipInfo()` | `POST /calls/{call_control_id}/actions/send_sip_info` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `contentType`, `body`, `callControlId` |
+| SIP Refer a call | `client.calls.actions.refer()` | `POST /calls/{call_control_id}/actions/refer` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `sip_address`, `call_control_id` |
+| Send SIP info | `client.calls.actions.sendSipInfo()` | `POST /calls/{call_control_id}/actions/send_sip_info` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `content_type`, `body`, `call_control_id` |
 
 ### Other Webhook Events
 
@@ -424,233 +424,233 @@ For exhaustive optional parameters, full response schemas, and complete webhook 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `active` | boolean | Specifies whether the connection can be used. |
-| `anchorsiteOverride` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
-| `dtmfType` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
-| `firstCommandTimeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
-| `firstCommandTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `anchorsite_override` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmf_type` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `first_command_timeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `first_command_timeout_secs` | integer | Specifies how many seconds to wait before timing out a dial command. |
 | `inbound` | object |  |
 | `outbound` | object |  |
-| `webhookApiVersion` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
-| `webhookEventFailoverUrl` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
-| `webhookTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a webhook. |
-| `callCostInWebhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
-| `redactDtmfDebugLogging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+| `webhook_api_version` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhook_event_failover_url` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhook_timeout_secs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `call_cost_in_webhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `redact_dtmf_debug_logging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
 
 ### Update a call control application — `client.callControlApplications.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `callCostInWebhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `call_cost_in_webhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
 | `active` | boolean | Specifies whether the connection can be used. |
-| `anchorsiteOverride` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
-| `dtmfType` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
-| `firstCommandTimeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
-| `firstCommandTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `anchorsite_override` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmf_type` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `first_command_timeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `first_command_timeout_secs` | integer | Specifies how many seconds to wait before timing out a dial command. |
 | `tags` | array[string] | Tags assigned to the Call Control Application. |
 | `inbound` | object |  |
 | `outbound` | object |  |
-| `webhookApiVersion` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
-| `webhookEventFailoverUrl` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
-| `webhookTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a webhook. |
-| `redactDtmfDebugLogging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+| `webhook_api_version` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhook_event_failover_url` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhook_timeout_secs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `redact_dtmf_debug_logging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
 
 ### Dial — `client.calls.dial()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `assistant` | object | AI Assistant configuration. |
-| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
-| `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
 | `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
-| `audioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
-| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
-| `mediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
-| `preferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
-| `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
-| `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
-| `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
-| `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
-| `deepfakeDetection` | object | Enables deepfake detection on the call. |
-| `conferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
-| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
-| `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
-| `linkTo` | string | Use another call's control id for sharing the same call session id |
-| `bridgeIntent` | boolean | Indicates the intent to bridge this call with the call specified in link_to. |
-| `bridgeOnAnswer` | boolean | Whether to automatically bridge answered call to the call specified in link_to. |
-| `preventDoubleBridge` | boolean | Prevents bridging and hangs up the call if the target is already bridged. |
-| `parkAfterUnbridge` | string | If supplied with the value `self`, the current leg will be parked after unbri... |
-| `mediaEncryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the call. |
-| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
-| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
-| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE request. |
-| `sipTransportProtocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
-| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
-| `streamUrl` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
-| `streamTrack` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
-| `streamCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
-| `streamBidirectionalMode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
-| `streamBidirectionalCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
-| `streamBidirectionalTargetLegs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
-| `streamBidirectionalSamplingRate` | enum (8000, 16000, 22050, 24000, 48000) | Audio sampling rate. |
-| `streamEstablishBeforeCallOriginate` | boolean | Establish websocket connection before dialing the destination. |
-| `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
-| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
-| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
-| `webhookUrls` | object | A map of event types to webhook URLs. |
-| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
-| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
+| `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
+| `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
+| `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `link_to` | string | Use another call's control id for sharing the same call session id |
+| `bridge_intent` | boolean | Indicates the intent to bridge this call with the call specified in link_to. |
+| `bridge_on_answer` | boolean | Whether to automatically bridge answered call to the call specified in link_to. |
+| `prevent_double_bridge` | boolean | Prevents bridging and hangs up the call if the target is already bridged. |
+| `park_after_unbridge` | string | If supplied with the value `self`, the current leg will be parked after unbri... |
+| `media_encryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the call. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE request. |
+| `sip_transport_protocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `stream_url` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `stream_track` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `stream_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `stream_bidirectional_mode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `stream_bidirectional_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `stream_bidirectional_target_legs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `stream_bidirectional_sampling_rate` | enum (8000, 16000, 22050, 24000, 48000) | Audio sampling rate. |
+| `stream_establish_before_call_originate` | boolean | Establish websocket connection before dialing the destination. |
+| `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
-| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
-| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
-| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
-| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
-| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
-| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
-| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
-| `superviseCallControlId` | string (UUID) | The call leg which will be supervised by the new call. |
-| `supervisorRole` | enum (barge, whisper, monitor) | The role of the supervisor call. |
-| `enableDialogflow` | boolean | Enables Dialogflow for the current call. |
-| `dialogflowConfig` | object |  |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `supervise_call_control_id` | string (UUID) | The call leg which will be supervised by the new call. |
+| `supervisor_role` | enum (barge, whisper, monitor) | The role of the supervisor call. |
+| `enable_dialogflow` | boolean | Enables Dialogflow for the current call. |
+| `dialogflow_config` | object |  |
 | `transcription` | boolean | Enable transcription upon call answer. |
-| `transcriptionConfig` | object |  |
-| `sipRegion` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
-| `streamAuthToken` | string | An authentication token to be sent as part of the WebSocket connection when u... |
+| `transcription_config` | object |  |
+| `sip_region` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `stream_auth_token` | string | An authentication token to be sent as part of the WebSocket connection when u... |
 
 ### Answer call — `client.calls.actions.answer()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `assistant` | object | AI Assistant configuration. |
-| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
-| `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
-| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE response. |
-| `preferredCodecs` | enum (G722,PCMU,PCMA,G729,OPUS,VP8,H264) | The list of comma-separated codecs in a preferred order for the forked media ... |
-| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE response. |
-| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
-| `streamUrl` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
-| `streamTrack` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
-| `streamCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
-| `streamBidirectionalMode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
-| `streamBidirectionalCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
-| `streamBidirectionalTargetLegs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
-| `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
-| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
-| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE response. |
+| `preferred_codecs` | enum (G722,PCMU,PCMA,G729,OPUS,VP8,H264) | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE response. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `stream_url` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `stream_track` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `stream_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `stream_bidirectional_mode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `stream_bidirectional_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `stream_bidirectional_target_legs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
 | `transcription` | boolean | Enable transcription upon call answer. |
-| `transcriptionConfig` | object |  |
+| `transcription_config` | object |  |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
-| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
-| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
-| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
-| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
-| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
-| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
-| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
-| `webhookUrls` | object | A map of event types to webhook URLs. |
-| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
-| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
-| `deepfakeDetection` | object | Enables deepfake detection on the call. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.calls.actions.bridge()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
 | `queue` | string | The name of the queue you want to bridge with, can't be used together with ca... |
-| `videoRoomId` | string (UUID) | The ID of the video room you want to bridge with, can't be used together with... |
-| `videoRoomContext` | string | The additional parameter that will be passed to the video conference. |
-| `preventDoubleBridge` | boolean | When set to `true`, it prevents bridging if the target call is already bridge... |
-| `parkAfterUnbridge` | string | Specifies behavior after the bridge ends (i.e. |
-| `playRingtone` | boolean | Specifies whether to play a ringtone if the call you want to bridge with has ... |
+| `video_room_id` | string (UUID) | The ID of the video room you want to bridge with, can't be used together with... |
+| `video_room_context` | string | The additional parameter that will be passed to the video conference. |
+| `prevent_double_bridge` | boolean | When set to `true`, it prevents bridging if the target call is already bridge... |
+| `park_after_unbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `play_ringtone` | boolean | Specifies whether to play a ringtone if the call you want to bridge with has ... |
 | `ringtone` | enum (at, au, be, bg, br, ...) | Specifies which country ringtone to play when `play_ringtone` is set to `true`. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
-| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
-| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
-| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
-| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
-| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
-| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
-| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
-| `muteDtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
-| `holdAfterUnbridge` | boolean | Specifies behavior after the bridge ends. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `mute_dtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `hold_after_unbridge` | boolean | Specifies behavior after the bridge ends. |
 
 ### Hangup call — `client.calls.actions.hangup()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
-| `customHeaders` | array[object] | Custom headers to be added to the SIP BYE message. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP BYE message. |
 
 ### SIP Refer a call — `client.calls.actions.refer()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid execution of duplicate commands. |
-| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
-| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
-| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
-| `sipHeaders` | array[object] | SIP headers to be added to the request. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid execution of duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the request. |
 
 ### Reject a call — `client.calls.actions.reject()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
 
 ### Send SIP info — `client.calls.actions.sendSipInfo()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
 
 ### Transfer call — `client.calls.actions.transfer()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
-| `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
 | `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
-| `audioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
-| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
-| `earlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
-| `mediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
-| `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
-| `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
-| `parkAfterUnbridge` | string | Specifies behavior after the bridge ends (i.e. |
-| `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
-| `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
-| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `targetLegClientState` | string | Use this field to add state to every subsequent webhook for the new leg. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
-| `mediaEncryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the new call leg. |
-| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
-| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
-| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE. |
-| `sipTransportProtocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
-| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
-| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
-| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
-| `muteDtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
+| `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
+| `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
+| `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `park_after_unbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `target_leg_client_state` | string | Use this field to add state to every subsequent webhook for the new leg. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `media_encryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the new call leg. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE. |
+| `sip_transport_protocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `mute_dtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
-| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
-| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
-| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
-| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
-| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
-| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
-| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
-| `sipRegion` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
-| `preferredCodecs` | string | The list of comma-separated codecs in order of preference to be used during t... |
-| `webhookUrls` | object | A map of event types to webhook URLs. |
-| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
-| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `sip_region` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `preferred_codecs` | string | The list of comma-separated codecs in order of preference to be used during t... |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |

--- a/skills/telnyx-twilio-migration/sdk-reference/python/10dlc.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/python/10dlc.md
@@ -130,7 +130,7 @@ telnyx_campaign_csp = client.messaging_10dlc.campaign_builder.submit(
     brand_id="BXXXXXX",
     description="Two-factor authentication messages",
     usecase="2FA",
-    sample_messages=["Your verification code is {{code}}"],
+    sample1="Your verification code is {{code}}",
 )
 print(telnyx_campaign_csp.brand_id)
 ```

--- a/skills/telnyx-twilio-migration/sdk-reference/python/ai-assistants.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/python/ai-assistants.md
@@ -654,6 +654,7 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |
 
 ### Update Tool — `client.ai.tools.update()`
@@ -667,4 +668,5 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |

--- a/skills/telnyx-twilio-migration/sdk-reference/ruby/10dlc.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/ruby/10dlc.md
@@ -118,8 +118,8 @@ Campaign submission is the compliance-critical step that determines whether traf
 telnyx_campaign_csp = client.messaging_10dlc.campaign_builder.submit(
   brand_id: "BXXXXXX",
   description: "Two-factor authentication messages",
-  usecase: "2FA"
-    sample_messages: ["Your verification code is {{code}}"],
+  usecase: "2FA",
+    sample1: "Your verification code is {{code}}",
 )
 
 puts(telnyx_campaign_csp)
@@ -147,7 +147,7 @@ Messaging profile assignment is the practical handoff from registration to send-
 
 ```ruby
 response = client.messaging_10dlc.phone_number_assignment_by_profile.assign(
-  messaging_profile_id: "4001767e-ce0f-4cae-9d5f-0d5e636e7809"
+  messaging_profile_id: "4001767e-ce0f-4cae-9d5f-0d5e636e7809",
     campaign_id: "CXXX001",
 )
 

--- a/skills/telnyx-twilio-migration/sdk-reference/ruby/ai-assistants.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/ruby/ai-assistants.md
@@ -629,6 +629,7 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |
 
 ### Update Tool — `client.ai.tools.update()`
@@ -642,4 +643,5 @@ dispat... |
 | `handoff` | object |  |
 | `invite` | object |  |
 | `webhook` | object |  |
+| `client_side_tool` | object |  |
 | `timeout_ms` | integer |  |

--- a/skills/telnyx-twilio-migration/sdk-reference/ruby/messaging.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/ruby/messaging.md
@@ -257,7 +257,7 @@ Let a messaging profile or number pool choose the sender for you.
 ```ruby
 response = client.messages.send_number_pool(
   messaging_profile_id: "abc85f64-5717-4562-b3fc-2c9600000000",
-  to: "+13125550002"
+  to: "+13125550002",
     text: "Hello from Telnyx!",
 )
 

--- a/skills/telnyx-voice-java/SKILL.md
+++ b/skills/telnyx-voice-java/SKILL.md
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.58.0</version>
+    <version>6.81.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.58.0")
+implementation("com.telnyx.sdk:telnyx:6.81.0")
 ```
 
 ## Setup

--- a/skills/telnyx-voice-javascript/SKILL.md
+++ b/skills/telnyx-voice-javascript/SKILL.md
@@ -95,10 +95,10 @@ Primary voice entrypoint. Agents need the async call-control identifiers returne
 |-----------|------|----------|-------------|
 | `to` | string (E.164) | Yes | The DID or SIP URI to dial out to. |
 | `from` | string (E.164) | Yes | The `from` number to be used as the caller id presented to t... |
-| `connectionId` | string (UUID) | Yes | The ID of the Call Control App (formerly ID of the connectio... |
-| `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
-| `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
+| `connection_id` | string (UUID) | Yes | The ID of the Call Control App (formerly ID of the connectio... |
+| `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
+| `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
 | ... | | | +56 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -127,10 +127,10 @@ Primary inbound call-control command.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
-| `billingGroupId` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `billing_group_id` | string (UUID) | No | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
+| `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
 | ... | | | +29 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -152,10 +152,10 @@ Common post-answer control path with downstream webhook implications.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `to` | string (E.164) | Yes | The DID or SIP URI to dial out to. |
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
-| `timeoutSecs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| `webhookUrl` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `timeout_secs` | integer | No | The number of seconds that Telnyx will wait for the call to ... |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
+| `webhook_url` | string (URL) | No | Use this field to override the URL for which Telnyx will sen... |
 | ... | | | +35 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -180,7 +180,7 @@ and `telnyx-timestamp` headers. Always verify signatures in production:
 // In your webhook handler (e.g., Express — use raw body, not parsed JSON):
 app.post('/webhooks', express.raw({ type: 'application/json' }), async (req, res) => {
   try {
-    const event = await client.webhooks.unwrap(req.body.toString(), {
+    const event = client.webhooks.unwrap(req.body.toString(), {
       headers: req.headers,
     });
     // Signature valid — event is the parsed webhook payload
@@ -252,10 +252,10 @@ End a live call from your webhook-driven control flow.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | No | Use this field to avoid duplicate commands. |
-| `customHeaders` | array[object] | No | Custom headers to be added to the SIP BYE message. |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | No | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | No | Custom headers to be added to the SIP BYE message. |
 
 ```javascript
 const response = await client.calls.actions.hangup('v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ');
@@ -274,11 +274,11 @@ Trigger a follow-up action in an existing workflow rather than creating a new to
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `callControlId` | string (UUID) | Yes | The Call Control ID of the call you want to bridge with, can... |
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | No | Use this field to avoid duplicate commands. |
-| `videoRoomId` | string (UUID) | No | The ID of the video room you want to bridge with, can't be u... |
+| `call_control_id` | string (UUID) | Yes | The Call Control ID of the call you want to bridge with, can... |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | No | Use this field to avoid duplicate commands. |
+| `video_room_id` | string (UUID) | No | The ID of the video room you want to bridge with, can't be u... |
 | ... | | | +16 optional params in [references/api-details.md](references/api-details.md) |
 
 ```javascript
@@ -301,9 +301,9 @@ Trigger a follow-up action in an existing workflow rather than creating a new to
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `cause` | enum (CALL_REJECTED, USER_BUSY) | Yes | Cause for call rejection. |
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
-| `clientState` | string | No | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | No | Use this field to avoid duplicate commands. |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `client_state` | string | No | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | No | Use this field to avoid duplicate commands. |
 
 ```javascript
 const response = await client.calls.actions.reject('call_control_id', { cause: 'USER_BUSY' });
@@ -322,7 +322,7 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `callControlId` | string (UUID) | Yes | Unique identifier and token for controlling the call |
+| `call_control_id` | string (UUID) | Yes | Unique identifier and token for controlling the call |
 
 ```javascript
 const response = await client.calls.retrieveStatus('v3:550e8400-e29b-41d4-a716-446655440000_gRU1OGRkYQ');
@@ -346,7 +346,7 @@ Fetch the current state before updating, deleting, or making control-flow decisi
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `connectionId` | string (UUID) | Yes | Telnyx connection id |
+| `connection_id` | string (UUID) | Yes | Telnyx connection id |
 | `page` | object | No | Consolidated page parameter (deepObject style). |
 
 ```javascript
@@ -410,12 +410,12 @@ Before using any operation below, read [the optional-parameters section](referen
 
 | Operation | SDK method | Endpoint | Use when | Required params |
 |-----------|------------|----------|----------|-----------------|
-| Create a call control application | `client.callControlApplications.create()` | `POST /call_control_applications` | Create or provision an additional resource when the core tasks do not cover this flow. | `applicationName`, `webhookEventUrl` |
+| Create a call control application | `client.callControlApplications.create()` | `POST /call_control_applications` | Create or provision an additional resource when the core tasks do not cover this flow. | `application_name`, `webhook_event_url` |
 | Retrieve a call control application | `client.callControlApplications.retrieve()` | `GET /call_control_applications/{id}` | Fetch the current state before updating, deleting, or making control-flow decisions. | `id` |
-| Update a call control application | `client.callControlApplications.update()` | `PATCH /call_control_applications/{id}` | Modify an existing resource without recreating it. | `applicationName`, `webhookEventUrl`, `id` |
+| Update a call control application | `client.callControlApplications.update()` | `PATCH /call_control_applications/{id}` | Modify an existing resource without recreating it. | `application_name`, `webhook_event_url`, `id` |
 | Delete a call control application | `client.callControlApplications.delete()` | `DELETE /call_control_applications/{id}` | Remove, detach, or clean up an existing resource. | `id` |
-| SIP Refer a call | `client.calls.actions.refer()` | `POST /calls/{call_control_id}/actions/refer` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `sipAddress`, `callControlId` |
-| Send SIP info | `client.calls.actions.sendSipInfo()` | `POST /calls/{call_control_id}/actions/send_sip_info` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `contentType`, `body`, `callControlId` |
+| SIP Refer a call | `client.calls.actions.refer()` | `POST /calls/{call_control_id}/actions/refer` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `sip_address`, `call_control_id` |
+| Send SIP info | `client.calls.actions.sendSipInfo()` | `POST /calls/{call_control_id}/actions/send_sip_info` | Trigger a follow-up action in an existing workflow rather than creating a new top-level resource. | `content_type`, `body`, `call_control_id` |
 
 ### Other Webhook Events
 

--- a/skills/telnyx-voice-javascript/references/api-details.md
+++ b/skills/telnyx-voice-javascript/references/api-details.md
@@ -94,236 +94,236 @@
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `active` | boolean | Specifies whether the connection can be used. |
-| `anchorsiteOverride` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
-| `dtmfType` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
-| `firstCommandTimeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
-| `firstCommandTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `anchorsite_override` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmf_type` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `first_command_timeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `first_command_timeout_secs` | integer | Specifies how many seconds to wait before timing out a dial command. |
 | `inbound` | object |  |
 | `outbound` | object |  |
-| `webhookApiVersion` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
-| `webhookEventFailoverUrl` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
-| `webhookTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a webhook. |
-| `callCostInWebhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
-| `redactDtmfDebugLogging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+| `webhook_api_version` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhook_event_failover_url` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhook_timeout_secs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `call_cost_in_webhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `redact_dtmf_debug_logging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
 
 ### Update a call control application — `client.callControlApplications.update()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `callCostInWebhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
+| `call_cost_in_webhooks` | boolean | Specifies if call cost webhooks should be sent for this Call Control Applicat... |
 | `active` | boolean | Specifies whether the connection can be used. |
-| `anchorsiteOverride` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
-| `dtmfType` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
-| `firstCommandTimeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
-| `firstCommandTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a dial command. |
+| `anchorsite_override` | enum (Latency, Chicago, IL, Ashburn, VA, San Jose, CA, London, UK, ...) | `Latency` directs Telnyx to route media through the site with the lowest roun... |
+| `dtmf_type` | enum (RFC 2833, Inband, SIP INFO) | Sets the type of DTMF digits sent from Telnyx to this Connection. |
+| `first_command_timeout` | boolean | Specifies whether calls to phone numbers associated with this connection shou... |
+| `first_command_timeout_secs` | integer | Specifies how many seconds to wait before timing out a dial command. |
 | `tags` | array[string] | Tags assigned to the Call Control Application. |
 | `inbound` | object |  |
 | `outbound` | object |  |
-| `webhookApiVersion` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
-| `webhookEventFailoverUrl` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
-| `webhookTimeoutSecs` | integer | Specifies how many seconds to wait before timing out a webhook. |
-| `redactDtmfDebugLogging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
+| `webhook_api_version` | enum (1, 2) | Determines which webhook format will be used, Telnyx API v1 or v2. |
+| `webhook_event_failover_url` | string (URL) | The failover URL where webhooks related to this connection will be sent if se... |
+| `webhook_timeout_secs` | integer | Specifies how many seconds to wait before timing out a webhook. |
+| `redact_dtmf_debug_logging` | boolean | When enabled, DTMF digits entered by users will be redacted in debug logs to ... |
 
 ### Dial — `client.calls.dial()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `assistant` | object | AI Assistant configuration. |
-| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
-| `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
 | `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
-| `audioUrl` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
-| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the called party answers. |
-| `mediaName` | string | The media_name of a file to be played back to the callee when the call is ans... |
-| `preferredCodecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
-| `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
-| `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
-| `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
-| `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
-| `deepfakeDetection` | object | Enables deepfake detection on the call. |
-| `conferenceConfig` | object | Optional configuration parameters to dial new participant into a conference. |
-| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
-| `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
-| `linkTo` | string | Use another call's control id for sharing the same call session id |
-| `bridgeIntent` | boolean | Indicates the intent to bridge this call with the call specified in link_to. |
-| `bridgeOnAnswer` | boolean | Whether to automatically bridge answered call to the call specified in link_to. |
-| `preventDoubleBridge` | boolean | Prevents bridging and hangs up the call if the target is already bridged. |
-| `parkAfterUnbridge` | string | If supplied with the value `self`, the current leg will be parked after unbri... |
-| `mediaEncryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the call. |
-| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
-| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
-| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE request. |
-| `sipTransportProtocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
-| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
-| `streamUrl` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
-| `streamTrack` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
-| `streamCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
-| `streamBidirectionalMode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
-| `streamBidirectionalCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
-| `streamBidirectionalTargetLegs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
-| `streamBidirectionalSamplingRate` | enum (8000, 16000, 22050, 24000, 48000) | Audio sampling rate. |
-| `streamEstablishBeforeCallOriginate` | boolean | Establish websocket connection before dialing the destination. |
-| `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
-| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
-| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
-| `webhookUrls` | object | A map of event types to webhook URLs. |
-| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
-| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `audio_url` | string (URL) | The URL of a file to be played back to the callee when the call is answered. |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the called party answers. |
+| `media_name` | string | The media_name of a file to be played back to the callee when the call is ans... |
+| `preferred_codecs` | string | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
+| `conference_config` | object | Optional configuration parameters to dial new participant into a conference. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `link_to` | string | Use another call's control id for sharing the same call session id |
+| `bridge_intent` | boolean | Indicates the intent to bridge this call with the call specified in link_to. |
+| `bridge_on_answer` | boolean | Whether to automatically bridge answered call to the call specified in link_to. |
+| `prevent_double_bridge` | boolean | Prevents bridging and hangs up the call if the target is already bridged. |
+| `park_after_unbridge` | string | If supplied with the value `self`, the current leg will be parked after unbri... |
+| `media_encryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the call. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE request. |
+| `sip_transport_protocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `stream_url` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `stream_track` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `stream_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `stream_bidirectional_mode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `stream_bidirectional_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `stream_bidirectional_target_legs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `stream_bidirectional_sampling_rate` | enum (8000, 16000, 22050, 24000, 48000) | Audio sampling rate. |
+| `stream_establish_before_call_originate` | boolean | Establish websocket connection before dialing the destination. |
+| `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
-| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
-| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
-| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
-| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
-| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
-| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
-| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
-| `superviseCallControlId` | string (UUID) | The call leg which will be supervised by the new call. |
-| `supervisorRole` | enum (barge, whisper, monitor) | The role of the supervisor call. |
-| `enableDialogflow` | boolean | Enables Dialogflow for the current call. |
-| `dialogflowConfig` | object |  |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `supervise_call_control_id` | string (UUID) | The call leg which will be supervised by the new call. |
+| `supervisor_role` | enum (barge, whisper, monitor) | The role of the supervisor call. |
+| `enable_dialogflow` | boolean | Enables Dialogflow for the current call. |
+| `dialogflow_config` | object |  |
 | `transcription` | boolean | Enable transcription upon call answer. |
-| `transcriptionConfig` | object |  |
-| `sipRegion` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
-| `streamAuthToken` | string | An authentication token to be sent as part of the WebSocket connection when u... |
+| `transcription_config` | object |  |
+| `sip_region` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `stream_auth_token` | string | An authentication token to be sent as part of the WebSocket connection when u... |
 
 ### Answer call — `client.calls.actions.answer()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `assistant` | object | AI Assistant configuration. |
-| `conversationRelayConfig` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
-| `billingGroupId` | string (UUID) | Use this field to set the Billing Group ID for the call. |
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
-| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE response. |
-| `preferredCodecs` | enum (G722,PCMU,PCMA,G729,OPUS,VP8,H264) | The list of comma-separated codecs in a preferred order for the forked media ... |
-| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE response. |
-| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
-| `streamUrl` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
-| `streamTrack` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
-| `streamCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
-| `streamBidirectionalMode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
-| `streamBidirectionalCodec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
-| `streamBidirectionalTargetLegs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
-| `sendSilenceWhenIdle` | boolean | Generate silence RTP packets when no transmission available. |
-| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
-| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `conversation_relay_config` | object | Starts a Conversation Relay session automatically when the answered/dialed ca... |
+| `billing_group_id` | string (UUID) | Use this field to set the Billing Group ID for the call. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE response. |
+| `preferred_codecs` | enum (G722,PCMU,PCMA,G729,OPUS,VP8,H264) | The list of comma-separated codecs in a preferred order for the forked media ... |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE response. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `stream_url` | string (URL) | The destination WebSocket address where the stream is going to be delivered. |
+| `stream_track` | enum (inbound_track, outbound_track, both_tracks) | Specifies which track should be streamed. |
+| `stream_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Specifies the codec to be used for the streamed audio. |
+| `stream_bidirectional_mode` | enum (mp3, rtp) | Configures method of bidirectional streaming (mp3, rtp). |
+| `stream_bidirectional_codec` | enum (PCMU, PCMA, G722, OPUS, AMR-WB, ...) | Indicates codec for bidirectional streaming RTP payloads. |
+| `stream_bidirectional_target_legs` | enum (both, self, opposite) | Specifies which call legs should receive the bidirectional stream audio. |
+| `send_silence_when_idle` | boolean | Generate silence RTP packets when no transmission available. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
 | `transcription` | boolean | Enable transcription upon call answer. |
-| `transcriptionConfig` | object |  |
+| `transcription_config` | object |  |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
-| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
-| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
-| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
-| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
-| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
-| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
-| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
-| `webhookUrls` | object | A map of event types to webhook URLs. |
-| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
-| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
-| `deepfakeDetection` | object | Enables deepfake detection on the call. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
+| `deepfake_detection` | object | Enables deepfake detection on the call. |
 
 ### Bridge calls — `client.calls.actions.bridge()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
 | `queue` | string | The name of the queue you want to bridge with, can't be used together with ca... |
-| `videoRoomId` | string (UUID) | The ID of the video room you want to bridge with, can't be used together with... |
-| `videoRoomContext` | string | The additional parameter that will be passed to the video conference. |
-| `preventDoubleBridge` | boolean | When set to `true`, it prevents bridging if the target call is already bridge... |
-| `parkAfterUnbridge` | string | Specifies behavior after the bridge ends (i.e. |
-| `playRingtone` | boolean | Specifies whether to play a ringtone if the call you want to bridge with has ... |
+| `video_room_id` | string (UUID) | The ID of the video room you want to bridge with, can't be used together with... |
+| `video_room_context` | string | The additional parameter that will be passed to the video conference. |
+| `prevent_double_bridge` | boolean | When set to `true`, it prevents bridging if the target call is already bridge... |
+| `park_after_unbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `play_ringtone` | boolean | Specifies whether to play a ringtone if the call you want to bridge with has ... |
 | `ringtone` | enum (at, au, be, bg, br, ...) | Specifies which country ringtone to play when `play_ringtone` is set to `true`. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
-| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
-| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
-| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
-| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
-| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
-| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
-| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
-| `muteDtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
-| `holdAfterUnbridge` | boolean | Specifies behavior after the bridge ends. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `mute_dtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `hold_after_unbridge` | boolean | Specifies behavior after the bridge ends. |
 
 ### Hangup call — `client.calls.actions.hangup()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
-| `customHeaders` | array[object] | Custom headers to be added to the SIP BYE message. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP BYE message. |
 
 ### SIP Refer a call — `client.calls.actions.refer()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid execution of duplicate commands. |
-| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
-| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
-| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
-| `sipHeaders` | array[object] | SIP headers to be added to the request. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid execution of duplicate commands. |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the request. |
 
 ### Reject a call — `client.calls.actions.reject()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
 
 ### Send SIP info — `client.calls.actions.sendSipInfo()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
 
 ### Transfer call — `client.calls.actions.transfer()`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `from` | string (E.164) | The `from` number to be used as the caller id presented to the destination (`... |
-| `fromDisplayName` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
+| `from_display_name` | string | The `from_display_name` string to be used as the caller id name (SIP From Dis... |
 | `privacy` | enum (id, none) | Indicates the privacy level to be used for the call. |
-| `audioUrl` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
-| `sendDigitsOnAnswer` | string | DTMF digits to send automatically after the transfer destination answers. |
-| `earlyMedia` | boolean | If set to false, early media will not be passed to the originating leg. |
-| `mediaName` | string | The media_name of a file to be played back when the transfer destination answ... |
-| `timeoutSecs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
-| `timeLimitSecs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
-| `parkAfterUnbridge` | string | Specifies behavior after the bridge ends (i.e. |
-| `answeringMachineDetection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
-| `answeringMachineDetectionConfig` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
-| `customHeaders` | array[object] | Custom headers to be added to the SIP INVITE. |
-| `clientState` | string | Use this field to add state to every subsequent webhook. |
-| `targetLegClientState` | string | Use this field to add state to every subsequent webhook for the new leg. |
-| `commandId` | string (UUID) | Use this field to avoid duplicate commands. |
-| `mediaEncryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the new call leg. |
-| `sipAuthUsername` | string | SIP Authentication username used for SIP challenges. |
-| `sipAuthPassword` | string | SIP Authentication password used for SIP challenges. |
-| `sipHeaders` | array[object] | SIP headers to be added to the SIP INVITE. |
-| `sipTransportProtocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
-| `soundModifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
-| `webhookUrl` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
-| `webhookUrlMethod` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
-| `muteDtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
+| `audio_url` | string (URL) | The URL of a file to be played back when the transfer destination answers bef... |
+| `send_digits_on_answer` | string | DTMF digits to send automatically after the transfer destination answers. |
+| `early_media` | boolean | If set to false, early media will not be passed to the originating leg. |
+| `media_name` | string | The media_name of a file to be played back when the transfer destination answ... |
+| `timeout_secs` | integer | The number of seconds that Telnyx will wait for the call to be answered by th... |
+| `time_limit_secs` | integer | Sets the maximum duration of a Call Control Leg in seconds. |
+| `park_after_unbridge` | string | Specifies behavior after the bridge ends (i.e. |
+| `answering_machine_detection` | enum (premium, detect, detect_beep, detect_words, greeting_end, ...) | Enables Answering Machine Detection. |
+| `answering_machine_detection_config` | object | Optional configuration parameters to modify 'answering_machine_detection' per... |
+| `custom_headers` | array[object] | Custom headers to be added to the SIP INVITE. |
+| `client_state` | string | Use this field to add state to every subsequent webhook. |
+| `target_leg_client_state` | string | Use this field to add state to every subsequent webhook for the new leg. |
+| `command_id` | string (UUID) | Use this field to avoid duplicate commands. |
+| `media_encryption` | enum (disabled, SRTP, DTLS) | Defines whether media should be encrypted on the new call leg. |
+| `sip_auth_username` | string | SIP Authentication username used for SIP challenges. |
+| `sip_auth_password` | string | SIP Authentication password used for SIP challenges. |
+| `sip_headers` | array[object] | SIP headers to be added to the SIP INVITE. |
+| `sip_transport_protocol` | enum (UDP, TCP, TLS) | Defines SIP transport protocol to be used on the call. |
+| `sound_modifications` | object | Use this field to modify sound effects, for example adjust the pitch. |
+| `webhook_url` | string (URL) | Use this field to override the URL for which Telnyx will send subsequent webh... |
+| `webhook_url_method` | enum (POST, GET) | HTTP request type used for `webhook_url`. |
+| `mute_dtmf` | enum (none, both, self, opposite) | When enabled, DTMF tones are not passed to the call participant. |
 | `record` | enum (record-from-answer) | Start recording automatically after an event. |
-| `recordChannels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
-| `recordFormat` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
-| `recordMaxLength` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
-| `recordTimeoutSecs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
-| `recordTrack` | enum (both, inbound, outbound) | The audio track to be recorded. |
-| `recordTrim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
-| `recordCustomFileName` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
-| `sipRegion` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
-| `preferredCodecs` | string | The list of comma-separated codecs in order of preference to be used during t... |
-| `webhookUrls` | object | A map of event types to webhook URLs. |
-| `webhookUrlsMethod` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
-| `webhookRetriesPolicies` | object | A map of event types to retry policies. |
+| `record_channels` | enum (single, dual) | Defines which channel should be recorded ('single' or 'dual') when `record` i... |
+| `record_format` | enum (wav, mp3) | Defines the format of the recording ('wav' or 'mp3') when `record` is specified. |
+| `record_max_length` | integer | Defines the maximum length for the recording in seconds when `record` is spec... |
+| `record_timeout_secs` | integer | The number of seconds that Telnyx will wait for the recording to be stopped i... |
+| `record_track` | enum (both, inbound, outbound) | The audio track to be recorded. |
+| `record_trim` | enum (trim-silence) | When set to `trim-silence`, silence will be removed from the beginning and en... |
+| `record_custom_file_name` | string | The custom recording file name to be used instead of the default `call_leg_id`. |
+| `sip_region` | enum (US, Europe, Canada, Australia, Middle East) | Defines the SIP region to be used for the call. |
+| `preferred_codecs` | string | The list of comma-separated codecs in order of preference to be used during t... |
+| `webhook_urls` | object | A map of event types to webhook URLs. |
+| `webhook_urls_method` | enum (POST, GET) | HTTP request method to invoke `webhook_urls`. |
+| `webhook_retries_policies` | object | A map of event types to retry policies. |
 
 ## Webhook Payload Fields
 


### PR DESCRIPTION
## Auto-generated Telnyx skills update

Fresh scoped generated-output verification for the SDK metadata refresh in the source generator repository.

## Source context

- Source PR: https://github.com/team-telnyx/telnyx-ext-skills-generator/pull/83
- Exact source commit: [`1b502a201aec8185e57673d7bf6be0a8db65fb33`](https://github.com/team-telnyx/telnyx-ext-skills-generator/commit/1b502a201aec8185e57673d7bf6be0a8db65fb33)
- Source base: `2da1170649e55368b4ba0d4709b3a7b646ad06b9`
- Supersedes closed generated-output PR: https://github.com/team-telnyx/ai/pull/228
- This PR is intentionally a draft because source PR #83 is still open and unmerged.

## Scope

- Manifest: `scopes/northstar-v2-pilot.json`
- Profile: `northstar-v2`
- Products (5): `messaging`, `voice`, `10dlc`, `numbers`, `ai-assistants`
- Languages (6): `curl`, `go`, `java`, `javascript`, `python`, `ruby`
- Generated product/language skills in scope: 30
- Exclude manifest: none

## Generated output and boundary audit

- Generated canonical skills copied: 30
- Manual/non-target canonical skills preserved: 206
- Canonical skills total after publish: 236
- Changed files: 129 (`+3162/-3102`)
  - Scoped canonical generated paths: 24 changed files
  - Claude provider copies of scoped generated paths: 24 changed files
  - Cursor provider copies of scoped generated paths: 24 changed files
  - Managed Twilio-migration derived references: 19 changed files on each of canonical, Claude, and Cursor surfaces (57 total)
- All 30 scoped canonical skill trees exist; canonical/Claude/Cursor copies are byte-identical.
- No changed path is outside the 30 manifest-selected skill trees, their provider copies, or exact managed `telnyx-twilio-migration` derived-reference paths.
- No non-skill surface changed; unmanaged and out-of-scope files were preserved.

## Derived reference behavior

The scoped publisher refreshed 30 in-scope Twilio migration SDK references and evaluated 5 shared, language-neutral SDK API-details files. It also evaluated the globally managed WebRTC references (5 server and 5 migration-client references); those shared/WebRTC files did not differ from `main`. The changed derived output is limited to 19 in-scope Twilio migration SDK reference files, propagated identically to canonical, Claude, and Cursor copies.

## SDK metadata and JavaScript webhook check

Committed metadata was extracted at `2026-07-20T15:17:41.379325+00:00`; all five extraction statuses show success on 2026-07-20 with zero consecutive failures:

- Go `v4.88.0`
- Java `6.81.0`
- JavaScript `7.8.0`
- Python `4.168.0`
- Ruby `5.156.0`

JavaScript `webhooks.is_async: false` was checked independently against `telnyx@7.8.0`, not accepted solely from the extraction status:

- Published `src/resources/webhooks.ts` declares synchronous `unwrap(...): UnwrapWebhookEvent` and calls synchronous `standardwebhooks` verification.
- SDK tests and the webhook-verification example call `client.webhooks.unwrap(...)` without `await`.
- A clean `telnyx@7.8.0` package install plus `sdk-extraction/extract_node.js` reported `unwrap.exists=true`, `arity=2`, and `is_async=false`.
- The generator's JavaScript webhook template renders `const event = client.webhooks.unwrap(...)` without `await`.

## Validation

Source checkout was pinned to `1b502a201aec8185e57673d7bf6be0a8db65fb33`. The full extractor was intentionally not rerun because it would create a newer timestamp-only metadata diff after the committed successful extraction.

- `python3.11 -m py_compile publish_ai.py generate_skills.py validate_skills.py render_templates.py sdk_surface_v2.py task_selection_v2.py operation_contract_v2.py` — passed
- `python3.11 -m pytest tests/test_publish_ai.py tests/test_northstar_v2.py` — 77 passed in 21.94s
- `git diff --check` — passed
- Scoped dry-run generation/validation — passed:
  - 30 skills, 5 products, 6 languages
  - 84/84 core tasks rendered
  - upstream SDK-version validation passed
  - rendered SDK method validation passed
  - diff-boundary validation passed
- Downstream `git diff --check` — passed

Dry-run command:

```bash
PUBLIC_REPO_URL=https://github.com/team-telnyx/ai.git ./publish.sh --dry-run --scope-manifest scopes/northstar-v2-pilot.json "chore: refresh scoped SDK-generated skills (source PR #83 @ 1b502a2)"
```

Real publish reused the exact validated dry-run output:

```bash
PUBLIC_REPO_URL=https://github.com/team-telnyx/ai.git ./publish.sh --skip-generate --scope-manifest scopes/northstar-v2-pilot.json "chore: refresh scoped SDK-generated skills"
```

## Expected CI skips

- `release doctor` — expected to skip because the branch is not a release branch.
- `API Write + Cleanup Tests (Telnyx network)` — expected to skip under the integration workflow's protected-network conditions.
