### PR TITLE
fix(aif-333): portable bin launcher + --version + status REST swap

### DIFF
--- a/cli/bin/telnyx-agent.mjs
+++ b/cli/bin/telnyx-agent.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * telnyx-agent launcher.
+ *
+ * This plain-JS launcher is the package `bin`. It exists so the executable
+ * shebang is a portable single-argument `#!/usr/bin/env node`, which works on
+ * Linux, macOS, and Windows.
+ *
+ * The previous entrypoint used `#!/usr/bin/env npx tsx`. That is a multi-argument
+ * shebang, which Linux `env` rejects without `-S` ("env: 'npx tsx': No such file
+ * or directory"), leaving the CLI unusable out of the box (AIF-333). Even the
+ * `-S` form (`#!/usr/bin/env -S npx tsx`) requires coreutils >= 8.30 and pays an
+ * `npx` resolution cost on every invocation.
+ *
+ * Instead we resolve the bundled `tsx` runtime (a declared dependency) and spawn
+ * it on the TypeScript entrypoint, forwarding argv and exit status. No `npx`, no
+ * network, no multi-arg shebang.
+ */
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const here = dirname(fileURLToPath(import.meta.url));
+const entrypoint = join(here, "telnyx-agent.ts");
+
+// Resolve the bundled tsx CLI from this package's own dependency tree so we do
+// not depend on a globally installed `tsx`/`npx`.
+let tsxCli;
+try {
+  tsxCli = require.resolve("tsx/cli");
+} catch {
+  console.error(
+    "telnyx-agent: unable to locate the bundled 'tsx' runtime. " +
+      "Reinstall the package (npm i -g @telnyx/agent-cli) to restore it.",
+  );
+  process.exit(1);
+}
+
+const result = spawnSync(process.execPath, [tsxCli, entrypoint, ...process.argv.slice(2)], {
+  stdio: "inherit",
+});
+
+if (result.error) {
+  console.error(`telnyx-agent: failed to launch — ${result.error.message}`);
+  process.exit(1);
+}
+
+// Re-raise a terminating signal as a non-zero exit; otherwise forward the code.
+if (result.signal) {
+  process.exit(1);
+}
+process.exit(result.status ?? 0);

--- a/cli/bin/telnyx-agent.ts
+++ b/cli/bin/telnyx-agent.ts
@@ -1,7 +1,10 @@
-#!/usr/bin/env npx tsx
 /**
  * telnyx-agent — Agent-friendly CLI for Telnyx API v2.
  * Composite commands that reduce multi-step workflows to a single command.
+ *
+ * This module is the TypeScript entrypoint. It is launched via the bundled tsx
+ * runtime by bin/telnyx-agent.mjs (the package `bin`), not executed directly, so
+ * it intentionally carries no shebang. See bin/telnyx-agent.mjs and AIF-333.
  */
 
 import { run } from "../src/index.ts";

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -14,7 +14,7 @@
         "tsx": "^4.19.0"
       },
       "bin": {
-        "telnyx-agent": "bin/telnyx-agent.ts"
+        "telnyx-agent": "bin/telnyx-agent.mjs"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -4,11 +4,11 @@
   "description": "Agent-friendly CLI for Telnyx API v2 — composite setup commands that reduce multi-step workflows to a single command",
   "type": "module",
   "bin": {
-    "telnyx-agent": "./bin/telnyx-agent.ts"
+    "telnyx-agent": "./bin/telnyx-agent.mjs"
   },
   "scripts": {
-    "start": "tsx bin/telnyx-agent.ts",
-    "test": "tsx --test tests/ai.test.ts tests/edge-handoff.test.ts tests/fax.test.ts tests/integration.test.ts tests/iot.test.ts tests/numbers.test.ts tests/rcs.test.ts tests/setup-10dlc.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
+    "start": "node bin/telnyx-agent.mjs",
+    "test": "tsx --test tests/ai.test.ts tests/bin-launcher.test.ts tests/edge-handoff.test.ts tests/fax.test.ts tests/integration.test.ts tests/iot.test.ts tests/numbers.test.ts tests/rcs.test.ts tests/setup-10dlc.test.ts tests/sms.test.ts tests/status-rest.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/version.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
     "typecheck": "tsc --noEmit",
     "postinstall": "tsx scripts/postinstall.ts",
     "build": "npm run typecheck"

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -1,9 +1,9 @@
 /**
  * telnyx-agent status — Account health at a glance.
- * All queries via telnyx CLI.
+ * Uses direct REST calls via TelnyxClient (no Go CLI dependency).
  */
 
-import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
+import { TelnyxClient, TelnyxAPIError } from "../client.ts";
 import { outputJson, printWarning } from "../utils/output.ts";
 
 interface StatusResult {
@@ -17,6 +17,7 @@ interface StatusResult {
 
 export async function statusCommand(flags: Record<string, string | boolean>): Promise<void> {
   const jsonOutput = flags.json === true;
+  const client = new TelnyxClient();
 
   const results: StatusResult = {
     balance: { available: "0.00", amount: "0.00", currency: "USD", credit_limit: "0.00" },
@@ -27,17 +28,16 @@ export async function statusCommand(flags: Record<string, string | boolean>): Pr
     warnings: [],
   };
 
-  // Run all queries concurrently via CLI
-  // List commands use { format: "raw" } — v0.21 list commands with --format json
-  // stream per-item JSON (concatenated, NOT a { data, meta } envelope), so raw
-  // format is needed to get the parseable REST response body.
+  // Run all queries concurrently via direct REST calls
   const [balanceRes, numbersRes, profilesRes, connectionsRes, assistantsRes] = await Promise.allSettled([
-    telnyxCli(["balance", "retrieve"]),
-    telnyxCli(["phone-numbers", "list", "--page-size", "1"], { format: "raw" }),
-    telnyxCli(["messaging-profiles", "list", "--page-size", "1"], { format: "raw" }),
-    telnyxCli(["credential-connections", "list", "--page-size", "1"], { format: "raw" }),
-    telnyxCli(["ai:assistants", "list"], { format: "raw" }),
+    client.get("/balance"),
+    client.get("/phone_numbers", { page_size: 1 }),
+    client.get("/messaging_profiles", { page_size: 1 }),
+    client.get("/credential_connections", { page_size: 1 }),
+    client.get("/ai_assistants", { page_size: 1 }),
   ]);
+
+  let failureCount = 0;
 
   // Balance
   if (balanceRes.status === "fulfilled") {
@@ -58,6 +58,7 @@ export async function statusCommand(flags: Record<string, string | boolean>): Pr
     results.balance.available = available.toFixed(2);
     if (available < 5) results.warnings.push(`Low available balance: $${results.balance.available} — consider topping up`);
   } else {
+    failureCount++;
     results.warnings.push(`Could not fetch balance: ${errorMsg(balanceRes.reason)}`);
   }
 
@@ -67,6 +68,7 @@ export async function statusCommand(flags: Record<string, string | boolean>): Pr
     results.phone_numbers.total = Number(meta?.total_results ?? 0);
     results.phone_numbers.active = results.phone_numbers.total; // Approximate
   } else {
+    failureCount++;
     results.warnings.push(`Could not fetch phone numbers: ${errorMsg(numbersRes.reason)}`);
   }
 
@@ -75,6 +77,7 @@ export async function statusCommand(flags: Record<string, string | boolean>): Pr
     const meta = profilesRes.value.meta as Record<string, unknown> | undefined;
     results.messaging_profiles.total = Number(meta?.total_results ?? 0);
   } else {
+    failureCount++;
     results.warnings.push(`Could not fetch messaging profiles: ${errorMsg(profilesRes.reason)}`);
   }
 
@@ -83,6 +86,7 @@ export async function statusCommand(flags: Record<string, string | boolean>): Pr
     const meta = connectionsRes.value.meta as Record<string, unknown> | undefined;
     results.connections.total = Number(meta?.total_results ?? 0);
   } else {
+    failureCount++;
     results.warnings.push(`Could not fetch connections: ${errorMsg(connectionsRes.reason)}`);
   }
 
@@ -92,37 +96,42 @@ export async function statusCommand(flags: Record<string, string | boolean>): Pr
     const data = assistantsRes.value.data as unknown[];
     results.ai_assistants.total = Number(meta?.total_results ?? data?.length ?? 0);
   } else {
+    failureCount++;
     results.warnings.push(`Could not fetch AI assistants: ${errorMsg(assistantsRes.reason)}`);
   }
 
   if (jsonOutput) {
     outputJson(results);
-    return;
-  }
+  } else {
+    // Human-readable output
+    console.log("\n📊 Telnyx Account Status");
+    console.log("========================\n");
+    console.log(`  Available Balance: $${results.balance.available} ${results.balance.currency}`);
+    console.log(`  Account Balance:    $${results.balance.amount} ${results.balance.currency}`);
+    console.log(`  Credit Limit:      $${results.balance.credit_limit}`);
+    console.log(`  Phone Numbers:      ${results.phone_numbers.total}`);
+    console.log(`  Messaging Profiles: ${results.messaging_profiles.total}`);
+    console.log(`  Voice Connections:  ${results.connections.total}`);
+    console.log(`  AI Assistants:      ${results.ai_assistants.total}`);
 
-  // Human-readable output
-  console.log("\n📊 Telnyx Account Status");
-  console.log("========================\n");
-  console.log(`  Available Balance: $${results.balance.available} ${results.balance.currency}`);
-  console.log(`  Account Balance:    $${results.balance.amount} ${results.balance.currency}`);
-  console.log(`  Credit Limit:      $${results.balance.credit_limit}`);
-  console.log(`  Phone Numbers:      ${results.phone_numbers.total}`);
-  console.log(`  Messaging Profiles: ${results.messaging_profiles.total}`);
-  console.log(`  Voice Connections:  ${results.connections.total}`);
-  console.log(`  AI Assistants:      ${results.ai_assistants.total}`);
-
-  if (results.warnings.length > 0) {
-    console.log("\n⚠️  Warnings:");
-    for (const w of results.warnings) {
-      printWarning(`  ${w}`);
+    if (results.warnings.length > 0) {
+      console.log("\n⚠️  Warnings:");
+      for (const w of results.warnings) {
+        printWarning(`  ${w}`);
+      }
     }
+
+    console.log();
   }
 
-  console.log();
+  // Exit non-zero if every query failed — the CLI is effectively non-functional.
+  if (failureCount === 5) {
+    process.exit(1);
+  }
 }
 
 function errorMsg(err: unknown): string {
-  if (err instanceof TelnyxCLIError) return err.stderr || err.message;
+  if (err instanceof TelnyxAPIError) return err.detail || err.message;
   if (err instanceof Error) return err.message;
   return String(err);
 }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -51,6 +51,10 @@ import {
 } from "./commands/sim-cards.ts";
 import { parseFlags } from "./utils/output.ts";
 
+// Version is read lazily so that `--version` works without loading any command modules.
+import { createRequire } from "node:module";
+const VERSION = createRequire(import.meta.url)("../package.json").version as string;
+
 const HELP = `
 telnyx-agent — Agent-friendly CLI for Telnyx API v2
 
@@ -488,6 +492,11 @@ const COMMANDS: Record<string, (
 
 export async function run(argv: string[]): Promise<void> {
   const { command, flags, occurrences } = parseFlags(argv);
+
+  if (command === "--version" || command === "-V") {
+    console.log(VERSION);
+    return;
+  }
 
   if (command === "help" || command === "--help" || command === "-h" || !command) {
     console.log(HELP);

--- a/cli/tests/bin-launcher.test.ts
+++ b/cli/tests/bin-launcher.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Regression tests for the package bin launcher (AIF-333).
+ *
+ * The CLI must be usable out of the box on Linux, macOS, and Windows. The
+ * previous entrypoint shebang was `#!/usr/bin/env npx tsx` — a multi-argument
+ * shebang that Linux `env` rejects without `-S`, making the very first command
+ * fail with "env: 'npx tsx': No such file or directory".
+ *
+ * These tests lock in the fix: the package bin is a plain-JS launcher with a
+ * portable single-argument `#!/usr/bin/env node` shebang that spawns the bundled
+ * tsx runtime on the TS entrypoint, forwards argv, and passes exit codes through.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliRoot = join(__dirname, "..");
+const launcher = join(cliRoot, "bin", "telnyx-agent.mjs");
+const entrypoint = join(cliRoot, "bin", "telnyx-agent.ts");
+
+describe("bin launcher shebang portability (AIF-333)", () => {
+  it("package.json bin points at the .mjs launcher, not the .ts entrypoint", () => {
+    const pkg = JSON.parse(readFileSync(join(cliRoot, "package.json"), "utf8"));
+    assert.equal(pkg.bin["telnyx-agent"], "./bin/telnyx-agent.mjs");
+  });
+
+  it("launcher uses a portable single-argument env shebang", () => {
+    const firstLine = readFileSync(launcher, "utf8").split("\n", 1)[0];
+    // Must be exactly `#!/usr/bin/env node` — a single argument to env. A
+    // multi-argument shebang (e.g. `env npx tsx`) breaks on Linux without -S.
+    assert.equal(firstLine, "#!/usr/bin/env node");
+    assert.doesNotMatch(firstLine, /\bnpx\b/);
+    const args = firstLine.replace("#!/usr/bin/env ", "").trim().split(/\s+/);
+    assert.equal(args.length, 1, `env shebang must take one arg, got: ${args.join(" ")}`);
+  });
+
+  it("the TS entrypoint no longer carries a broken multi-arg shebang", () => {
+    const firstLine = readFileSync(entrypoint, "utf8").split("\n", 1)[0];
+    assert.doesNotMatch(firstLine, /^#!/, "entrypoint should not be directly executable");
+  });
+
+  it("launcher boots the CLI and prints usage (exit 0)", () => {
+    const out = execFileSync(process.execPath, [launcher, "--help"], {
+      cwd: cliRoot,
+      encoding: "utf8",
+      timeout: 30000,
+    });
+    assert.match(out, /telnyx-agent/);
+    assert.match(out, /Usage:/);
+  });
+
+  it("launcher forwards argv to the CLI (unknown command name echoed)", () => {
+    // Exercise argv forwarding without touching the network or live account
+    // state: an unknown command makes the CLI echo the name back and print
+    // usage, proving argv reached the TS entrypoint through the launcher.
+    const result = spawnSync(process.execPath, [launcher, "totally-made-up-cmd"], {
+      cwd: cliRoot,
+      encoding: "utf8",
+      timeout: 30000,
+    });
+    const combined = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+    assert.match(combined, /totally-made-up-cmd/);
+    assert.match(combined, /Usage:/);
+  });
+
+  it("launcher passes through a non-zero exit code on unknown command", () => {
+    const result = spawnSync(process.execPath, [launcher, "definitely-not-a-command"], {
+      cwd: cliRoot,
+      encoding: "utf8",
+      timeout: 30000,
+    });
+    assert.notEqual(result.status, 0, "unknown command must exit non-zero");
+  });
+});

--- a/cli/tests/status-rest.test.ts
+++ b/cli/tests/status-rest.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Regression tests for status command — REST-based (no Go CLI dependency).
+ *
+ * status was REST-swapped from Go CLI shell-outs to direct TelnyxClient calls.
+ * These tests verify:
+ * 1. status exits non-zero when all API queries fail (no API key)
+ * 2. status produces JSON output with the expected shape
+ *
+ * The previous test (in telnyx-cli-flags.test.ts) checked Go CLI flag
+ * compatibility, which is no longer relevant since status no longer uses
+ * the Go CLI.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliRoot = join(__dirname, "..");
+const launcher = join(cliRoot, "bin", "telnyx-agent.mjs");
+
+describe("status command (REST-based)", () => {
+  it("exits non-zero when all API queries fail (no API key)", () => {
+    // Run with an invalid API key so all 5 REST calls fail.
+    // The command should exit 1, not 0.
+    const result = spawnSync(
+      process.execPath,
+      [launcher, "status", "--json"],
+      {
+        cwd: cliRoot,
+        encoding: "utf8",
+        timeout: 30000,
+        env: {
+          ...process.env,
+          TELNYX_API_KEY: "invalid-test-key-00000",
+          // Ensure no config file overrides the env var
+          HOME: "/tmp/nonexistent-home-for-status-test",
+        },
+      },
+    );
+
+    assert.notEqual(result.status, 0, "status must exit non-zero when all queries fail");
+    assert.ok(result.stdout, "status should produce output even on failure");
+  });
+
+  it("produces JSON output with the expected shape", () => {
+    const result = spawnSync(
+      process.execPath,
+      [launcher, "status", "--json"],
+      {
+        cwd: cliRoot,
+        encoding: "utf8",
+        timeout: 30000,
+        env: {
+          ...process.env,
+          TELNYX_API_KEY: "invalid-test-key-00000",
+          HOME: "/tmp/nonexistent-home-for-status-test",
+        },
+      },
+    );
+
+    const output = result.stdout.trim();
+    const data = JSON.parse(output);
+    assert.ok(data.balance, "should have balance object");
+    assert.ok(data.phone_numbers, "should have phone_numbers object");
+    assert.ok(data.messaging_profiles, "should have messaging_profiles object");
+    assert.ok(data.connections, "should have connections object");
+    assert.ok(data.ai_assistants, "should have ai_assistants object");
+    assert.ok(Array.isArray(data.warnings), "should have warnings array");
+    assert.ok(data.warnings.length > 0, "should have warnings when queries fail");
+  });
+
+  it("does not invoke the telnyx Go CLI binary", () => {
+    // Set TELNYX_CLI_PATH to a sentinel that would fail if called.
+    // If status still works (via REST), it proves it doesn't use the Go CLI.
+    const result = spawnSync(
+      process.execPath,
+      [launcher, "status", "--json"],
+      {
+        cwd: cliRoot,
+        encoding: "utf8",
+        timeout: 30000,
+        env: {
+          ...process.env,
+          TELNYX_API_KEY: "invalid-test-key-00000",
+          TELNYX_CLI_PATH: "/tmp/totally-nonexistent-telnyx-binary-should-not-be-called",
+          HOME: "/tmp/nonexistent-home-for-status-test",
+        },
+      },
+    );
+
+    // Should still produce valid JSON output (not a "binary not found" error)
+    const output = result.stdout.trim();
+    assert.doesNotMatch(output, /telnyx CLI not found/i);
+    assert.doesNotMatch(output, /No such file or directory.*telnyx/i);
+    JSON.parse(output); // should parse as valid JSON
+  });
+});

--- a/cli/tests/telnyx-cli-flags.test.ts
+++ b/cli/tests/telnyx-cli-flags.test.ts
@@ -96,36 +96,9 @@ describe("telnyx CLI flag compatibility", () => {
     assert.equal(parsed.flags.model, "new");
   });
 
-  it("status uses --page-size for paginated list commands and no page-size for ai:assistants", () => {
-    const fake = setupFakeTelnyx();
-
-    const output = execFileSync("npx", ["tsx", cliBin, "status", "--json"], {
-      cwd: cliRoot,
-      encoding: "utf8",
-      env: fake.env,
-      timeout: 30000,
-    });
-
-    const data = JSON.parse(output);
-    assert.equal(data.ai_assistants.total, 2);
-
-    const calls = readLoggedArgs(fake.logPath);
-    assert.ok(calls.every((args) => !args.includes("--page.size")), "must not use unsupported --page.size flag");
-
-    const numbersCall = calls.find((args) => args.slice(0, 2).join(" ") === "phone-numbers list");
-    const profilesCall = calls.find((args) => args.slice(0, 2).join(" ") === "messaging-profiles list");
-    const connectionsCall = calls.find((args) => args.slice(0, 2).join(" ") === "credential-connections list");
-    assert.ok(numbersCall, "status should query phone-numbers list");
-    assert.ok(profilesCall, "status should query messaging-profiles list");
-    assert.ok(connectionsCall, "status should query credential-connections list");
-    assertFlagValue(numbersCall, "--page-size", "1");
-    assertFlagValue(profilesCall, "--page-size", "1");
-    assertFlagValue(connectionsCall, "--page-size", "1");
-
-    const assistantsCall = calls.find((args) => args.slice(0, 2).join(" ") === "ai:assistants list");
-    assert.ok(assistantsCall, "status should query ai:assistants list");
-    assert.ok(!assistantsCall.includes("--page-size"), "ai:assistants list does not support pagination flags");
-  });
+  // NOTE: `status` was REST-swapped from Go CLI to TelnyxClient (direct fetch)
+  // and no longer shells out to `telnyx`. Its Go CLI flag compat is no longer
+  // relevant. See tests/status-rest.test.ts for the new REST-based tests.
 
   it("searchNumbers uses the Go CLI's --filter.limit flag for limits", async () => {
     const fake = setupFakeTelnyx();

--- a/cli/tests/version.test.ts
+++ b/cli/tests/version.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Regression tests for --version / -V support.
+ *
+ * The CLI must respond to --version and -V by printing the package version
+ * and exiting 0. Previously these fell through to "Unknown command" and
+ * exited non-zero (found by blind E2E test agent, 2026-07-26).
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliRoot = join(__dirname, "..");
+const launcher = join(cliRoot, "bin", "telnyx-agent.mjs");
+
+describe("--version / -V support", () => {
+  it("--version prints the package version and exits 0", () => {
+    const pkg = JSON.parse(readFileSync(join(cliRoot, "package.json"), "utf8"));
+    const out = execFileSync(process.execPath, [launcher, "--version"], {
+      cwd: cliRoot,
+      encoding: "utf8",
+      timeout: 30000,
+    });
+    assert.equal(out.trim(), pkg.version);
+  });
+
+  it("-V prints the package version and exits 0", () => {
+    const pkg = JSON.parse(readFileSync(join(cliRoot, "package.json"), "utf8"));
+    const out = execFileSync(process.execPath, [launcher, "-V"], {
+      cwd: cliRoot,
+      encoding: "utf8",
+      timeout: 30000,
+    });
+    assert.equal(out.trim(), pkg.version);
+  });
+
+  it("--version does NOT print usage or 'Unknown command'", () => {
+    const out = execFileSync(process.execPath, [launcher, "--version"], {
+      cwd: cliRoot,
+      encoding: "utf8",
+      timeout: 30000,
+    });
+    assert.doesNotMatch(out, /Unknown command/i);
+    assert.doesNotMatch(out, /Usage:/);
+  });
+});


### PR DESCRIPTION
## AIF-333: Linux bin shebang `#!/usr/bin/env npx tsx` fails — CLI unusable out of the box

### Problem
On Linux, `npm i -g @telnyx/agent-cli && telnyx-agent status` fails with:
```
/usr/bin/env: 'npx tsx': No such file or directory
```
Linux `env` doesn't support multi-argument shebangs without `-S`.

### Fix
- **Portable bin launcher** (`bin/telnyx-agent.mjs`): plain-JS with `#!/usr/bin/env node` (single-arg, works on Linux/macOS/Windows). Resolves bundled `tsx` from package deps and spawns it on the TS entrypoint. No `npx`, no network, no multi-arg shebang.
- **`package.json` bin** → `./bin/telnyx-agent.mjs` (was `./bin/telnyx-agent.ts`)
- **`npm start`** → `node bin/telnyx-agent.mjs` (was `tsx bin/telnyx-agent.ts`)
- **Removed shebang** from `bin/telnyx-agent.ts` (no longer directly executable)

### Bonus fixes (found by blind E2E test agents)
- **`--version` / `-V`** — was treated as unknown command, now prints package version and exits 0
- **`status` REST swap** — replaced 5 Go CLI `telnyxCli()` calls with direct `TelnyxClient.get()` REST calls. No longer depends on Go CLI binary. Now exits non-zero when all queries fail (was exiting 0).

### Tests (208 pass, 0 fail)
- `tests/bin-launcher.test.ts` — 6 tests (shebang portability, boot, argv forwarding, exit code)
- `tests/version.test.ts` — 3 tests (`--version`, `-V`, no usage leak)
- `tests/status-rest.test.ts` — 3 tests (exit code on failure, JSON shape, no Go CLI dependency)
- Updated `tests/telnyx-cli-flags.test.ts` — removed obsolete status Go CLI test

### E2E Verification
Two blind test agents (black-box QA + developer experience) ran full E2E tests. All 9 original test steps pass, including the 2 that previously failed.

Closes AIF-333