### PR TITLE
feat: Add retry-on-timeout to agent CLI

### DIFF
--- a/cli/src/commands/call-dial.ts
+++ b/cli/src/commands/call-dial.ts
@@ -44,6 +44,7 @@ export async function callDialCommand(flags: Record<string, string | boolean>): 
   const webhookUrl = flags["webhook-url"] as string | undefined;
   const audioUrl = flags["audio-url"] as string | undefined;
   const timeoutSecs = flags["timeout-secs"] as string | undefined;
+  const retryOnTimeout = flags["retry-on-timeout"];
   // New flags (number masking + advanced dial options).
   const privacy = flags["privacy"] as string | undefined;
   const fromDisplayName = flags["from-display-name"] as string | undefined;
@@ -80,6 +81,16 @@ export async function callDialCommand(flags: Record<string, string | boolean>): 
     printError(`Invalid --timeout-secs: ${timeoutSecs}. Must be a positive integer`);
     process.exit(1);
   }
+  if (
+    retryOnTimeout !== undefined
+    && retryOnTimeout !== true
+    && retryOnTimeout !== false
+    && retryOnTimeout !== "true"
+    && retryOnTimeout !== "false"
+  ) {
+    printError(`Invalid --retry-on-timeout: ${String(retryOnTimeout)}. Must be true or false`);
+    process.exit(1);
+  }
   if (privacy !== undefined && !["id", "none"].includes(privacy)) {
     printError(`Invalid --privacy: ${privacy}. Must be 'id' (number masking) or 'none'`);
     process.exit(1);
@@ -112,6 +123,9 @@ export async function callDialCommand(flags: Record<string, string | boolean>): 
   if (webhookUrl) body.webhook_url = webhookUrl;
   if (audioUrl) body.audio_url = audioUrl;
   if (timeoutSecs) body.timeout_secs = Number(timeoutSecs);
+  if (retryOnTimeout !== undefined) {
+    body.retry_on_timeout = retryOnTimeout === true || retryOnTimeout === "true";
+  }
   if (privacy) body.privacy = privacy;
   if (fromDisplayName) body.from_display_name = fromDisplayName;
   if (timeLimitSecs) body.time_limit_secs = Number(timeLimitSecs);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -325,6 +325,7 @@ Voice Call Flags:
   --webhook-url                  Webhook URL override (call-dial, call-control answer)
   --audio-url                    Audio URL to play on answer (call-dial); start-playback (required); gather-using-audio (optional)
   --timeout-secs                 Dial timeout in seconds (call-dial)
+  --retry-on-timeout [true|false] Continue through remaining routing paths after a dial timeout (call-dial, default: true)
   --privacy                      Number masking: 'id' hides caller ID, 'none' is normal (call-dial, default: none)
   --from-display-name            Caller ID display name (call-dial)
   --time-limit-secs              Max call duration in seconds (call-dial)
@@ -655,6 +656,7 @@ const KNOWN_FLAGS = new Set<string>([
   "payload", "phone", "phone-number", "phone-number-id", "phone-numbers", "port-type",
   "preview-format", "privacy", "profile-name", "promote-to-main", "provider", "quality",
   "queue-name", "record", "remaining-numbers-action", "requirement-group-id", "response-format",
+  "retry-on-timeout",
   "role", "rx", "sample-message", "sample-message-2", "sample1", "sample2", "send-at",
   "service-type", "sim-card-group-id", "sip-address", "sole-prop", "sort", "source",
   "start-message", "starts-with", "status", "stop", "stop-message", "store-media", "store-preview",

--- a/cli/src/utils/output.ts
+++ b/cli/src/utils/output.ts
@@ -112,7 +112,7 @@ export const BOOLEAN_FLAGS = new Set<string>([
 ]);
 
 const COMMAND_BOOLEAN_FLAGS = new Map<string, Set<string>>([
-  ["call-dial", new Set(["transcription"])],
+  ["call-dial", new Set(["retry-on-timeout", "transcription"])],
 ]);
 
 export function isBooleanFlag(command: string, key: string): boolean {
@@ -142,7 +142,8 @@ const BOOLEAN_VALUE_FLAGS = new Set<string>([
 ]);
 
 function isBooleanValueFlag(command: string, key: string): boolean {
-  return BOOLEAN_VALUE_FLAGS.has(key) || (command === "call-dial" && key === "transcription");
+  return BOOLEAN_VALUE_FLAGS.has(key)
+    || (command === "call-dial" && (key === "retry-on-timeout" || key === "transcription"));
 }
 
 export function parseFlags(args: string[]): {

--- a/cli/tests/voice.test.ts
+++ b/cli/tests/voice.test.ts
@@ -175,11 +175,89 @@ describe("Voice API action commands", () => {
       // Detection fields absent when not requested.
       assert.equal(received?.answering_machine_detection, undefined);
       assert.equal(received?.deepfake_detection, undefined);
+      assert.equal(received?.retry_on_timeout, undefined);
       // Must NOT shell out to the Go CLI anymore.
       assertNoLoggedCalls(fake.logPath);
     } finally {
       await mock.close();
     }
+  });
+
+  for (const [label, retryArgs] of [
+    ["bare", ["--retry-on-timeout"]],
+    ["explicit true", ["--retry-on-timeout", "true"]],
+  ] as const) {
+    it(`call-dial maps ${label} --retry-on-timeout to true in the REST body`, async () => {
+      let received: Record<string, unknown> | undefined;
+      const mock = await startMockApi((req, res) => {
+        let raw = "";
+        req.on("data", (c) => (raw += c.toString()));
+        req.on("end", () => {
+          received = JSON.parse(raw);
+          res.writeHead(200, { "content-type": "application/json" });
+          res.end(JSON.stringify({ data: { call_control_id: "call-dial-123" } }));
+        });
+      });
+      try {
+        const fake = setupFakeTelnyx();
+        const { status } = await runAsync(
+          [
+            "call-dial", "--connection-id", "conn-1",
+            "--from", "+15550001000", "--to", "+15550001001",
+            ...retryArgs, "--json",
+          ],
+          { ...fake.env, TELNYX_API_KEY: "***", TELNYX_API_BASE_URL: mock.baseUrl },
+        );
+        assert.equal(status, 0);
+        assert.equal(received?.retry_on_timeout, true);
+        assertNoLoggedCalls(fake.logPath);
+      } finally {
+        await mock.close();
+      }
+    });
+  }
+
+  it("call-dial maps explicit false --retry-on-timeout to false in the REST body", async () => {
+    let received: Record<string, unknown> | undefined;
+    const mock = await startMockApi((req, res) => {
+      let raw = "";
+      req.on("data", (c) => (raw += c.toString()));
+      req.on("end", () => {
+        received = JSON.parse(raw);
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ data: { call_control_id: "call-dial-123" } }));
+      });
+    });
+    try {
+      const fake = setupFakeTelnyx();
+      const { status } = await runAsync(
+        [
+          "call-dial", "--connection-id", "conn-1",
+          "--from", "+15550001000", "--to", "+15550001001",
+          "--retry-on-timeout", "false", "--json",
+        ],
+        { ...fake.env, TELNYX_API_KEY: "***", TELNYX_API_BASE_URL: mock.baseUrl },
+      );
+      assert.equal(status, 0);
+      assert.equal(received?.retry_on_timeout, false);
+      assertNoLoggedCalls(fake.logPath);
+    } finally {
+      await mock.close();
+    }
+  });
+
+  it("call-dial rejects invalid --retry-on-timeout before any network call", () => {
+    const fake = setupFakeTelnyx();
+    const stderr = runFailure(
+      [
+        "call-dial", "--connection-id", "conn-1",
+        "--from", "+15550001000", "--to", "+15550001001",
+        "--retry-on-timeout", "sometimes", "--json",
+      ],
+      { ...fake.env, TELNYX_API_KEY: "***", TELNYX_API_BASE_URL: "http://127.0.0.1:1" },
+    );
+    assert.match(stderr, /Invalid --retry-on-timeout: sometimes\. Must be true or false/);
+    assertNoLoggedCalls(fake.logPath);
   });
 
   it("call-dial maps AMD (bare), deepfake and record into the REST body (AIF-327)", async () => {


### PR DESCRIPTION
## Summary
- adapt `call-dial --retry-on-timeout` to the current direct `POST /v2/calls` transport
- preserve omission while mapping bare/explicit `true` and explicit `false` to `retry_on_timeout`
- reject malformed boolean values before any network request
- register the flag in command-scoped parsing, help, and known-flag inventories

## Current-main reconciliation
PR #328 replaced the original Go CLI subprocess path with direct REST. This branch now preserves that architecture and no longer duplicates the Telnyx CLI version change.

## Dependency and merge order
**2 of 3.** Merge [#311](https://github.com/team-telnyx/ai/pull/311) first because current `main` pins Telnyx CLI v0.11.0 and #311 supplies the required v0.24.0 runtime floor. Then merge this PR before refreshing [#330](https://github.com/team-telnyx/ai/pull/330).

## Verification
- `npm run typecheck`
- `node --import tsx --test tests/voice.test.ts` — 73/73 passed
- `npm test` — 404/404 passed on the byte-identical candidate tree
- `git diff --check`
- independent evaluator: PASS, no findings

Linear: [AIF-382](https://linear.app/telnyx/issue/AIF-382/feat-add-retry-on-timeout-to-agent-cli)
