### PR TITLE
fix(cli): intercept --help/-h before dispatch so setup-* never buys resources (AIF-325)

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -486,10 +486,35 @@ const COMMANDS: Record<string, (
   "disable-sim-card": disableSimCardCommand,
 };
 
+// Detect a help request in FLAG position only. A help token counts when it is
+// the command itself (`help`, `--help`, `-h`) or a standalone flag on a
+// subcommand (`setup-voice --help`, `setup-voice -h`). It must NOT count when
+// `-h`/`--help` is consumed as the VALUE of another flag (e.g.
+// `send-sms --text "-h"`), so we walk argv the same way parseFlags does and skip
+// consumed values. This keeps help interception consistent with the parser and
+// avoids a false positive that would block legitimate sends.
+function isHelpRequested(argv: string[]): boolean {
+  const command = argv[0];
+  if (command === "help" || command === "--help" || command === "-h") return true;
+  for (let i = 1; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--help" || arg === "-h") return true;
+    if (arg.startsWith("--")) {
+      const next = argv[i + 1];
+      if (next && !next.startsWith("--")) i++; // skip value consumed by this flag
+    }
+  }
+  return false;
+}
+
 export async function run(argv: string[]): Promise<void> {
   const { command, flags, occurrences } = parseFlags(argv);
 
-  if (command === "help" || command === "--help" || command === "-h" || !command) {
+  // Intercept help BEFORE dispatching to any command handler. setup-* handlers
+  // make live API calls and purchase billable resources (numbers, connections)
+  // before hitting an unknown flag, so a `--help`/`-h` request must never fall
+  // through to a handler. See isHelpRequested for flag-position vs value nuance.
+  if (!command || command === "help" || isHelpRequested(argv)) {
     console.log(HELP);
     return;
   }

--- a/cli/tests/telnyx-cli-flags.test.ts
+++ b/cli/tests/telnyx-cli-flags.test.ts
@@ -4,7 +4,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, chmodSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -158,4 +158,88 @@ describe("telnyx CLI flag compatibility", () => {
       else process.env.TELNYX_FAKE_ARGS_LOG = previousArgsLog;
     }
   });
+});
+
+describe("help flag never triggers command execution (AIF-325)", () => {
+  // A --help/-h flag on a setup-* command must print help and make ZERO Go CLI
+  // calls. Regression: `setup-voice --help` previously fell through to the handler
+  // and purchased a billable number/connection before erroring on the unknown flag.
+  const helpInvocations: string[][] = [
+    ["setup-voice", "--help"],
+    ["setup-sms", "--help"],
+    ["setup-verify", "-h"],
+    ["setup-ai", "--help"],
+    ["setup-10dlc", "--help"],
+    ["help"],
+    ["--help"],
+    ["-h"],
+    [],
+  ];
+
+  for (const argv of helpInvocations) {
+    const label = argv.length ? argv.join(" ") : "(no args)";
+    it(`prints help and makes no Go CLI calls for: ${label}`, () => {
+      const fake = setupFakeTelnyx();
+
+      const output = execFileSync("npx", ["tsx", cliBin, ...argv], {
+        cwd: cliRoot,
+        encoding: "utf8",
+        env: fake.env,
+        timeout: 30000,
+      });
+
+      // Help text was printed.
+      assert.match(output, /telnyx-agent — Agent-friendly CLI for Telnyx API v2/);
+      assert.match(output, /Usage:/);
+
+      // The fake telnyx binary only creates its log file when invoked. If it was
+      // never called, the log file must not exist at all — proving zero API calls.
+      if (existsSync(fake.logPath)) {
+        const calls = readLoggedArgs(fake.logPath);
+        assert.equal(
+          calls.length,
+          0,
+          `expected zero Go CLI calls for \`${label}\`, got: ${JSON.stringify(calls)}`,
+        );
+      }
+    });
+  }
+});
+
+describe("help detection ignores -h in flag-VALUE position (AIF-325)", () => {
+  // A literal "-h" passed as the VALUE of another flag (e.g. an SMS body or
+  // password) must NOT be treated as a help request. parseFlags captures "-h" as
+  // a real value (single-dash tokens are not flags), so the command must dispatch
+  // to the handler and reach the Go CLI as normal.
+  // Note: "--help" as a value is a separate parser limitation (parseFlags never
+  // consumes a `--`-prefixed token as a value), so it is intentionally not tested
+  // here — that input is non-functional independent of this fix.
+  const valueInvocations: string[][] = [
+    ["send-sms", "--from", "+10000000000", "--to", "+20000000000", "--text", "-h"],
+  ];
+
+  for (const argv of valueInvocations) {
+    const label = argv.join(" ");
+    it(`dispatches to the handler (no help short-circuit) for: ${label}`, () => {
+      const fake = setupFakeTelnyx();
+
+      const output = execFileSync("npx", ["tsx", cliBin, ...argv], {
+        cwd: cliRoot,
+        encoding: "utf8",
+        env: fake.env,
+        timeout: 30000,
+      });
+
+      // Must NOT be the top-level help screen.
+      assert.doesNotMatch(output, /telnyx-agent — Agent-friendly CLI for Telnyx API v2/);
+
+      // The command reached the Go CLI (fake logged at least one invocation).
+      assert.equal(existsSync(fake.logPath), true, "expected the Go CLI to be invoked");
+      const calls = readLoggedArgs(fake.logPath);
+      assert.ok(
+        calls.length >= 1,
+        `expected at least one Go CLI call for \`${label}\`, got: ${JSON.stringify(calls)}`,
+      );
+    });
+  }
 });


### PR DESCRIPTION
## Summary

`setup-*` commands (`setup-voice`, `setup-sms`, `setup-verify`, `setup-ai`, `setup-10dlc`) previously **fell through to their handlers** when invoked with `--help`/`-h`. Because those handlers make live Telnyx API calls, the CLI would **purchase billable numbers and connections** before erroring on the unknown flag. `setup-voice --help` should print help — not buy a number.

This intercepts help **before** command dispatch in `run()`.

## Root cause

`run()` only checked for help when it was the *command* (`help` / `--help` / `-h` as `argv[0]`). A help flag attached to a subcommand (`setup-voice --help`) was not caught, so dispatch proceeded into the setup handler and its provisioning calls.

## Fix

New `isHelpRequested(argv)` helper walks `argv` the same way `parseFlags` does and treats `--help`/`-h` as a help request **only in flag position** — not when consumed as another flag's value.

The value-position nuance matters: a naive `argv.includes("-h")` would match a legitimate `-h` **value** (e.g. `send-sms --text "-h"`, an SMS body of `-h`) and wrongly print help instead of sending. The helper skips values consumed by a preceding flag, keeping help detection consistent with the parser.

> Note: `--text "--help"` (double-dash as a value) still short-circuits to help, but that is a pre-existing `parseFlags` limitation — it never captures a `--`-prefixed token as a value — and is independent of this change. `-h` is the only genuinely capturable value.

## Tests

Added an AIF-325 regression block in `cli/tests/telnyx-cli-flags.test.ts`:

- **9 help invocations** (`setup-voice --help`, `setup-sms --help`, `setup-verify -h`, `setup-ai --help`, `setup-10dlc --help`, `help`, `--help`, `-h`, no-args) each assert **zero Go CLI calls** — proving no resource was purchased.
- **1 negative test**: `send-sms --from … --to … --text "-h"` must dispatch to the handler (reach the Go CLI), proving a literal `-h` body is not mistaken for a help request.

### Verification

- Full CLI suite: **207/207 pass**
- AIF-325 file: **13/13 pass**
- `tsc --noEmit`: clean

## Risk

Low. Behavior change is limited to help-flag handling; no functional command paths altered. Zero network calls in the new tests.

Fixes AIF-325.
