### PR TITLE
docs: cover account management in README verbiage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Telnyx AI
 
-This repo is the one-stop shop for AI Agents and AI-first developers building with Telnyx.
+This repo is the one-stop shop for AI Agents and AI-first developers building with Telnyx — everything an agent needs to sign up, fund an account, and ship production integrations.
 
 > [!NOTE]
 > This repository is a work in progress under active development. We are continuously improving based on testing and feedback. Contributions and feedback encouraged!
@@ -11,7 +11,7 @@ This repo is the one-stop shop for AI Agents and AI-first developers building wi
 
 - [Agent Toolkit](#agent-toolkit) - integrate Telnyx APIs with popular agent frameworks including OpenAI's Agent SDK, LangChain, CrewAI, and Vercel's AI SDK through function calling — available in [Python](#python) and [TypeScript](#typescript).
   
-- [Agent Skills](#agent-skills) - give AI coding assistants accurate, up-to-date context about Telnyx APIs and SDKs.
+- [Agent Skills](#agent-skills) - give AI agents accurate, up-to-date context about Telnyx APIs and SDKs, plus account-management skills for signup and payments (MPP and x402 account funding).
   
 - [Agent CLI](#agent-cli) - provision and build on Telnyx infrastructure in a single command.
 
@@ -20,11 +20,11 @@ This repo is the one-stop shop for AI Agents and AI-first developers building wi
 - [Guides](#guides) - step-by-step tutorials for common workflows
  
 
-## Plugins and Extenstion
+## Plugins and Extensions
 
-Install the unified Telnyx plugin to give your AI coding assistant Telnyx MCP server access and 228 Agent Skills covering messaging, voice, numbers, AI, IoT, WebRTC, Twilio migration, and more. 
+Install the unified Telnyx plugin to give your AI coding assistant Telnyx MCP server access and 238 Agent Skills covering messaging, voice, numbers, AI, IoT, WebRTC, Twilio migration, account management (signup, MPP/x402 payments), and more. 
 
-Empowers coding agents to generate correct, production-ready code without relying on pre-training or fragile doc retrieval.
+Empowers agents to generate correct, production-ready code — and to manage their own accounts — without relying on pre-training or fragile doc retrieval.
 
 ### Claude Code Plugin
 
@@ -174,8 +174,12 @@ Install individual skills for your coding assistant via the [Skills CLI](https:/
 npx skills add team-telnyx/ai --skill <SKILL> --agent <AGENT>
 ```
 
+Skills cover two areas: **building with Telnyx** (messaging, voice, numbers, AI inference, WebRTC, Twilio migration, and more) and **account management** (programmatic [signup](https://telnyx.com/agent-signup.md), plus funding an account via MPP or x402 payments).
+
+Skills are also published on telnyx.com for runtime discovery at [`/.well-known/agent-skills/index.json`](https://telnyx.com/.well-known/agent-skills/index.json).
+
 > [!NOTE]
-> See [Skills](/skills/README.md) for full install instrcuctions and comprehensive list of available skills
+> See [Skills](/skills/README.md) for full install instructions and a comprehensive list of available skills
 
 
 ## Agent CLI
@@ -221,7 +225,7 @@ From `tools/mcp-apps`, use `npm install`, `npm run typecheck`, `npm run build`, 
 
 ## Guides
 
-Curl-first operational guides for common Telnyx workflows — SMS messaging, voice call control, AI assistants, phone numbers, porting, verification, webhooks, 10DLC registration, WireGuard networking, x402 payments, and Edge Compute handoff patterns.
+Curl-first operational guides for common Telnyx workflows — SMS messaging, voice call control, AI assistants, phone numbers, porting, verification, webhooks, 10DLC registration, WireGuard networking, MPP and x402 account payments, and Edge Compute handoff patterns.
 
 For Edge Compute specifically, the goal is to make the handoff testable fast: start from a real `telnyx-edge` example, deploy it, and let `team-telnyx/ai` orchestrate against that live endpoint.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Telnyx AI
 
-This repo is the one-stop shop for AI Agents and AI-first developers building with Telnyx — everything an agent needs to sign up, fund an account, and ship production integrations.
+This repo is the one-stop shop for AI Agents and AI-first developers building with Telnyx — everything an agent needs to build production-grade applications and manage its account, from signup to funding.
 
 > [!NOTE]
 > This repository is a work in progress under active development. We are continuously improving based on testing and feedback. Contributions and feedback encouraged!

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,10 +1,10 @@
 # Telnyx Agent Skills
 
-Official Agent Skills for building on Telnyx.
+Official Agent Skills for building on Telnyx and managing your Telnyx account.
 
-These skills give coding agents structured, up-to-date context to generate correct, production-ready code without relying on pre-training or fragile doc retrieval.
+These skills give agents structured, up-to-date context to generate correct, production-ready code — and to handle account management like signup and payments — without relying on pre-training or fragile doc retrieval.
 
-They include accurate schemas, SDK patterns, workflows, and API references, so agents can implement Telnyx APIs reliably in real-world applications.
+They include accurate schemas, SDK patterns, workflows, and API references, so agents can implement Telnyx APIs reliably in real-world applications — from first signup to funded, production accounts.
 
 Telnyx Agent Skills follow the [Agent Skills specification](https://agentskills.io/specification) and are compatible with coding agents like Claude Code, Cursor, Windsurf, and others.
 
@@ -181,7 +181,9 @@ npx skills add team-telnyx/ai --skill telnyx-messaging-python --agent cursor
 
 ## Payments
 
-Fund a Telnyx account programmatically — built for agentic payment flows where an AI agent adds account credit on your behalf:
+Fund a Telnyx account programmatically — built for agentic payment flows where an AI agent adds account credit on your behalf. No account yet? Agents can sign up programmatically first via the [bot signup skill](https://telnyx.com/agent-signup.md).
+
+Available payment skills:
 
 | Skill | Description |
 |-------|-------------|

--- a/skills/README.md
+++ b/skills/README.md
@@ -4,7 +4,7 @@ Official Agent Skills for building on Telnyx and managing your Telnyx account.
 
 These skills give agents structured, up-to-date context to generate correct, production-ready code — and to handle account management like signup and payments — without relying on pre-training or fragile doc retrieval.
 
-They include accurate schemas, SDK patterns, workflows, and API references, so agents can implement Telnyx APIs reliably in real-world applications — from first signup to funded, production accounts.
+They include accurate schemas, SDK patterns, workflows, and API references, so agents can build production-grade applications on Telnyx — with account management (signup, funding, payments) covered alongside.
 
 Telnyx Agent Skills follow the [Agent Skills specification](https://agentskills.io/specification) and are compatible with coding agents like Claude Code, Cursor, Windsurf, and others.
 


### PR DESCRIPTION
## Summary

Follow-up to #324. The root and skills READMEs still described Agent Skills as code-generation-only ("give AI coding assistants accurate, up-to-date context about Telnyx APIs and SDKs"), but the catalog now includes account-management skills. Full verbiage pass:

- Reframe the repo tagline and Agent Skills descriptions around both **building with Telnyx** and **account management** (programmatic signup, MPP/x402 account funding)
- Fix the stale plugin skill count: 228 → 238 (matches `ls skills | wc -l` minus README)
- Guides summary now says "MPP and x402 account payments" (guides/mpp-payments.md shipped in #324)
- Link the canonical runtime discovery index on telnyx.com (`/.well-known/agent-skills/index.json`) and the bot-signup runbook (`/agent-signup.md`)
- Chain signup → funding in the skills README Payments section
- Typo fixes: "Extenstion" → "Extensions", "instrcuctions" → "instructions"

## Related

- team-telnyx/dotcom-monorepo#2931 publishes `telnyx-bot-signup`, `telnyx-mpp-payment`, and `telnyx-x402-payment` in the telnyx.com discovery index.

## Slack Context

Same thread as #324 (David Kapp's payment-skills publishing request).