### PR TITLE
docs: Update edge-compute guide for function lifecycle

### DIFF
--- a/guides/edge-compute.md
+++ b/guides/edge-compute.md
@@ -21,7 +21,7 @@ git clone --depth 1 https://github.com/team-telnyx/edge-compute.git
 
 ## Prerequisites and readiness
 
-1. Download the latest CLI from the [Edge Compute CLI releases page](https://github.com/team-telnyx/edge-compute-cli/releases). SQL databases require CLI v0.3.0 or newer.
+1. Download the latest CLI from the [Edge Compute releases page](https://github.com/team-telnyx/edge-compute/releases). SQL databases require CLI v0.3.0 or newer.
 2. Authenticate interactively or with an API key stored by the CLI.
 3. Run the root status diagnostic. Unlike `auth status`, this validates configuration, credentials, and API connectivity.
 
@@ -191,10 +191,10 @@ telnyx-edge ship --from-dir=./my-function
 Delete a function when it is no longer needed:
 
 ```bash
-telnyx-edge delete-func my-function
+telnyx-edge delete-func my-function --yes
 ```
 
-`delete-func` is irreversible. Confirm the function name before running it, especially when cleaning up an end-to-end test deployment.
+`delete-func` is irreversible. Use `--yes` (`-y`) in scripts, agents, and CI to skip the interactive confirmation; see [Non-interactive destructive commands](#non-interactive-destructive-commands) for the full list.
 
 ### Revisions and rollback
 

--- a/guides/edge-compute.md
+++ b/guides/edge-compute.md
@@ -21,7 +21,7 @@ git clone --depth 1 https://github.com/team-telnyx/edge-compute.git
 
 ## Prerequisites and readiness
 
-1. Download the latest CLI from the [Edge Compute releases page](https://github.com/team-telnyx/edge-compute/releases).
+1. Download the latest CLI from the [Edge Compute CLI releases page](https://github.com/team-telnyx/edge-compute-cli/releases).
 2. Authenticate interactively or with an API key stored by the CLI.
 3. Run the root status diagnostic. Unlike `auth status`, this validates configuration, credentials, and API connectivity.
 
@@ -157,9 +157,13 @@ Do not put `WEBHOOK_SECRET` in the request body or an Authorization header unles
 
 ## API Reference
 
-### Create, deploy, inspect, and recover
+### List, create, deploy, inspect, and recover
 
 ```bash
+# List deployed functions. Use --page and --page-size for larger accounts.
+telnyx-edge list
+telnyx-edge list --page 2 --page-size 25
+
 # New generated project
 telnyx-edge new-func --language=ts --name=my-function
 
@@ -181,6 +185,14 @@ telnyx-edge ship --from-dir=./my-function
 ```
 
 `reset-func` applies to failed states, not healthy deployments. Teardown is asynchronous.
+
+Delete a function when it is no longer needed:
+
+```bash
+telnyx-edge delete-func my-function
+```
+
+`delete-func` is irreversible. Confirm the function name before running it, especially when cleaning up an end-to-end test deployment.
 
 ### Revisions and rollback
 


### PR DESCRIPTION
## Summary
- point installation guidance at the dedicated Edge Compute CLI release repository
- document function inventory with `telnyx-edge list` and pagination
- document irreversible cleanup with `telnyx-edge delete-func`

## Audit context
The v0.2.5 command reference includes list and delete lifecycle operations that were absent from the agent guide, and the release link targeted the source/examples repository instead of the CLI repository.

## Verification
- compared against edge-compute-cli v0.2.5 `RELEASE_NOTES.md` and `docs/cli-reference/commands.md`
- `git diff --check`