### PR TITLE
fix(aif-330): setup-verify sends SMS channel block via REST

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -76,6 +76,20 @@ telnyx-agent setup-iot --json
 
 Output: `{ sim_id, group_id, status, apn_config }`
 
+### `telnyx-agent setup-verify`
+
+**One command: zero to phone verification.**
+
+Creates a verify profile with SMS channel settings (default timeout 300s, code length 6, whitelisted destinations US), searches for an available number with SMS capability, buys it, and outputs everything you need to start sending verifications.
+
+```bash
+telnyx-agent setup-verify
+telnyx-agent setup-verify --destinations US,GB,LK
+telnyx-agent setup-verify --profile-name "My Verify Profile" --json
+```
+
+Output: `{ profile_id, profile_name, phone_number, phone_number_id, timeout_secs, test_command, ready }`
+
 ### `telnyx-agent setup-ai`
 
 **One command: zero to AI assistant on a phone number.**

--- a/cli/package.json
+++ b/cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "tsx bin/telnyx-agent.ts",
-    "test": "tsx --test tests/ai.test.ts tests/edge-handoff.test.ts tests/fax.test.ts tests/integration.test.ts tests/iot.test.ts tests/numbers.test.ts tests/rcs.test.ts tests/setup-10dlc.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
+    "test": "tsx --test tests/ai.test.ts tests/edge-handoff.test.ts tests/fax.test.ts tests/integration.test.ts tests/iot.test.ts tests/numbers.test.ts tests/rcs.test.ts tests/setup-10dlc.test.ts tests/setup-verify.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
     "typecheck": "tsc --noEmit",
     "postinstall": "tsx scripts/postinstall.ts",
     "build": "npm run typecheck"

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -1,7 +1,7 @@
 /**
  * Telnyx API client — ONLY for operations with no CLI equivalent.
  *
- * The following 8 operations have no `telnyx` CLI command and must use direct API calls:
+ * The following 9 operations have no `telnyx` CLI command and must use direct API calls:
  * 1. POST /texml_applications (setup-ai)
  * 2. POST /sim_card_groups (setup-iot)
  * 3. PATCH /sim_cards/:id (setup-iot)
@@ -10,6 +10,11 @@
  * 6. POST /wireguard_peers (setup-wireguard)
  * 7. POST /x402/credit_account/quote (fund-account)
  * 8. POST /x402/credit_account (fund-account)
+ * 9. POST /verify_profiles (setup-verify)
+ *
+ * Additionally, some operations use direct REST due to Go CLI bugs (see commit history):
+ * - POST /text-to-speech/speech (tts — Go CLI does not map --voice to the API body)
+ * - POST /messages (schedule-sms — Go CLI hits nonexistent /messages/schedule endpoint)
  *
  * All other operations go through the telnyx CLI wrapper (see telnyx-cli.ts).
  */
@@ -47,7 +52,7 @@ export class TelnyxClient {
 
   constructor(apiKey?: string, baseUrl?: string, timeout?: number) {
     this.apiKey = apiKey || resolveApiKey();
-    this.baseUrl = (baseUrl ?? "https://api.telnyx.com/v2").replace(/\/$/, "");
+    this.baseUrl = (baseUrl ?? process.env.TELNYX_API_BASE_URL ?? "https://api.telnyx.com/v2").replace(/\/$/, "");
     this.timeout = timeout ?? 30000;
     this.telemetry = new TelemetryReporter();
     this.friction = new FrictionReporter();

--- a/cli/src/commands/setup-verify.ts
+++ b/cli/src/commands/setup-verify.ts
@@ -8,7 +8,8 @@
  * 4. Output profile + number for use
  */
 
-import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
+import { TelnyxCLIError } from "../telnyx-cli.ts";
+import { TelnyxClient, TelnyxAPIError } from "../client.ts";
 import { printStep, printSuccess, printError, outputJson, type StepResult } from "../utils/output.ts";
 import { searchNumbers, orderNumber } from "../utils/number-order.ts";
 
@@ -41,13 +42,26 @@ export async function setupVerifyCommand(flags: Record<string, string | boolean>
     profileName = (flags["profile-name"] as string) || `Agent Verify Profile - ${ts}`;
     if (!jsonOutput) console.log("\n🚀 Setting up Phone Verification...\n");
 
-    // Step 1: Create verify profile via CLI
+    // Step 1: Create verify profile via REST API (AIF-330: Go CLI sends no
+    // channel settings → 400 "No channel setting provided: sms, call, etc")
     const step1Start = Date.now();
     try {
-      const profileRes = await telnyxCli([
-        "verify-profiles", "create",
-        "--name", profileName,
-      ]);
+      const destinations = ((flags.destinations as string) || "US")
+        .split(",")
+        .map((d) => d.trim().toUpperCase())
+        .filter(Boolean);
+
+      const client = new TelnyxClient();
+      const profileBody: Record<string, unknown> = {
+        name: profileName,
+        sms: {
+          default_verification_timeout_secs: timeoutSecs,
+          code_length: 6,
+          whitelisted_destinations: destinations,
+        },
+      };
+
+      const profileRes = await client.post("/verify_profiles", profileBody);
       const profileData = profileRes.data as Record<string, unknown>;
       profileId = String(profileData.id);
       steps.push({ step: 1, name: "Create verify profile", status: "completed", resourceId: profileId, detail: profileName, elapsedMs: Date.now() - step1Start });
@@ -138,6 +152,7 @@ export async function setupVerifyCommand(flags: Record<string, string | boolean>
 }
 
 function errorMsg(err: unknown): string {
+  if (err instanceof TelnyxAPIError) return err.detail || err.message;
   if (err instanceof TelnyxCLIError) return err.stderr || err.message;
   if (err instanceof Error) return err.message;
   return String(err);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -112,6 +112,7 @@ Setup-specific Flags:
   --name            AI assistant name (setup-ai)
   --network-id      Use existing network (setup-wireguard)
   --profile-name    Custom verify profile name (setup-verify)
+  --destinations    Whitelisted destination countries for verify (setup-verify, default: US)
 
 Verify Flags:
   --phone-number    E.164 number to verify (verify-send, required)
@@ -352,6 +353,8 @@ Examples:
   telnyx-agent status --json
   telnyx-agent capabilities
   telnyx-agent setup-sms --country US
+  telnyx-agent setup-verify
+  telnyx-agent setup-verify --destinations US,GB,LK
   telnyx-agent setup-voice --webhook https://example.com/calls
   telnyx-agent setup-ai --instructions "You are a pizza ordering bot"
   telnyx-agent setup-porting --phone-numbers +131****0001,+131****0002 --customer-name "Acme Corp"

--- a/cli/tests/setup-verify.test.ts
+++ b/cli/tests/setup-verify.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Tests for the `telnyx-agent setup-verify` command.
+ *
+ * Step 1 (create verify profile) uses a direct REST POST /verify_profiles
+ * with an SMS channel block (AIF-330 fix — Go CLI sent no channel settings).
+ * Steps 2-4 (search number, buy number, link) still use the Go CLI.
+ *
+ * The test uses a mock HTTP server for the REST call and a fake Go CLI
+ * binary for the number search/order steps.
+ */
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync, spawn } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, chmodSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createServer, type Server, type IncomingMessage, type ServerResponse } from "node:http";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliRoot = join(__dirname, "..");
+const cliBin = join(cliRoot, "bin", "telnyx-agent.ts");
+
+// ---------------------------------------------------------------------------
+// Mock HTTP server for REST POST /verify_profiles
+// ---------------------------------------------------------------------------
+
+interface CapturedRequest {
+  method: string;
+  path: string;
+  body: Record<string, unknown> | null;
+}
+
+let mockServer: Server;
+let mockPort: number;
+let lastRequest: CapturedRequest | null = null;
+
+function startMockServer(): Promise<void> {
+  return new Promise((resolve) => {
+    mockServer = createServer((req: IncomingMessage, res: ServerResponse) => {
+      let body = "";
+      req.on("data", (chunk: Buffer) => (body += chunk.toString()));
+      req.on("end", () => {
+        let parsedBody: Record<string, unknown> | null = null;
+        try {
+          parsedBody = body ? JSON.parse(body) : null;
+        } catch { /* ignore */ }
+        lastRequest = { method: req.method ?? "", path: req.url ?? "", body: parsedBody };
+
+        if (req.method === "POST" && req.url === "/v2/verify_profiles") {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({
+            data: {
+              id: "prof_abc123",
+              name: (parsedBody as Record<string, unknown>)?.name ?? "test",
+              record_type: "verify_profile",
+            },
+          }));
+          return;
+        }
+
+        res.writeHead(404, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ errors: [{ code: "10005", detail: "Not found" }] }));
+      });
+    });
+    mockServer.listen(0, "127.0.0.1", () => {
+      const addr = mockServer.address();
+      mockPort = typeof addr === "object" && addr ? addr.port : 0;
+      resolve();
+    });
+  });
+}
+
+function stopMockServer(): Promise<void> {
+  return new Promise((resolve) => {
+    mockServer.close(() => resolve());
+  });
+}
+
+function capturedRequest(): CapturedRequest {
+  assert.ok(lastRequest, "expected the mock server to have received a request");
+  return lastRequest as CapturedRequest;
+}
+
+// ---------------------------------------------------------------------------
+// Fake Go CLI binary for number search/order steps
+// ---------------------------------------------------------------------------
+
+function setupFakeTelnyx(): { fakeTelnyx: string; logPath: string; env: NodeJS.ProcessEnv } {
+  const tempDir = mkdtempSync(join(tmpdir(), "telnyx-agent-setup-verify-"));
+  const binDir = join(tempDir, "bin");
+  const logPath = join(tempDir, "args.jsonl");
+  mkdirSync(binDir, { recursive: true });
+
+  const fakeTelnyx = join(binDir, "telnyx");
+  writeFileSync(
+    fakeTelnyx,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.TELNYX_FAKE_ARGS_LOG, JSON.stringify(args) + "\\n");
+
+// Strip --format raw and --format json to inspect the command
+const fmtIdx = args.indexOf("--format");
+const fmt = fmtIdx >= 0 ? args[fmtIdx + 1] : "json";
+const cmd = args.filter((a, i) => !(a === "--format" || (i > 0 && args[i-1] === "--format")));
+const joined = cmd.join(" ");
+
+if (joined.startsWith("available-phone-numbers list")) {
+  // With --format raw, output { data: [...] } envelope
+  const out = { data: [
+    { phone_number: "+13125550001", country: "US", capabilities: ["sms", "voice"] },
+  ] };
+  if (fmt === "raw") {
+    console.log(JSON.stringify(out));
+  } else {
+    console.log(JSON.stringify(out));
+  }
+} else if (joined.startsWith("number-order create") || joined.startsWith("number-orders create")) {
+  console.log(JSON.stringify({ data: { id: "order_123", phone_number: "+13125550001" } }));
+} else if (joined.startsWith("phone-numbers retrieve")) {
+  console.log(JSON.stringify({ data: { id: "num_123", phone_number: "+13125550001" } }));
+} else {
+  console.log(JSON.stringify({ data: {} }));
+}
+`,
+  );
+  chmodSync(fakeTelnyx, 0o755);
+
+  return {
+    fakeTelnyx,
+    logPath,
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH}`,
+      TELNYX_CLI_PATH: fakeTelnyx,
+      TELNYX_FAKE_ARGS_LOG: logPath,
+      TELNYX_API_KEY: "***",
+      TELNYX_API_BASE_URL: `http://127.0.0.1:${mockPort}/v2`,
+    },
+  };
+}
+
+function readLoggedArgs(logPath: string): string[][] {
+  if (!existsSync(logPath)) return [];
+  return readFileSync(logPath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+// Async spawn — mock server needs event loop
+function runSetupVerifyAsync(args: string[], env: NodeJS.ProcessEnv): Promise<{ status: number; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    const child = spawn("npx", ["tsx", cliBin, "setup-verify", ...args], {
+      cwd: cliRoot,
+      env,
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (c: Buffer) => (stdout += c.toString()));
+    child.stderr.on("data", (c: Buffer) => (stderr += c.toString()));
+    child.on("close", (code) => resolve({ status: code ?? -1, stdout, stderr }));
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("setup-verify (AIF-330: profile with SMS channel settings)", () => {
+  before(async () => {
+    await startMockServer();
+  });
+
+  after(async () => {
+    await stopMockServer();
+  });
+
+  it("POSTs to /verify_profiles with SMS channel block and default US destination", async () => {
+    lastRequest = null;
+    const fake = setupFakeTelnyx();
+    const r = await runSetupVerifyAsync(["--json"], fake.env);
+
+    assert.equal(r.status, 0, `expected exit 0, got ${r.status}: ${r.stderr}`);
+    const req = capturedRequest();
+    assert.equal(req.method, "POST");
+    assert.equal(req.path, "/v2/verify_profiles");
+
+    const body = capturedRequest().body as Record<string, unknown> | null;
+    assert.ok(body);
+    const sms = body!.sms as Record<string, unknown> | undefined;
+    assert.ok(sms, "expected sms channel block in request body");
+    assert.ok(sms!.whitelisted_destinations, "expected whitelisted_destinations");
+    assert.deepEqual(sms!.whitelisted_destinations, ["US"]);
+    assert.equal(sms!.code_length, 6);
+    assert.equal(sms!.default_verification_timeout_secs, 300);
+  });
+
+  it("accepts --destinations flag with multiple countries", async () => {
+    lastRequest = null;
+    const fake = setupFakeTelnyx();
+    const r = await runSetupVerifyAsync(["--destinations", "US,GB,LK", "--json"], fake.env);
+
+    assert.equal(r.status, 0, `expected exit 0, got ${r.status}: ${r.stderr}`);
+    const body = capturedRequest().body as Record<string, unknown> | null;
+    assert.ok(body);
+    const sms = body!.sms as Record<string, unknown> | undefined;
+    assert.ok(sms);
+    assert.deepEqual(sms!.whitelisted_destinations, ["US", "GB", "LK"]);
+  });
+
+  it("accepts --profile-name and includes it in the request body", async () => {
+    lastRequest = null;
+    const fake = setupFakeTelnyx();
+    const r = await runSetupVerifyAsync(["--profile-name", "My Custom Profile", "--json"], fake.env);
+
+    assert.equal(r.status, 0, `expected exit 0, got ${r.status}: ${r.stderr}`);
+    const body = capturedRequest().body as Record<string, unknown> | null;
+    assert.ok(body);
+    assert.equal(body!.name, "My Custom Profile");
+  });
+
+  it("returns profile_id and phone_number in JSON output", async () => {
+    lastRequest = null;
+    const fake = setupFakeTelnyx();
+    const r = await runSetupVerifyAsync(["--json"], fake.env);
+
+    assert.equal(r.status, 0);
+    const data = JSON.parse(r.stdout);
+    assert.equal(data.profile_id, "prof_abc123");
+    assert.equal(data.phone_number, "+13125550001");
+    assert.equal(data.ready, true);
+  });
+
+  it("includes 4 steps in the output", async () => {
+    lastRequest = null;
+    const fake = setupFakeTelnyx();
+    const r = await runSetupVerifyAsync(["--json"], fake.env);
+
+    assert.equal(r.status, 0);
+    const data = JSON.parse(r.stdout);
+    assert.equal(data.steps.length, 4);
+    assert.equal(data.steps[0].name, "Create verify profile");
+    assert.equal(data.steps[0].status, "completed");
+  });
+
+  it("lists setup-verify in the help text", () => {
+    const { stdout, status } = (function () {
+      try {
+        const out = execFileSync("npx", ["tsx", cliBin, "help"], {
+          cwd: cliRoot,
+          encoding: "utf8",
+          env: { ...process.env },
+          timeout: 30000,
+        });
+        return { stdout: out, status: 0 };
+      } catch (err: any) {
+        return { stdout: err.stdout?.toString() ?? "", status: err.status ?? 1 };
+      }
+    })();
+
+    assert.equal(status, 0);
+    assert.match(stdout, /setup-verify/);
+    assert.match(stdout, /--destinations/);
+  });
+});


### PR DESCRIPTION
## AIF-330 — setup-verify creates profile with no channel settings → 400

### Problem
`setup-verify` called `verify-profiles create` via the Go CLI with only `--name`. The API returned:
```
400 "No channel setting provided: sms, call, etc"
```
Even after adding an SMS channel block, the API also mandated `sms.whitelisted_destinations`. Verify setup was completely broken — nothing could be created.

### Fix
Replaced Go CLI call with direct REST `POST /verify_profiles`:

- **`src/commands/setup-verify.ts`** — Uses `TelnyxClient.post()` with:
  ```json
  {
    "name": "...",
    "sms": {
      "default_verification_timeout_secs": 300,
      "code_length": 6,
      "whitelisted_destinations": ["US"]
    }
  }
  ```
- **`src/client.ts`** — Added `TELNYX_API_BASE_URL` env override for mock-server testing
- **`src/index.ts`** — Added `--destinations` flag documentation + setup-verify examples
- **`tests/setup-verify.test.ts`** — 6 new mock-HTTP-server tests:
  - SMS channel block with default US destination
  - `--destinations` flag with multiple countries (US,GB,LK)
  - `--profile-name` in request body
  - JSON output structure (profile_id, phone_number, ready)
  - 4-step output with correct names/statuses
  - Help text lists setup-verify and --destinations
- **`package.json`** — Added `setup-verify.test.ts` to test script

### New —destinations flag
`--destinations` (default: `US`) — comma-separated ISO country codes, auto-trimmed and uppercased. Example: `--destinations US,GB,LK`

### What stayed the same
- `verify-send` and `verify-check` — unchanged, they work fine once a valid profile exists
- Steps 2-4 (search number, buy number, link) — still use Go CLI

### Verification
- Typecheck: clean (exit 0)
- Full suite: **203/203 pass, 0 fail**
- Blind agent E2E: 12 PASS, 2 minor docs gaps (non-blocking)
- Human dev E2E: 15/15 PASS

### Linear
[AIF-330](https://linear.app/telnyx/issue/AIF-330)