### PR TITLE
fix(aif-328): setup-voice creates Call Control Application

### DIFF
--- a/cli/E2E-BLIND-REPORT-328.md
+++ b/cli/E2E-BLIND-REPORT-328.md
@@ -1,0 +1,404 @@
+# E2E Blind Test Report — AIF-328 setup-voice
+
+**Date:** 2026-07-27  
+**Tester:** Blind agent (zero prior knowledge of codebase)  
+**Branch:** `fix/aif-328-setup-voice-call-control-app`  
+**Commit:** `f3b0e85` (latest on branch)
+
+---
+
+## 1. Discovery
+
+### 1.1 `help` command lists setup-voice with "Call Control App"
+
+**Command:** `npx tsx bin/telnyx-agent.ts help`  
+**Exit code:** 0  
+**Key observations:**  
+- setup-voice listed as: `setup-voice       Zero to voice: create Call Control App, buy number, assign it`
+- Mentions "Call Control App" explicitly ✅
+
+**Verdict:** ✅ PASS
+
+### 1.2 `--webhook` and `--outbound-voice-profile-id` documented in help
+
+**Command:** (same help output as 1.1)  
+**Key observations:**  
+- `--webhook <url>` is listed under "Setup-specific Flags" with description "Webhook URL (setup-voice, default: https://example.com/webhook)"
+- `--outbound-voice-profile-id` is listed with description "Outbound voice profile ID (setup-voice, default: auto-detect first available)"
+- `--webhook-url` is NOT separately listed in the help text (only `--webhook`). The code accepts both `--webhook-url` and `--webhook`. The README documents both. Minor doc gap in help text.
+
+**Verdict:** ⚠️ PASS (minor: `--webhook-url` not explicitly shown in help, only `--webhook` alias)
+
+### 1.3 `setup-voice --help` shows help, does NOT run the command
+
+**Command:** `npx tsx bin/telnyx-agent.ts setup-voice --help`  
+**Exit code:** 0  
+**Key observations:**  
+- Shows the full help text
+- Does NOT execute setup-voice (no API calls, no "Setting up Voice..." output)
+- `helpRequested` flag in parseFlags intercepts `--help` before the command handler runs
+
+**Verdict:** ✅ PASS
+
+### 1.4 `setup-voice -h` shows help
+
+**Command:** `npx tsx bin/telnyx-agent.ts setup-voice -h`  
+**Exit code:** 0  
+**Key observations:**  
+- Identical behavior to `--help` — shows full help text, does not run setup-voice
+
+**Verdict:** ✅ PASS
+
+---
+
+## 2. Source Code Audit — `src/commands/setup-voice.ts`
+
+### 2.1 Step 1: GETs /outbound_voice_profiles (or uses --outbound-voice-profile-id)
+
+**Key observations:**  
+- When `--outbound-voice-profile-id` is NOT provided: `await client.get("/outbound_voice_profiles")` and takes `profilesData[0].id`
+- When `--outbound-voice-profile-id` IS provided: skips the GET entirely, uses the provided ID
+- Empty profiles list throws clear error: "No outbound voice profiles found. Create one in the Telnyx portal or pass --outbound-voice-profile-id."
+
+**Verdict:** ✅ PASS
+
+### 2.2 Step 2: POSTs to /call_control_applications (NOT /credential_connections)
+
+**Key observations:**  
+- `await client.post("/call_control_applications", appBody)` — correct endpoint
+- No reference to `/credential_connections` anywhere in the source file
+- grep for `credential_connection` in all `src/` files: zero results
+
+**Verdict:** ✅ PASS
+
+### 2.3 Step 2 body includes application_name, webhook_event_url, outbound.outbound_voice_profile_id
+
+**Key observations:**  
+```typescript
+const appBody = {
+  application_name: connectionName,
+  webhook_event_url: webhookUrl,
+  outbound: {
+    outbound_voice_profile_id: outboundProfileId,
+  },
+};
+```
+All three required fields present. ✅
+
+**Verdict:** ✅ PASS
+
+### 2.4 Step 5: PATCHes /phone_numbers/:id with connection_id from the Call Control App
+
+**Key observations:**  
+- `await client.patch(`/phone_numbers/${phoneNumberId}`, { connection_id: connectionId })`
+- `connectionId` is set from `String(appData.id)` where `appData` comes from the CCA POST response
+
+**Verdict:** ✅ PASS
+
+### 2.5 Does NOT import or call telnyxCli for the REST path
+
+**Key observations:**  
+- Imports: `TelnyxClient`, `TelnyxAPIError` from `../client.ts` (REST client)
+- Imports: `TelnyxCLIError` from `../telnyx-cli.ts` (only for error type detection in `errorMsg`)
+- Imports: `searchAndBuyNumber` from `../utils/number-order.ts` (wraps Go CLI for number search/buy only)
+- All REST calls (GET/POST/PATCH) go through `TelnyxClient`, not the Go CLI
+
+**Verdict:** ✅ PASS
+
+### 2.6 Error handler covers TelnyxAPIError
+
+**Key observations:**  
+```typescript
+function errorMsg(err: unknown): string {
+  if (err instanceof TelnyxAPIError) return `${err.detail} (HTTP ${err.statusCode})`;
+  if (err instanceof TelnyxCLIError) return err.stderr || err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+```
+Covers TelnyxAPIError, TelnyxCLIError, generic Error, and unknown. ✅
+
+**Verdict:** ✅ PASS
+
+### 2.7 SetupVoiceResult interface has required fields
+
+**Key observations:**  
+```typescript
+interface SetupVoiceResult {
+  connection_id: string;
+  connection_name: string;
+  phone_number: string;
+  phone_number_id: string;
+  webhook_url: string;
+  outbound_voice_profile_id: string;
+  ready: boolean;
+  steps: StepResult[];
+}
+```
+All required fields present: `connection_id` ✅, `phone_number` ✅, `webhook_url` ✅, `outbound_voice_profile_id` ✅, `ready` ✅  
+Extra fields (`connection_name`, `phone_number_id`, `steps`) are additive and don't break the contract.
+
+**Verdict:** ✅ PASS
+
+### 2.8 No leftover references to sip_username, sip_password, or credential connections
+
+**Key observations:**  
+- `grep -rn "sip_username|sip_password|credential_connection" src/commands/setup-voice.ts` → zero results
+- `grep -rn "credential_connection" src/ --include="*.ts"` → zero results across all source files
+- Note: `src/utils/output.ts` has `sipPassword` in the `isSensitiveKey` redaction function — this is legacy redaction support, NOT credential connection creation. Not a bug.
+
+**Verdict:** ✅ PASS
+
+---
+
+## 3. No API Key Tests
+
+### 3.1 No API key with --json
+
+**Command:** `env -u TELNYX_API_KEY HOME=/tmp/nohome npx tsx bin/telnyx-agent.ts setup-voice --json`  
+**Exit code:** 1  
+**Key observations:**  
+- Output: `Fatal: No Telnyx API key found.\nSet TELNYX_API_KEY environment variable or configure ~/.config/telnyx/config.json`
+- Clean failure, exit code 1, no partial output
+
+**Verdict:** ✅ PASS
+
+### 3.2 No API key without --json
+
+**Command:** `env -u TELNYX_API_KEY HOME=/tmp/nohome npx tsx bin/telnyx-agent.ts setup-voice`  
+**Exit code:** 1  
+**Key observations:**  
+- Same clear auth error message
+- Exit code 1
+
+**Verdict:** ✅ PASS
+
+---
+
+## 4. README Check
+
+### 4.1 setup-voice section mentions "Call Control Application", webhook, outbound voice profile
+
+**Key observations:**  
+- "Creates a Call Control Application (with webhook URL + outbound voice profile), searches for a voice-capable number, buys it, and assigns it to the app."
+- "The output `connection_id` works directly with `call-dial`."
+- Documents `--webhook-url (or --webhook)` and `--outbound-voice-profile-id` and `--country`
+
+**Verdict:** ✅ PASS
+
+### 4.2 Examples include --outbound-voice-profile-id
+
+**Key observations:**  
+```bash
+telnyx-agent setup-voice
+telnyx-agent setup-voice --webhook https://example.com/calls
+telnyx-agent setup-voice --outbound-voice-profile-id 2927726759434519857
+telnyx-agent setup-voice --country US --json
+```
+
+**Verdict:** ✅ PASS
+
+### 4.3 Output format docs match SetupVoiceResult interface
+
+**Key observations:**  
+README says: `Output: { connection_id, connection_name, phone_number, phone_number_id, webhook_url, outbound_voice_profile_id, ready }`  
+Source has: `interface SetupVoiceResult { connection_id, connection_name, phone_number, phone_number_id, webhook_url, outbound_voice_profile_id, ready, steps }`  
+The `steps` field is extra in the actual interface but not listed in the README. This is an additive difference — the README shows the key fields, the `steps` array is diagnostic. Not a breaking issue.
+
+**Verdict:** ✅ PASS
+
+---
+
+## 5. Test Suite
+
+### 5.1 `tests/setup-voice.test.ts` audit
+
+| Test | What it checks | Verdict |
+|------|----------------|--------|
+| POSTs to /call_control_applications | Asserts POST to `/v2/call_control_applications` and zero POSTs to `/v2/credential_connections` | ✅ PASS |
+| webhook_event_url and outbound_voice_profile_id in body | Asserts `body.webhook_event_url` and `body.outbound.outbound_voice_profile_id` | ✅ PASS |
+| GETs /outbound_voice_profiles when no flag | Asserts one GET to `/v2/outbound_voice_profiles` | ✅ PASS |
+| Skips GET when --outbound-voice-profile-id provided | Asserts zero GETs, uses explicit ID in CCA body | ✅ PASS |
+| Default webhook URL when no flag | Asserts `body.webhook_event_url === "https://example.com/webhook"` | ✅ PASS |
+| --webhook alias works | Asserts `body.webhook_event_url === "https://alias.example.com/hook"` | ✅ PASS |
+| PATCHes /phone_numbers/:id with CCA connection_id | Asserts PATCH with `connection_id === "cca_abc123"` | ✅ PASS |
+| Does NOT POST to /credential_connections | Separate explicit assertion | ✅ PASS |
+| JSON output has connection_id, phone_number, webhook_url, outbound_voice_profile_id, ready | Parses stdout JSON and asserts each field | ✅ PASS |
+| 5 steps with correct names | Asserts step names and all `status: "completed"` | ✅ PASS |
+| Help lists setup-voice and --outbound-voice-profile-id | Runs `help` command, checks output | ✅ PASS |
+
+### 5.2 `tests/setup-voice-edge.test.ts` audit
+
+| Test | What it checks | Verdict |
+|------|----------------|--------|
+| Empty outbound voice profiles → clear error | Sets mode="empty-profiles", asserts exit 1, `ready: false`, error matches /No outbound voice profiles found/ | ✅ PASS |
+| CCA POST 422 → error in JSON | Sets mode="cca-error", asserts exit 1, error matches /Invalid webhook URL/ and /HTTP 422/ | ✅ PASS |
+| PATCH error → step 5 failure | Sets mode="patch-error", asserts exit 1, step 5 status="failed", connection_id still set | ✅ PASS |
+| Human mode: empty profiles → prints error | No --json, asserts exit 1, stdout matches /No outbound voice profiles found/ | ✅ PASS |
+
+### 5.3 `npm test` run
+
+**Command:** `npm test`  
+**Exit code:** 0  
+**Results:** 212 tests, 212 pass, 0 fail, 0 cancelled, 0 skipped  
+**Duration:** ~64s
+
+**Verdict:** ✅ PASS (all tests green)
+
+---
+
+## 6. Client.ts Check
+
+### 6.1 TELNYX_API_BASE_URL env support
+
+**Key observations:**  
+```typescript
+this.baseUrl = (baseUrl ?? process.env.TELNYX_API_BASE_URL ?? "https://api.telnyx.com/v2").replace(/\/$/, "");
+```
+- Supports `TELNYX_API_BASE_URL` environment variable
+- Defaults to `https://api.telnyx.com/v2`
+- Strips trailing slash
+
+**Verdict:** ✅ PASS
+
+### 6.2 Comment block mentions call_control_applications and outbound_voice_profiles
+
+**Key observations:**  
+The comment block in client.ts lists operations that use direct REST:
+- `POST /call_control_applications (setup-voice — Go CLI creates credential connections, not Call Control Apps)` ✅
+- `GET /outbound_voice_profiles (setup-voice — needed to resolve default outbound profile)` ✅
+
+**Verdict:** ✅ PASS
+
+---
+
+## 7. Index.ts Check
+
+### 7.1 helpRequested intercept is present
+
+**Key observations:**  
+```typescript
+const { command, flags, occurrences, helpRequested } = parseFlags(argv);
+// ...
+if (helpRequested) {
+  console.log(HELP);
+  return;
+}
+```
+- `parseFlags` returns `helpRequested: boolean`
+- Checked before command dispatch
+- Works for ALL commands (verified: `status --help`, `tts --help`, `setup-sms -h` all show help)
+
+**Verdict:** ✅ PASS
+
+### 7.2 setup-voice help text mentions Call Control App, --webhook, --outbound-voice-profile-id
+
+**Key observations:**  
+- Help line: `setup-voice       Zero to voice: create Call Control App, buy number, assign it` ✅
+- Setup-specific Flags: `--webhook <url>` ✅, `--outbound-voice-profile-id` ✅
+- Examples include: `telnyx-agent setup-voice`, `telnyx-agent setup-voice --webhook https://example.com/calls`, `telnyx-agent setup-voice --outbound-voice-profile-id 2927726759434519857`
+
+**Verdict:** ✅ PASS
+
+---
+
+## 8. Try to Break It
+
+### 8.1 Invalid country `--country XX`
+
+**Command:** `npx tsx bin/telnyx-agent.ts setup-voice --json --country XX`  
+**Exit code:** 1  
+**Key observations:**  
+- Steps 1 and 2 succeed (outbound profile resolved, CCA created)
+- Step 3 fails (number search/buy fails — in this environment, the Go CLI `available-phone-numbers:list` command isn't found)
+- JSON output includes `status: "failed"`, `ready: false`, error detail
+- Exit code 1
+- Fails gracefully — no crash, no unhandled exception, structured JSON error
+
+**Verdict:** ✅ PASS (fails gracefully with exit 1)
+
+### 8.2 Other commands with --help/-h still work
+
+**Commands tested:**  
+- `status --help` → shows help ✅
+- `tts --help` → shows help ✅
+- `setup-sms -h` → shows help ✅
+
+**Key observations:**  
+- `helpRequested` is a global feature in `parseFlags`, not specific to setup-voice
+- All commands respect `--help` and `-h`
+
+**Verdict:** ✅ PASS
+
+### 8.3 `--webhook-url` flag (not just `--webhook`)
+
+**Command:** `npx tsx bin/telnyx-agent.ts setup-voice --webhook-url https://test.example.com/whook --json`  
+**Exit code:** 1 (fails at step 3 due to Go CLI not installed, not a code bug)  
+**Key observations:**  
+- `--webhook-url` is accepted by the code (`flags["webhook-url"]` in setup-voice.ts)
+- Step 2 (CCA creation) succeeded with the webhook URL
+- Confirmed both `--webhook-url` and `--webhook` are accepted as aliases
+
+**Verdict:** ✅ PASS
+
+---
+
+## Issues Found
+
+### Issue 1: `--webhook-url` not explicitly listed in help text (MINOR)
+
+**Severity:** Low (documentation gap)  
+**Description:** The code accepts both `--webhook-url` and `--webhook` as flags. The README documents both (`--webhook-url (or --webhook)`). However, the help text only lists `--webhook <url>` in the Setup-specific Flags section. A user who reads the README and then runs `help` might not immediately connect that `--webhook` is the same as `--webhook-url`.  
+**Recommendation:** Add `--webhook-url` as an alias note in the help text, e.g.:
+```
+--webhook-url <url>   Webhook URL (setup-voice, alias: --webhook, default: https://example.com/webhook)
+```
+
+### Issue 2: `isSensitiveKey` still references `sipPassword` (OBSERVATION, NOT A BUG)
+
+**Severity:** None (legacy redaction support)  
+**Description:** `src/utils/output.ts` has `sipPassword` in the `isSensitiveKey` regex for redacting sensitive values in output. This is not a code issue — it's just redaction safety for any field that might contain SIP passwords. No credential connections are created.  
+**Recommendation:** No action needed. Could be cleaned up in a future pass if desired.
+
+---
+
+## Summary
+
+| # | Test | Verdict |
+|---|------|---------|
+| 1.1 | help lists setup-voice with "Call Control App" | ✅ PASS |
+| 1.2 | --webhook/--outbound-voice-profile-id in help | ⚠️ PASS (minor: --webhook-url not shown) |
+| 1.3 | setup-voice --help shows help, doesn't run | ✅ PASS |
+| 1.4 | setup-voice -h shows help | ✅ PASS |
+| 2.1 | Step 1: GETs /outbound_voice_profiles or uses flag | ✅ PASS |
+| 2.2 | Step 2: POSTs to /call_control_applications | ✅ PASS |
+| 2.3 | Step 2 body: application_name, webhook_event_url, outbound profile | ✅ PASS |
+| 2.4 | Step 5: PATCHes /phone_numbers/:id with CCA connection_id | ✅ PASS |
+| 2.5 | Does NOT use telnyxCli for REST path | ✅ PASS |
+| 2.6 | Error handler covers TelnyxAPIError | ✅ PASS |
+| 2.7 | SetupVoiceResult has all required fields | ✅ PASS |
+| 2.8 | No leftover sip_username/sip_password/credential refs | ✅ PASS |
+| 3.1 | No API key + --json → clear auth error, exit 1 | ✅ PASS |
+| 3.2 | No API key + human → clear auth error, exit 1 | ✅ PASS |
+| 4.1 | README mentions CCA, webhook, outbound profile | ✅ PASS |
+| 4.2 | README examples include --outbound-voice-profile-id | ✅ PASS |
+| 4.3 | README output format matches SetupVoiceResult | ✅ PASS |
+| 5.1 | setup-voice.test.ts: all assertions verified | ✅ PASS |
+| 5.2 | setup-voice-edge.test.ts: all edge cases verified | ✅ PASS |
+| 5.3 | npm test: 212 pass, 0 fail | ✅ PASS |
+| 6.1 | TELNYX_API_BASE_URL env support in client.ts | ✅ PASS |
+| 6.2 | client.ts comment mentions call_control_applications | ✅ PASS |
+| 7.1 | helpRequested intercept in index.ts | ✅ PASS |
+| 7.2 | Help text mentions CCA, --webhook, --outbound-voice-profile-id | ✅ PASS |
+| 8.1 | --country XX fails gracefully | ✅ PASS |
+| 8.2 | Other commands respect --help/-h | ✅ PASS |
+| 8.3 | --webhook-url flag works as alias | ✅ PASS |
+
+### Overall Verdict: ✅ PASS
+
+**Tests passed:** 26/26  
+**Issues found:** 1 minor (help text doesn't list `--webhook-url` explicitly)  
+**Bugs found:** 0  
+**Test suite:** 212/212 pass, 0 fail
+
+The AIF-328 fix is solid. `setup-voice` correctly creates a Call Control Application (not a credential connection), the output `connection_id` is usable with `call-dial`, the test suite is comprehensive, and edge cases are handled gracefully.

--- a/cli/E2E-HUMAN-REPORT-328.md
+++ b/cli/E2E-HUMAN-REPORT-328.md
@@ -1,0 +1,83 @@
+# E2E HUMAN DEV REPORT — AIF-328
+
+**Branch:** `fix/aif-328-setup-voice-call-control-app`
+**Date:** 2026-07-27
+**Tester:** Agent Zero (human dev walkthrough)
+
+## Summary
+
+All tests PASS. The fix replaces credential connection creation with Call Control Application creation, making `setup-voice` output compatible with `call-dial`.
+
+## Test Results
+
+### 1. Typecheck
+- `npm run typecheck` → PASS (0 errors)
+
+### 2. Help text
+- `help` lists `setup-voice` with "Zero to voice: create Call Control App, buy number, assign it" ✓
+- `--webhook <url>` documented with default `https://example.com/webhook` ✓
+- `--outbound-voice-profile-id` documented with "auto-detect first available" ✓
+- Examples include `--outbound-voice-profile-id 2927726759434519857` ✓
+
+### 3. Per-command --help
+- `setup-voice --help` → shows help, does NOT run command ✓
+- `setup-voice -h` → shows help ✓
+- All 39 commands tested with `--help` → 39/39 PASS ✓
+- 4 commands tested with `-h` → 4/4 PASS ✓
+
+### 4. No API key
+- `env -u TELNYX_API_KEY setup-voice --json` → "Fatal: No Telnyx API key found." exit 1 ✓
+- `env -u TELNYX_API_KEY setup-voice` (human mode) → same clean error ✓
+
+### 5. Source code audit
+- Step 1: GETs `/outbound_voice_profiles` or uses `--outbound-voice-profile-id` ✓
+- Step 2: POSTs to `/call_control_applications` (NOT `/credential_connections`) ✓
+- Step 2 body includes `application_name`, `webhook_event_url`, `outbound.outbound_voice_profile_id` ✓
+- Step 5: PATCHes `/phone_numbers/:id` with `connection_id` from CCA ✓
+- NO `telnyxCli` import ✓
+- `TelnyxAPIError` handled in errorMsg ✓
+- `SetupVoiceResult` interface: `connection_id`, `connection_name`, `phone_number`, `phone_number_id`, `webhook_url`, `outbound_voice_profile_id`, `ready`, `steps` ✓
+- Zero references to `sip_username`, `sip_password`, or `credential_connections` ✓
+
+### 6. README
+- Mentions "Call Control Application" ✓
+- Mentions webhook URL + outbound voice profile ✓
+- Examples include `--outbound-voice-profile-id` ✓
+- Flags documented: `--webhook-url`/`--webhook`, `--outbound-voice-profile-id`, `--country` ✓
+- Output format matches `SetupVoiceResult` interface ✓
+
+### 7. Client.ts
+- `TELNYX_API_BASE_URL` env support added ✓
+- Comment block mentions `call_control_applications` and `outbound_voice_profiles` ✓
+
+### 8. Index.ts
+- `helpRequested` intercept present ✓
+- Setup-voice help text mentions Call Control App ✓
+
+### 9. Test suite
+- `tests/setup-voice.test.ts` — 11 tests, all PASS ✓
+  - POSTs to /call_control_applications (not /credential_connections) ✓
+  - webhook_event_url + outbound_voice_profile_id in body ✓
+  - GETs /outbound_voice_profiles when no --outbound-voice-profile-id ✓
+  - Skips GET when --outbound-voice-profile-id provided ✓
+  - Default webhook URL used ✓
+  - --webhook alias works ✓
+  - PATCH /phone_numbers with CCA connection_id ✓
+  - Zero POSTs to /credential_connections ✓
+  - JSON output has connection_id, phone_number, webhook_url, outbound_voice_profile_id ✓
+  - 5 steps with correct names ✓
+  - Help lists --outbound-voice-profile-id ✓
+
+- `tests/setup-voice-edge.test.ts` — 4 tests, all PASS ✓
+  - Empty outbound voice profiles → clear error ✓
+  - CCA POST 422 → error in JSON ✓
+  - PATCH error → step 5 failure, connection_id still set ✓
+  - Human mode error output ✓
+
+- Full suite: 212/212 PASS, 0 FAIL ✓
+
+### 10. Try to break it
+- `setup-voice --json --country XX` without API key → clean auth error ✓
+- All 39 commands with `--help` → all show help ✓
+
+## Verdict: PASS ✅

--- a/cli/README.md
+++ b/cli/README.md
@@ -53,15 +53,21 @@ Output: `{ profile_id, phone_number, ready: true }`
 
 **One command: zero to making/receiving calls.**
 
-Creates a SIP credential connection, searches for a voice-capable number, buys it, and assigns it to the connection.
+Creates a Call Control Application (with webhook URL + outbound voice profile), searches for a voice-capable number, buys it, and assigns it to the app. The output `connection_id` works directly with `call-dial`.
 
 ```bash
 telnyx-agent setup-voice
 telnyx-agent setup-voice --webhook https://example.com/calls
+telnyx-agent setup-voice --outbound-voice-profile-id 2927726759434519857
 telnyx-agent setup-voice --country US --json
 ```
 
-Output: `{ connection_id, phone_number, sip_username, sip_password }`
+**Flags:**
+- `--webhook-url` (or `--webhook`) — Webhook URL for call events (default: `https://example.com/webhook`)
+- `--outbound-voice-profile-id` — Outbound voice profile ID (default: auto-detect first available)
+- `--country` — ISO country code for number search (default: `US`)
+
+Output: `{ connection_id, connection_name, phone_number, phone_number_id, webhook_url, outbound_voice_profile_id, ready }`
 
 ### `telnyx-agent setup-iot`
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "tsx bin/telnyx-agent.ts",
-    "test": "tsx --test tests/ai.test.ts tests/edge-handoff.test.ts tests/fax.test.ts tests/integration.test.ts tests/iot.test.ts tests/numbers.test.ts tests/rcs.test.ts tests/setup-10dlc.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
+    "test": "tsx --test tests/ai.test.ts tests/edge-handoff.test.ts tests/fax.test.ts tests/integration.test.ts tests/iot.test.ts tests/numbers.test.ts tests/rcs.test.ts tests/setup-10dlc.test.ts tests/setup-voice.test.ts tests/setup-voice-edge.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
     "typecheck": "tsc --noEmit",
     "postinstall": "tsx scripts/postinstall.ts",
     "build": "npm run typecheck"

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -11,6 +11,14 @@
  * 7. POST /x402/credit_account/quote (fund-account)
  * 8. POST /x402/credit_account (fund-account)
  *
+ * Additionally, some operations use direct REST due to Go CLI bugs (see commit history):
+ * - POST /text-to-speech/speech (tts — Go CLI does not map --voice to the API body)
+ * - POST /messages (schedule-sms — Go CLI hits nonexistent /messages/schedule endpoint)
+ * - POST /verify_profiles (setup-verify — Go CLI sends no channel settings)
+ * - PATCH /phone_numbers/:id (setup-voice, setup-sms — Go CLI doesn't support --force / --messaging-profile-id)
+ * - POST /call_control_applications (setup-voice — Go CLI creates credential connections, not Call Control Apps)
+ * - GET /outbound_voice_profiles (setup-voice — needed to resolve default outbound profile)
+ *
  * All other operations go through the telnyx CLI wrapper (see telnyx-cli.ts).
  */
 
@@ -47,7 +55,7 @@ export class TelnyxClient {
 
   constructor(apiKey?: string, baseUrl?: string, timeout?: number) {
     this.apiKey = apiKey || resolveApiKey();
-    this.baseUrl = (baseUrl ?? "https://api.telnyx.com/v2").replace(/\/$/, "");
+    this.baseUrl = (baseUrl ?? process.env.TELNYX_API_BASE_URL ?? "https://api.telnyx.com/v2").replace(/\/$/, "");
     this.timeout = timeout ?? 30000;
     this.telemetry = new TelemetryReporter();
     this.friction = new FrictionReporter();

--- a/cli/src/commands/setup-voice.ts
+++ b/cli/src/commands/setup-voice.ts
@@ -2,14 +2,18 @@
  * telnyx-agent setup-voice — Zero to making/receiving calls in one command.
  *
  * Steps:
- * 1. Create a credential connection (direct API — CLI doesn't expose user_name/password for SIP creds)
- * 2. Search for a phone number with voice capability (via telnyx CLI)
- * 3. Buy the number (via telnyx CLI)
- * 4. Assign number to connection (via telnyx CLI)
+ * 1. Resolve outbound voice profile (GET /outbound_voice_profiles, or use --outbound-voice-profile-id)
+ * 2. Create a Call Control Application (POST /call_control_applications with webhook + outbound profile)
+ * 3. Search for a phone number with voice capability (via telnyx CLI)
+ * 4. Buy the number (via telnyx CLI)
+ * 5. Assign number to the Call Control App (PATCH /phone_numbers/:id)
+ *
+ * AIF-328: Previously created a credential connection which call-dial cannot
+ * use. call-dial requires a Call Control Application with a valid webhook URL.
  */
 
 import { TelnyxClient, TelnyxAPIError } from "../client.ts";
-import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
+import { TelnyxCLIError } from "../telnyx-cli.ts";
 import { printStep, printSuccess, printError, outputJson, type StepResult } from "../utils/output.ts";
 import { searchAndBuyNumber } from "../utils/number-order.ts";
 
@@ -18,9 +22,8 @@ interface SetupVoiceResult {
   connection_name: string;
   phone_number: string;
   phone_number_id: string;
-  sip_username: string;
-  sip_password: string;
-  webhook_url: string | null;
+  webhook_url: string;
+  outbound_voice_profile_id: string;
   ready: boolean;
   steps: StepResult[];
 }
@@ -29,8 +32,9 @@ export async function setupVoiceCommand(flags: Record<string, string | boolean>)
   const client = new TelnyxClient();
   const jsonOutput = flags.json === true;
   const country = (flags.country as string) || "US";
-  const webhookUrl = (flags.webhook as string) || null;
-  const totalSteps = 4;
+  const webhookUrl = (flags["webhook-url"] as string) || (flags.webhook as string) || "https://example.com/webhook";
+  const outboundProfileIdFlag = (flags["outbound-voice-profile-id"] as string) || "";
+  const totalSteps = 5;
   const steps: StepResult[] = [];
   const startTime = Date.now();
 
@@ -38,43 +42,56 @@ export async function setupVoiceCommand(flags: Record<string, string | boolean>)
   let connectionName = "";
   let phoneNumber = "";
   let phoneNumberId = "";
-  let sipUsername = "";
-  let sipPassword = "";
+  let outboundProfileId = "";
 
   try {
-    // Step 1: Create credential connection (direct API — need SIP username/password)
-    const ts = new Date().toISOString().slice(0, 19).replace("T", " ");
-    connectionName = `Agent Voice Connection - ${ts}`;
     if (!jsonOutput) console.log("\n🚀 Setting up Voice...\n");
 
+    // Step 1: Resolve outbound voice profile
     const step1Start = Date.now();
     try {
-      // Generate SIP credentials — username must be alphanumeric only
-      const generatedUser = "agent" + Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
-      const generatedPass = "Ag" + Math.random().toString(36).slice(2, 10) + "1!";
-      const connBody: Record<string, unknown> = {
-        connection_name: connectionName,
-        active: true,
-        user_name: generatedUser,
-        password: generatedPass,
-      };
-      if (webhookUrl) {
-        connBody.webhook_event_url = webhookUrl;
+      if (outboundProfileIdFlag) {
+        outboundProfileId = outboundProfileIdFlag;
+      } else {
+        // Fetch the first available outbound voice profile
+        const profilesRes = await client.get("/outbound_voice_profiles");
+        const profilesData = profilesRes.data as Record<string, unknown>[];
+        if (!profilesData || profilesData.length === 0) {
+          throw new Error("No outbound voice profiles found. Create one in the Telnyx portal or pass --outbound-voice-profile-id.");
+        }
+        outboundProfileId = String(profilesData[0].id);
       }
-      const connRes = await client.post("/credential_connections", connBody);
-      const connData = connRes.data as Record<string, unknown>;
-      connectionId = String(connData.id);
-      sipUsername = String(connData.user_name ?? generatedUser);
-      sipPassword = String(connData.password ?? generatedPass);
-      steps.push({ step: 1, name: "Create credential connection", status: "completed", resourceId: connectionId, detail: connectionName, elapsedMs: Date.now() - step1Start });
+      steps.push({ step: 1, name: "Resolve outbound voice profile", status: "completed", resourceId: outboundProfileId, elapsedMs: Date.now() - step1Start });
     } catch (err) {
-      steps.push({ step: 1, name: "Create credential connection", status: "failed", detail: errorMsg(err), elapsedMs: Date.now() - step1Start });
+      steps.push({ step: 1, name: "Resolve outbound voice profile", status: "failed", detail: errorMsg(err), elapsedMs: Date.now() - step1Start });
       throw err;
     }
     if (!jsonOutput) printStep(steps[steps.length - 1], totalSteps);
 
-    // Steps 2+3: Search and buy number via CLI (handles 409 retries automatically)
+    // Step 2: Create Call Control Application
     const step2Start = Date.now();
+    try {
+      const ts = new Date().toISOString().slice(0, 19).replace("T", " ");
+      connectionName = `Agent Voice App - ${ts}`;
+      const appBody: Record<string, unknown> = {
+        application_name: connectionName,
+        webhook_event_url: webhookUrl,
+        outbound: {
+          outbound_voice_profile_id: outboundProfileId,
+        },
+      };
+      const appRes = await client.post("/call_control_applications", appBody);
+      const appData = appRes.data as Record<string, unknown>;
+      connectionId = String(appData.id);
+      steps.push({ step: 2, name: "Create Call Control Application", status: "completed", resourceId: connectionId, detail: connectionName, elapsedMs: Date.now() - step2Start });
+    } catch (err) {
+      steps.push({ step: 2, name: "Create Call Control Application", status: "failed", detail: errorMsg(err), elapsedMs: Date.now() - step2Start });
+      throw err;
+    }
+    if (!jsonOutput) printStep(steps[steps.length - 1], totalSteps);
+
+    // Steps 3+4: Search and buy number via CLI
+    const step3Start = Date.now();
     try {
       const result = await searchAndBuyNumber(country, {
         features: "voice",
@@ -83,10 +100,10 @@ export async function setupVoiceCommand(flags: Record<string, string | boolean>)
       });
       phoneNumber = result.phoneNumber;
       phoneNumberId = result.phoneNumberId;
-      steps.push({ step: 2, name: "Search for number", status: "completed", detail: phoneNumber, elapsedMs: Date.now() - step2Start });
-      steps.push({ step: 3, name: "Buy number", status: "completed", resourceId: phoneNumberId, detail: phoneNumber, elapsedMs: 0 });
+      steps.push({ step: 3, name: "Search for number", status: "completed", detail: phoneNumber, elapsedMs: Date.now() - step3Start });
+      steps.push({ step: 4, name: "Buy number", status: "completed", resourceId: phoneNumberId, detail: phoneNumber, elapsedMs: 0 });
     } catch (err) {
-      steps.push({ step: 2, name: "Search & buy number", status: "failed", detail: errorMsg(err), elapsedMs: Date.now() - step2Start });
+      steps.push({ step: 3, name: "Search & buy number", status: "failed", detail: errorMsg(err), elapsedMs: Date.now() - step3Start });
       throw err;
     }
     if (!jsonOutput) {
@@ -94,20 +111,17 @@ export async function setupVoiceCommand(flags: Record<string, string | boolean>)
       printStep(steps[steps.length - 1], totalSteps);
     }
 
-    // Step 4: Assign number to connection via CLI
-    const step4Start = Date.now();
+    // Step 5: Assign number to Call Control Application
+    const step5Start = Date.now();
     try {
-      if (phoneNumber) {
-        await telnyxCli([
-          "phone-numbers", "update",
-          "--phone-number-id", phoneNumber,
-          "--connection-id", connectionId,
-          "--force",
-        ]);
+      if (phoneNumberId) {
+        await client.patch(`/phone_numbers/${phoneNumberId}`, {
+          connection_id: connectionId,
+        });
       }
-      steps.push({ step: 4, name: "Assign number to connection", status: "completed", elapsedMs: Date.now() - step4Start });
+      steps.push({ step: 5, name: "Assign number to Call Control App", status: "completed", elapsedMs: Date.now() - step5Start });
     } catch (err) {
-      steps.push({ step: 4, name: "Assign number to connection", status: "failed", detail: errorMsg(err), elapsedMs: Date.now() - step4Start });
+      steps.push({ step: 5, name: "Assign number to Call Control App", status: "failed", detail: errorMsg(err), elapsedMs: Date.now() - step5Start });
       throw err;
     }
     if (!jsonOutput) printStep(steps[steps.length - 1], totalSteps);
@@ -117,9 +131,8 @@ export async function setupVoiceCommand(flags: Record<string, string | boolean>)
       connection_name: connectionName,
       phone_number: phoneNumber,
       phone_number_id: phoneNumberId,
-      sip_username: sipUsername,
-      sip_password: sipPassword,
       webhook_url: webhookUrl,
+      outbound_voice_profile_id: outboundProfileId,
       ready: true,
       steps,
     };
@@ -129,14 +142,13 @@ export async function setupVoiceCommand(flags: Record<string, string | boolean>)
     } else {
       printSuccess("Voice setup complete!", {
         "Connection ID": connectionId,
-        "Connection Name": connectionName,
+        "App Name": connectionName,
         "Phone Number": phoneNumber,
-        "SIP Username": sipUsername || "(see portal)",
-        "SIP Password": sipPassword || "(see portal)",
-        "Webhook URL": webhookUrl || "(none)",
+        "Webhook URL": webhookUrl,
+        "Outbound Profile": outboundProfileId,
         Ready: "✓",
       });
-      console.log("  ⚠️  Save your SIP credentials — they cannot be retrieved later.\n");
+      console.log("  💡 Use the Connection ID above with: telnyx-agent call-dial --connection-id " + connectionId + " ...\n");
     }
   } catch (err) {
     const result = {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -59,7 +59,7 @@ Usage:
 
 Commands:
   setup-sms         Zero to SMS: create profile, buy number, assign it
-  setup-voice       Zero to voice: create connection, buy number, assign it
+  setup-voice       Zero to voice: create Call Control App, buy number, assign it
   setup-iot         Zero to IoT: list SIMs, create group, activate SIM
   list-sim-cards    List IoT SIM cards with filters and pagination
   retrieve-sim-card Retrieve one IoT SIM card by ID
@@ -107,7 +107,8 @@ Global Flags:
   --country <code>  Country code for number search (default: US)
 
 Setup-specific Flags:
-  --webhook <url>   Webhook URL (setup-voice)
+  --webhook-url <url>          Webhook URL for setup-voice (alias: --webhook; default: https://example.com/webhook)
+  --outbound-voice-profile-id  Outbound voice profile ID (setup-voice, default: auto-detect first available)
   --instructions    AI assistant instructions (setup-ai)
   --name            AI assistant name (setup-ai)
   --network-id      Use existing network (setup-wireguard)
@@ -352,7 +353,9 @@ Examples:
   telnyx-agent status --json
   telnyx-agent capabilities
   telnyx-agent setup-sms --country US
+  telnyx-agent setup-voice
   telnyx-agent setup-voice --webhook https://example.com/calls
+  telnyx-agent setup-voice --outbound-voice-profile-id 2927726759434519857
   telnyx-agent setup-ai --instructions "You are a pizza ordering bot"
   telnyx-agent setup-porting --phone-numbers +131****0001,+131****0002 --customer-name "Acme Corp"
   telnyx-agent verify-send --phone-number +131****0001 --verify-profile-id prof_xxx --method sms
@@ -487,9 +490,15 @@ const COMMANDS: Record<string, (
 };
 
 export async function run(argv: string[]): Promise<void> {
-  const { command, flags, occurrences } = parseFlags(argv);
+  const { command, flags, occurrences, helpRequested } = parseFlags(argv);
 
   if (command === "help" || command === "--help" || command === "-h" || !command) {
+    console.log(HELP);
+    return;
+  }
+
+  // Per-command help: `telnyx-agent tts --help` or `telnyx-agent tts -h`
+  if (helpRequested) {
     console.log(HELP);
     return;
   }

--- a/cli/src/utils/output.ts
+++ b/cli/src/utils/output.ts
@@ -71,17 +71,23 @@ export function parseFlags(args: string[]): {
   command: string;
   flags: Record<string, string | boolean>;
   occurrences: Record<string, Array<string | boolean>>;
+  helpRequested: boolean;
 } {
   const command = args[0] ?? "help";
   const flags: Record<string, string | boolean> = {};
   const occurrences: Record<string, Array<string | boolean>> = Object.create(null);
+  let helpRequested = false;
 
   for (let i = 1; i < args.length; i++) {
     const arg = args[i];
+    if (arg === "--help" || arg === "-h") {
+      helpRequested = true;
+      continue;
+    }
     if (arg.startsWith("--")) {
       const key = arg.slice(2);
       const next = args[i + 1];
-      if (next && !next.startsWith("--")) {
+      if (next !== undefined && next !== null && !next.startsWith("--")) {
         flags[key] = next;
         (occurrences[key] ??= []).push(next);
         i++;
@@ -92,5 +98,5 @@ export function parseFlags(args: string[]): {
     }
   }
 
-  return { command, flags, occurrences };
+  return { command, flags, occurrences, helpRequested };
 }

--- a/cli/tests/setup-voice-edge.test.ts
+++ b/cli/tests/setup-voice-edge.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Edge case tests for setup-voice AIF-328:
+ * - Empty outbound voice profiles list
+ * - API error on call_control_applications POST
+ * - API error on phone_numbers PATCH
+ */
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createServer, type Server } from "node:http";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliRoot = join(__dirname, "..");
+const cliBin = join(cliRoot, "bin", "telnyx-agent.ts");
+
+let mockServer: Server;
+let mockPort: number;
+let mode = "normal";
+
+function startMockServer(): Promise<void> {
+  return new Promise((resolve) => {
+    mockServer = createServer((req, res) => {
+      let body = "";
+      req.on("data", (c) => (body += c.toString()));
+      req.on("end", () => {
+        let parsed: Record<string, unknown> | null = null;
+        try { parsed = body ? JSON.parse(body) : null; } catch {}
+
+        if (mode === "empty-profiles" && req.method === "GET" && req.url === "/v2/outbound_voice_profiles") {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ data: [] }));
+          return;
+        }
+
+        if (mode === "cca-error" && req.method === "POST" && req.url === "/v2/call_control_applications") {
+          res.writeHead(422, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ errors: [{ code: "10014", detail: "Invalid webhook URL" }] }));
+          return;
+        }
+
+        if (mode === "patch-error" && req.method === "PATCH" && req.url?.startsWith("/v2/phone_numbers/")) {
+          res.writeHead(422, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ errors: [{ code: "10016", detail: "Number not found" }] }));
+          return;
+        }
+
+        // Normal responses
+        if (req.method === "GET" && req.url === "/v2/outbound_voice_profiles") {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ data: [{ id: "ovp_test", name: "Default" }] }));
+          return;
+        }
+        if (req.method === "POST" && req.url === "/v2/call_control_applications") {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ data: { id: "cca_test", application_name: "test" } }));
+          return;
+        }
+        if (req.method === "PATCH" && req.url?.startsWith("/v2/phone_numbers/")) {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ data: { id: "num_test" } }));
+          return;
+        }
+        res.writeHead(404).end(JSON.stringify({ errors: [{ detail: "NF" }] }));
+      });
+    });
+    mockServer.listen(0, "127.0.0.1", () => {
+      const a = mockServer.address();
+      mockPort = typeof a === "object" && a ? a.port : 0;
+      resolve();
+    });
+  });
+}
+
+function stopMockServer(): Promise<void> {
+  return new Promise((r) => mockServer.close(() => r()));
+}
+
+function setupFake(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const tmp = mkdtempSync(join(tmpdir(), "aif328-edge-"));
+  const bin = join(tmp, "bin");
+  mkdirSync(bin, { recursive: true });
+  const fake = join(bin, "telnyx");
+  writeFileSync(fake, `#!/usr/bin/env node
+const args = process.argv.slice(2).filter(a => a !== "--format" && a !== "json");
+const cmd = args.join(" ");
+if (cmd.startsWith("available-phone-numbers")) {
+  console.log(JSON.stringify({ data: [{ phone_number: "+13125550001", country: "US" }] }));
+} else if (cmd.startsWith("number-order") || cmd.startsWith("number-orders")) {
+  console.log(JSON.stringify({ data: { id: "order_123", status: "complete" } }));
+} else if (cmd.startsWith("phone-numbers retrieve")) {
+  console.log(JSON.stringify({ data: { id: "num_123", phone_number: "+13125550001" } }));
+} else {
+  console.log(JSON.stringify({ data: {} }));
+}
+`);
+  chmodSync(fake, 0o755);
+  return {
+    ...env,
+    PATH: `${bin}:${env.PATH}`,
+    TELNYX_CLI_PATH: fake,
+    TELNYX_API_KEY: "test_key",
+    TELNYX_API_BASE_URL: `http://127.0.0.1:${mockPort}/v2`,
+  };
+}
+
+function run(args: string[], env: NodeJS.ProcessEnv): Promise<{ status: number; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    const c = spawn("npx", ["tsx", cliBin, ...args], { cwd: cliRoot, env });
+    let out = "", err = "";
+    c.stdout.on("data", (d) => (out += d.toString()));
+    c.stderr.on("data", (d) => (err += d.toString()));
+    c.on("close", (code) => resolve({ status: code ?? -1, stdout: out, stderr: err }));
+  });
+}
+
+describe("setup-voice edge cases (AIF-328)", () => {
+  before(async () => { await startMockServer(); });
+  after(async () => { await stopMockServer(); });
+
+  it("empty outbound voice profiles list → clear error", async () => {
+    mode = "empty-profiles";
+    const env = setupFake(process.env);
+    const r = await run(["setup-voice", "--json"], env);
+    assert.equal(r.status, 1);
+    const data = JSON.parse(r.stdout);
+    assert.equal(data.ready, false);
+    assert.match(data.error, /No outbound voice profiles found/);
+  });
+
+  it("call_control_applications POST 422 → error in JSON", async () => {
+    mode = "cca-error";
+    const env = setupFake(process.env);
+    const r = await run(["setup-voice", "--json"], env);
+    assert.equal(r.status, 1);
+    const data = JSON.parse(r.stdout);
+    assert.equal(data.ready, false);
+    assert.match(data.error, /Invalid webhook URL/);
+    assert.match(data.error, /HTTP 422/);
+  });
+
+  it("phone_numbers PATCH error → error with step 5 failure", async () => {
+    mode = "patch-error";
+    const env = setupFake(process.env);
+    const r = await run(["setup-voice", "--json"], env);
+    assert.equal(r.status, 1);
+    const data = JSON.parse(r.stdout);
+    assert.equal(data.ready, false);
+    // Steps 1-4 should succeed, step 5 should fail
+    const step5 = data.steps.find((s: any) => s.step === 5);
+    assert.equal(step5.status, "failed");
+    assert.match(step5.detail, /Number not found/);
+    // connection_id should be set (steps 1-2 succeeded)
+    assert.ok(data.connection_id, "connection_id should be set even if step 5 fails");
+  });
+
+  it("human mode: empty profiles → prints error + steps", async () => {
+    mode = "empty-profiles";
+    const env = setupFake(process.env);
+    const r = await run(["setup-voice"], env);
+    assert.equal(r.status, 1);
+    assert.match(r.stdout, /No outbound voice profiles found/);
+  });
+});

--- a/cli/tests/setup-voice.test.ts
+++ b/cli/tests/setup-voice.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Tests for AIF-328: setup-voice creates a Call Control Application
+ * (not a credential connection) so call-dial can use the output.
+ *
+ * The test uses a mock HTTP server for REST calls and a fake Go CLI
+ * binary for number search/order steps.
+ */
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { spawn, execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createServer, type Server, type IncomingMessage, type ServerResponse } from "node:http";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliRoot = join(__dirname, "..");
+const cliBin = join(cliRoot, "bin", "telnyx-agent.ts");
+
+// ---------------------------------------------------------------------------
+// Mock HTTP server
+// ---------------------------------------------------------------------------
+
+interface CapturedRequest {
+  method: string;
+  path: string;
+  body: Record<string, unknown> | null;
+}
+
+let mockServer: Server;
+let mockPort: number;
+let capturedRequests: CapturedRequest[] = [];
+
+function startMockServer(): Promise<void> {
+  return new Promise((resolve) => {
+    mockServer = createServer((req: IncomingMessage, res: ServerResponse) => {
+      let body = "";
+      req.on("data", (chunk: Buffer) => (body += chunk.toString()));
+      req.on("end", () => {
+        let parsedBody: Record<string, unknown> | null = null;
+        try {
+          parsedBody = body ? JSON.parse(body) : null;
+        } catch { /* ignore */ }
+        capturedRequests.push({ method: req.method ?? "", path: req.url ?? "", body: parsedBody });
+
+        // GET /outbound_voice_profiles
+        if (req.method === "GET" && req.url === "/v2/outbound_voice_profiles") {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({
+            data: [
+              { id: "ovp_abc123", name: "Default Voice Profile", active: true },
+            ],
+          }));
+          return;
+        }
+
+        // POST /call_control_applications
+        if (req.method === "POST" && req.url === "/v2/call_control_applications") {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({
+            data: {
+              id: "cca_abc123",
+              application_name: (parsedBody as Record<string, unknown>)?.application_name ?? "test",
+              webhook_event_url: (parsedBody as Record<string, unknown>)?.webhook_event_url ?? "",
+            },
+          }));
+          return;
+        }
+
+        // PATCH /phone_numbers/:id
+        if (req.method === "PATCH" && req.url?.startsWith("/v2/phone_numbers/")) {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({
+            data: { id: req.url.split("/").pop(), ...parsedBody },
+          }));
+          return;
+        }
+
+        res.writeHead(404, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ errors: [{ code: "10005", detail: "Not found" }] }));
+      });
+    });
+    mockServer.listen(0, "127.0.0.1", () => {
+      const addr = mockServer.address();
+      mockPort = typeof addr === "object" && addr ? addr.port : 0;
+      resolve();
+    });
+  });
+}
+
+function stopMockServer(): Promise<void> {
+  return new Promise((resolve) => {
+    mockServer.close(() => resolve());
+  });
+}
+
+function postRequests(pathPattern: RegExp): CapturedRequest[] {
+  return capturedRequests.filter((r) => r.method === "POST" && pathPattern.test(r.path));
+}
+
+function patchRequests(): CapturedRequest[] {
+  return capturedRequests.filter((r) => r.method === "PATCH");
+}
+
+function getRequests(pathPattern: RegExp): CapturedRequest[] {
+  return capturedRequests.filter((r) => r.method === "GET" && pathPattern.test(r.path));
+}
+
+// ---------------------------------------------------------------------------
+// Fake Go CLI binary for number search/order
+// ---------------------------------------------------------------------------
+
+function setupFakeTelnyx(): { fakeTelnyx: string; logPath: string; env: NodeJS.ProcessEnv } {
+  const tempDir = mkdtempSync(join(tmpdir(), "telnyx-agent-aif328-"));
+  const binDir = join(tempDir, "bin");
+  const logPath = join(tempDir, "args.jsonl");
+  mkdirSync(binDir, { recursive: true });
+
+  const fakeTelnyx = join(binDir, "telnyx");
+  writeFileSync(
+    fakeTelnyx,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.TELNYX_FAKE_ARGS_LOG, JSON.stringify(args) + "\\n");
+
+const fmtIdx = args.indexOf("--format");
+const cmd = args.filter((a, i) => !(a === "--format" || (i > 0 && args[i-1] === "--format")));
+
+if (cmd.join(" ").startsWith("available-phone-numbers list")) {
+  console.log(JSON.stringify({ data: [
+    { phone_number: "+13125550001", country: "US", capabilities: ["voice"] },
+  ] }));
+} else if (cmd.join(" ").startsWith("number-orders create") || cmd.join(" ").startsWith("number-order create")) {
+  console.log(JSON.stringify({ data: { id: "order_123", status: "complete" } }));
+} else if (cmd.join(" ").startsWith("phone-numbers retrieve")) {
+  console.log(JSON.stringify({ data: { id: "num_123456", phone_number: "+13125550001" } }));
+} else {
+  console.log(JSON.stringify({ data: {} }));
+}
+`,
+  );
+  chmodSync(fakeTelnyx, 0o755);
+
+  return {
+    fakeTelnyx,
+    logPath,
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH}`,
+      TELNYX_CLI_PATH: fakeTelnyx,
+      TELNYX_FAKE_ARGS_LOG: logPath,
+      TELNYX_API_KEY: "***",
+      TELNYX_API_BASE_URL: `http://127.0.0.1:${mockPort}/v2`,
+    },
+  };
+}
+
+function runAsync(args: string[], env: NodeJS.ProcessEnv): Promise<{ status: number; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    const child = spawn("npx", ["tsx", cliBin, ...args], { cwd: cliRoot, env });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (c: Buffer) => (stdout += c.toString()));
+    child.stderr.on("data", (c: Buffer) => (stderr += c.toString()));
+    child.on("close", (code) => resolve({ status: code ?? -1, stdout, stderr }));
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("setup-voice (AIF-328: Call Control Application, not credential connection)", () => {
+  before(async () => { await startMockServer(); });
+  after(async () => { await stopMockServer(); });
+
+  it("POSTs to /call_control_applications (not /credential_connections)", async () => {
+    capturedRequests = [];
+    const fake = setupFakeTelnyx();
+    const r = await runAsync(["setup-voice", "--json"], fake.env);
+
+    assert.equal(r.status, 0, `expected exit 0, got ${r.status}: ${r.stderr}`);
+    const ccaPosts = postRequests(/\/v2\/call_control_applications/);
+    assert.equal(ccaPosts.length, 1, "expected exactly one POST /call_control_applications");
+    const credPosts = postRequests(/\/v2\/credential_connections/);
+    assert.equal(credPosts.length, 0, "expected zero POST /credential_connections");
+  });
+
+  it("includes webhook_event_url and outbound_voice_profile_id in the app body", async () => {
+    capturedRequests = [];
+    const fake = setupFakeTelnyx();
+    await runAsync(["setup-voice", "--webhook-url", "https://myhook.example.com/calls", "--json"], fake.env);
+
+    const ccaPosts = postRequests(/\/v2\/call_control_applications/);
+    assert.equal(ccaPosts.length, 1);
+    const body = ccaPosts[0].body as Record<string, unknown>;
+    assert.ok(body);
+    assert.equal(body.webhook_event_url, "https://myhook.example.com/calls");
+    assert.ok(body.outbound, "expected outbound block in app body");
+    const outbound = body.outbound as Record<string, unknown>;
+    assert.ok(outbound.outbound_voice_profile_id, "expected outbound_voice_profile_id");
+  });
+
+  it("GETs /outbound_voice_profiles when --outbound-voice-profile-id is not provided", async () => {
+    capturedRequests = [];
+    const fake = setupFakeTelnyx();
+    await runAsync(["setup-voice", "--json"], fake.env);
+
+    const profileGets = getRequests(/\/v2\/outbound_voice_profiles/);
+    assert.equal(profileGets.length, 1, "expected one GET /outbound_voice_profiles");
+  });
+
+  it("skips GET /outbound_voice_profiles when --outbound-voice-profile-id is provided", async () => {
+    capturedRequests = [];
+    const fake = setupFakeTelnyx();
+    await runAsync(["setup-voice", "--outbound-voice-profile-id", "ovp_explicit123", "--json"], fake.env);
+
+    const profileGets = getRequests(/\/v2\/outbound_voice_profiles/);
+    assert.equal(profileGets.length, 0, "expected zero GET /outbound_voice_profiles when explicit ID provided");
+
+    const ccaPosts = postRequests(/\/v2\/call_control_applications/);
+    const outbound = (ccaPosts[0].body as Record<string, unknown>).outbound as Record<string, unknown>;
+    assert.equal(outbound.outbound_voice_profile_id, "ovp_explicit123");
+  });
+
+  it("uses default webhook URL when --webhook-url is not provided", async () => {
+    capturedRequests = [];
+    const fake = setupFakeTelnyx();
+    await runAsync(["setup-voice", "--json"], fake.env);
+
+    const ccaPosts = postRequests(/\/v2\/call_control_applications/);
+    const body = ccaPosts[0].body as Record<string, unknown>;
+    assert.ok(body.webhook_event_url, "expected webhook_event_url even without flag");
+    assert.equal(body.webhook_event_url, "https://example.com/webhook");
+  });
+
+  it("accepts --webhook as alias for --webhook-url", async () => {
+    capturedRequests = [];
+    const fake = setupFakeTelnyx();
+    await runAsync(["setup-voice", "--webhook", "https://alias.example.com/hook", "--json"], fake.env);
+
+    const ccaPosts = postRequests(/\/v2\/call_control_applications/);
+    const body = ccaPosts[0].body as Record<string, unknown>;
+    assert.equal(body.webhook_event_url, "https://alias.example.com/hook");
+  });
+
+  it("PATCHes /phone_numbers/:id with the Call Control App connection_id", async () => {
+    capturedRequests = [];
+    const fake = setupFakeTelnyx();
+    await runAsync(["setup-voice", "--json"], fake.env);
+
+    const patches = patchRequests();
+    assert.equal(patches.length, 1, "expected one PATCH");
+    assert.match(patches[0].path, /^\/v2\/phone_numbers\//);
+    const body = patches[0].body as Record<string, unknown>;
+    assert.ok(body);
+    assert.equal(body.connection_id, "cca_abc123", "expected connection_id to be the Call Control App ID");
+  });
+
+  it("does NOT POST to /credential_connections", async () => {
+    capturedRequests = [];
+    const fake = setupFakeTelnyx();
+    await runAsync(["setup-voice", "--json"], fake.env);
+
+    const credPosts = postRequests(/\/v2\/credential_connections/);
+    assert.equal(credPosts.length, 0, "must not create credential connections");
+  });
+
+  it("returns connection_id, phone_number, webhook_url, outbound_voice_profile_id in JSON", async () => {
+    capturedRequests = [];
+    const fake = setupFakeTelnyx();
+    const r = await runAsync(["setup-voice", "--json"], fake.env);
+
+    assert.equal(r.status, 0);
+    const data = JSON.parse(r.stdout);
+    assert.equal(data.connection_id, "cca_abc123");
+    assert.ok(data.phone_number, "expected phone_number in output");
+    assert.ok(data.webhook_url, "expected webhook_url in output");
+    assert.ok(data.outbound_voice_profile_id, "expected outbound_voice_profile_id in output");
+    assert.equal(data.ready, true);
+  });
+
+  it("has 5 steps with correct names", async () => {
+    capturedRequests = [];
+    const fake = setupFakeTelnyx();
+    const r = await runAsync(["setup-voice", "--json"], fake.env);
+
+    assert.equal(r.status, 0);
+    const data = JSON.parse(r.stdout);
+    assert.equal(data.steps.length, 5);
+    assert.equal(data.steps[0].name, "Resolve outbound voice profile");
+    assert.equal(data.steps[1].name, "Create Call Control Application");
+    assert.equal(data.steps[2].name, "Search for number");
+    assert.equal(data.steps[3].name, "Buy number");
+    assert.equal(data.steps[4].name, "Assign number to Call Control App");
+    for (const s of data.steps) {
+      assert.equal(s.status, "completed");
+    }
+  });
+
+  it("lists setup-voice in help with --outbound-voice-profile-id flag", () => {
+    let stdout = "";
+    let status = 0;
+    try {
+      stdout = execFileSync("npx", ["tsx", cliBin, "help"], { cwd: cliRoot, encoding: "utf8", env: { ...process.env }, timeout: 30000 });
+    } catch (err: any) {
+      status = err.status ?? 1;
+      stdout = err.stdout?.toString() ?? "";
+    }
+    assert.equal(status, 0);
+    assert.match(stdout, /setup-voice/);
+    assert.match(stdout, /--outbound-voice-profile-id/);
+  });
+});


### PR DESCRIPTION
## AIF-328: setup-voice creates Call Control Application instead of credential connection

### Problem
`setup-voice` was creating a `POST /credential_connections` resource, but `call-dial` requires a Call Control Application (`POST /call_control_applications`) with a `webhook_event_url` and `outbound_voice_profile_id`. These are different API resources — the credential connection ID cannot be used with `call-dial`.

### Fix
Replaced credential connection creation with Call Control Application creation.

**New 5-step flow:**
1. Resolve outbound voice profile (GET /outbound_voice_profiles, or use `--outbound-voice-profile-id`)
2. Create Call Control Application (POST /call_control_applications with webhook + outbound profile)
3. Search for a voice-capable number (via telnyx CLI)
4. Buy the number (via telnyx CLI)
5. Assign number to Call Control App (PATCH /phone_numbers/:id with connection_id)

### New Flags
- `--webhook-url` (alias `--webhook`) — Webhook URL for call events (default: `https://example.com/webhook`)
- `--outbound-voice-profile-id` — Outbound voice profile ID (default: auto-detect first available)

### Also includes
- `TELNYX_API_BASE_URL` env var support in client.ts
- `--help`/`-h` per-command fix (helpRequested intercept in parseFlags + run())
- Updated README with new flags and output format

### Testing
- 15 new tests (11 main + 4 edge cases)
- 212/212 tests pass, 0 fail
- E2E tested: human dev walkthrough + blind agent — 0 bugs found
- Edge cases: empty profiles list, CCA POST 422, PATCH error, human mode errors

### Output
```json
{
  "connection_id": "cca_...",
  "connection_name": "...",
  "phone_number": "+1...",
  "phone_number_id": "...",
  "webhook_url": "https://...",
  "outbound_voice_profile_id": "ovp_...",
  "ready": true,
  "steps": [...]
}
```

The `connection_id` works directly with `call-dial`.