### PR TITLE
feat: Add Edge readiness checks to agent CLI

### DIFF
--- a/cli/src/commands/setup-edge-mcp.ts
+++ b/cli/src/commands/setup-edge-mcp.ts
@@ -5,6 +5,7 @@
 import { outputJson, printError, printSuccess, printWarning } from "../utils/output.ts";
 import {
   getEdgeAuthStatus,
+  getEdgeRootStatus,
   hasEdgeCli,
   supportsActorInstances,
   supportsApiKeyAuth,
@@ -18,6 +19,7 @@ interface SetupEdgeMcpResult {
   telnyx_edge_installed: boolean;
   authenticated: boolean;
   auth_mode: "api_key" | "oauth" | "none" | "unknown";
+  root_status_passed: boolean;
   api_key_auth_supported: boolean;
   stateful_actors_supported: boolean;
   inspect_supported: boolean;
@@ -47,6 +49,7 @@ export async function setupEdgeMcpCommand(flags: Record<string, string | boolean
   const inspectSupported = hasEdge ? supportsInspect() : false;
   const actorInstancesSupported = hasEdge ? supportsActorInstances() : false;
   const authStatus = hasEdge ? safeAuthStatus() : { authenticated: false, mode: "none" as const };
+  const rootStatusPassed = hasEdge ? safeRootStatus() : false;
   const authCommand = apiKeyAuthSupported
     ? `: "\${TELNYX_API_KEY:?Export TELNYX_API_KEY first}" && telnyx-edge auth api-key set "$TELNYX_API_KEY"`
     : "telnyx-edge auth login";
@@ -89,6 +92,11 @@ export async function setupEdgeMcpCommand(flags: Record<string, string | boolean
     ? ["Install telnyx-edge from the Edge Compute releases page, then rerun this command."]
     : !authStatus.authenticated
       ? [`Authenticate first: ${authCommand}`, "Run telnyx-edge status, then rerun this handoff."]
+      : !rootStatusPassed
+        ? [
+            "Run telnyx-edge status and resolve every failed config, credential, or connectivity check.",
+            "Rerun this handoff after telnyx-edge status reports that all checks passed.",
+          ]
       : [
           "Export TELNYX_API_KEY and a high-entropy SHARED_SECRET (for example, openssl rand -hex 32).",
           "Run deploy_command from the directory where you want the function project created.",
@@ -96,10 +104,11 @@ export async function setupEdgeMcpCommand(flags: Record<string, string | boolean
         ];
 
   const result: SetupEdgeMcpResult = {
-    ready: hasEdge && authStatus.authenticated,
+    ready: hasEdge && authStatus.authenticated && rootStatusPassed,
     telnyx_edge_installed: hasEdge,
     authenticated: authStatus.authenticated,
     auth_mode: authStatus.mode,
+    root_status_passed: rootStatusPassed,
     api_key_auth_supported: apiKeyAuthSupported,
     stateful_actors_supported: statefulActorsSupported,
     inspect_supported: inspectSupported,
@@ -132,10 +141,16 @@ export async function setupEdgeMcpCommand(flags: Record<string, string | boolean
       Ready: "✓",
     });
   } else {
-    printError(hasEdge ? "telnyx-edge is not positively authenticated." : "telnyx-edge is not installed.");
-    printWarning(hasEdge
-      ? `Authenticate first with: ${authCommand}`
-      : "This command is a handoff helper — it depends on the dedicated Edge Compute CLI.");
+    printError(!hasEdge
+      ? "telnyx-edge is not installed."
+      : !authStatus.authenticated
+        ? "telnyx-edge is not positively authenticated."
+        : "telnyx-edge status did not pass every config, credential, and connectivity check.");
+    printWarning(!hasEdge
+      ? "This command is a handoff helper — it depends on the dedicated Edge Compute CLI."
+      : !authStatus.authenticated
+        ? `Authenticate first with: ${authCommand}`
+        : "Run telnyx-edge status and resolve every failed check before deploying.");
   }
 
   console.log(`  Source repository: ${SOURCE_REPO}`);
@@ -162,5 +177,13 @@ function safeAuthStatus(): { authenticated: boolean; mode: "api_key" | "oauth" |
     return { authenticated: status.authenticated, mode: status.mode };
   } catch {
     return { authenticated: false, mode: "unknown" };
+  }
+}
+
+function safeRootStatus(): boolean {
+  try {
+    return getEdgeRootStatus().passed;
+  } catch {
+    return false;
   }
 }

--- a/cli/src/commands/setup-edge-webhook.ts
+++ b/cli/src/commands/setup-edge-webhook.ts
@@ -5,6 +5,7 @@
 import { outputJson, printError, printSuccess, printWarning } from "../utils/output.ts";
 import {
   getEdgeAuthStatus,
+  getEdgeRootStatus,
   hasEdgeCli,
   supportsActorInstances,
   supportsApiKeyAuth,
@@ -18,6 +19,7 @@ interface SetupEdgeWebhookResult {
   telnyx_edge_installed: boolean;
   authenticated: boolean;
   auth_mode: "api_key" | "oauth" | "none" | "unknown";
+  root_status_passed: boolean;
   api_key_auth_supported: boolean;
   stateful_actors_supported: boolean;
   inspect_supported: boolean;
@@ -47,6 +49,7 @@ export async function setupEdgeWebhookCommand(flags: Record<string, string | boo
   const inspectSupported = hasEdge ? supportsInspect() : false;
   const actorInstancesSupported = hasEdge ? supportsActorInstances() : false;
   const authStatus = hasEdge ? safeAuthStatus() : { authenticated: false, mode: "none" as const };
+  const rootStatusPassed = hasEdge ? safeRootStatus() : false;
   const authCommand = apiKeyAuthSupported
     ? `: "\${TELNYX_API_KEY:?Export TELNYX_API_KEY first}" && telnyx-edge auth api-key set "$TELNYX_API_KEY"`
     : "telnyx-edge auth login";
@@ -85,6 +88,11 @@ export async function setupEdgeWebhookCommand(flags: Record<string, string | boo
     ? ["Install telnyx-edge from the Edge Compute releases page, then rerun this command."]
     : !authStatus.authenticated
       ? [`Authenticate first: ${authCommand}`, "Run telnyx-edge status, then rerun this handoff."]
+      : !rootStatusPassed
+        ? [
+            "Run telnyx-edge status and resolve every failed config, credential, or connectivity check.",
+            "Rerun this handoff after telnyx-edge status reports that all checks passed.",
+          ]
       : [
           "Export a high-entropy WEBHOOK_SECRET (for example: export WEBHOOK_SECRET=\"$(openssl rand -hex 32)\").",
           "Run deploy_command from the directory where you want the function project created.",
@@ -92,10 +100,11 @@ export async function setupEdgeWebhookCommand(flags: Record<string, string | boo
         ];
 
   const result: SetupEdgeWebhookResult = {
-    ready: hasEdge && authStatus.authenticated,
+    ready: hasEdge && authStatus.authenticated && rootStatusPassed,
     telnyx_edge_installed: hasEdge,
     authenticated: authStatus.authenticated,
     auth_mode: authStatus.mode,
+    root_status_passed: rootStatusPassed,
     api_key_auth_supported: apiKeyAuthSupported,
     stateful_actors_supported: statefulActorsSupported,
     inspect_supported: inspectSupported,
@@ -129,10 +138,16 @@ export async function setupEdgeWebhookCommand(flags: Record<string, string | boo
       Ready: "✓",
     });
   } else {
-    printError(hasEdge ? "telnyx-edge is not positively authenticated." : "telnyx-edge is not installed.");
-    printWarning(hasEdge
-      ? `Authenticate first with: ${authCommand}`
-      : "This command is a handoff helper — it depends on the dedicated Edge Compute CLI.");
+    printError(!hasEdge
+      ? "telnyx-edge is not installed."
+      : !authStatus.authenticated
+        ? "telnyx-edge is not positively authenticated."
+        : "telnyx-edge status did not pass every config, credential, and connectivity check.");
+    printWarning(!hasEdge
+      ? "This command is a handoff helper — it depends on the dedicated Edge Compute CLI."
+      : !authStatus.authenticated
+        ? `Authenticate first with: ${authCommand}`
+        : "Run telnyx-edge status and resolve every failed check before deploying.");
   }
 
   console.log(`  Source repository: ${SOURCE_REPO}`);
@@ -159,5 +174,13 @@ function safeAuthStatus(): { authenticated: boolean; mode: "api_key" | "oauth" |
     return { authenticated: status.authenticated, mode: status.mode };
   } catch {
     return { authenticated: false, mode: "unknown" };
+  }
+}
+
+function safeRootStatus(): boolean {
+  try {
+    return getEdgeRootStatus().passed;
+  } catch {
+    return false;
   }
 }

--- a/cli/tests/edge-handoff.test.ts
+++ b/cli/tests/edge-handoff.test.ts
@@ -211,6 +211,7 @@ describe("CLI — Edge Compute handoff", () => {
     const data = JSON.parse(run(["setup-edge-mcp", "--json", "--name", "demo-mcp"], fake.env));
     assert.equal(data.ready, true);
     assert.equal(data.telnyx_edge_installed, true);
+    assert.equal(data.root_status_passed, true);
     assert.equal(data.inspect_supported, true);
     assert.equal(data.actor_instances_supported, true);
     assert.equal(data.source_repo, "https://github.com/team-telnyx/edge-compute.git");
@@ -229,6 +230,7 @@ describe("CLI — Edge Compute handoff", () => {
     const fake = withFakeEdgeCli("api_key");
     const data = JSON.parse(run(["setup-edge-webhook", "--json", "--name", "demo-webhook"], fake.env));
     assert.equal(data.ready, true);
+    assert.equal(data.root_status_passed, true);
     assert.equal(data.source_path, "examples/js/webhook-receiver");
     assert.ok(data.deploy_command.includes("git clone --depth 1"));
     assert.ok(data.deploy_command.includes('secrets add WEBHOOK_SECRET "$WEBHOOK_SECRET"'));
@@ -236,6 +238,18 @@ describe("CLI — Edge Compute handoff", () => {
     assert.ok(data.deploy_command.includes("telnyx-edge inspect demo-webhook"));
     assert.ok(data.notes.some((note: string) => note.includes("HMAC-SHA256")));
     assert.ok(data.next_steps.some((step: string) => step.includes("HMAC-sign")));
+  });
+
+  it("setup handoffs stay unready when authenticated but the root status check fails", () => {
+    const fake = withFakeEdgeCli({ auth: "api_key", rootStatus: "fail" });
+    for (const command of ["setup-edge-mcp", "setup-edge-webhook"]) {
+      const data = JSON.parse(run([command, "--json"], fake.env));
+      assert.equal(data.telnyx_edge_installed, true);
+      assert.equal(data.authenticated, true);
+      assert.equal(data.root_status_passed, false);
+      assert.equal(data.ready, false);
+      assert.ok(data.next_steps.some((step: string) => step.includes("telnyx-edge status")));
+    }
   });
 
   it("setup handoffs omit inspect from executable flows when the authenticated CLI does not support it", () => {


### PR DESCRIPTION
## Summary
- require `telnyx-edge status` to pass before MCP/webhook setup handoffs report ready
- expose `root_status_passed` in both JSON result shapes
- add actionable remediation for credential, configuration, and connectivity failures
- cover authenticated-but-failing status checks with the existing fake Edge binary

## Audit context
The setup helpers trusted the local `auth status` marker, unlike `edge-doctor`; revoked credentials or unreachable endpoints could therefore be reported as deployment-ready.

## Verification
- `npx tsc --noEmit`
- `npx tsx --test tests/edge-handoff.test.ts` (13 passed)
- `git diff --check`

Linear: [AIF-385](https://linear.app/telnyx/issue/AIF-385/feat-add-edge-readiness-checks-to-agent-cli)