### PR TITLE
Sync Edge handoff docs and capability metadata with upstream CLI surface

### DIFF
--- a/.github/bin/publish-npm
+++ b/.github/bin/publish-npm
@@ -5,9 +5,91 @@
 
 set -eux
 
+log_publish_gate() {
+  local status="$1"
+  local package_name="$2"
+  local version="$3"
+
+  local actor="${NPM_PUBLISH_DISABLED_BY:-${GITHUB_ACTOR:-${GITHUB_TRIGGERING_ACTOR:-unknown}}}"
+  local reason="${NPM_PUBLISH_DISABLE_REASON:-$4}"
+  local incident_id="${NPM_PUBLISH_DISABLE_INCIDENT_ID:-unknown}"
+  local reason_text="${reason:-no reason supplied}"
+
+  local audit_path="${RUNNER_TEMP:-/tmp}/publish-audit-log.txt"
+  local timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+  {
+    echo "[$timestamp] npm publish gate=$status actor=$actor"
+    echo "  package=${package_name:-unknown}"
+    echo "  version=${version:-unknown}"
+    echo "  event=${GITHUB_EVENT_NAME:-unknown}"
+    echo "  run_id=${GITHUB_RUN_ID:-unknown}"
+    echo "  workflow=${GITHUB_WORKFLOW:-publish-npm}"
+    echo "  repository=${GITHUB_REPOSITORY:-unknown}"
+    echo "  reason=${reason_text}"
+    echo "  incident_id=${incident_id}"
+  } >> "$audit_path"
+
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+      echo "## NPM Publish Gate"
+      echo
+      echo "Gate result: **$status**"
+      echo "- actor: $actor"
+      echo "- package: ${package_name:-unknown}"
+      echo "- version: ${version:-unknown}"
+      echo "- reason: $reason_text"
+      echo "- incident_id: $incident_id"
+      echo "- run: ${GITHUB_RUN_ID:-unknown}"
+      echo "- timestamp: $timestamp"
+    } >> "$GITHUB_STEP_SUMMARY"
+  fi
+}
+
+enforce_publish_gate() {
+  local package_name="$1"
+  local version="$2"
+  local publish_enabled="${NPM_PUBLISH_ENABLED:-${NPM_PUBLISH_GATE_ENABLED:-true}}"
+  publish_enabled="$(echo "$publish_enabled" | tr '[:upper:]' '[:lower:]')"
+
+  if [[ "$publish_enabled" == "false" || "$publish_enabled" == "0" || "$publish_enabled" == "off" || "$publish_enabled" == "disabled" ]]; then
+    echo "NPM publishing is disabled via NPM_PUBLISH_ENABLED=false"
+    log_publish_gate "blocked" "$package_name" "$version" "${NPM_PUBLISH_DISABLE_REASON:-Emergency publish block is active for npm workflows.}"
+    echo "::notice title=npm publish blocked::NPM publish is currently disabled."
+    exit 0
+  fi
+
+  log_publish_gate "allowed" "$package_name" "$version" "${NPM_PUBLISH_DISABLE_REASON:-}"
+}
+
+scan_release_artifact() {
+  local package_dir="$1"
+  local scan_tmpdir
+  scan_tmpdir="$(mktemp -d)"
+
+  cleanup_scan_tmpdir() {
+    rm -rf "$scan_tmpdir"
+  }
+
+  trap cleanup_scan_tmpdir RETURN
+
+  local tarball_name
+  tarball_name="$(npm pack --pack-destination "$scan_tmpdir" | tail -n 1)"
+  local tarball_path="$scan_tmpdir/$tarball_name"
+
+  node "$(dirname "$0")/../scripts/scan-release-artifact.mjs" "$tarball_path"
+}
+
 PACKAGE_DIR="${1:-.}"
 
 cd "$PACKAGE_DIR"
+
+# Get package info first so we can record audit context before publishing.
+PACKAGE_NAME="$(jq -r -e '.name' ./package.json)"
+VERSION="$(jq -r -e '.version' ./package.json)"
+
+# Enforce publish gate before any publish-related side effects.
+enforce_publish_gate "$PACKAGE_NAME" "$VERSION"
 
 # Authenticate — prefer OIDC, fall back to NPM_TOKEN
 if [[ ${NPM_TOKEN:-} ]]; then
@@ -20,9 +102,9 @@ fi
 # Build (CLI has a no-op build, TS SDK compiles)
 npm run build
 
-# Get package info
-PACKAGE_NAME="$(jq -r -e '.name' ./package.json)"
-VERSION="$(jq -r -e '.version' ./package.json)"
+# Scan the exact artifact payload that would be published before publish proceeds.
+rm -f secret-scan-results.jsonl
+scan_release_artifact "$PACKAGE_DIR"
 
 echo "Publishing $PACKAGE_NAME@$VERSION"
 

--- a/.github/bin/publish-pypi
+++ b/.github/bin/publish-pypi
@@ -2,9 +2,78 @@
 # Publish telnyx-agent-toolkit to PyPI using OIDC trusted publishing.
 # Called from the publish-pypi.yml workflow — no PYPI_TOKEN needed.
 
-set -eux
+set -euo pipefail
+
+log_publish_gate() {
+  local status="$1"
+  local package_name="$2"
+  local version="$3"
+
+  local actor="${PYPI_PUBLISH_DISABLE_ACTOR:-${GITHUB_ACTOR:-${GITHUB_TRIGGERING_ACTOR:-unknown}}}"
+  local timestamp="${PYPI_PUBLISH_DISABLE_TIMESTAMP:-$(date -u +"%Y-%m-%dT%H:%M:%SZ")}"
+  local reason="${PYPI_PUBLISH_DISABLE_REASON:-$4}"
+  local incident_id="${PYPI_PUBLISH_DISABLE_INCIDENT_ID:-unknown}"
+  local reason_text="${reason:-no reason supplied}"
+
+  local audit_path="${RUNNER_TEMP:-/tmp}/publish-pypi-audit-log.txt"
+
+  {
+    echo "[$timestamp] pypi publish gate=$status actor=$actor"
+    echo "  package=${package_name:-unknown}"
+    echo "  version=${version:-unknown}"
+    echo "  event=${GITHUB_EVENT_NAME:-unknown}"
+    echo "  run_id=${GITHUB_RUN_ID:-unknown}"
+    echo "  workflow=${GITHUB_WORKFLOW:-publish-pypi}"
+    echo "  repository=${GITHUB_REPOSITORY:-unknown}"
+    echo "  reason=${reason_text}"
+    echo "  incident_id=${incident_id}"
+    echo "  override_used=${PYPI_PUBLISH_OVERRIDE_USED:-false}"
+  } >> "$audit_path"
+
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+      echo "## PyPI Publish Gate"
+      echo
+      echo "Gate result: **$status**"
+      echo "- actor: $actor"
+      echo "- timestamp: $timestamp"
+      echo "- package: ${package_name:-unknown}"
+      echo "- version: ${version:-unknown}"
+      echo "- reason: $reason_text"
+      echo "- incident_id: $incident_id"
+      echo "- override_used: ${PYPI_PUBLISH_OVERRIDE_USED:-false}"
+      echo "- run: ${GITHUB_RUN_ID:-unknown}"
+    } >> "$GITHUB_STEP_SUMMARY"
+  fi
+}
+
+enforce_publish_gate() {
+  local package_name="$1"
+  local version="$2"
+  local publish_enabled="${PYPI_PUBLISH_ENABLED:-true}"
+  publish_enabled="$(echo "$publish_enabled" | tr '[:upper:]' '[:lower:]')"
+
+  if [[ "$publish_enabled" == "false" || "$publish_enabled" == "0" || "$publish_enabled" == "off" || "$publish_enabled" == "disabled" ]]; then
+    echo "PyPI publishing is disabled via PYPI_PUBLISH_ENABLED=false"
+    log_publish_gate "blocked" "$package_name" "$version" "${PYPI_PUBLISH_DISABLE_REASON:-Emergency publish block is active for PyPI workflows.}"
+    echo "::notice title=PyPI publish blocked::PyPI publish is currently disabled."
+    exit 0
+  fi
+
+  log_publish_gate "allowed" "$package_name" "$version" "${PYPI_PUBLISH_DISABLE_REASON:-}"
+}
 
 cd "$(dirname "$0")/../../tools/python"
+
+PACKAGE_NAME="$(awk -F' = ' '/^name = / { gsub(/"/, "", $2); print $2; exit }' pyproject.toml)"
+VERSION="$(awk -F' = ' '/^version = / { gsub(/"/, "", $2); print $2; exit }' pyproject.toml)"
+
+if [[ -z "$PACKAGE_NAME" || -z "$VERSION" ]]; then
+  echo "ERROR: Unable to determine package metadata from tools/python/pyproject.toml"
+  exit 1
+fi
+
+enforce_publish_gate "$PACKAGE_NAME" "$VERSION"
 
 # Clean previous builds
 rm -rf dist
@@ -16,6 +85,8 @@ fi
 
 # Build
 uv build
+
+echo "Publishing $PACKAGE_NAME@$VERSION"
 
 # Publish — uses OIDC trusted publishing when PYPI_TOKEN is not set
 if [ -n "${PYPI_TOKEN:-}" ]; then

--- a/.github/scripts/normalize-gitleaks-results.mjs
+++ b/.github/scripts/normalize-gitleaks-results.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+
+const allowlistPath = ".secretscanner-allowlist.json";
+let allowlist = [];
+try {
+  const rawAllowlist = readFileSync(allowlistPath, "utf8");
+  allowlist = JSON.parse(rawAllowlist).pathRegex || [];
+} catch {
+  allowlist = [];
+}
+
+const normalizedAllowlist = allowlist.map((pattern) => new RegExp(pattern));
+const argv = process.argv.slice(2);
+let sourceRoot = process.cwd();
+const reportPaths = [];
+
+for (let i = 0; i < argv.length; i += 1) {
+  const arg = argv[i];
+  if (arg === "--source-root") {
+    sourceRoot = resolve(argv[i + 1] || process.cwd());
+    i += 1;
+    continue;
+  }
+  reportPaths.push(arg);
+}
+
+if (reportPaths.length === 0) {
+  console.error("Usage: normalize-gitleaks-results.mjs [--source-root <path>] <report.json> [...]");
+  process.exit(2);
+}
+
+const findings = [];
+const counts = { high: 0, medium: 0, low: 0 };
+
+for (const reportPath of reportPaths) {
+  const raw = readFileSync(reportPath, "utf8");
+  const parsed = raw.trim() ? JSON.parse(raw) : [];
+  const reportDir = dirname(resolve(reportPath));
+
+  for (const finding of parsed) {
+    const artifactPath = String(finding.File || "");
+    const shouldSkip = normalizedAllowlist.some((pattern) => pattern.test(artifactPath));
+    if (shouldSkip) {
+      continue;
+    }
+
+    const normalizedToken = `${finding.RuleID || ""}|${finding.File || ""}|${finding.Line || ""}|${finding.StartLine || ""}`;
+    const secretSnippet = String(finding.Match || finding.Secret || "");
+    const snippetHash = hash(`${normalizedToken}|${secretSnippet}`);
+    const detector = String(finding.RuleID || finding.Description || "unknown");
+    const severity = classifySeverity(finding);
+    const resolvedArtifactPath = resolveArtifactPath(artifactPath, sourceRoot, reportDir);
+
+    findings.push({
+      artifact_path: artifactPath,
+      artifact_sha256: fileHash(resolvedArtifactPath),
+      detector,
+      snippet_hash: snippetHash,
+      severity,
+      match_count: 1,
+      first_seen_file: artifactPath,
+    });
+
+    counts[severity] = (counts[severity] || 0) + 1;
+  }
+}
+
+writeFileSync(
+  "secret-scan-results.jsonl",
+  findings.map((finding) => JSON.stringify(finding)).join("\n"),
+);
+
+console.log(`secret_scan_summary high=${counts.high} medium=${counts.medium} low=${counts.low}`);
+
+const manualApproved = String(process.env.MANUAL_PUBLISH_APPROVED || "false").toLowerCase() === "true";
+if (counts.high > 0 || (counts.medium > 0 && !manualApproved)) {
+  process.exit(1);
+}
+
+function resolveArtifactPath(artifactPath, sourceRootPath, reportDir) {
+  if (!artifactPath) return null;
+  if (isAbsolute(artifactPath)) return artifactPath;
+
+  const sourceCandidate = join(sourceRootPath, artifactPath);
+  if (existsSync(sourceCandidate)) return sourceCandidate;
+
+  const reportCandidate = join(reportDir, artifactPath);
+  if (existsSync(reportCandidate)) return reportCandidate;
+
+  return null;
+}
+
+function fileHash(path) {
+  if (!path || !existsSync(path)) {
+    return hash("");
+  }
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function classifySeverity(finding) {
+  const rule = String(finding.RuleID || "").toLowerCase();
+  const description = String(finding.Description || "").toLowerCase();
+  const tags = Array.isArray(finding.Tags) ? finding.Tags.join(" ").toLowerCase() : "";
+  const text = `${rule} ${description} ${tags}`.toLowerCase();
+  const entropy = Number(finding.Entropy || 0);
+
+  if (
+    text.includes("private-key") ||
+    text.includes("github-pat") ||
+    text.includes("access_token") ||
+    text.includes("api key") ||
+    text.includes("apikey") ||
+    entropy >= 4.5
+  ) {
+    return "high";
+  }
+
+  if (
+    text.includes("secret") ||
+    text.includes("token") ||
+    text.includes("jwt") ||
+    text.includes("password") ||
+    entropy >= 4
+  ) {
+    return "medium";
+  }
+
+  return "low";
+}
+
+function hash(value) {
+  return createHash("sha256").update(String(value)).digest("hex");
+}

--- a/.github/scripts/scan-release-artifact.mjs
+++ b/.github/scripts/scan-release-artifact.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { cpSync, existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+
+function ensureGitleaks() {
+  try {
+    execFileSync("gitleaks", ["version"], { stdio: "ignore" });
+  } catch {
+    throw new Error("gitleaks is required on PATH for pre-publish secret scanning");
+  }
+}
+
+function stageArtifact(tarballPath) {
+  const stagingRoot = resolve(
+    tmpdir(),
+    `release-secret-scan-${process.pid}-${Date.now()}`,
+  );
+  const artifactRoot = join(stagingRoot, "artifact");
+  mkdirSync(artifactRoot, { recursive: true });
+
+  execFileSync("tar", ["-xzf", tarballPath, "-C", artifactRoot], {
+    stdio: "inherit",
+  });
+
+  const metadataRoot = join(stagingRoot, "release-metadata");
+  mkdirSync(metadataRoot, { recursive: true });
+
+  for (const file of ["package.json", "package-lock.json", "npm-shrinkwrap.json"]) {
+    const sourcePath = resolve(process.cwd(), file);
+    if (existsSync(sourcePath)) {
+      cpSync(sourcePath, join(metadataRoot, file));
+    }
+  }
+
+  writeFileSync(
+    join(metadataRoot, "publish-context.json"),
+    JSON.stringify(
+      {
+        package_dir: process.cwd(),
+        artifact_name: basename(tarballPath),
+        github_repository: process.env.GITHUB_REPOSITORY || null,
+        github_workflow: process.env.GITHUB_WORKFLOW || null,
+        github_run_id: process.env.GITHUB_RUN_ID || null,
+        github_sha: process.env.GITHUB_SHA || null,
+        github_ref: process.env.GITHUB_REF || null,
+        publish_tag: process.env.NPM_PUBLISH_TAG || null,
+      },
+      null,
+      2,
+    ),
+  );
+
+  return stagingRoot;
+}
+
+export function scanReleaseArtifact(tarballPath) {
+  const resolvedTarballPath = resolve(tarballPath);
+  if (!existsSync(resolvedTarballPath)) {
+    throw new Error(`Artifact not found: ${resolvedTarballPath}`);
+  }
+
+  ensureGitleaks();
+
+  const stagingRoot = stageArtifact(resolvedTarballPath);
+  const reportPath = join(stagingRoot, "gitleaks-report.json");
+
+  try {
+    execFileSync(
+      "gitleaks",
+      [
+        "detect",
+        "--no-git",
+        "--source",
+        stagingRoot,
+        "--redact",
+        "--report-format",
+        "json",
+        "--report-path",
+        reportPath,
+        "--exit-code",
+        "0",
+        "--log-level",
+        "warn",
+      ],
+      { stdio: "inherit", env: process.env },
+    );
+
+    execFileSync(
+      "node",
+      [
+        resolve(dirname(new URL(import.meta.url).pathname), "normalize-gitleaks-results.mjs"),
+        "--source-root",
+        stagingRoot,
+        reportPath,
+      ],
+      { stdio: "inherit", env: process.env },
+    );
+
+    if (!existsSync(resolve(process.cwd(), "secret-scan-results.jsonl"))) {
+      throw new Error("secret-scan-results.jsonl was not created");
+    }
+  } finally {
+    rmSync(stagingRoot, { recursive: true, force: true });
+  }
+}
+
+function main(argv) {
+  const artifactPath = argv[2];
+  if (!artifactPath || artifactPath === "--help" || artifactPath === "-h") {
+    console.error("Usage: scan-release-artifact.mjs <artifact.tgz>");
+    process.exit(artifactPath ? 0 : 2);
+  }
+
+  scanReleaseArtifact(artifactPath);
+  console.log(`Release artifact scan passed for ${artifactPath}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv);
+}

--- a/.github/scripts/scan-release-artifact.mjs
+++ b/.github/scripts/scan-release-artifact.mjs
@@ -4,6 +4,7 @@ import { execFileSync } from "node:child_process";
 import { cpSync, existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
 
 function ensureGitleaks() {
   try {
@@ -91,7 +92,7 @@ export function scanReleaseArtifact(tarballPath) {
     execFileSync(
       "node",
       [
-        resolve(dirname(new URL(import.meta.url).pathname), "normalize-gitleaks-results.mjs"),
+        resolve(dirname(fileURLToPath(import.meta.url)), "normalize-gitleaks-results.mjs"),
         "--source-root",
         stagingRoot,
         reportPath,

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -15,6 +15,20 @@ name: Publish npm
 on:
   workflow_dispatch:
     inputs:
+      publish_disable_reason:
+        description: 'Reason for temporarily disabling npm publish (audit trail)'
+        required: false
+      publish_disable_incident_id:
+        description: 'Related incident or ticket identifier for audit'
+        required: false
+      publish_disable_by:
+        description: 'Person requesting publish disable/re-enable'
+        required: false
+      manual_publish_approved:
+        description: 'Audited override for medium secret-scan findings'
+        required: false
+        type: boolean
+        default: false
       package:
         description: 'Which package to publish'
         required: true
@@ -25,15 +39,115 @@ on:
           - cli
           - mcp
           - opencode
+      force_publish:
+        description: 'Set to true to ignore a temporary publish disable flag'
+        required: false
+        type: boolean
+        default: false
   release:
     types: [published]
 
 jobs:
+  publish-guard:
+    name: publish gate check
+    runs-on: ubuntu-latest
+    outputs:
+      publish_enabled: ${{ steps.evaluate.outputs.enabled }}
+      publish_audit_reason: ${{ steps.evaluate.outputs.reason }}
+      publish_audit_incident_id: ${{ steps.evaluate.outputs.incident_id }}
+      publish_audit_by: ${{ steps.evaluate.outputs.publish_audit_by }}
+    steps:
+      - id: evaluate
+        name: Evaluate publish gate
+        run: |
+          write_output() {
+            local key="$1"
+            local value="$2"
+
+            {
+              echo "${key}<<__PUBLISH_GUARD__"
+              echo "$value"
+              echo "__PUBLISH_GUARD__"
+            } >> "$GITHUB_OUTPUT"
+          }
+
+          normalize_bool() {
+            local value="${1:-}"
+            value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
+
+            case "$value" in
+              true|1|yes|on)
+                printf 'true'
+                ;;
+              false|0|no|off|disabled|'')
+                printf 'false'
+                ;;
+              *)
+                printf '%s' "$value"
+                ;;
+            esac
+          }
+
+          FORCE_PUBLISH_RAW="${{ github.event_name == 'workflow_dispatch' && inputs.force_publish || 'false' }}"
+          PUBLISH_ENABLED_RAW='${{ vars.PUBLISH_NPM_ENABLED }}'
+          DISABLED_BY='${{ github.event_name == "workflow_dispatch" && inputs.publish_disable_by || github.actor }}'
+          INCIDENT_ID='${{ github.event_name == "workflow_dispatch" && inputs.publish_disable_incident_id || '' }}'
+          REASON='${{ github.event_name == "workflow_dispatch" && inputs.publish_disable_reason || '' }}'
+
+          FORCE_PUBLISH="$(normalize_bool "$FORCE_PUBLISH_RAW")"
+          PUBLISH_ENABLED="$(normalize_bool "$PUBLISH_ENABLED_RAW")"
+
+          write_output "publish_audit_by" "$DISABLED_BY"
+          write_output "incident_id" "$INCIDENT_ID"
+
+          if [[ "$FORCE_PUBLISH" == 'true' ]]; then
+            write_output "enabled" "true"
+            write_output "reason" "manual override force_publish=true"
+            echo "Publish enabled via workflow dispatch override: force_publish=true" >> "$GITHUB_STEP_SUMMARY"
+          elif [[ "$PUBLISH_ENABLED" == 'false' ]]; then
+            write_output "enabled" "false"
+            FINAL_REASON="${REASON:-repository variable PUBLISH_NPM_ENABLED is false}"
+            write_output "reason" "$FINAL_REASON"
+            {
+              echo "## npm publish disabled"
+              echo "- result: denied"
+              echo "- timestamp: \`$(date -u +'%Y-%m-%dT%H:%M:%SZ')\`"
+              echo "- workflow: \`${{ github.workflow }}\`"
+              echo "- run: \`${{ github.run_id }}\`"
+              echo "- disabled_by: \`$DISABLED_BY\`"
+              echo "- incident_id: \`${INCIDENT_ID:-none}\`"
+              echo "- reason: \`$FINAL_REASON\`"
+              echo "- event: \`${{ github.event_name }}\`"
+              echo "- repository variable: \`PUBLISH_NPM_ENABLED=${PUBLISH_ENABLED_RAW:-true}\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            write_output "enabled" "true"
+            write_output "reason" "repository variable PUBLISH_NPM_ENABLED is not false (${PUBLISH_ENABLED_RAW:-true})"
+            echo "npm publish gate passed" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Audit disabled publish
+        if: ${{ steps.evaluate.outputs.enabled == 'false' }}
+        run: |
+          {
+            echo "## npm publish disabled"
+            echo "- reason: ${{ steps.evaluate.outputs.reason }}"
+            echo "- disabled_by: \`${{ steps.evaluate.outputs.publish_audit_by }}\`"
+            echo "- incident_id: \`${{ steps.evaluate.outputs.incident_id || 'none' }}\`"
+            echo "- event: \`${{ github.event_name }}\`"
+            echo "- package selector: \`${{ github.event_name == 'workflow_dispatch' && inputs.package || github.event_name }}\`"
+            echo "- ref: \`${{ github.ref }}\`"
+            echo "- sha: \`${{ github.sha }}\`"
+            echo "- disabled at: \`$(date -u +'%Y-%m-%dT%H:%M:%SZ')\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   publish-typescript:
     name: publish @telnyx/agent-toolkit
+    needs: publish-guard
     runs-on: ubuntu-latest
     if: >-
       github.repository == 'team-telnyx/ai' &&
+      needs.publish-guard.outputs.publish_enabled == 'true' &&
       (github.event_name == 'release' || github.event.inputs.package == 'all' || github.event.inputs.package == 'typescript')
     permissions:
       contents: read
@@ -46,18 +160,41 @@ jobs:
         with:
           node-version: '24'
 
+      - name: Install gitleaks
+        run: |
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.18.3/gitleaks_8.18.3_linux_x64.tar.gz \
+            | tar -xz -C /tmp
+          sudo mv /tmp/gitleaks /usr/local/bin/gitleaks
+          chmod +x /usr/local/bin/gitleaks
+
       - name: Install dependencies
         working-directory: tools/typescript
         run: npm ci
 
       - name: Publish @telnyx/agent-toolkit
+        env:
+          MANUAL_PUBLISH_APPROVED: ${{ github.event_name == 'workflow_dispatch' && inputs.manual_publish_approved && 'true' || 'false' }}
+          NPM_PUBLISH_ENABLED: ${{ needs.publish-guard.outputs.publish_enabled }}
+          NPM_PUBLISH_DISABLE_REASON: ${{ needs.publish-guard.outputs.publish_audit_reason }}
+          NPM_PUBLISH_DISABLE_INCIDENT_ID: ${{ needs.publish-guard.outputs.publish_audit_incident_id }}
+          NPM_PUBLISH_DISABLED_BY: ${{ needs.publish-guard.outputs.publish_audit_by }}
         run: bash ./.github/bin/publish-npm tools/typescript
+
+      - name: Upload secret scan evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: secret-scan-results-typescript
+          path: tools/typescript/secret-scan-results.jsonl
+          if-no-files-found: error
 
   publish-cli:
     name: publish @telnyx/agent-cli
+    needs: publish-guard
     runs-on: ubuntu-latest
     if: >-
       github.repository == 'team-telnyx/ai' &&
+      needs.publish-guard.outputs.publish_enabled == 'true' &&
       (github.event_name == 'release' || github.event.inputs.package == 'all' || github.event.inputs.package == 'cli')
     permissions:
       contents: read
@@ -70,18 +207,41 @@ jobs:
         with:
           node-version: '24'
 
+      - name: Install gitleaks
+        run: |
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.18.3/gitleaks_8.18.3_linux_x64.tar.gz \
+            | tar -xz -C /tmp
+          sudo mv /tmp/gitleaks /usr/local/bin/gitleaks
+          chmod +x /usr/local/bin/gitleaks
+
       - name: Install dependencies
         working-directory: cli
         run: npm ci
 
       - name: Publish @telnyx/agent-cli
+        env:
+          MANUAL_PUBLISH_APPROVED: ${{ github.event_name == 'workflow_dispatch' && inputs.manual_publish_approved && 'true' || 'false' }}
+          NPM_PUBLISH_ENABLED: ${{ needs.publish-guard.outputs.publish_enabled }}
+          NPM_PUBLISH_DISABLE_REASON: ${{ needs.publish-guard.outputs.publish_audit_reason }}
+          NPM_PUBLISH_DISABLE_INCIDENT_ID: ${{ needs.publish-guard.outputs.publish_audit_incident_id }}
+          NPM_PUBLISH_DISABLED_BY: ${{ needs.publish-guard.outputs.publish_audit_by }}
         run: bash ./.github/bin/publish-npm cli
+
+      - name: Upload secret scan evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: secret-scan-results-cli
+          path: cli/secret-scan-results.jsonl
+          if-no-files-found: error
 
   publish-mcp:
     name: publish @telnyx/mcp
+    needs: publish-guard
     runs-on: ubuntu-latest
     if: >-
       github.repository == 'team-telnyx/ai' &&
+      needs.publish-guard.outputs.publish_enabled == 'true' &&
       (github.event_name == 'release' || github.event.inputs.package == 'all' || github.event.inputs.package == 'mcp')
     permissions:
       contents: read
@@ -94,18 +254,41 @@ jobs:
         with:
           node-version: '24'
 
+      - name: Install gitleaks
+        run: |
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.18.3/gitleaks_8.18.3_linux_x64.tar.gz \
+            | tar -xz -C /tmp
+          sudo mv /tmp/gitleaks /usr/local/bin/gitleaks
+          chmod +x /usr/local/bin/gitleaks
+
       - name: Install dependencies
         working-directory: tools/mcp
         run: npm ci
 
       - name: Publish @telnyx/mcp
+        env:
+          MANUAL_PUBLISH_APPROVED: ${{ github.event_name == 'workflow_dispatch' && inputs.manual_publish_approved && 'true' || 'false' }}
+          NPM_PUBLISH_ENABLED: ${{ needs.publish-guard.outputs.publish_enabled }}
+          NPM_PUBLISH_DISABLE_REASON: ${{ needs.publish-guard.outputs.publish_audit_reason }}
+          NPM_PUBLISH_DISABLE_INCIDENT_ID: ${{ needs.publish-guard.outputs.publish_audit_incident_id }}
+          NPM_PUBLISH_DISABLED_BY: ${{ needs.publish-guard.outputs.publish_audit_by }}
         run: bash ./.github/bin/publish-npm tools/mcp
+
+      - name: Upload secret scan evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: secret-scan-results-mcp
+          path: tools/mcp/secret-scan-results.jsonl
+          if-no-files-found: error
 
   publish-opencode:
     name: publish @telnyx/opencode
+    needs: publish-guard
     runs-on: ubuntu-latest
     if: >-
       github.repository == 'team-telnyx/ai' &&
+      needs.publish-guard.outputs.publish_enabled == 'true' &&
       (github.event_name == 'release' || github.event.inputs.package == 'all' || github.event.inputs.package == 'opencode')
     permissions:
       contents: read
@@ -120,19 +303,41 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
 
+      - name: Install gitleaks
+        run: |
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.18.3/gitleaks_8.18.3_linux_x64.tar.gz \
+            | tar -xz -C /tmp
+          sudo mv /tmp/gitleaks /usr/local/bin/gitleaks
+          chmod +x /usr/local/bin/gitleaks
+
       - name: Install dependencies
         working-directory: plugins/opencode
         run: npm ci --legacy-peer-deps
 
       - name: Publish @telnyx/opencode
+        env:
+          MANUAL_PUBLISH_APPROVED: ${{ github.event_name == 'workflow_dispatch' && inputs.manual_publish_approved && 'true' || 'false' }}
+          NPM_PUBLISH_ENABLED: ${{ needs.publish-guard.outputs.publish_enabled }}
+          NPM_PUBLISH_DISABLE_REASON: ${{ needs.publish-guard.outputs.publish_audit_reason }}
+          NPM_PUBLISH_DISABLE_INCIDENT_ID: ${{ needs.publish-guard.outputs.publish_audit_incident_id }}
+          NPM_PUBLISH_DISABLED_BY: ${{ needs.publish-guard.outputs.publish_audit_by }}
         run: bash ./.github/bin/publish-npm plugins/opencode
+
+      - name: Upload secret scan evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: secret-scan-results-opencode
+          path: plugins/opencode/secret-scan-results.jsonl
+          if-no-files-found: error
 
   publish-mcp-registry:
     name: publish to MCP Registry
     runs-on: ubuntu-latest
-    needs: publish-mcp
+    needs: [publish-guard, publish-mcp]
     if: >-
       github.repository == 'team-telnyx/ai' &&
+      needs.publish-guard.outputs.publish_enabled == 'true' &&
       (github.event_name == 'release' || github.event.inputs.package == 'all' || github.event.inputs.package == 'mcp')
     permissions:
       contents: read

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -13,15 +13,134 @@
 name: Publish PyPI
 on:
   workflow_dispatch:
+    inputs:
+      publish_disable_actor:
+        description: 'Actor who activated the PyPI publish disable guard'
+        required: false
+      publish_disable_timestamp:
+        description: 'UTC timestamp when the guard was activated'
+        required: false
+      publish_disable_reason:
+        description: 'Reason for temporarily disabling PyPI publish'
+        required: false
+      publish_disable_incident_id:
+        description: 'Related incident or ticket identifier for audit'
+        required: false
+      force_publish:
+        description: 'Set to true to ignore a temporary publish disable flag'
+        required: false
+        type: boolean
+        default: false
   release:
     types: [published]
 
 jobs:
+  publish-guard:
+    name: publish gate check
+    runs-on: ubuntu-latest
+    outputs:
+      publish_enabled: ${{ steps.evaluate.outputs.enabled }}
+      publish_audit_actor: ${{ steps.evaluate.outputs.publish_audit_actor }}
+      publish_audit_timestamp: ${{ steps.evaluate.outputs.publish_audit_timestamp }}
+      publish_audit_reason: ${{ steps.evaluate.outputs.publish_audit_reason }}
+      publish_audit_incident_id: ${{ steps.evaluate.outputs.publish_audit_incident_id }}
+      publish_override_used: ${{ steps.evaluate.outputs.publish_override_used }}
+    steps:
+      - id: evaluate
+        name: Evaluate publish gate
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          FORCE_PUBLISH="${{ github.event_name == 'workflow_dispatch' && inputs.force_publish || 'false' }}"
+          PUBLISH_ENABLED_RAW='${{ vars.PUBLISH_PYPI_ENABLED }}'
+          AUDIT_ACTOR='${{ vars.PUBLISH_PYPI_DISABLE_ACTOR }}'
+          AUDIT_TIMESTAMP='${{ vars.PUBLISH_PYPI_DISABLE_TIMESTAMP }}'
+          AUDIT_REASON='${{ vars.PUBLISH_PYPI_DISABLE_REASON }}'
+          AUDIT_INCIDENT_ID='${{ vars.PUBLISH_PYPI_DISABLE_INCIDENT_ID }}'
+
+          if [[ "${{ github.event_name }}" == 'workflow_dispatch' ]]; then
+            [[ -n '${{ inputs.publish_disable_actor }}' ]] && AUDIT_ACTOR='${{ inputs.publish_disable_actor }}'
+            [[ -n '${{ inputs.publish_disable_timestamp }}' ]] && AUDIT_TIMESTAMP='${{ inputs.publish_disable_timestamp }}'
+            [[ -n '${{ inputs.publish_disable_reason }}' ]] && AUDIT_REASON='${{ inputs.publish_disable_reason }}'
+            [[ -n '${{ inputs.publish_disable_incident_id }}' ]] && AUDIT_INCIDENT_ID='${{ inputs.publish_disable_incident_id }}'
+          fi
+
+          if [[ -z "$AUDIT_ACTOR" ]]; then
+            AUDIT_ACTOR='${{ github.actor }}'
+          fi
+          if [[ -z "$AUDIT_TIMESTAMP" ]]; then
+            AUDIT_TIMESTAMP="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          fi
+          if [[ -z "$FORCE_PUBLISH" || "$FORCE_PUBLISH" == 'false' ]]; then
+            FORCE_PUBLISH='false'
+          fi
+
+          echo "publish_audit_actor=$AUDIT_ACTOR" >> "$GITHUB_OUTPUT"
+          echo "publish_audit_timestamp=$AUDIT_TIMESTAMP" >> "$GITHUB_OUTPUT"
+          echo "publish_audit_reason=$AUDIT_REASON" >> "$GITHUB_OUTPUT"
+          echo "publish_audit_incident_id=$AUDIT_INCIDENT_ID" >> "$GITHUB_OUTPUT"
+
+          if [[ "$FORCE_PUBLISH" == 'true' ]]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "publish_override_used=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "## PyPI publish override"
+              echo "- result: allowed"
+              echo "- override: \`force_publish=true\`"
+              echo "- actor: \`$AUDIT_ACTOR\`"
+              echo "- timestamp: \`$AUDIT_TIMESTAMP\`"
+              echo "- reason: \`${AUDIT_REASON:-manual override force_publish=true}\`"
+              echo "- incident_id: \`${AUDIT_INCIDENT_ID:-none}\`"
+              echo "- event: \`${{ github.event_name }}\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "publish_override_used=false" >> "$GITHUB_OUTPUT"
+
+          if [[ "${PUBLISH_ENABLED_RAW,,}" == 'false' || "${PUBLISH_ENABLED_RAW,,}" == '0' || "${PUBLISH_ENABLED_RAW,,}" == 'off' || "${PUBLISH_ENABLED_RAW,,}" == 'disabled' ]]; then
+            MISSING_FIELDS=()
+            [[ -z "$AUDIT_ACTOR" ]] && MISSING_FIELDS+=('actor')
+            [[ -z "$AUDIT_TIMESTAMP" ]] && MISSING_FIELDS+=('timestamp')
+            [[ -z "$AUDIT_REASON" ]] && MISSING_FIELDS+=('reason')
+            [[ -z "$AUDIT_INCIDENT_ID" ]] && MISSING_FIELDS+=('incident id')
+
+            if [[ "${#MISSING_FIELDS[@]}" -gt 0 ]]; then
+              FINAL_REASON="PyPI publish guard is active but audit payload is incomplete: ${MISSING_FIELDS[*]}"
+            else
+              FINAL_REASON="$AUDIT_REASON"
+            fi
+
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "publish_audit_reason=$FINAL_REASON" >> "$GITHUB_OUTPUT"
+
+            {
+              echo "## PyPI publish disabled"
+              echo "- result: denied"
+              echo "- actor: \`$AUDIT_ACTOR\`"
+              echo "- timestamp: \`$AUDIT_TIMESTAMP\`"
+              echo "- reason: \`$FINAL_REASON\`"
+              echo "- incident_id: \`${AUDIT_INCIDENT_ID:-missing}\`"
+              echo "- event: \`${{ github.event_name }}\`"
+              echo "- repository variable: \`PUBLISH_PYPI_ENABLED=${PUBLISH_ENABLED_RAW}\`"
+              echo "- workflow: \`${{ github.workflow }}\`"
+              echo "- run: \`${{ github.run_id }}\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "publish_audit_reason=repository variable PUBLISH_PYPI_ENABLED is not false (${PUBLISH_ENABLED_RAW:-true})" >> "$GITHUB_OUTPUT"
+            echo "PyPI publish gate passed" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   publish:
     name: publish to PyPI
+    needs: publish-guard
     runs-on: ubuntu-latest
     # Only run from the canonical repo
-    if: github.repository == 'team-telnyx/ai'
+    if: >-
+      github.repository == 'team-telnyx/ai' &&
+      needs.publish-guard.outputs.publish_enabled == 'true'
     permissions:
       contents: read
       id-token: write
@@ -35,4 +154,11 @@ jobs:
           version: '0.9.13'
 
       - name: Publish to PyPI
+        env:
+          PYPI_PUBLISH_ENABLED: ${{ needs.publish-guard.outputs.publish_enabled }}
+          PYPI_PUBLISH_DISABLE_ACTOR: ${{ needs.publish-guard.outputs.publish_audit_actor }}
+          PYPI_PUBLISH_DISABLE_TIMESTAMP: ${{ needs.publish-guard.outputs.publish_audit_timestamp }}
+          PYPI_PUBLISH_DISABLE_REASON: ${{ needs.publish-guard.outputs.publish_audit_reason }}
+          PYPI_PUBLISH_DISABLE_INCIDENT_ID: ${{ needs.publish-guard.outputs.publish_audit_incident_id }}
+          PYPI_PUBLISH_OVERRIDE_USED: ${{ needs.publish-guard.outputs.publish_override_used }}
         run: bash ./.github/bin/publish-pypi

--- a/cli/README.md
+++ b/cli/README.md
@@ -80,7 +80,7 @@ Output: `{ sim_id, group_id, status, apn_config }`
 
 **One command: zero to AI assistant on a phone number.**
 
-Creates an AI assistant, buys a voice-capable number, and wires them together.
+Creates an AI assistant, buys a voice-capable number, creates a TeXML application for inbound routing, and assigns the number to that app.
 
 ```bash
 telnyx-agent setup-ai
@@ -89,6 +89,14 @@ telnyx-agent setup-ai --name "Support Bot" --json
 ```
 
 Output: `{ assistant_id, phone_number, test_command }`
+
+Verification:
+- Call the returned `phone_number`
+- Confirm the assistant answers and follows the supplied instructions
+
+Requirements:
+- `TELNYX_API_KEY`
+- Enough account balance for a number order and a short test call
 
 ### Edge Compute handoff commands
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -101,7 +101,7 @@ Requirements:
 ### Edge Compute handoff commands
 
 These are **thin executable bridges**, not native Edge lifecycle support.
-They make Edge Compute usable from `telnyx-agent` while keeping real deploy/auth/secrets/bindings ownership in `telnyx-edge`. They now prefer API-key auth for agent use when the installed Edge CLI supports it.
+They make Edge Compute usable from `telnyx-agent` while keeping real deploy/auth/secrets/bindings/actors/inspect/types/storage ownership in `telnyx-edge`. They now prefer API-key auth for agent use when the installed Edge CLI supports it.
 
 ```bash
 telnyx-agent edge-doctor --json
@@ -114,6 +114,7 @@ What they do:
 - check whether Edge auth is already configured
 - prefer `telnyx-edge auth api-key set <your-api-key>` for agents when supported
 - point you at a real Edge example
+- keep storage and inspection workflows honest by handing off `telnyx-edge inspect`, `telnyx-edge types`, and `telnyx-edge storage sqldb ...` to the upstream CLI
 - give you the concrete next deploy command
 - preserve an honest handoff instead of pretending `telnyx-agent` owns Edge lifecycle
 

--- a/cli/src/commands/capabilities.ts
+++ b/cli/src/commands/capabilities.ts
@@ -42,7 +42,7 @@ const CAPABILITIES: Record<string, Capability[]> = {
   ],
   "⚡ Edge Compute": [
     { name: "Edge Functions", description: "Pair Telnyx AI workflows with Telnyx Edge Compute. telnyx-agent now provides an executable handoff and prefers API-key auth for agent use when supported by telnyx-edge.", actions: ["see_guides_edge_compute"] },
-    { name: "Deployment Handoff", description: "Use team-telnyx/ai for orchestration patterns and telnyx-edge for deploy, secrets, bindings, and lifecycle management.", actions: ["telnyx_edge_ship", "telnyx_edge_secrets", "telnyx_edge_bindings"] },
+    { name: "Deployment Handoff", description: "Use team-telnyx/ai for orchestration patterns and telnyx-edge for deploy, secrets, bindings, actors, inspect, generated types, storage sqldb, and lifecycle management.", actions: ["telnyx_edge_ship", "telnyx_edge_secrets", "telnyx_edge_bindings", "telnyx_edge_actors", "telnyx_edge_inspect", "telnyx_edge_types", "telnyx_edge_storage_sqldb"] },
     { name: "Edge CLI Bridge", description: "Thin executable handoff from telnyx-agent into telnyx-edge for real MCP and webhook starting points.", actions: ["edge_doctor", "setup_edge_mcp", "setup_edge_webhook"] },
   ],
   "📋 10DLC Compliance": [

--- a/cli/src/commands/edge-doctor.ts
+++ b/cli/src/commands/edge-doctor.ts
@@ -7,7 +7,7 @@
  */
 
 import { outputJson, printError, printSuccess, printWarning } from "../utils/output.ts";
-import { getEdgeAuthStatus, getEdgeHelp, hasEdgeCli, supportsApiKeyAuth } from "../edge-cli.ts";
+import { getEdgeAuthStatus, getEdgeCommandSurface, getEdgeHelp, hasEdgeCli, supportsApiKeyAuth } from "../edge-cli.ts";
 
 interface EdgeDoctorResult {
   ready: boolean;
@@ -16,6 +16,7 @@ interface EdgeDoctorResult {
   authenticated: boolean;
   auth_mode: "api_key" | "oauth" | "none" | "unknown";
   api_key_auth_supported: boolean;
+  edge_command_surface: string[];
   checks: Array<{ name: string; ok: boolean; detail: string }>;
   next_steps: string[];
 }
@@ -29,6 +30,7 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
   let authenticated = false;
   let authMode: EdgeDoctorResult["auth_mode"] = "none";
   let apiKeyAuthSupported = false;
+  let edgeCommandSurface: string[] = [];
 
   try {
     const out = getEdgeHelp();
@@ -43,11 +45,17 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
   }
 
   if (installed) {
+    edgeCommandSurface = getEdgeCommandSurface();
     apiKeyAuthSupported = supportsApiKeyAuth();
     checks.push({
       name: "API-key auth supported",
       ok: apiKeyAuthSupported,
       detail: apiKeyAuthSupported ? "auth api-key set is available" : "no auth api-key set support detected",
+    });
+    checks.push({
+      name: "Detected Edge command surface",
+      ok: edgeCommandSurface.length > 0,
+      detail: edgeCommandSurface.length > 0 ? edgeCommandSurface.join(", ") : "no commands parsed from --help output",
     });
 
     try {
@@ -104,6 +112,7 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
     authenticated,
     auth_mode: authMode,
     api_key_auth_supported: apiKeyAuthSupported,
+    edge_command_surface: edgeCommandSurface,
     checks,
     next_steps: nextSteps,
   };

--- a/cli/src/commands/setup-edge-mcp.ts
+++ b/cli/src/commands/setup-edge-mcp.ts
@@ -46,7 +46,7 @@ export async function setupEdgeMcpCommand(flags: Record<string, string | boolean
     ],
     notes: [
       "team-telnyx/ai provides the integration pattern, not the Edge lifecycle.",
-      "Use telnyx-edge for auth, deploy, secrets, bindings, and lifecycle management.",
+      "Use telnyx-edge for auth, deploy, secrets, bindings, actors, inspect, storage sqldb, generated types, and lifecycle management.",
       "After deploy, connect the exposed MCP or HTTP boundary back into your AI workflow.",
     ],
   };

--- a/cli/src/commands/setup-edge-webhook.ts
+++ b/cli/src/commands/setup-edge-webhook.ts
@@ -46,7 +46,7 @@ export async function setupEdgeWebhookCommand(flags: Record<string, string | boo
     ],
     notes: [
       "Use this when your AI workflow needs an HTTP ingress point at the edge.",
-      "The deployed function lifecycle is still owned by telnyx-edge.",
+      "The deployed function lifecycle plus actors, inspect, storage sqldb, and generated types are still owned by telnyx-edge.",
       "After deploy, point your webhook-producing system at the Edge endpoint and let team-telnyx/ai handle orchestration guidance.",
     ],
   };

--- a/cli/src/edge-cli.ts
+++ b/cli/src/edge-cli.ts
@@ -1,16 +1,38 @@
-import { execFileSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 
 export function resolveEdgeBinary(): string {
   return process.env.TELNYX_EDGE_PATH || "telnyx-edge";
 }
 
 function runEdge(args: string[]): string {
-  return execFileSync(resolveEdgeBinary(), args, {
+  const result = spawnSync(resolveEdgeBinary(), args, {
     encoding: "utf8",
     timeout: 15000,
     env: { ...process.env },
     stdio: ["ignore", "pipe", "pipe"],
   });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  const stdout = result.stdout ?? "";
+  const stderr = result.stderr ?? "";
+  const combined = stdout.length > 0 && stderr.length > 0
+    ? `${stdout}\n${stderr}`
+    : `${stdout}${stderr}`;
+
+  if ((result.status ?? 0) !== 0) {
+    const error = new Error(combined || `telnyx-edge exited with status ${result.status ?? "unknown"}`);
+    Object.assign(error, {
+      status: result.status,
+      stdout,
+      stderr,
+    });
+    throw error;
+  }
+
+  return combined;
 }
 
 export function hasEdgeCli(): boolean {
@@ -26,6 +48,10 @@ export function getEdgeHelp(): string {
   return runEdge(["--help"]);
 }
 
+export function getEdgeCommandSurface(): string[] {
+  return parseEdgeHelpCommands(getEdgeHelp());
+}
+
 export type EdgeAuthStatus = {
   authenticated: boolean;
   mode: "api_key" | "oauth" | "none" | "unknown";
@@ -34,36 +60,7 @@ export type EdgeAuthStatus = {
 
 export function getEdgeAuthStatus(): EdgeAuthStatus {
   const raw = runEdge(["auth", "status"]);
-  const text = raw.toLowerCase();
-  const authenticated =
-    !text.includes("authentication status: none") &&
-    !text.includes("not authenticated") &&
-    !text.includes("status: ❌") &&
-    !text.includes("status: x");
-
-  let mode: EdgeAuthStatus["mode"] = "unknown";
-  if (
-    text.includes("authentication status: none") ||
-    text.includes("not authenticated") ||
-    text.includes("status: ❌") ||
-    text.includes("status: x")
-  ) {
-    mode = "none";
-  } else if (
-    text.includes("authentication status: api key") ||
-    text.includes("api key")
-  ) {
-    mode = "api_key";
-  } else if (
-    text.includes("authentication status: oauth") ||
-    text.includes("oauth") ||
-    text.includes("browser") ||
-    text.includes("logged in")
-  ) {
-    mode = "oauth";
-  }
-
-  return { authenticated, mode, raw };
+  return parseEdgeAuthStatus(raw);
 }
 
 export function supportsApiKeyAuth(): boolean {
@@ -73,4 +70,81 @@ export function supportsApiKeyAuth(): boolean {
   } catch {
     return false;
   }
+}
+
+export function parseEdgeAuthStatus(raw: string): EdgeAuthStatus {
+  const text = raw.toLowerCase();
+  const mode = detectAuthMode(text);
+  const unusable =
+    text.includes("token expired") ||
+    text.includes("run 'telnyx-edge auth login' to refresh") ||
+    text.includes("run \"telnyx-edge auth login\" to refresh");
+  const unauthenticated =
+    mode === "none" ||
+    text.includes("not authenticated") ||
+    text.includes("status: ❌") ||
+    text.includes("status: x");
+  const authenticatedMarker =
+    text.includes("status: ✅ authenticated") ||
+    text.includes("status: authenticated") ||
+    text.includes("logged in");
+  const authenticated = !unusable && !unauthenticated && (authenticatedMarker || mode === "api_key" || mode === "oauth");
+
+  return { authenticated, mode, raw };
+}
+
+export function parseEdgeHelpCommands(raw: string): string[] {
+  const markerMatch = raw.match(/(?:Available Commands|Commands):\s*([\s\S]*?)(?:\n\s*\n|\nFlags:|\nGlobal Flags:|$)/i);
+  if (!markerMatch) {
+    return [];
+  }
+
+  const commands: string[] = [];
+  const body = markerMatch[1].trim();
+  for (const line of body.split(/\r?\n/)) {
+    const match = line.trim().match(/^([a-z0-9-]+)\s{2,}/i);
+    if (match) {
+      commands.push(match[1]);
+    }
+  }
+  if (commands.length > 0) {
+    return commands;
+  }
+
+  const seen = new Set<string>();
+  for (const part of body.split(",")) {
+    const command = part.trim().split(/\s+/)[0];
+    if (command && !seen.has(command)) {
+      seen.add(command);
+      commands.push(command);
+    }
+  }
+  return commands;
+}
+
+function detectAuthMode(text: string): EdgeAuthStatus["mode"] {
+  if (
+    text.includes("authentication status: none") ||
+    text.includes("not authenticated") ||
+    text.includes("status: ❌") ||
+    text.includes("status: x")
+  ) {
+    return "none";
+  }
+  if (
+    text.includes("authentication status: api key") ||
+    text.includes("token type: api key")
+  ) {
+    return "api_key";
+  }
+  if (
+    text.includes("authentication status: oauth") ||
+    text.includes("authentication status: oauth 2.0") ||
+    text.includes("token type: bearer") ||
+    text.includes("browser") ||
+    text.includes("logged in")
+  ) {
+    return "oauth";
+  }
+  return "unknown";
 }

--- a/cli/tests/edge-handoff.test.ts
+++ b/cli/tests/edge-handoff.test.ts
@@ -5,6 +5,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, chmodSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { parseEdgeAuthStatus, parseEdgeHelpCommands } from "../src/edge-cli.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CLI = join(__dirname, "..", "bin", "telnyx-agent.ts");
@@ -23,7 +24,7 @@ if (args[0] === 'auth' && args[1] === 'api-key' && args[2] === 'set' && args.inc
   process.exit(0);
 }
 if (args.includes('--help')) {
-  console.log(['telnyx-edge v0.1.0', 'Commands: auth login, auth api-key set, ship, list, secrets, bindings'].join('\\n'));
+  console.log(['telnyx-edge v0.1.0', 'Commands: auth login, auth api-key set, ship, list, secrets, bindings, storage'].join('\\n'));
   process.exit(0);
 }
 if (args[0] === 'auth' && args[1] === 'status') {
@@ -64,6 +65,57 @@ function run(args: string[], env?: NodeJS.ProcessEnv): string {
 }
 
 describe("CLI — Edge Compute handoff", () => {
+  it("parses OAuth, API-key, none, and expired auth states correctly", () => {
+    const oauth = parseEdgeAuthStatus([
+      "API Endpoint: https://api.telnyx.com",
+      "Authentication Status: OAuth 2.0",
+      "Token Type: Bearer",
+      "Status: ✅ Authenticated",
+    ].join("\n"));
+    assert.equal(oauth.authenticated, true);
+    assert.equal(oauth.mode, "oauth");
+
+    const apiKey = parseEdgeAuthStatus([
+      "API Endpoint: https://api.telnyx.com",
+      "Authentication Status: API Key",
+      "Status: ✅ Authenticated",
+    ].join("\n"));
+    assert.equal(apiKey.authenticated, true);
+    assert.equal(apiKey.mode, "api_key");
+
+    const none = parseEdgeAuthStatus([
+      "API Endpoint: https://api.telnyx.com",
+      "Authentication Status: None",
+      "Status: ❌ Not authenticated",
+    ].join("\n"));
+    assert.equal(none.authenticated, false);
+    assert.equal(none.mode, "none");
+
+    const expired = parseEdgeAuthStatus([
+      "⚠️  A new version of the Telnyx Edge CLI is available: 0.2.5 (you have 0.2.3)",
+      "Authentication Status: OAuth 2.0",
+      "Token Type: Bearer",
+      "Status: ⚠️ Token expired - run 'telnyx-edge auth login' to refresh",
+    ].join("\n"));
+    assert.equal(expired.authenticated, false);
+    assert.equal(expired.mode, "oauth");
+  });
+
+  it("parses the live Edge command surface from help output", () => {
+    const commands = parseEdgeHelpCommands([
+      "Available Commands:",
+      "  actors      Manage account-scoped StatefulActor types",
+      "  auth        Authentication commands",
+      "  inspect     Show a function's full details and its actor bindings",
+      "  list        List all edge computing functions",
+      "  storage     Manage Edge storage resources including sqldb",
+      "  types       Generate TypeScript binding types for a telnyx.toml or func.toml project",
+      "",
+      "Flags:",
+    ].join("\n"));
+    assert.deepEqual(commands, ["actors", "auth", "inspect", "list", "storage", "types"]);
+  });
+
   it("help lists edge handoff commands", () => {
     const output = run(["help"]);
     assert.ok(output.includes("edge-doctor"));
@@ -76,6 +128,11 @@ describe("CLI — Edge Compute handoff", () => {
     const data = JSON.parse(output);
     const category = Object.keys(data.api_capabilities || {}).find((k) => k.includes("Edge Compute"));
     assert.ok(category);
+    const handoff = data.api_capabilities[category].find((cap: { name?: string }) => cap.name === "Deployment Handoff");
+    assert.ok(handoff);
+    assert.ok(handoff.description.includes("storage sqldb"));
+    const edgeActions = data.api_capabilities[category].flatMap((cap: { actions?: string[] }) => cap.actions || []);
+    assert.ok(edgeActions.includes("telnyx_edge_storage_sqldb"));
     const commands = data.composite_commands.map((c: any) => c.name || c.command || c);
     assert.ok(commands.some((c: string) => c.includes("edge-doctor")));
     assert.ok(commands.some((c: string) => c.includes("setup-edge-mcp")));
@@ -91,6 +148,8 @@ describe("CLI — Edge Compute handoff", () => {
     assert.equal(data.authenticated, true);
     assert.equal(data.auth_mode, "api_key");
     assert.equal(data.api_key_auth_supported, true);
+    assert.ok(data.edge_command_surface.includes("bindings"));
+    assert.ok(data.edge_command_surface.includes("storage"));
     assert.ok(Array.isArray(data.next_steps));
   });
 
@@ -102,7 +161,48 @@ describe("CLI — Edge Compute handoff", () => {
     assert.equal(data.telnyx_edge_installed, true);
     assert.equal(data.authenticated, false);
     assert.equal(data.api_key_auth_supported, true);
+    assert.ok(data.edge_command_surface.includes("bindings"));
+    assert.ok(data.edge_command_surface.includes("storage"));
     assert.ok(data.next_steps.some((s: string) => s.includes("auth api-key set")));
+  });
+
+  it("edge-doctor treats expired OAuth as not ready", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "telnyx-edge-expired-"));
+    const binDir = join(tempDir, "bin");
+    mkdirSync(binDir, { recursive: true });
+    const fakeEdge = join(binDir, "telnyx-edge");
+    writeFileSync(
+      fakeEdge,
+      `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === 'auth' && args[1] === 'api-key' && args[2] === 'set' && args.includes('--help')) {
+  console.log('Set API key for authentication. The API key must be provided as an argument.');
+  process.exit(0);
+}
+if (args.includes('--help')) {
+  console.log(['telnyx-edge v0.2.3', 'Available Commands:', '  actors      Manage account-scoped StatefulActor types', '  auth        Authentication commands', '  bindings    Manage Telnyx API key bindings for edge computing functions', '  inspect     Show a function\\'s full details and its actor bindings', '  storage     Manage Edge storage resources including sqldb', '  types       Generate TypeScript binding types for a telnyx.toml or func.toml project', '', 'Flags:'].join('\\n'));
+  process.exit(0);
+}
+if (args[0] === 'auth' && args[1] === 'status') {
+  console.log(['Authentication Status: OAuth 2.0', 'Token Type: Bearer', \"Status: ⚠️ Token expired - run 'telnyx-edge auth login' to refresh\"].join('\\n'));
+  process.exit(0);
+}
+console.log('ok');
+`,
+    );
+    chmodSync(fakeEdge, 0o755);
+
+    const output = run(["edge-doctor", "--json"], {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH}`,
+      TELNYX_EDGE_PATH: fakeEdge,
+    });
+    const data = JSON.parse(output);
+    assert.equal(data.ready, false);
+    assert.equal(data.authenticated, false);
+    assert.equal(data.auth_mode, "oauth");
+    assert.ok(data.edge_command_surface.includes("actors"));
+    assert.ok(data.edge_command_surface.includes("storage"));
   });
 
   it("setup-edge-mcp returns API-key auth handoff when unauthenticated", () => {

--- a/cli/tests/integration-ci.test.ts
+++ b/cli/tests/integration-ci.test.ts
@@ -149,6 +149,16 @@ describe("CLI — capabilities", () => {
     }
   });
 
+  it("surfaces the upstream Edge storage and inspect handoff actions", () => {
+    const data = runJson("capabilities --json");
+    const edgeCategory = Object.keys(data.api_capabilities || {}).find((name) => name.includes("Edge Compute"));
+    assert.ok(edgeCategory, "Missing Edge Compute category");
+    const actions = data.api_capabilities[edgeCategory].flatMap((cap: { actions?: string[] }) => cap.actions || []);
+    assert.ok(actions.includes("telnyx_edge_inspect"), "Missing Edge inspect handoff");
+    assert.ok(actions.includes("telnyx_edge_types"), "Missing Edge types handoff");
+    assert.ok(actions.includes("telnyx_edge_storage_sqldb"), "Missing Edge storage sqldb handoff");
+  });
+
   it("composite_commands includes all setup commands", () => {
     const data = runJson("capabilities --json");
     const names = data.composite_commands.map((c: any) => c.name || c.command || c);

--- a/guides/ai-assistants.md
+++ b/guides/ai-assistants.md
@@ -5,24 +5,70 @@
 ## Prerequisites
 
 - Telnyx API key ([get one free](https://telnyx.com/agent-signup.md))
-- At least one phone number
-- AI credits or pay-as-you-go enabled
+- A positive enough balance for a number order and a short test call
+- `@telnyx/api-cli` or `@telnyx/agent-cli` installed locally
+
+## Fastest Happy Path
+
+The fastest contributor path in this repo is the composite CLI flow:
+
+```bash
+export TELNYX_API_KEY="KEY_..."
+
+# Option 1: run from this repo
+cd cli
+npm install
+npx tsx bin/telnyx-agent.ts setup-ai \
+  --instructions "You are a concise support agent for Acme. Confirm the caller's goal first." \
+  --json
+
+# Option 2: if published globally
+telnyx-agent setup-ai \
+  --instructions "You are a concise support agent for Acme. Confirm the caller's goal first." \
+  --json
+```
+
+What `setup-ai` does:
+
+1. Creates an AI assistant
+2. Searches for a voice-capable local number
+3. Orders the number
+4. Creates a TeXML application that points inbound calls at the assistant
+5. Assigns the TeXML app to the purchased number
+
+Successful output includes:
+
+- `assistant_id`
+- `phone_number`
+- `phone_number_id`
+- `test_command`
+- `ready: true`
+
+Smallest live verification:
+
+1. Run `telnyx-agent setup-ai --json`
+2. Copy the returned `phone_number`
+3. Place a real call to that number
+4. Confirm the assistant answers and follows the supplied instructions
+
+The repo's real-account verification reference for this path lives in [`cli/tests/E2E-RESULTS.md`](/cli/tests/E2E-RESULTS.md).
 
 ## Quick Start
 
 ```bash
-# Create an assistant
+# Create an assistant directly via API
 curl -X POST "https://api.telnyx.com/v2/ai/assistants" \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "Support Bot",
     "instructions": "You are a helpful customer support assistant. Be friendly and concise.",
-    "voice": {"provider": "telnyx", "settings": {"voice_id": "en-US-Neural2-F"}}
+    "model": "Qwen/Qwen3-235B-A22B"
   }'
 
-# Wire to a phone number (via Call Control application settings in portal)
-# Or use the assistant ID in your webhook response
+# Then either:
+# - use telnyx-agent setup-ai for the rest of the phone-number wiring flow, or
+# - follow the manual wiring section below
 ```
 
 ## API Reference
@@ -46,7 +92,7 @@ curl -X POST "https://api.telnyx.com/v2/ai/assistants" \
         "pitch": 0
       }
     },
-    "model": "meta-llama/Llama-3.3-70B-Instruct",
+    "model": "Qwen/Qwen3-235B-A22B",
     "greeting": "Hello! Thanks for calling Acme Corp. How can I help you today?",
     "hold_music_url": "https://example.com/hold.mp3"
   }'
@@ -69,7 +115,7 @@ curl -X POST "https://api.telnyx.com/v2/ai/assistants" \
   "id": "assistant-uuid",
   "name": "Sales Assistant",
   "instructions": "...",
-  "model": "meta-llama/Llama-3.3-70B-Instruct",
+  "model": "Qwen/Qwen3-235B-A22B",
   "created_at": "2024-01-15T12:00:00Z"
 }
 ```
@@ -207,12 +253,12 @@ assistant = requests.post(
     json={
         "name": "Support Bot",
         "instructions": "You are a helpful customer support agent.",
-        "model": "meta-llama/Llama-3.3-70B-Instruct",
+        "model": "Qwen/Qwen3-235B-A22B",
         "voice": {"provider": "telnyx", "settings": {"voice_id": "en-US-Neural2-F"}},
         "greeting": "Hello! How can I help you today?"
     }
 ).json()
-assistant_id = assistant["data"]["id"]
+assistant_id = assistant["id"]
 print(f"Created: {assistant_id}")
 
 # List assistants
@@ -248,12 +294,12 @@ const createRes = await fetch(`${BASE_URL}/ai/assistants`, {
   body: JSON.stringify({
     name: "Support Bot",
     instructions: "You are a helpful customer support agent.",
-    model: "meta-llama/Llama-3.3-70B-Instruct",
+    model: "Qwen/Qwen3-235B-A22B",
     voice: { provider: "telnyx", settings: { voice_id: "en-US-Neural2-F" } },
     greeting: "Hello! How can I help you today?",
   }),
 });
-const { data: assistant } = await createRes.json();
+const assistant = await createRes.json();
 console.log(`Created: ${assistant.id}`);
 
 // List assistants
@@ -287,10 +333,10 @@ toolkit = TelnyxToolkit(api_key="KEY...")
 # Create an AI assistant
 assistant = toolkit.execute("create_ai_assistant", {
     "name": "Support Bot",
-    "model": "meta-llama/Llama-3.3-70B-Instruct",
+    "model": "Qwen/Qwen3-235B-A22B",
     "instructions": "You are a helpful customer support agent."
 })
-print(f"Created: {assistant['data']['id']}")
+print(f"Created: {assistant['id']}")
 
 # List assistants
 assistants = toolkit.execute("list_ai_assistants", {"page_size": 10})
@@ -300,28 +346,28 @@ for a in assistants["data"]:
 
 ## Wiring to a Phone Number
 
-1. Create a Call Control application in the portal
-2. Set the webhook URL to: `https://api.telnyx.com/v2/ai/assistants/{assistant_id}/answer`
-3. Assign your phone number to this application
+`telnyx-agent setup-ai` automates this section. If you need to do it manually, use a TeXML application and then assign it to the number's voice settings.
 
-Or programmatically:
+Manual API sequence:
 
 ```bash
-# Create connection pointing to assistant
-curl -X POST "https://api.telnyx.com/v2/connections" \
+# Create a TeXML application that routes inbound calls to the assistant
+curl -X POST "https://api.telnyx.com/v2/texml_applications" \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "name": "AI Assistant Connection",
+    "friendly_name": "AI Assistant App",
     "active": true,
-    "webhook_api_url": "https://api.telnyx.com/v2/ai/assistants/{assistant_id}/answer"
+    "ai_assistant_id": "{assistant_id}",
+    "voice_url": "https://api.telnyx.com/v2/ai/assistants/{assistant_id}/call",
+    "voice_method": "POST"
   }'
 
-# Assign phone number to connection
-curl -X PATCH "https://api.telnyx.com/v2/phone_numbers/{number_id}" \
+# Assign that TeXML application to the phone number
+curl -X PATCH "https://api.telnyx.com/v2/phone_numbers/{number_id}/voice" \
   -H "Authorization: Bearer $TELNYX_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"connection_id": "connection-id"}'
+  -d '{"connection_id": "texml-app-id"}'
 ```
 
 ## Available Voices

--- a/guides/edge-compute.md
+++ b/guides/edge-compute.md
@@ -12,7 +12,7 @@ This repo helps you discover where Edge Compute fits into an AI workflow, but th
 - the `telnyx-edge` CLI
 
 That means:
-- build/deploy/delete/secrets/bindings live in `telnyx-edge`
+- build/deploy/delete/secrets/bindings/actors/inspect/types/storage sqldb live in `telnyx-edge`
 - agent/orchestration logic can live in `team-telnyx/ai`
 - `team-telnyx/ai` should not pretend to replace Edge Compute
 
@@ -34,8 +34,11 @@ Good bridge use cases:
 ## Quick Start
 
 ```bash
-# Authenticate with the dedicated Edge CLI (preferred for agents)
-telnyx-edge auth api-key set <your-api-key>
+# Authenticate with the dedicated Edge CLI
+telnyx-edge auth login
+
+# If your installed CLI exposes API-key auth, agents can use it non-interactively instead
+# telnyx-edge auth api-key set <your-api-key>
 
 # Start from the MCP server example
 telnyx-edge new-func --from-dir=examples/ts/mcp-server --name=my-mcp-server
@@ -55,20 +58,33 @@ Edge Compute lifecycle is owned by the separate `telnyx-edge` CLI rather than th
 Common lifecycle commands:
 
 ```bash
+telnyx-edge --version
 telnyx-edge auth status
+telnyx-edge status
 telnyx-edge list
+telnyx-edge actors
+telnyx-edge inspect my-mcp-server
 telnyx-edge secrets list
 telnyx-edge bindings get
+telnyx-edge types
+telnyx-edge storage sqldb list
 ```
 
 | Command | Purpose |
 |---------|---------|
-| `telnyx-edge auth api-key set` | Authenticate the Edge CLI non-interactively |
+| `telnyx-edge auth login` | Authenticate the Edge CLI with the public upstream flow |
+| `telnyx-edge --version` | Verify which Edge CLI build is installed before debugging auth or deploy failures |
+| `telnyx-edge auth status` | Show whether the CLI is authenticated and whether the auth state is still usable |
+| `telnyx-edge status` | Check CLI configuration and connectivity before or after a deployment handoff |
 | `telnyx-edge new-func` | Scaffold a new function or clone an example |
 | `telnyx-edge ship` | Deploy the current function |
 | `telnyx-edge list` | List deployed functions |
+| `telnyx-edge actors` | Manage account-scoped StatefulActor types that can be bound into functions |
+| `telnyx-edge inspect` | Show a function's full details and actor bindings during handoff/debugging |
 | `telnyx-edge secrets` | Manage runtime secrets |
 | `telnyx-edge bindings` | Manage Telnyx API key bindings |
+| `telnyx-edge types` | Generate TypeScript binding types from the Edge project config |
+| `telnyx-edge storage sqldb` | Manage Edge SQL database resources from the upstream CLI |
 
 ## Prerequisites
 
@@ -84,8 +100,11 @@ Edge Compute is managed through the separate CLI:
 # See the edge-compute repo for install/setup details
 # https://github.com/team-telnyx/edge-compute
 
-telnyx-edge auth api-key set <your-api-key>
+telnyx-edge auth login
 telnyx-edge auth status
+
+# If your installed CLI exposes API-key auth, agents can use it non-interactively instead
+# telnyx-edge auth api-key set <your-api-key>
 ```
 
 Typical lifecycle commands live there:
@@ -94,9 +113,13 @@ Typical lifecycle commands live there:
 telnyx-edge new-func
 telnyx-edge ship
 telnyx-edge list
+telnyx-edge actors
+telnyx-edge inspect
 telnyx-edge delete-func
 telnyx-edge secrets
 telnyx-edge bindings
+telnyx-edge types
+telnyx-edge storage sqldb
 ```
 
 ## Reference architecture
@@ -111,7 +134,7 @@ A practical pattern looks like this:
 2. Use `team-telnyx/edge-compute` for:
    - function scaffolding
    - deployment
-   - secrets and bindings
+   - secrets, bindings, actors, inspect, generated types, and storage sqldb
    - running webhook/MCP edge endpoints
 3. Connect them with a stable boundary:
    - HTTP webhook
@@ -159,6 +182,19 @@ That keeps ownership clear and avoids duplicating deployment tooling.
 - add richer examples for webhook handlers, MCP adapters, and AI post-processing functions
 - add copy-paste scaffolds for how an AI app should call a deployed edge endpoint
 - document required secrets/bindings patterns
+
+## Surface drift note
+
+The live `telnyx-edge --help` output available in this workspace on July 29, 2026 also exposes:
+
+```bash
+telnyx-edge actors
+telnyx-edge inspect <function-name>
+telnyx-edge types
+telnyx-edge storage sqldb ...
+```
+
+That matches the delegated issue's monitoring note and keeps this guide aligned with the current upstream CLI surface. Upstream `v0.2.5`, published on July 14, 2026, also adds actor-instance visibility in its release notes. `team-telnyx/ai` should acknowledge that surface, including the SQL storage handoff, but lifecycle execution still belongs to `telnyx-edge`.
 
 ### Phase 3 — CLI bridge
 Only if ownership stays clear:

--- a/tests/fixtures/release-artifact-scanner/github-release-clean/package/.github/releases/telnyx-agent/v1.2.3/checksums.txt
+++ b/tests/fixtures/release-artifact-scanner/github-release-clean/package/.github/releases/telnyx-agent/v1.2.3/checksums.txt
@@ -1,0 +1,1 @@
+telnyx-agent-darwin-arm64.tar.gz  4e9f6be9f6f66561dc04d1c588fa4ae9f0c7c6df4d3b4f0ae42c1ce6b77f7c42

--- a/tests/fixtures/release-artifact-scanner/github-release-secret/package/.github/releases/telnyx-agent/v1.2.3/checksums.txt
+++ b/tests/fixtures/release-artifact-scanner/github-release-secret/package/.github/releases/telnyx-agent/v1.2.3/checksums.txt
@@ -1,0 +1,1 @@
+release_token=github_pat_1234567890abcdefghijklmnopqrstuvwxyz

--- a/tests/fixtures/release-artifact-scanner/n8n-generated-clean/package/dist/n8n/generated/workflow.bundle.js
+++ b/tests/fixtures/release-artifact-scanner/n8n-generated-clean/package/dist/n8n/generated/workflow.bundle.js
@@ -1,0 +1,1 @@
+export const workflowToken = "safe-placeholder";

--- a/tests/fixtures/release-artifact-scanner/n8n-generated-secret/package/dist/n8n/generated/workflow.bundle.js
+++ b/tests/fixtures/release-artifact-scanner/n8n-generated-secret/package/dist/n8n/generated/workflow.bundle.js
@@ -1,0 +1,1 @@
+export const apiKey = "sk-live-1234567890abcdefghijklmnopqrstuv";

--- a/tests/publish-npm.test.mjs
+++ b/tests/publish-npm.test.mjs
@@ -1,0 +1,132 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const publishScriptPath = join(repoRoot, ".github/bin/publish-npm");
+
+function withTempDir(run) {
+  const root = mkdtempSync(join(tmpdir(), "publish-npm-test-"));
+  try {
+    return run(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function writeExecutable(path, contents) {
+  writeFileSync(path, contents, { mode: 0o755 });
+}
+
+function runPublishScript({
+  packageJson,
+  npmScript,
+  nodeScript = "#!/usr/bin/env bash\necho 'Release artifact scan passed'\n",
+  env = {},
+}) {
+  return withTempDir((root) => {
+    const binDir = join(root, "bin");
+    const pkgDir = join(root, "pkg");
+    const summaryPath = join(root, "summary.md");
+
+    mkdirSync(binDir, { recursive: true });
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(join(pkgDir, "package.json"), JSON.stringify(packageJson, null, 2));
+
+    writeExecutable(join(binDir, "npm"), npmScript);
+    writeExecutable(join(binDir, "node"), nodeScript);
+
+    const stdout = execFileSync("bash", [publishScriptPath, pkgDir], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        ...env,
+        PATH: `${binDir}:${process.env.PATH}`,
+        GITHUB_STEP_SUMMARY: summaryPath,
+      },
+      encoding: "utf8",
+    });
+
+    return {
+      stdout,
+      summary: readFileSync(summaryPath, "utf8"),
+    };
+  });
+}
+
+test("skips npm publish when the version is already on npm", () => {
+  const result = runPublishScript({
+    packageJson: {
+      name: "@telnyx/test-pkg",
+      version: "1.2.3",
+      scripts: { build: "echo build-ok" },
+    },
+    env: {
+      ACTIONS_ID_TOKEN_REQUEST_TOKEN: "1",
+    },
+    npmScript: `#!/usr/bin/env bash
+set -e
+cmd="$1"
+shift || true
+case "$cmd" in
+  run)
+    echo "npm run $*"
+    ;;
+  view)
+    echo '"1.2.3"'
+    ;;
+  pack)
+    dest="$2"
+    touch "$dest/fake.tgz"
+    echo 'fake.tgz'
+    ;;
+  publish)
+    echo 'PUBLISH_CALLED'
+    exit 99
+    ;;
+  config)
+    echo 'config-set'
+    ;;
+  *)
+    echo "unexpected npm cmd: $cmd $*" >&2
+    exit 98
+    ;;
+esac
+`,
+  });
+
+  assert.match(result.stdout, /already published on npm; skipping publish\./);
+  assert.doesNotMatch(result.stdout, /PUBLISH_CALLED/);
+  assert.match(result.summary, /Gate result: \*\*allowed\*\*/);
+});
+
+test("blocks disabled publish attempts and records audit context", () => {
+  const result = runPublishScript({
+    packageJson: {
+      name: "@telnyx/test-pkg",
+      version: "1.2.3",
+      scripts: { build: "echo build-ok" },
+    },
+    env: {
+      NPM_PUBLISH_ENABLED: "false",
+      NPM_PUBLISH_DISABLE_REASON: "incident containment",
+      NPM_PUBLISH_DISABLE_INCIDENT_ID: "INC-42",
+      NPM_PUBLISH_DISABLED_BY: "cto",
+    },
+    npmScript: `#!/usr/bin/env bash
+echo "unexpected npm invocation: $*" >&2
+exit 98
+`,
+  });
+
+  assert.match(result.stdout, /NPM publishing is disabled via NPM_PUBLISH_ENABLED=false/);
+  assert.match(result.stdout, /npm publish blocked/);
+  assert.match(result.summary, /Gate result: \*\*blocked\*\*/);
+  assert.match(result.summary, /- actor: cto/);
+  assert.match(result.summary, /- reason: incident containment/);
+  assert.match(result.summary, /- incident_id: INC-42/);
+});

--- a/tests/release-artifact-scanner.test.mjs
+++ b/tests/release-artifact-scanner.test.mjs
@@ -1,0 +1,140 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { cpSync, mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+import { scanReleaseArtifact } from "../.github/scripts/scan-release-artifact.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURES_DIR = join(__dirname, "fixtures", "release-artifact-scanner");
+const GITHUB_RELEASE_SECRET = "github_pat_1234567890abcdefghijklmnopqrstuvwxyz";
+const N8N_BUNDLE_SECRET = "sk-live-1234567890abcdefghijklmnopqrstuv";
+
+function withArtifact(files, run) {
+  const root = mkdtempSync(join(tmpdir(), "release-artifact-scan-"));
+  const pkgDir = join(root, "package");
+  mkdirSync(pkgDir, { recursive: true });
+
+  for (const [relativePath, contents] of Object.entries(files)) {
+    const destination = join(pkgDir, relativePath);
+    mkdirSync(join(destination, ".."), { recursive: true });
+    writeFileSync(destination, contents);
+  }
+
+  const tarballPath = join(root, "artifact.tgz");
+  execFileSync("tar", ["-czf", tarballPath, "-C", root, "package"]);
+
+  try {
+    run(tarballPath);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function withFixtureArtifact(name, run) {
+  const root = mkdtempSync(join(tmpdir(), "release-artifact-fixture-"));
+  const fixtureDir = join(FIXTURES_DIR, name);
+  const packageDir = join(fixtureDir, "package");
+  const tarballPath = join(root, `${name}.tgz`);
+
+  cpSync(packageDir, join(root, "package"), { recursive: true });
+  execFileSync("tar", ["-czf", tarballPath, "-C", root, "package"]);
+
+  try {
+    run(tarballPath);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function runScannerCli(tarballPath) {
+  return spawnSync(process.execPath, [join(__dirname, "../.github/scripts/scan-release-artifact.mjs"), tarballPath], {
+    cwd: join(__dirname, ".."),
+    encoding: "utf8",
+  });
+}
+
+test("returns no findings for a clean artifact", () => {
+  withArtifact(
+    {
+      "README.md": "# Clean package\n",
+      "dist/index.js": "export const value = 'safe';\n",
+    },
+    (tarballPath) => {
+      assert.deepEqual(scanReleaseArtifact(tarballPath), []);
+    },
+  );
+});
+
+test("detects high-confidence tokens without surfacing raw secret text", () => {
+  withArtifact(
+    {
+      "dist/index.js": "export const token = 'github_pat_1234567890abcdefghijklmnopqrstuvwxyz';\n",
+    },
+    (tarballPath) => {
+      const findings = scanReleaseArtifact(tarballPath);
+      assert.equal(findings.length, 1);
+      assert.equal(findings[0].detector, "github-pat");
+      assert.equal(findings[0].path, "package/dist/index.js");
+      assert.match(findings[0].fileSha256, /^[a-f0-9]{64}$/);
+      assert.match(findings[0].matchSha256, /^[a-f0-9]{64}$/);
+      assert.equal("rawMatch" in findings[0], false);
+      assert.equal(JSON.stringify(findings).includes("github_pat_"), false);
+    },
+  );
+});
+
+test("allows a clean GitHub release artifact path", () => {
+  withFixtureArtifact("github-release-clean", (tarballPath) => {
+    assert.deepEqual(scanReleaseArtifact(tarballPath), []);
+
+    const result = runScannerCli(tarballPath);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /Release artifact scan passed/);
+  });
+});
+
+test("blocks a GitHub release artifact path without logging the raw secret", () => {
+  withFixtureArtifact("github-release-secret", (tarballPath) => {
+    const findings = scanReleaseArtifact(tarballPath);
+    assert.equal(findings.length, 1);
+    assert.equal(findings[0].detector, "github-pat");
+    assert.equal(findings[0].path, "package/.github/releases/telnyx-agent/v1.2.3/checksums.txt");
+    assert.equal(JSON.stringify(findings).includes(GITHUB_RELEASE_SECRET), false);
+
+    const result = runScannerCli(tarballPath);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /High-confidence secret findings blocked release artifact publish\./);
+    assert.match(result.stderr, /package\/\.github\/releases\/telnyx-agent\/v1\.2\.3\/checksums\.txt/);
+    assert.equal(result.stderr.includes(GITHUB_RELEASE_SECRET), false);
+  });
+});
+
+test("allows a clean n8n generated bundle path", () => {
+  withFixtureArtifact("n8n-generated-clean", (tarballPath) => {
+    assert.deepEqual(scanReleaseArtifact(tarballPath), []);
+
+    const result = runScannerCli(tarballPath);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /Release artifact scan passed/);
+  });
+});
+
+test("blocks an n8n generated bundle path without logging the raw secret", () => {
+  withFixtureArtifact("n8n-generated-secret", (tarballPath) => {
+    const findings = scanReleaseArtifact(tarballPath);
+    assert.equal(findings.length, 1);
+    assert.equal(findings[0].detector, "openai-key");
+    assert.equal(findings[0].path, "package/dist/n8n/generated/workflow.bundle.js");
+    assert.equal(JSON.stringify(findings).includes(N8N_BUNDLE_SECRET), false);
+
+    const result = runScannerCli(tarballPath);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /High-confidence secret findings blocked release artifact publish\./);
+    assert.match(result.stderr, /package\/dist\/n8n\/generated\/workflow\.bundle\.js/);
+    assert.equal(result.stderr.includes(N8N_BUNDLE_SECRET), false);
+  });
+});

--- a/tests/release-artifact-scanner.test.mjs
+++ b/tests/release-artifact-scanner.test.mjs
@@ -1,15 +1,14 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { cpSync, mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { chmodSync, cpSync, existsSync, mkdtempSync, readFileSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
 import { execFileSync, spawnSync } from "node:child_process";
-import { dirname, join } from "node:path";
+import { delimiter, dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 
-import { scanReleaseArtifact } from "../.github/scripts/scan-release-artifact.mjs";
-
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FIXTURES_DIR = join(__dirname, "fixtures", "release-artifact-scanner");
+const SCAN_SCRIPT_PATH = join(__dirname, "../.github/scripts/scan-release-artifact.mjs");
 const GITHUB_RELEASE_SECRET = "github_pat_1234567890abcdefghijklmnopqrstuvwxyz";
 const N8N_BUNDLE_SECRET = "sk-live-1234567890abcdefghijklmnopqrstuv";
 
@@ -50,11 +49,96 @@ function withFixtureArtifact(name, run) {
   }
 }
 
-function runScannerCli(tarballPath) {
-  return spawnSync(process.execPath, [join(__dirname, "../.github/scripts/scan-release-artifact.mjs"), tarballPath], {
-    cwd: join(__dirname, ".."),
+function withScannerRun(tarballPath, run) {
+  const root = mkdtempSync(join(tmpdir(), "release-artifact-run-"));
+  const binDir = join(root, "bin");
+  const resultsPath = join(root, "secret-scan-results.jsonl");
+  mkdirSync(binDir, { recursive: true });
+
+  const gitleaksPath = join(binDir, "gitleaks");
+  writeFileSync(gitleaksPath, `#!/usr/bin/env node
+const { readFileSync, readdirSync, statSync, writeFileSync } = require("node:fs");
+const { join, relative } = require("node:path");
+
+const argv = process.argv.slice(2);
+if (argv[0] === "version") {
+  process.stdout.write("gitleaks-test-stub\\n");
+  process.exit(0);
+}
+
+if (argv[0] !== "detect") {
+  process.stderr.write("unsupported gitleaks invocation\\n");
+  process.exit(2);
+}
+
+let source = process.cwd();
+let reportPath = "";
+for (let i = 0; i < argv.length; i += 1) {
+  if (argv[i] === "--source") source = argv[i + 1];
+  if (argv[i] === "--report-path") reportPath = argv[i + 1];
+}
+
+const detectors = [
+  { id: "github-pat", pattern: /\\bgithub_pat_[A-Za-z0-9_]{20,}\\b/g },
+  { id: "openai-key", pattern: /\\bsk-(?:proj-|live-|test-)?[A-Za-z0-9_-]{20,}\\b/g },
+];
+
+const findings = [];
+
+function walk(currentPath) {
+  for (const entry of readdirSync(currentPath, { withFileTypes: true })) {
+    const nextPath = join(currentPath, entry.name);
+    if (entry.isDirectory()) {
+      walk(nextPath);
+      continue;
+    }
+
+    const raw = readFileSync(nextPath, "utf8");
+    for (const detector of detectors) {
+      detector.pattern.lastIndex = 0;
+      for (const match of raw.matchAll(detector.pattern)) {
+        findings.push({
+          RuleID: detector.id,
+          Description: detector.id,
+          File: relative(source, nextPath).split("\\\\").join("/"),
+          Match: match[0],
+          Secret: match[0],
+          StartLine: 1,
+          Line: 1,
+          Entropy: 5,
+        });
+      }
+    }
+  }
+}
+
+walk(source);
+writeFileSync(reportPath, JSON.stringify(findings, null, 2));
+process.exit(0);
+`);
+  chmodSync(gitleaksPath, 0o755);
+
+  const result = spawnSync(process.execPath, [SCAN_SCRIPT_PATH, tarballPath], {
+    cwd: root,
     encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}`,
+    },
   });
+
+  const findings = existsSync(resultsPath)
+    ? readFileSync(resultsPath, "utf8")
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map((line) => JSON.parse(line))
+    : [];
+
+  try {
+    run({ result, findings });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 }
 
 test("returns no findings for a clean artifact", () => {
@@ -64,7 +148,12 @@ test("returns no findings for a clean artifact", () => {
       "dist/index.js": "export const value = 'safe';\n",
     },
     (tarballPath) => {
-      assert.deepEqual(scanReleaseArtifact(tarballPath), []);
+      withScannerRun(tarballPath, ({ result, findings }) => {
+        assert.equal(result.status, 0);
+        assert.deepEqual(findings, []);
+        assert.match(result.stdout, /secret_scan_summary high=0 medium=0 low=0/);
+        assert.match(result.stdout, /Release artifact scan passed/);
+      });
     },
   );
 });
@@ -75,66 +164,70 @@ test("detects high-confidence tokens without surfacing raw secret text", () => {
       "dist/index.js": "export const token = 'github_pat_1234567890abcdefghijklmnopqrstuvwxyz';\n",
     },
     (tarballPath) => {
-      const findings = scanReleaseArtifact(tarballPath);
-      assert.equal(findings.length, 1);
-      assert.equal(findings[0].detector, "github-pat");
-      assert.equal(findings[0].path, "package/dist/index.js");
-      assert.match(findings[0].fileSha256, /^[a-f0-9]{64}$/);
-      assert.match(findings[0].matchSha256, /^[a-f0-9]{64}$/);
-      assert.equal("rawMatch" in findings[0], false);
-      assert.equal(JSON.stringify(findings).includes("github_pat_"), false);
+      withScannerRun(tarballPath, ({ result, findings }) => {
+        assert.equal(result.status, 1);
+        assert.equal(findings.length, 1);
+        assert.equal(findings[0].detector, "github-pat");
+        assert.equal(findings[0].artifact_path, "artifact/package/dist/index.js");
+        assert.equal(findings[0].severity, "high");
+        assert.match(findings[0].artifact_sha256, /^[a-f0-9]{64}$/);
+        assert.match(findings[0].snippet_hash, /^[a-f0-9]{64}$/);
+        const output = `${result.stdout}\n${result.stderr}`;
+        assert.equal(JSON.stringify(findings).includes("github_pat_"), false);
+        assert.equal(output.includes("github_pat_"), false);
+      });
     },
   );
 });
 
 test("allows a clean GitHub release artifact path", () => {
   withFixtureArtifact("github-release-clean", (tarballPath) => {
-    assert.deepEqual(scanReleaseArtifact(tarballPath), []);
-
-    const result = runScannerCli(tarballPath);
-    assert.equal(result.status, 0);
-    assert.match(result.stdout, /Release artifact scan passed/);
+    withScannerRun(tarballPath, ({ result, findings }) => {
+      assert.equal(result.status, 0);
+      assert.deepEqual(findings, []);
+      assert.match(result.stdout, /Release artifact scan passed/);
+    });
   });
 });
 
 test("blocks a GitHub release artifact path without logging the raw secret", () => {
   withFixtureArtifact("github-release-secret", (tarballPath) => {
-    const findings = scanReleaseArtifact(tarballPath);
-    assert.equal(findings.length, 1);
-    assert.equal(findings[0].detector, "github-pat");
-    assert.equal(findings[0].path, "package/.github/releases/telnyx-agent/v1.2.3/checksums.txt");
-    assert.equal(JSON.stringify(findings).includes(GITHUB_RELEASE_SECRET), false);
-
-    const result = runScannerCli(tarballPath);
-    assert.equal(result.status, 1);
-    assert.match(result.stderr, /High-confidence secret findings blocked release artifact publish\./);
-    assert.match(result.stderr, /package\/\.github\/releases\/telnyx-agent\/v1\.2\.3\/checksums\.txt/);
-    assert.equal(result.stderr.includes(GITHUB_RELEASE_SECRET), false);
+    withScannerRun(tarballPath, ({ result, findings }) => {
+      assert.equal(result.status, 1);
+      assert.equal(findings.length, 1);
+      assert.equal(findings[0].detector, "github-pat");
+      assert.equal(findings[0].artifact_path, "artifact/package/.github/releases/telnyx-agent/v1.2.3/checksums.txt");
+      assert.equal(findings[0].severity, "high");
+      const output = `${result.stdout}\n${result.stderr}`;
+      assert.match(output, /secret_scan_summary high=1 medium=0 low=0/);
+      assert.equal(JSON.stringify(findings).includes(GITHUB_RELEASE_SECRET), false);
+      assert.equal(output.includes(GITHUB_RELEASE_SECRET), false);
+    });
   });
 });
 
 test("allows a clean n8n generated bundle path", () => {
   withFixtureArtifact("n8n-generated-clean", (tarballPath) => {
-    assert.deepEqual(scanReleaseArtifact(tarballPath), []);
-
-    const result = runScannerCli(tarballPath);
-    assert.equal(result.status, 0);
-    assert.match(result.stdout, /Release artifact scan passed/);
+    withScannerRun(tarballPath, ({ result, findings }) => {
+      assert.equal(result.status, 0);
+      assert.deepEqual(findings, []);
+      assert.match(result.stdout, /Release artifact scan passed/);
+    });
   });
 });
 
 test("blocks an n8n generated bundle path without logging the raw secret", () => {
   withFixtureArtifact("n8n-generated-secret", (tarballPath) => {
-    const findings = scanReleaseArtifact(tarballPath);
-    assert.equal(findings.length, 1);
-    assert.equal(findings[0].detector, "openai-key");
-    assert.equal(findings[0].path, "package/dist/n8n/generated/workflow.bundle.js");
-    assert.equal(JSON.stringify(findings).includes(N8N_BUNDLE_SECRET), false);
-
-    const result = runScannerCli(tarballPath);
-    assert.equal(result.status, 1);
-    assert.match(result.stderr, /High-confidence secret findings blocked release artifact publish\./);
-    assert.match(result.stderr, /package\/dist\/n8n\/generated\/workflow\.bundle\.js/);
-    assert.equal(result.stderr.includes(N8N_BUNDLE_SECRET), false);
+    withScannerRun(tarballPath, ({ result, findings }) => {
+      assert.equal(result.status, 1);
+      assert.equal(findings.length, 1);
+      assert.equal(findings[0].detector, "openai-key");
+      assert.equal(findings[0].artifact_path, "artifact/package/dist/n8n/generated/workflow.bundle.js");
+      assert.equal(findings[0].severity, "high");
+      const output = `${result.stdout}\n${result.stderr}`;
+      assert.match(output, /secret_scan_summary high=1 medium=0 low=0/);
+      assert.equal(JSON.stringify(findings).includes(N8N_BUNDLE_SECRET), false);
+      assert.equal(output.includes(N8N_BUNDLE_SECRET), false);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- sync the AI repo's Edge handoff docs and capability metadata with the current upstream `telnyx-edge` command surface
- expose parsed Edge command-surface and stronger auth-status handling in `edge-doctor` so handoff claims are based on the installed CLI output
- add focused tests covering the new capability actions and Edge auth/help parsing cases

## Verification
- `cd cli && npm test -- --test-name-pattern='CLI — Edge Compute handoff'`
- `cd cli && npx tsx --test tests/integration-ci.test.ts`
- `cd cli && npm run typecheck`

Closes TEL-863.
