### PR TITLE
fix(aif-332): schedule-sms REST swap from Go CLI to POST /v2/messages

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "tsx bin/telnyx-agent.ts",
-    "test": "tsx --test tests/ai.test.ts tests/edge-handoff.test.ts tests/fax.test.ts tests/integration.test.ts tests/iot.test.ts tests/numbers.test.ts tests/rcs.test.ts tests/setup-10dlc.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
+    "test": "tsx --test tests/ai.test.ts tests/edge-handoff.test.ts tests/fax.test.ts tests/integration.test.ts tests/iot.test.ts tests/numbers.test.ts tests/rcs.test.ts tests/schedule-sms-rest.test.ts tests/setup-10dlc.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
     "typecheck": "tsc --noEmit",
     "postinstall": "tsx scripts/postinstall.ts",
     "build": "npm run typecheck"

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -47,7 +47,7 @@ export class TelnyxClient {
 
   constructor(apiKey?: string, baseUrl?: string, timeout?: number) {
     this.apiKey = apiKey || resolveApiKey();
-    this.baseUrl = (baseUrl ?? "https://api.telnyx.com/v2").replace(/\/$/, "");
+    this.baseUrl = (baseUrl ?? process.env.TELNYX_API_BASE_URL ?? "https://api.telnyx.com/v2").replace(/\/$/, "");
     this.timeout = timeout ?? 30000;
     this.telemetry = new TelemetryReporter();
     this.friction = new FrictionReporter();

--- a/cli/src/commands/schedule-sms.ts
+++ b/cli/src/commands/schedule-sms.ts
@@ -1,10 +1,16 @@
 /**
  * telnyx-agent schedule-sms — Schedule an SMS for later delivery.
  *
- * Shells out to the Go telnyx CLI `messages schedule` subcommand.
+ * Uses direct REST call: POST /v2/messages with a `send_at` field.
+ * The old Go CLI `messages schedule` subcommand posted to a nonexistent
+ * /v2/messages/schedule endpoint (404). See AIF-332.
+ *
+ * API quirk: the create response echoes `send_at: null` even though
+ * scheduling is in effect — the per-recipient `to[].status` field
+ * correctly reports "scheduled".
  */
 
-import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
+import { TelnyxClient, TelnyxAPIError } from "../client.ts";
 import { printSuccess, printError, outputJson } from "../utils/output.ts";
 import { deriveMessageStatus } from "../utils/message-status.ts";
 
@@ -43,21 +49,30 @@ export async function scheduleSmsCommand(flags: Record<string, string | boolean>
     process.exit(1);
   }
 
-  const args: string[] = [
-    "messages", "schedule",
-    "--from", from,
-    "--to", to,
-    "--text", text,
-    "--send-at", sendAt,
-  ];
-  if (messagingProfileId) args.push("--messaging-profile-id", messagingProfileId);
-  if (mediaUrl) args.push("--media-url", mediaUrl);
+  // Validate ISO 8601 — quick sanity check, not a full parser
+  if (isNaN(Date.parse(sendAt))) {
+    printError(`--send-at must be a valid ISO 8601 datetime, got: ${sendAt}`);
+    process.exit(1);
+  }
+
+  const client = new TelnyxClient();
+
+  const body: Record<string, unknown> = {
+    from,
+    to,
+    text,
+    send_at: sendAt,
+  };
+  if (messagingProfileId) body.messaging_profile_id = messagingProfileId;
+  if (mediaUrl) body.media_urls = [mediaUrl];
 
   try {
-    const res = await telnyxCli(args);
-    const data = (res?.data ?? res) as Record<string, unknown>;
+    const res = await client.post("/messages", body);
+    const data = (res.data ?? res) as Record<string, unknown>;
     const messageId = String(data.id ?? data.message_id ?? "");
     // Delivery state lives on each recipient (data.to[].status), not top-level.
+    // The API quirk: send_at may echo back as null, but to[].status = "scheduled"
+    // confirms the message is scheduled.
     const status = deriveMessageStatus(data, "scheduled");
 
     const result: ScheduleSmsResult = {
@@ -66,7 +81,7 @@ export async function scheduleSmsCommand(flags: Record<string, string | boolean>
       from,
       to,
       send_at: sendAt,
-      scheduled: true,
+      scheduled: status.includes("scheduled"),
     };
 
     if (jsonOutput) {
@@ -91,7 +106,7 @@ export async function scheduleSmsCommand(flags: Record<string, string | boolean>
 }
 
 function errorMsg(err: unknown): string {
-  if (err instanceof TelnyxCLIError) return err.stderr || err.message;
+  if (err instanceof TelnyxAPIError) return err.detail || err.message;
   if (err instanceof Error) return err.message;
   return String(err);
 }

--- a/cli/tests/schedule-sms-rest.test.ts
+++ b/cli/tests/schedule-sms-rest.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Regression tests for schedule-sms REST path (AIF-332).
+ *
+ * schedule-sms was REST-swapped from the Go CLI `messages schedule`
+ * subcommand (which hit a nonexistent /v2/messages/schedule endpoint → 404)
+ * to a direct POST /v2/messages with a `send_at` field.
+ *
+ * Tests use a mock HTTP server to verify the request payload and response parsing.
+ */
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createServer, type Server, type IncomingMessage, type ServerResponse } from "node:http";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliRoot = join(__dirname, "..");
+const launcher = join(cliRoot, "bin", "telnyx-agent.ts");
+
+interface CapturedRequest {
+  method: string;
+  path: string;
+  body: Record<string, unknown> | null;
+}
+
+let mockServer: Server;
+let mockPort: number;
+
+// Track the last request for assertions
+let lastRequest: CapturedRequest | null = null;
+
+/** Assert a request was captured and return it with a non-null type. */
+function capturedRequest(): CapturedRequest {
+  assert.ok(lastRequest, "expected the mock server to have received a request");
+  return lastRequest as CapturedRequest;
+}
+
+function startMockServer(): Promise<void> {
+  return new Promise((resolve) => {
+    mockServer = createServer((req: IncomingMessage, res: ServerResponse) => {
+      let body = "";
+      req.on("data", (chunk: Buffer) => (body += chunk.toString()));
+      req.on("end", () => {
+        let parsedBody: Record<string, unknown> | null = null;
+        try {
+          parsedBody = body ? JSON.parse(body) : null;
+        } catch { /* ignore parse errors */ }
+        lastRequest = { method: req.method ?? "", path: req.url ?? "", body: parsedBody };
+
+        if (req.method === "POST" && req.url === "/v2/messages") {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({
+            data: {
+              id: "sched-abc-123",
+              record_type: "message",
+              direction: "outbound",
+              from: { phone_number: parsedBody?.from ?? "", carrier: "", line_type: "" },
+              to: [{ phone_number: parsedBody?.to ?? "", status: "scheduled", carrier: "", line_type: "" }],
+              send_at: null, // API quirk: echoes null even though scheduling is in effect
+              text: parsedBody?.text ?? "",
+            },
+          }));
+          return;
+        }
+
+        res.writeHead(404, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ errors: [{ code: "10005", detail: "Not found" }] }));
+      });
+    });
+    mockServer.listen(0, "127.0.0.1", () => {
+      const addr = mockServer.address();
+      mockPort = typeof addr === "object" && addr ? addr.port : 0;
+      resolve();
+    });
+  });
+}
+
+function stopMockServer(): Promise<void> {
+  return new Promise((resolve) => {
+    mockServer.close(() => resolve());
+  });
+}
+
+describe("schedule-sms REST (AIF-332)", () => {
+  before(async () => {
+    await startMockServer();
+  });
+
+  after(async () => {
+    await stopMockServer();
+  });
+
+  // NOTE: must be async (spawn, not spawnSync). The mock HTTP server runs in
+  // this same process; a synchronous spawn would block the event loop and the
+  // server could never respond to the CLI's request → deadlock.
+  function run(args: string[]): Promise<{ status: number; stdout: string; stderr: string }> {
+    return new Promise((resolve) => {
+      const child = spawn("npx", ["tsx", launcher, "schedule-sms", ...args], {
+        cwd: cliRoot,
+        env: {
+          ...process.env,
+          TELNYX_API_KEY: "***",
+          TELNYX_API_BASE_URL: `http://127.0.0.1:${mockPort}/v2`,
+        },
+      });
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", (c: Buffer) => (stdout += c.toString()));
+      child.stderr.on("data", (c: Buffer) => (stderr += c.toString()));
+      child.on("close", (code) => resolve({ status: code ?? -1, stdout, stderr }));
+    });
+  }
+
+  it("POSTs to /v2/messages (not /v2/messages/schedule)", async () => {
+    lastRequest = null;
+    const r = await run(["--from", "+13125550000", "--to", "+13125550001", "--text", "later", "--send-at", "2026-12-31T00:00:00Z", "--json"]);
+    assert.equal(r.status, 0, `exit 0 expected, got ${r.status}: ${r.stderr}`);
+    const req = capturedRequest();
+    assert.equal(req.method, "POST");
+    assert.equal(req.path, "/v2/messages");
+  });
+
+  it("includes send_at, from, to, text in the request body", async () => {
+    lastRequest = null;
+    await run(["--from", "+13125550000", "--to", "+13125550001", "--text", "later", "--send-at", "2026-12-31T00:00:00Z", "--json"]);
+    const body = capturedRequest().body;
+    assert.ok(body);
+    assert.equal(body.send_at, "2026-12-31T00:00:00Z");
+    assert.equal(body.from, "+13125550000");
+    assert.equal(body.to, "+13125550001");
+    assert.equal(body.text, "later");
+  });
+
+  it("parses scheduled status from to[].status (API quirk: send_at echoes null)", async () => {
+    const r = await run(["--from", "+13125550000", "--to", "+13125550001", "--text", "later", "--send-at", "2026-12-31T00:00:00Z", "--json"]);
+    assert.equal(r.status, 0);
+    const data = JSON.parse(r.stdout);
+    assert.equal(data.message_id, "sched-abc-123");
+    assert.equal(data.status, "scheduled");
+    assert.equal(data.scheduled, true);
+    assert.equal(data.send_at, "2026-12-31T00:00:00Z");
+  });
+
+  it("passes messaging-profile-id in the request body", async () => {
+    lastRequest = null;
+    await run(["--from", "+13125550000", "--to", "+13125550001", "--text", "later", "--send-at", "2026-12-31T00:00:00Z", "--messaging-profile-id", "prof_abc123", "--json"]);
+    const body = capturedRequest().body;
+    assert.ok(body);
+    assert.equal(body.messaging_profile_id, "prof_abc123");
+  });
+
+  it("passes media-url as media_urls array in the request body", async () => {
+    lastRequest = null;
+    await run(["--from", "+13125550000", "--to", "+13125550001", "--text", "later", "--send-at", "2026-12-31T00:00:00Z", "--media-url", "https://example.com/image.png", "--json"]);
+    const body = capturedRequest().body;
+    assert.ok(body);
+    assert.deepEqual(body.media_urls, ["https://example.com/image.png"]);
+  });
+
+  it("exits non-zero when --from is missing", async () => {
+    const r = await run(["--to", "+13125550001", "--text", "later", "--send-at", "2026-12-31T00:00:00Z", "--json"]);
+    assert.notEqual(r.status, 0);
+    assert.match(r.stderr, /--from is required/);
+  });
+
+  it("exits non-zero when --to is missing", async () => {
+    const r = await run(["--from", "+13125550000", "--text", "later", "--send-at", "2026-12-31T00:00:00Z", "--json"]);
+    assert.notEqual(r.status, 0);
+    assert.match(r.stderr, /--to is required/);
+  });
+
+  it("exits non-zero when --text is missing", async () => {
+    const r = await run(["--from", "+13125550000", "--to", "+13125550001", "--send-at", "2026-12-31T00:00:00Z", "--json"]);
+    assert.notEqual(r.status, 0);
+    assert.match(r.stderr, /--text is required/);
+  });
+
+  it("exits non-zero when --send-at is missing", async () => {
+    const r = await run(["--from", "+13125550000", "--to", "+13125550001", "--text", "later", "--json"]);
+    assert.notEqual(r.status, 0);
+    assert.match(r.stderr, /--send-at is required/);
+  });
+
+  it("exits non-zero when --send-at is not valid ISO 8601", async () => {
+    const r = await run(["--from", "+13125550000", "--to", "+13125550001", "--text", "later", "--send-at", "not-a-date", "--json"]);
+    assert.notEqual(r.status, 0);
+    assert.match(r.stderr, /--send-at must be a valid ISO 8601/);
+  });
+
+  it("does not call the Go CLI binary", async () => {
+    const r = await run(["--from", "+13125550000", "--to", "+13125550001", "--text", "later", "--send-at", "2026-12-31T00:00:00Z", "--json"]);
+    assert.equal(r.status, 0);
+    assert.doesNotMatch(r.stderr, /telnyx CLI not found/i);
+  });
+});

--- a/cli/tests/sms.test.ts
+++ b/cli/tests/sms.test.ts
@@ -284,35 +284,8 @@ describe("SMS action commands", () => {
     );
   });
 
-  it("schedule-sms passes --send-at to messages schedule", () => {
-    const fake = setupFakeTelnyx();
-
-    const out = runAgent(
-      [
-        "schedule-sms",
-        "--from", "+13125550000",
-        "--to", "+13125550001",
-        "--text", "later",
-        "--send-at", "2024-12-31T00:00:00Z",
-        "--json",
-      ],
-      fake.env,
-    );
-
-    const data = JSON.parse(out);
-    assert.equal(data.message_id, "sched-456");
-    assert.equal(data.status, "scheduled");
-    assert.equal(data.send_at, "2024-12-31T00:00:00Z");
-
-    const calls = readLoggedArgs(fake.logPath);
-    const schedCall = calls.find((a) => a.slice(0, 2).join(" ") === "messages schedule");
-    assert.ok(schedCall, "should call messages schedule");
-    assertFlagValue(schedCall, "--from", "+13125550000");
-    assertFlagValue(schedCall, "--to", "+13125550001");
-    assertFlagValue(schedCall, "--text", "later");
-    assertFlagValue(schedCall, "--send-at", "2024-12-31T00:00:00Z");
-    assert.ok(!schedCall.includes("--type"), "schedule should not include --type");
-  });
+  // schedule-sms was REST-swapped from Go CLI to POST /v2/messages with send_at.
+  // Tests for the REST path are in tests/schedule-sms-rest.test.ts
 
   it("sms-status retrieve calls messages retrieve", () => {
     const fake = setupFakeTelnyx();


### PR DESCRIPTION
## AIF-332 — schedule-sms REST fix

### Problem
`schedule-sms` was hitting a nonexistent `/v2/messages/schedule` endpoint via the Go CLI `messages schedule` subcommand → 404. Scheduling via CLI was impossible.

### Fix
Replaced the Go CLI subcommand with a direct `POST /v2/messages` including a `send_at` field:

- **`src/commands/schedule-sms.ts`** — REST `POST /v2/messages` with `send_at`, ISO 8601 validation for `--send-at`, `media-url`→`media_urls` array, `messaging-profile-id`→`messaging_profile_id`
- **`src/client.ts`** — added `TELNYX_API_BASE_URL` env override (enables mock-server testing + staging use)
- **`tests/schedule-sms-rest.test.ts`** — 11 new mock-HTTP-server tests (endpoint, payload, send_at parsing, profile-id, media_urls, validation errors, no Go CLI invocation)
- **`tests/sms.test.ts`** — removed obsolete Go CLI schedule test
- **`package.json`** — added new test file to test script

### Verification
- Typecheck: clean (exit 0)
- Full suite: **207/207 pass, 0 fail**
- Tests use async `spawn` (not `spawnSync`) so in-process mock server can respond
- Launcher path uses `npx tsx` for compatibility with main branch (no .mjs launcher)

### Linear
[AIF-332](https://linear.app/telnyx/issue/AIF-332)