### PR TITLE
chore(release): bump agent toolkits to 0.3.0

### DIFF
--- a/tools/python/pyproject.toml
+++ b/tools/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "telnyx-agent-toolkit"
-version = "0.2.0"
+version = "0.3.0"
 description = "Telnyx Agent Toolkit — tools for building AI agents with Telnyx APIs"
 readme = "README.md"
 license = "MIT"

--- a/tools/python/telnyx_agent_toolkit/__init__.py
+++ b/tools/python/telnyx_agent_toolkit/__init__.py
@@ -3,4 +3,4 @@
 from telnyx_agent_toolkit.configuration import TelnyxAgentToolkit, TelnyxConfig
 
 __all__ = ["TelnyxAgentToolkit", "TelnyxConfig"]
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/tools/python/telnyx_agent_toolkit/shared/friction.py
+++ b/tools/python/telnyx_agent_toolkit/shared/friction.py
@@ -73,7 +73,7 @@ class FrictionReporter:
                 "api_path": api_path,
                 "error_detail": error_message,
                 "sdk": "python",
-                "sdk_version": "0.2.0",
+                "sdk_version": "0.3.0",
             },
         }
 

--- a/tools/python/uv.lock
+++ b/tools/python/uv.lock
@@ -3087,7 +3087,7 @@ wheels = [
 
 [[package]]
 name = "telnyx-agent-toolkit"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/tools/typescript/package-lock.json
+++ b/tools/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@telnyx/agent-toolkit",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@telnyx/agent-toolkit",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/tools/typescript/package.json
+++ b/tools/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telnyx/agent-toolkit",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Telnyx Agent Toolkit for TypeScript — tools for OpenAI, Vercel AI SDK, and LangChain.js",
   "type": "module",
   "main": "./dist/index.js",

--- a/tools/typescript/src/shared/friction.ts
+++ b/tools/typescript/src/shared/friction.ts
@@ -65,7 +65,7 @@ export class FrictionReporter {
         api_path: event.api_path,
         error_detail: event.error_message,
         sdk: "typescript",
-        sdk_version: "0.2.0",
+        sdk_version: "0.3.0",
       },
     };
 


### PR DESCRIPTION
## Summary
- bump `@telnyx/agent-toolkit` from 0.2.0 to 0.3.0
- bump `telnyx-agent-toolkit` from 0.2.0 to 0.3.0
- synchronize manifests, lockfiles, exported runtime versions, and friction telemetry versions

This releases the 211-tool parity work merged in https://github.com/team-telnyx/ai/pull/302.

## Validation
- release doctor: passed
- TypeScript hermetic tests/build/npm pack: passed
- Python hermetic suite: 169 passed, 62 live/optional skipped
- Python wheel and sdist build: passed
- manifest/lock/artifact version consistency: passed
- live registries: both remain at 0.2.0; 0.3.0 is unpublished

## Independent review
- Spec: 10/10
- Quality: 10/10
- Verdict: PASS
- Findings: none

## Release plan
After merge:
1. dispatch **Publish npm** with `package=typescript`
2. dispatch **Publish PyPI**
3. verify `@telnyx/agent-toolkit@0.3.0` on npm and `telnyx-agent-toolkit==0.3.0` on PyPI
