### PR TITLE
fix(aif-329): setup-voice/sms assign number via REST + pre-existing bug fixes

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -212,6 +212,45 @@ telnyx-agent fund-account --amount 50.00 --json              # JSON output
 **Output (without --wallet-key):**
 Returns `payment_requirements` JSON for external signing by agents or wallets.
 
+### `telnyx-agent tts`
+
+**Generate speech from text (text-to-speech).**
+
+Supports multiple providers (telnyx, aws, azure, elevenlabs, minimax, resemble, rime, xai). Returns base64-encoded audio.
+
+```bash
+telnyx-agent tts --text "Hello world" --voice Telnyx.Bayan.Amanda
+telnyx-agent tts --text "Bonjour" --voice Amy --provider aws --language fr
+telnyx-agent tts --text "Hello" --provider elevenlabs --json
+telnyx-agent tts --text "<speak>Hello</speak>" --text-type ssml
+```
+
+**Flags:**
+- `--text` — Text to synthesize (required)
+- `--voice` — Voice ID (e.g., `Telnyx.Bayan.Amanda`, `Amy`)
+- `--provider` — TTS provider (default: `telnyx`)
+- `--language` — Language code (default: `en`)
+- `--output-type` — Output format: `base64` (default). `binary_output` is not supported by this wrapper.
+- `--text-type` — `text` (default) or `ssml`
+- `--disable-cache` — Skip TTS cache
+
+Output: `{ text, voice, provider, output_type, audio_data, has_audio_data }`
+
+### `telnyx-agent tts-voices`
+
+**List available TTS voices, optionally filtered by provider.**
+
+```bash
+telnyx-agent tts-voices
+telnyx-agent tts-voices --provider aws
+telnyx-agent tts-voices --provider elevenlabs --json
+```
+
+**Flags:**
+- `--provider` — Filter by provider (default: `telnyx`)
+
+Output: `{ provider, count, voices: [...] }`
+
 ## Authentication
 
 The CLI looks for an API key in this order:

--- a/cli/package.json
+++ b/cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "tsx bin/telnyx-agent.ts",
-    "test": "tsx --test tests/ai.test.ts tests/edge-handoff.test.ts tests/fax.test.ts tests/integration.test.ts tests/iot.test.ts tests/numbers.test.ts tests/rcs.test.ts tests/setup-10dlc.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
+    "test": "tsx --test tests/ai.test.ts tests/bugfixes.test.ts tests/edge-handoff.test.ts tests/fax.test.ts tests/integration.test.ts tests/iot.test.ts tests/numbers.test.ts tests/rcs.test.ts tests/setup-10dlc.test.ts tests/setup-assign-flags.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
     "typecheck": "tsc --noEmit",
     "postinstall": "tsx scripts/postinstall.ts",
     "build": "npm run typecheck"

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -11,6 +11,12 @@
  * 7. POST /x402/credit_account/quote (fund-account)
  * 8. POST /x402/credit_account (fund-account)
  *
+ * Additionally, some operations use direct REST due to Go CLI bugs (see commit history):
+ * - POST /text-to-speech/speech (tts — Go CLI does not map --voice to the API body)
+ * - POST /messages (schedule-sms — Go CLI hits nonexistent /messages/schedule endpoint)
+ * - POST /verify_profiles (setup-verify — Go CLI sends no channel settings)
+ * - PATCH /phone_numbers/:id (setup-voice, setup-sms — Go CLI doesn't support --force / --messaging-profile-id)
+ *
  * All other operations go through the telnyx CLI wrapper (see telnyx-cli.ts).
  */
 
@@ -47,7 +53,7 @@ export class TelnyxClient {
 
   constructor(apiKey?: string, baseUrl?: string, timeout?: number) {
     this.apiKey = apiKey || resolveApiKey();
-    this.baseUrl = (baseUrl ?? "https://api.telnyx.com/v2").replace(/\/$/, "");
+    this.baseUrl = (baseUrl ?? process.env.TELNYX_API_BASE_URL ?? "https://api.telnyx.com/v2").replace(/\/$/, "");
     this.timeout = timeout ?? 30000;
     this.telemetry = new TelemetryReporter();
     this.friction = new FrictionReporter();

--- a/cli/src/commands/rcs-capabilities.ts
+++ b/cli/src/commands/rcs-capabilities.ts
@@ -6,7 +6,7 @@
  */
 
 import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
-import { printSuccess, printError, outputJson } from "../utils/output.ts";
+import { printSuccess, printError, outputJson, failWith } from "../utils/output.ts";
 
 interface RcsCapabilitiesResult {
   agent_id: string;
@@ -23,14 +23,10 @@ export async function rcsCapabilitiesCommand(flags: Record<string, string | bool
   const phoneNumber = flags["phone-number"] as string | undefined;
 
   if (!agentId) {
-    printError("--agent-id is required");
-    process.exit(1);
-    return;
+    failWith("--agent-id is required", jsonOutput);
   }
   if (!phoneNumber) {
-    printError("--phone-number is required (E.164 format, e.g., +131****0001)");
-    process.exit(1);
-    return;
+    failWith("--phone-number is required (E.164 format, e.g., +131****0001)", jsonOutput);
   }
 
   try {

--- a/cli/src/commands/rcs-send.ts
+++ b/cli/src/commands/rcs-send.ts
@@ -7,7 +7,7 @@
  */
 
 import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
-import { printSuccess, printError, outputJson } from "../utils/output.ts";
+import { printSuccess, printError, outputJson, failWith } from "../utils/output.ts";
 import { deriveMessageStatus } from "../utils/message-status.ts";
 
 interface RcsSendResult {
@@ -29,24 +29,16 @@ export async function rcsSendCommand(flags: Record<string, string | boolean>): P
   const webhookUrl = flags["webhook-url"] as string | undefined;
 
   if (!agentId) {
-    printError("--agent-id is required");
-    process.exit(1);
-    return;
+    failWith("--agent-id is required", jsonOutput);
   }
   if (!messagingProfileId) {
-    printError("--messaging-profile-id is required");
-    process.exit(1);
-    return;
+    failWith("--messaging-profile-id is required", jsonOutput);
   }
   if (!to) {
-    printError("--to is required (E.164 format, e.g., +131****0001)");
-    process.exit(1);
-    return;
+    failWith("--to is required (E.164 format, e.g., +131****0001)", jsonOutput);
   }
   if (!text) {
-    printError("--text is required");
-    process.exit(1);
-    return;
+    failWith("--text is required", jsonOutput);
   }
 
   const args = [

--- a/cli/src/commands/setup-10dlc.ts
+++ b/cli/src/commands/setup-10dlc.ts
@@ -13,7 +13,7 @@
  */
 
 import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
-import { printStep, printSuccess, printError, printWarning, outputJson, type StepResult } from "../utils/output.ts";
+import { printStep, printSuccess, printError, printWarning, outputJson, failWith, type StepResult } from "../utils/output.ts";
 
 // ─── 10DLC domain constants ──────────────────────────────────────────────────
 
@@ -240,24 +240,19 @@ export async function setup10dlcCommand(flags: Record<string, string | boolean>)
   const email = flags.email as string;
 
   if (!phone || !email) {
-    printError("--phone and --email are required for 10DLC brand registration.");
-    process.exit(1);
+    failWith("--phone and --email are required for 10DLC brand registration.", jsonOutput);
   }
 
   // ── Validate use case ──
   const usecase = (flags.usecase as string) || "CUSTOMER_CARE";
   if (!VALID_USE_CASES.includes(usecase as (typeof VALID_USE_CASES)[number])) {
-    printError(
-      `Invalid use case '${usecase}'. Valid values: ${VALID_USE_CASES.map((u) => USE_CASE_LABELS[u]).join(", ")}`,
-    );
-    process.exit(1);
+    failWith(`Invalid use case '${usecase}'. Valid values: ${VALID_USE_CASES.map((u) => USE_CASE_LABELS[u]).join(", ")}`, jsonOutput);
   }
 
   // ── Validate opt-in method ──
   const optInMethod = (flags["opt-in-method"] as string) || "web";
   if (!VALID_OPT_IN_METHODS.includes(optInMethod as (typeof VALID_OPT_IN_METHODS)[number])) {
-    printError(`Invalid opt-in method '${optInMethod}'. Valid values: ${VALID_OPT_IN_METHODS.join(", ")}`);
-    process.exit(1);
+    failWith(`Invalid opt-in method '${optInMethod}'. Valid values: ${VALID_OPT_IN_METHODS.join(", ")}`, jsonOutput);
   }
 
   const phoneNumberId = (flags["phone-number-id"] as string) || "";
@@ -291,11 +286,8 @@ export async function setup10dlcCommand(flags: Record<string, string | boolean>)
     const flowIssues = lintMessageFlow(messageFlow);
     const blockingFlowIssues = flowIssues.filter((i) => i.severity === "blocking");
     if (blockingFlowIssues.length > 0) {
-      printError("Message flow failed compliance validation (blocking issues):");
-      for (const issue of blockingFlowIssues) {
-        console.error(`  • ${issue.message}`);
-      }
-      process.exit(1);
+      const issues = blockingFlowIssues.map((i) => i.message).join("; ");
+      failWith(`Message flow failed compliance validation: ${issues}`, jsonOutput);
     }
     flowIssues.filter((i) => i.severity === "warning").forEach((i) => warnings.push(i.message));
 
@@ -310,11 +302,8 @@ export async function setup10dlcCommand(flags: Record<string, string | boolean>)
 
     const blockingSamples = sampleIssues.filter((i) => i.severity === "blocking");
     if (blockingSamples.length > 0) {
-      printError("Sample message validation failed (blocking issues):");
-      for (const issue of blockingSamples) {
-        console.error(`  • ${issue.message}`);
-      }
-      process.exit(1);
+      const issues = blockingSamples.map((i) => i.message).join("; ");
+      failWith(`Sample message validation failed: ${issues}`, jsonOutput);
     }
     sampleIssues.filter((i) => i.severity === "warning").forEach((i) => warnings.push(i.message));
 

--- a/cli/src/commands/setup-sms.ts
+++ b/cli/src/commands/setup-sms.ts
@@ -8,8 +8,8 @@
  * 4. Assign number to the messaging profile (via telnyx CLI)
  */
 
-import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
-import { TelnyxClient } from "../client.ts";
+import { TelnyxCLIError } from "../telnyx-cli.ts";
+import { TelnyxClient, TelnyxAPIError } from "../client.ts";
 import { printStep, printSuccess, printError, outputJson, type StepResult } from "../utils/output.ts";
 import { searchAndBuyNumber } from "../utils/number-order.ts";
 
@@ -81,16 +81,14 @@ export async function setupSmsCommand(flags: Record<string, string | boolean>): 
       printStep(steps[steps.length - 1], totalSteps);
     }
 
-    // Step 4: Assign number to messaging profile via CLI
+    // Step 4: Assign number to messaging profile via REST (AIF-329: Go CLI
+    // doesn't support --messaging-profile-id or --force on phone-numbers update)
     const step4Start = Date.now();
     try {
-      if (phoneNumber) {
-        await telnyxCli([
-          "phone-numbers", "update",
-          "--phone-number-id", phoneNumber,
-          "--messaging-profile-id", profileId,
-          "--force",
-        ]);
+      if (phoneNumberId) {
+        await client.patch(`/phone_numbers/${phoneNumberId}`, {
+          messaging_profile_id: profileId,
+        });
       }
       steps.push({ step: 4, name: "Assign number to profile", status: "completed", elapsedMs: Date.now() - step4Start });
     } catch (err) {
@@ -143,6 +141,7 @@ export async function setupSmsCommand(flags: Record<string, string | boolean>): 
 }
 
 function errorMsg(err: unknown): string {
+  if (err instanceof TelnyxAPIError) return err.detail || err.message;
   if (err instanceof TelnyxCLIError) return err.stderr || err.message;
   if (err instanceof Error) return err.message;
   return String(err);

--- a/cli/src/commands/setup-voice.ts
+++ b/cli/src/commands/setup-voice.ts
@@ -9,7 +9,7 @@
  */
 
 import { TelnyxClient, TelnyxAPIError } from "../client.ts";
-import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
+import { TelnyxCLIError } from "../telnyx-cli.ts";
 import { printStep, printSuccess, printError, outputJson, type StepResult } from "../utils/output.ts";
 import { searchAndBuyNumber } from "../utils/number-order.ts";
 
@@ -94,16 +94,14 @@ export async function setupVoiceCommand(flags: Record<string, string | boolean>)
       printStep(steps[steps.length - 1], totalSteps);
     }
 
-    // Step 4: Assign number to connection via CLI
+    // Step 4: Assign number to connection via REST (AIF-329: Go CLI doesn't
+    // support --force on phone-numbers update)
     const step4Start = Date.now();
     try {
-      if (phoneNumber) {
-        await telnyxCli([
-          "phone-numbers", "update",
-          "--phone-number-id", phoneNumber,
-          "--connection-id", connectionId,
-          "--force",
-        ]);
+      if (phoneNumberId) {
+        await client.patch(`/phone_numbers/${phoneNumberId}`, {
+          connection_id: connectionId,
+        });
       }
       steps.push({ step: 4, name: "Assign number to connection", status: "completed", elapsedMs: Date.now() - step4Start });
     } catch (err) {

--- a/cli/src/commands/whatsapp-send.ts
+++ b/cli/src/commands/whatsapp-send.ts
@@ -6,7 +6,7 @@
  */
 
 import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
-import { printSuccess, printError, outputJson } from "../utils/output.ts";
+import { printSuccess, printError, outputJson, failWith } from "../utils/output.ts";
 
 interface WhatsappSendResult {
   from: string;
@@ -26,8 +26,7 @@ export async function whatsappSendCommand(flags: Record<string, string | boolean
   const messagingProfileId = flags["messaging-profile-id"] as string;
 
   if (!from || !to) {
-    printError("--from and --to are required (E.164 phone numbers)");
-    process.exit(1);
+    failWith("--from and --to are required (E.164 phone numbers)", jsonOutput);
   }
 
   // Build the whatsapp_message JSON string. Initialize to keep strict mode happy.
@@ -43,8 +42,7 @@ export async function whatsappSendCommand(flags: Record<string, string | boolean
       template: { name: templateName, language: { code: templateLanguage } },
     });
   } else {
-    printError("Provide --text for a text message or --template-name for a template message");
-    process.exit(1);
+    failWith("Provide --text for a text message or --template-name for a template message", jsonOutput);
   }
 
   try {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -487,9 +487,15 @@ const COMMANDS: Record<string, (
 };
 
 export async function run(argv: string[]): Promise<void> {
-  const { command, flags, occurrences } = parseFlags(argv);
+  const { command, flags, occurrences, helpRequested } = parseFlags(argv);
 
   if (command === "help" || command === "--help" || command === "-h" || !command) {
+    console.log(HELP);
+    return;
+  }
+
+  // Per-command help: `telnyx-agent tts --help` or `telnyx-agent tts -h`
+  if (helpRequested) {
     console.log(HELP);
     return;
   }

--- a/cli/src/utils/output.ts
+++ b/cli/src/utils/output.ts
@@ -35,6 +35,19 @@ export function printError(message: string, remediation?: string): void {
   console.error();
 }
 
+/**
+ * Print an error in the correct format based on --json flag, then exit(1).
+ * Use this for validation errors in command handlers.
+ */
+export function failWith(message: string, jsonOutput: boolean): never {
+  if (jsonOutput) {
+    outputJson({ error: message });
+  } else {
+    printError(message);
+  }
+  process.exit(1);
+}
+
 export function printWarning(message: string): void {
   console.error(`⚠️  ${message}`);
 }
@@ -71,17 +84,25 @@ export function parseFlags(args: string[]): {
   command: string;
   flags: Record<string, string | boolean>;
   occurrences: Record<string, Array<string | boolean>>;
+  helpRequested: boolean;
 } {
   const command = args[0] ?? "help";
   const flags: Record<string, string | boolean> = {};
   const occurrences: Record<string, Array<string | boolean>> = Object.create(null);
+  let helpRequested = false;
 
   for (let i = 1; i < args.length; i++) {
     const arg = args[i];
+    if (arg === "--help" || arg === "-h") {
+      helpRequested = true;
+      continue;
+    }
     if (arg.startsWith("--")) {
       const key = arg.slice(2);
       const next = args[i + 1];
-      if (next && !next.startsWith("--")) {
+      // Treat `--flag ""` as an empty string value, not a boolean.
+      // The old code used `next && ...` which treated `""` as falsy.
+      if (next !== undefined && next !== null && !next.startsWith("--")) {
         flags[key] = next;
         (occurrences[key] ??= []).push(next);
         i++;
@@ -92,5 +113,5 @@ export function parseFlags(args: string[]): {
     }
   }
 
-  return { command, flags, occurrences };
+  return { command, flags, occurrences, helpRequested };
 }

--- a/cli/tests/bugfixes.test.ts
+++ b/cli/tests/bugfixes.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for pre-existing bug fixes:
+ * - Bug 1: --help/-h passed to commands now shows help instead of running the command
+ * - Bug 2: --flag "" (empty string) now stored as "" not true
+ * - Bug 3: README has tts/tts-voices sections
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseFlags } from "../src/utils/output.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliRoot = join(__dirname, "..");
+const cliBin = join(cliRoot, "bin", "telnyx-agent.ts");
+
+function runCli(args: string[], env?: NodeJS.ProcessEnv): { stdout: string; status: number } {
+  try {
+    const stdout = execFileSync("npx", ["tsx", cliBin, ...args], {
+      cwd: cliRoot,
+      encoding: "utf8",
+      env: env ?? { ...process.env },
+      timeout: 30000,
+    });
+    return { stdout, status: 0 };
+  } catch (err: any) {
+    return { stdout: err.stdout?.toString() ?? "", status: err.status ?? 1 };
+  }
+}
+
+describe("Bug fix: --help/-h shows help instead of running the command", () => {
+  it("tts --help shows help and exits 0", () => {
+    const { stdout, status } = runCli(["tts", "--help"]);
+    assert.equal(status, 0, "expected --help to exit 0");
+    assert.match(stdout, /Usage:/);
+    assert.match(stdout, /tts/);
+  });
+
+  it("tts -h shows help and exits 0", () => {
+    const { stdout, status } = runCli(["tts", "-h"]);
+    assert.equal(status, 0, "expected -h to exit 0");
+    assert.match(stdout, /Usage:/);
+  });
+
+  it("setup-voice --help shows help and exits 0", () => {
+    const { stdout, status } = runCli(["setup-voice", "--help"]);
+    assert.equal(status, 0);
+    assert.match(stdout, /Usage:/);
+  });
+
+  it("setup-sms --help shows help and exits 0", () => {
+    const { stdout, status } = runCli(["setup-sms", "--help"]);
+    assert.equal(status, 0);
+    assert.match(stdout, /Usage:/);
+  });
+
+  it("tts --help does NOT make an API call (no auth error)", () => {
+    const { stdout, status } = runCli(["tts", "--help"], { ...process.env, TELNYX_API_KEY: "" });
+    assert.equal(status, 0, "expected --help to exit 0 without API key");
+    // If the command ran, it would fail with auth error, not show help
+    assert.doesNotMatch(stdout, /error/i);
+    assert.match(stdout, /Usage:/);
+  });
+});
+
+describe("Bug fix: parseFlags handles empty string values", () => {
+  it('stores empty string for --flag ""', () => {
+    const parsed = parseFlags(["cmd", "--text", ""]);
+    assert.equal(parsed.flags.text, "", 'expected flags.text to be "" not true');
+  });
+
+  it("stores empty string for --text with explicit empty value", () => {
+    const parsed = parseFlags(["tts", "--text", "", "--voice", "Amy"]);
+    assert.equal(parsed.flags.text, "");
+    assert.equal(parsed.flags.voice, "Amy");
+  });
+
+  it("still stores boolean true for bare --flag", () => {
+    const parsed = parseFlags(["cmd", "--json"]);
+    assert.equal(parsed.flags.json, true);
+  });
+
+  it("still stores string for --flag value", () => {
+    const parsed = parseFlags(["cmd", "--text", "hello"]);
+    assert.equal(parsed.flags.text, "hello");
+  });
+
+  it("occurrences track empty strings correctly", () => {
+    const parsed = parseFlags(["cmd", "--text", ""]);
+    assert.deepEqual(parsed.occurrences.text, [""]);
+  });
+
+  it("helpRequested is true when --help is passed", () => {
+    const parsed = parseFlags(["cmd", "--help"]);
+    assert.equal(parsed.helpRequested, true);
+  });
+
+  it("helpRequested is true when -h is passed", () => {
+    const parsed = parseFlags(["cmd", "-h"]);
+    assert.equal(parsed.helpRequested, true);
+  });
+
+  it("helpRequested is false when --help is not passed", () => {
+    const parsed = parseFlags(["cmd", "--json"]);
+    assert.equal(parsed.helpRequested, false);
+  });
+
+  it("--help does not create a flags.help entry", () => {
+    const parsed = parseFlags(["cmd", "--help", "--json"]);
+    assert.equal(parsed.flags.help, undefined);
+    assert.equal(parsed.flags.json, true);
+  });
+});
+
+describe("Bug fix: --json validation errors output JSON not human text", () => {
+  it("rcs-send --json with missing --agent-id outputs JSON error", () => {
+    const { stdout, status } = runCli(["rcs-send", "--json"], { ...process.env });
+    assert.notEqual(status, 0, "expected non-zero exit");
+    const data = JSON.parse(stdout);
+    assert.ok(data.error, "expected error field in JSON");
+    assert.match(data.error, /agent-id is required/i);
+  });
+
+  it("rcs-capabilities --json with missing --agent-id outputs JSON error", () => {
+    const { stdout, status } = runCli(["rcs-capabilities", "--json"], { ...process.env });
+    assert.notEqual(status, 0);
+    const data = JSON.parse(stdout);
+    assert.ok(data.error);
+    assert.match(data.error, /agent-id is required/i);
+  });
+
+  it("whatsapp-send --json with missing --from/--to outputs JSON error", () => {
+    const { stdout, status } = runCli(["whatsapp-send", "--json"], { ...process.env });
+    assert.notEqual(status, 0);
+    const data = JSON.parse(stdout);
+    assert.ok(data.error);
+    assert.match(data.error, /from and --to are required/i);
+  });
+
+  it("whatsapp-send --json with no --text or --template-name outputs JSON error", () => {
+    const { stdout, status } = runCli(["whatsapp-send", "--from", "+13125550001", "--to", "+13125550002", "--json"], { ...process.env });
+    assert.notEqual(status, 0);
+    const data = JSON.parse(stdout);
+    assert.ok(data.error);
+    assert.match(data.error, /text.*template-name/i);
+  });
+
+  it("setup-10dlc --json with missing --phone/--email outputs JSON error", () => {
+    const { stdout, status } = runCli(["setup-10dlc", "--json"], { ...process.env });
+    assert.notEqual(status, 0);
+    const data = JSON.parse(stdout);
+    assert.ok(data.error);
+    assert.match(data.error, /phone and --email are required/i);
+  });
+
+  it("setup-10dlc --json with invalid --usecase outputs JSON error", () => {
+    const { stdout, status } = runCli(["setup-10dlc", "--phone", "+13125550001", "--email", "test@test.com", "--usecase", "INVALID", "--json"], { ...process.env });
+    assert.notEqual(status, 0);
+    const data = JSON.parse(stdout);
+    assert.ok(data.error);
+    assert.match(data.error, /invalid use case/i);
+  });
+
+  it("rcs-send without --json still outputs human-readable error", () => {
+    const { stdout, status } = runCli(["rcs-send"], { ...process.env });
+    assert.notEqual(status, 0);
+    // Without --json, output goes to stderr as human text, stdout should be empty or non-JSON
+    if (stdout.trim()) {
+      assert.throws(() => JSON.parse(stdout), "expected non-JSON output without --json");
+    }
+  });
+});
+
+describe("Bug fix: README has tts and tts-voices sections", () => {
+  it("README contains a tts section", () => {
+    const readme = readFileSync(join(cliRoot, "README.md"), "utf8");
+    assert.match(readme, /### `telnyx-agent tts`/);
+  });
+
+  it("README contains a tts-voices section", () => {
+    const readme = readFileSync(join(cliRoot, "README.md"), "utf8");
+    assert.match(readme, /### `telnyx-agent tts-voices`/);
+  });
+
+  it("README tts section mentions --text and --voice flags", () => {
+    const readme = readFileSync(join(cliRoot, "README.md"), "utf8");
+    assert.match(readme, /--text/);
+    assert.match(readme, /--voice/);
+  });
+});

--- a/cli/tests/setup-assign-flags.test.ts
+++ b/cli/tests/setup-assign-flags.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Tests for AIF-329: setup-voice and setup-sms step 4 (assign number) via REST PATCH.
+ *
+ * The Go CLI's `phone-numbers update` doesn't support --force or
+ * --messaging-profile-id on v0.21.0. Step 4 now uses direct REST
+ * PATCH /phone_numbers/{id} instead.
+ *
+ * These tests verify the PATCH call is made with the correct path and body
+ * by using a mock HTTP server for the REST calls and a fake Go CLI binary
+ * for the number search/order steps (steps 2-3).
+ */
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { spawn, execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createServer, type Server, type IncomingMessage, type ServerResponse } from "node:http";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliRoot = join(__dirname, "..");
+const cliBin = join(cliRoot, "bin", "telnyx-agent.ts");
+
+// ---------------------------------------------------------------------------
+// Mock HTTP server
+// ---------------------------------------------------------------------------
+
+interface CapturedRequest {
+  method: string;
+  path: string;
+  body: Record<string, unknown> | null;
+}
+
+let mockServer: Server;
+let mockPort: number;
+let capturedRequests: CapturedRequest[] = [];
+
+function startMockServer(): Promise<void> {
+  return new Promise((resolve) => {
+    mockServer = createServer((req: IncomingMessage, res: ServerResponse) => {
+      let body = "";
+      req.on("data", (chunk: Buffer) => (body += chunk.toString()));
+      req.on("end", () => {
+        let parsedBody: Record<string, unknown> | null = null;
+        try {
+          parsedBody = body ? JSON.parse(body) : null;
+        } catch { /* ignore */ }
+        const captured: CapturedRequest = { method: req.method ?? "", path: req.url ?? "", body: parsedBody };
+        capturedRequests.push(captured);
+
+        // POST /credential_connections (setup-voice step 1)
+        if (req.method === "POST" && req.url === "/v2/credential_connections") {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({
+            data: {
+              id: "conn_abc123",
+              name: (parsedBody as Record<string, unknown>)?.name ?? "test",
+              user_name: "agentuser",
+              password: "agentpass",
+            },
+          }));
+          return;
+        }
+
+        // POST /messaging_profiles (setup-sms step 1)
+        if (req.method === "POST" && req.url === "/v2/messaging_profiles") {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({
+            data: {
+              id: "prof_abc123",
+              name: (parsedBody as Record<string, unknown>)?.name ?? "test",
+            },
+          }));
+          return;
+        }
+
+        // PATCH /phone_numbers/:id (step 4 — the AIF-329 fix)
+        if (req.method === "PATCH" && req.url?.startsWith("/v2/phone_numbers/")) {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({
+            data: {
+              id: req.url.split("/").pop(),
+              ...parsedBody,
+            },
+          }));
+          return;
+        }
+
+        res.writeHead(404, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ errors: [{ code: "10005", detail: "Not found" }] }));
+      });
+    });
+    mockServer.listen(0, "127.0.0.1", () => {
+      const addr = mockServer.address();
+      mockPort = typeof addr === "object" && addr ? addr.port : 0;
+      resolve();
+    });
+  });
+}
+
+function stopMockServer(): Promise<void> {
+  return new Promise((resolve) => {
+    mockServer.close(() => resolve());
+  });
+}
+
+function patchRequests(): CapturedRequest[] {
+  return capturedRequests.filter((r) => r.method === "PATCH");
+}
+
+// ---------------------------------------------------------------------------
+// Fake Go CLI binary for number search/order steps
+// ---------------------------------------------------------------------------
+
+function setupFakeTelnyx(): { fakeTelnyx: string; logPath: string; env: NodeJS.ProcessEnv } {
+  const tempDir = mkdtempSync(join(tmpdir(), "telnyx-agent-aif329-"));
+  const binDir = join(tempDir, "bin");
+  const logPath = join(tempDir, "args.jsonl");
+  mkdirSync(binDir, { recursive: true });
+
+  const fakeTelnyx = join(binDir, "telnyx");
+  writeFileSync(
+    fakeTelnyx,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.TELNYX_FAKE_ARGS_LOG, JSON.stringify(args) + "\\n");
+
+// Strip --format raw/json to inspect the command
+const fmtIdx = args.indexOf("--format");
+const cmd = args.filter((a, i) => !(a === "--format" || (i > 0 && args[i-1] === "--format")));
+
+if (cmd.join(" ").startsWith("available-phone-numbers list")) {
+  console.log(JSON.stringify({ data: [
+    { phone_number: "+13125550001", country: "US", capabilities: ["sms", "voice"] },
+  ] }));
+} else if (cmd.join(" ").startsWith("number-orders create") || cmd.join(" ").startsWith("number-order create")) {
+  console.log(JSON.stringify({ data: { id: "order_123", status: "complete" } }));
+} else if (cmd.join(" ").startsWith("phone-numbers retrieve")) {
+  console.log(JSON.stringify({ data: { id: "num_123456", phone_number: "+13125550001" } }));
+} else {
+  console.log(JSON.stringify({ data: {} }));
+}
+`,
+  );
+  chmodSync(fakeTelnyx, 0o755);
+
+  return {
+    fakeTelnyx,
+    logPath,
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH}`,
+      TELNYX_CLI_PATH: fakeTelnyx,
+      TELNYX_FAKE_ARGS_LOG: logPath,
+      TELNYX_API_KEY: "***",
+      TELNYX_API_BASE_URL: `http://127.0.0.1:${mockPort}/v2`,
+    },
+  };
+}
+
+function runAsync(args: string[], env: NodeJS.ProcessEnv): Promise<{ status: number; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    const child = spawn("npx", ["tsx", cliBin, ...args], { cwd: cliRoot, env });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (c: Buffer) => (stdout += c.toString()));
+    child.stderr.on("data", (c: Buffer) => (stderr += c.toString()));
+    child.on("close", (code) => resolve({ status: code ?? -1, stdout, stderr }));
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("setup-voice step 4 (AIF-329: REST PATCH instead of Go CLI)", () => {
+  before(async () => { await startMockServer(); });
+  after(async () => { await stopMockServer(); });
+
+  it("PATCHes /phone_numbers/:id with connection_id instead of Go CLI --force", async () => {
+    capturedRequests = [];
+    const fake = setupFakeTelnyx();
+    const r = await runAsync(["setup-voice", "--json"], fake.env);
+
+    assert.equal(r.status, 0, `expected exit 0, got ${r.status}: ${r.stderr}`);
+    const patches = patchRequests();
+    assert.equal(patches.length, 1, "expected exactly one PATCH request");
+    assert.match(patches[0].path, /^\/v2\/phone_numbers\//);
+    assert.ok(patches[0].body);
+    assert.ok(patches[0].body!.connection_id, "expected connection_id in PATCH body");
+  });
+
+  it("does not invoke Go CLI phone-numbers update with --force", async () => {
+    const fake = setupFakeTelnyx();
+    await runAsync(["setup-voice", "--json"], fake.env);
+
+    const logPath = fake.logPath;
+    const { readFileSync } = await import("node:fs");
+    if (readFileSync(logPath, "utf8").trim()) {
+      const calls = readFileSync(logPath, "utf8").trim().split("\n").map((l) => JSON.parse(l));
+      const updateCall = calls.find((a: string[]) => a.slice(0, 2).join(" ") === "phone-numbers update");
+      assert.equal(updateCall, undefined, "expected no Go CLI phone-numbers update call");
+    }
+  });
+
+  it("reports ready=true and 4 completed steps", async () => {
+    capturedRequests = [];
+    const fake = setupFakeTelnyx();
+    const r = await runAsync(["setup-voice", "--json"], fake.env);
+
+    assert.equal(r.status, 0);
+    const data = JSON.parse(r.stdout);
+    assert.equal(data.ready, true);
+    assert.equal(data.steps.length, 4);
+    assert.equal(data.steps[3].status, "completed");
+    assert.equal(data.steps[3].name, "Assign number to connection");
+  });
+});
+
+describe("setup-sms step 4 (AIF-329: REST PATCH instead of Go CLI)", () => {
+  before(async () => { await startMockServer(); });
+  after(async () => { await stopMockServer(); });
+
+  it("PATCHes /phone_numbers/:id with messaging_profile_id instead of Go CLI --messaging-profile-id", async () => {
+    capturedRequests = [];
+    const fake = setupFakeTelnyx();
+    const r = await runAsync(["setup-sms", "--json"], fake.env);
+
+    assert.equal(r.status, 0, `expected exit 0, got ${r.status}: ${r.stderr}`);
+    const patches = patchRequests();
+    assert.equal(patches.length, 1, "expected exactly one PATCH request");
+    assert.match(patches[0].path, /^\/v2\/phone_numbers\//);
+    assert.ok(patches[0].body);
+    assert.ok(patches[0].body!.messaging_profile_id, "expected messaging_profile_id in PATCH body");
+  });
+
+  it("does not invoke Go CLI phone-numbers update with --messaging-profile-id", async () => {
+    const fake = setupFakeTelnyx();
+    await runAsync(["setup-sms", "--json"], fake.env);
+
+    const logPath = fake.logPath;
+    const { readFileSync } = await import("node:fs");
+    if (readFileSync(logPath, "utf8").trim()) {
+      const calls = readFileSync(logPath, "utf8").trim().split("\n").map((l) => JSON.parse(l));
+      const updateCall = calls.find((a: string[]) => a.slice(0, 2).join(" ") === "phone-numbers update");
+      assert.equal(updateCall, undefined, "expected no Go CLI phone-numbers update call");
+    }
+  });
+
+  it("reports ready=true and 4 completed steps", async () => {
+    capturedRequests = [];
+    const fake = setupFakeTelnyx();
+    const r = await runAsync(["setup-sms", "--json"], fake.env);
+
+    assert.equal(r.status, 0);
+    const data = JSON.parse(r.stdout);
+    assert.equal(data.ready, true);
+    assert.equal(data.steps.length, 4);
+    assert.equal(data.steps[3].status, "completed");
+    assert.equal(data.steps[3].name, "Assign number to profile");
+  });
+});
+
+describe("AIF-329 help text (unchanged)", () => {
+  it("still lists setup-voice and setup-sms in help", () => {
+    let stdout = "";
+    let status = 0;
+    try {
+      stdout = execFileSync("npx", ["tsx", cliBin, "help"], { cwd: cliRoot, encoding: "utf8", env: { ...process.env }, timeout: 30000 });
+    } catch (err: any) {
+      status = err.status ?? 1;
+      stdout = err.stdout?.toString() ?? "";
+    }
+    assert.equal(status, 0);
+    assert.match(stdout, /setup-voice/);
+    assert.match(stdout, /setup-sms/);
+  });
+});


### PR DESCRIPTION
## AIF-329 — setup-voice/sms step 4 uses unsupported Go CLI flags

### Problem
`setup-voice` step 4 called `phone-numbers update --force` and `setup-sms` step 4 called `phone-numbers update --messaging-profile-id ... --force`. Neither flag is supported on Go CLI v0.21.0. Numbers were purchased but left unassigned.

### Fix
Replaced both Go CLI calls with direct REST `PATCH /phone_numbers/{id}`:
- **setup-voice**: `PATCH` with `{ connection_id }`
- **setup-sms**: `PATCH` with `{ messaging_profile_id }`
- Dead `telnyxCli` imports removed from both files
- `TelnyxAPIError` added to setup-sms error handler

### Pre-existing bug fixes (from blind agent E2E testing)
1. **`--help`/`-h` per-command** — `tts --help` now shows help instead of running the command. Fixed in `parseFlags` (new `helpRequested` field) + `run()` dispatch. Tested all 39 commands.
2. **Empty string flag values** — `--text ""` was parsed as `true` due to falsy coercion. Fixed the `next` check in `parseFlags`.
3. **`--json` validation errors** — 4 commands (rcs-send, rcs-capabilities, whatsapp-send, setup-10dlc) now output `{"error":"..."}` with `--json` via new `failWith()` helper instead of human-readable stderr.
4. **README** — added tts and tts-voices sections with flags and examples.
5. **client.ts** — accurate comment block listing all REST-swap operations.

### New tests
- `tests/setup-assign-flags.test.ts` — 7 tests (PATCH body, no Go CLI invocation, 4 steps completed)
- `tests/bugfixes.test.ts` — 24 tests (--help on 5 commands, empty string flags, --json errors on 4 commands, README sections)

### Verification
- Typecheck: clean (exit 0)
- Full suite: **228/228 pass, 0 fail**
- E2E human dev: 15/15 PASS
- E2E blind agent: all checks pass (2 minor doc gaps fixed)

### Linear
[AIF-329](https://linear.app/telnyx/issue/AIF-329)