### PR TITLE
feat: Add AI assistant actions to agent CLI

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "tsx bin/telnyx-agent.ts",
-    "test": "tsx --test tests/ai.test.ts tests/edge-handoff.test.ts tests/fax.test.ts tests/integration.test.ts tests/iot.test.ts tests/numbers.test.ts tests/rcs.test.ts tests/setup-10dlc.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
+    "test": "tsx --test tests/ai-assistants.test.ts tests/ai.test.ts tests/edge-handoff.test.ts tests/fax.test.ts tests/integration.test.ts tests/iot.test.ts tests/numbers.test.ts tests/rcs.test.ts tests/setup-10dlc.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
     "typecheck": "tsc --noEmit",
     "postinstall": "tsx scripts/postinstall.ts",
     "build": "npm run typecheck"

--- a/cli/src/commands/ai-assistants.ts
+++ b/cli/src/commands/ai-assistants.ts
@@ -92,19 +92,23 @@ export async function updateAiAssistantCommand(flags: Flags): Promise<void> {
   const jsonOutput = flags.json === true;
   const assistantId = assistantIdFlag(flags, jsonOutput);
   const args = ["ai:assistants", "update", "--assistant-id", assistantId];
+  const requestBody: JsonRecord = {};
 
-  addAssistantFields(args, flags, jsonOutput);
+  addAssistantFields(args, flags, jsonOutput, requestBody);
   addMappedFlag(args, flags, "name", "--name");
   addMappedFlag(args, flags, "instructions", "--instructions");
   addMappedFlag(args, flags, "version-name", "--version-name");
   addBooleanFlag(args, flags, "promote-to-main", "--promote-to-main", jsonOutput);
 
-  if (args.length === 4) {
+  if (args.length === 4 && Object.keys(requestBody).length === 0) {
     fail("at least one AI assistant field must be supplied for update", jsonOutput);
   }
 
   try {
-    const response = await telnyxCli(args);
+    const response = await telnyxCli(
+      args,
+      Object.keys(requestBody).length > 0 ? { stdin: JSON.stringify(requestBody) } : undefined,
+    );
     presentAssistant("AI assistant updated!", normalizeAssistant(response, assistantId), jsonOutput);
   } catch (err) {
     fail(errorMsg(err), jsonOutput);
@@ -145,6 +149,7 @@ function addAssistantFields(
   args: string[],
   flags: Flags,
   jsonOutput: boolean,
+  requestBody?: JsonRecord,
 ): void {
   addMappedFlag(args, flags, "description", "--description");
   addMappedFlag(args, flags, "model", "--model");
@@ -160,8 +165,26 @@ function addAssistantFields(
     10_000,
     jsonOutput,
   );
-  addCsvFlag(args, flags, "tags", "--tag", jsonOutput);
-  addCsvFlag(args, flags, "tool-ids", "--tool-id", jsonOutput);
+  addCsvOrClearFlag(
+    args,
+    flags,
+    "tags",
+    "--tag",
+    "clear-tags",
+    "tags",
+    requestBody,
+    jsonOutput,
+  );
+  addCsvOrClearFlag(
+    args,
+    flags,
+    "tool-ids",
+    "--tool-id",
+    "clear-tool-ids",
+    "tool_ids",
+    requestBody,
+    jsonOutput,
+  );
   addMappedFlag(args, flags, "voice", "--voice-settings.voice");
   addMappedFlag(args, flags, "transcription-model", "--transcription.model");
   addMappedFlag(args, flags, "transcription-language", "--transcription.language");
@@ -253,6 +276,33 @@ function addJsonObjectFlag(
   args.push(target, value);
 }
 
+function addCsvOrClearFlag(
+  args: string[],
+  flags: Flags,
+  source: string,
+  target: string,
+  clearSource: string,
+  bodyField: string,
+  requestBody: JsonRecord | undefined,
+  jsonOutput: boolean,
+): void {
+  const clearValue = flags[clearSource];
+  if (clearValue === undefined) {
+    addCsvFlag(args, flags, source, target, jsonOutput);
+    return;
+  }
+  if (clearValue !== true) {
+    fail(`--${clearSource} is a boolean flag and does not take a value`, jsonOutput);
+  }
+  if (!requestBody) {
+    fail(`--${clearSource} is only valid for update-ai-assistant`, jsonOutput);
+  }
+  if (flags[source] !== undefined) {
+    fail(`--${source} and --${clearSource} cannot be used together`, jsonOutput);
+  }
+  requestBody[bodyField] = [];
+}
+
 function addCsvFlag(
   args: string[],
   flags: Flags,
@@ -260,11 +310,14 @@ function addCsvFlag(
   target: string,
   jsonOutput: boolean,
 ): void {
-  const value = optionalStringFlag(flags, source);
-  if (value === undefined) return;
-  const values = value.split(",").map((item) => item.trim()).filter(Boolean);
+  const raw = flags[source];
+  if (raw === undefined) return;
+  if (typeof raw !== "string") {
+    fail(`--${source} must contain at least one value`, jsonOutput);
+  }
+  const values = raw.split(",").map((item) => item.trim()).filter(Boolean);
   if (values.length === 0) fail(`--${source} must contain at least one value`, jsonOutput);
-  args.push(target, JSON.stringify(values));
+  for (const value of values) args.push(target, value);
 }
 
 function addIntegerRangeFlag(

--- a/cli/src/commands/ai-assistants.ts
+++ b/cli/src/commands/ai-assistants.ts
@@ -1,0 +1,335 @@
+/**
+ * Direct AI assistant lifecycle actions backed by the Stainless-generated Go CLI.
+ *
+ * List requests use raw output so the Go CLI returns one parseable `{ data, meta }`
+ * envelope instead of streaming one JSON document per assistant.
+ */
+
+import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
+import { outputJson, printError, printSuccess } from "../utils/output.ts";
+
+type Flags = Record<string, string | boolean>;
+type JsonRecord = Record<string, unknown>;
+
+interface AssistantListResult {
+  count: number;
+  ai_assistants: JsonRecord[];
+  meta: JsonRecord;
+}
+
+interface AssistantResult {
+  assistant_id: string;
+  ai_assistant: JsonRecord;
+}
+
+interface DeleteAssistantResult {
+  assistant_id: string;
+  deleted: true;
+}
+
+export async function listAiAssistantsCommand(flags: Flags): Promise<void> {
+  const jsonOutput = flags.json === true;
+
+  try {
+    const response = await telnyxCli(["ai:assistants", "list"], { format: "raw" });
+    const result = normalizeAssistantList(response);
+    if (jsonOutput) {
+      outputJson(result);
+      return;
+    }
+
+    printSuccess("AI assistants retrieved!", { Count: result.count });
+    for (const assistant of result.ai_assistants) {
+      const id = stringValue(assistant.id) || "(unknown)";
+      const name = stringValue(assistant.name) || "(unnamed)";
+      const model = stringValue(assistant.model);
+      console.log(`  • ${name} — ${id}${model ? ` · ${model}` : ""}`);
+    }
+    if (result.count === 0) console.log("  (no AI assistants returned)");
+    console.log();
+  } catch (err) {
+    fail(errorMsg(err), jsonOutput);
+  }
+}
+
+export async function createAiAssistantCommand(flags: Flags): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const name = requiredStringFlag(flags, "name", jsonOutput);
+  const instructions = requiredStringFlag(flags, "instructions", jsonOutput);
+  const args = [
+    "ai:assistants",
+    "create",
+    "--name",
+    name,
+    "--instructions",
+    instructions,
+  ];
+
+  addAssistantFields(args, flags, jsonOutput);
+
+  try {
+    const response = await telnyxCli(args);
+    presentAssistant("AI assistant created!", normalizeAssistant(response), jsonOutput);
+  } catch (err) {
+    fail(errorMsg(err), jsonOutput);
+  }
+}
+
+export async function getAiAssistantCommand(flags: Flags): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const assistantId = assistantIdFlag(flags, jsonOutput);
+  const args = ["ai:assistants", "retrieve", "--assistant-id", assistantId];
+
+  try {
+    const response = await telnyxCli(args);
+    presentAssistant("AI assistant retrieved!", normalizeAssistant(response, assistantId), jsonOutput);
+  } catch (err) {
+    fail(errorMsg(err), jsonOutput);
+  }
+}
+
+export async function updateAiAssistantCommand(flags: Flags): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const assistantId = assistantIdFlag(flags, jsonOutput);
+  const args = ["ai:assistants", "update", "--assistant-id", assistantId];
+
+  addAssistantFields(args, flags, jsonOutput);
+  addMappedFlag(args, flags, "name", "--name");
+  addMappedFlag(args, flags, "instructions", "--instructions");
+  addMappedFlag(args, flags, "version-name", "--version-name");
+  addBooleanFlag(args, flags, "promote-to-main", "--promote-to-main", jsonOutput);
+
+  if (args.length === 4) {
+    fail("at least one AI assistant field must be supplied for update", jsonOutput);
+  }
+
+  try {
+    const response = await telnyxCli(args);
+    presentAssistant("AI assistant updated!", normalizeAssistant(response, assistantId), jsonOutput);
+  } catch (err) {
+    fail(errorMsg(err), jsonOutput);
+  }
+}
+
+export async function deleteAiAssistantCommand(flags: Flags): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const assistantId = assistantIdFlag(flags, jsonOutput);
+  if (!booleanFlagIsTrue(flags, "confirm")) {
+    fail("--confirm is required to delete an AI assistant", jsonOutput);
+  }
+
+  try {
+    const response = await telnyxCli([
+      "ai:assistants",
+      "delete",
+      "--assistant-id",
+      assistantId,
+    ]);
+    const data = asRecord(asRecord(response).data ?? response);
+    const result: DeleteAssistantResult = {
+      assistant_id: stringValue(data.id) || assistantId,
+      deleted: true,
+    };
+
+    if (jsonOutput) {
+      outputJson(result);
+    } else {
+      printSuccess("AI assistant deleted!", { "Assistant ID": result.assistant_id });
+    }
+  } catch (err) {
+    fail(errorMsg(err), jsonOutput);
+  }
+}
+
+function addAssistantFields(
+  args: string[],
+  flags: Flags,
+  jsonOutput: boolean,
+): void {
+  addMappedFlag(args, flags, "description", "--description");
+  addMappedFlag(args, flags, "model", "--model");
+  addMappedFlag(args, flags, "greeting", "--greeting", true);
+  addMappedFlag(args, flags, "dynamic-variables-webhook-url", "--dynamic-variables-webhook-url");
+  addJsonObjectFlag(args, flags, "dynamic-variables", "--dynamic-variables", jsonOutput);
+  addIntegerRangeFlag(
+    args,
+    flags,
+    "dynamic-variables-webhook-timeout-ms",
+    "--dynamic-variables-webhook-timeout-ms",
+    1,
+    10_000,
+    jsonOutput,
+  );
+  addCsvFlag(args, flags, "tags", "--tag", jsonOutput);
+  addCsvFlag(args, flags, "tool-ids", "--tool-id", jsonOutput);
+  addMappedFlag(args, flags, "voice", "--voice-settings.voice");
+  addMappedFlag(args, flags, "transcription-model", "--transcription.model");
+  addMappedFlag(args, flags, "transcription-language", "--transcription.language");
+}
+
+function normalizeAssistantList(response: unknown): AssistantListResult {
+  const envelope = asRecord(response);
+  const rawAssistants = Array.isArray(response)
+    ? response
+    : Array.isArray(envelope.data)
+      ? envelope.data
+      : [];
+  const assistants = rawAssistants.filter(
+    (item): item is JsonRecord => Boolean(item) && typeof item === "object" && !Array.isArray(item),
+  );
+  return {
+    count: assistants.length,
+    ai_assistants: assistants,
+    meta: asRecord(envelope.meta),
+  };
+}
+
+function normalizeAssistant(response: unknown, fallbackId = ""): AssistantResult {
+  const assistant = asRecord(asRecord(response).data ?? response);
+  return {
+    assistant_id: stringValue(assistant.id) || fallbackId,
+    ai_assistant: assistant,
+  };
+}
+
+function presentAssistant(title: string, result: AssistantResult, jsonOutput: boolean): void {
+  if (jsonOutput) {
+    outputJson(result);
+    return;
+  }
+
+  printSuccess(title, {
+    "Assistant ID": result.assistant_id || "(not returned)",
+    Name: stringValue(result.ai_assistant.name) || "(not returned)",
+    Model: stringValue(result.ai_assistant.model) || "(default)",
+    Greeting: stringValue(result.ai_assistant.greeting) || "(none)",
+  });
+}
+
+function assistantIdFlag(flags: Flags, jsonOutput: boolean): string {
+  const id = nonEmptyStringFlag(flags, "id");
+  const assistantId = nonEmptyStringFlag(flags, "assistant-id");
+  if (id && assistantId && id !== assistantId) {
+    fail("--id and --assistant-id cannot specify different values", jsonOutput);
+  }
+  const value = assistantId ?? id;
+  if (!value) fail("--id is required (AI assistant ID; --assistant-id is also accepted)", jsonOutput);
+  return value;
+}
+
+function requiredStringFlag(flags: Flags, key: string, jsonOutput: boolean): string {
+  const value = nonEmptyStringFlag(flags, key);
+  if (!value) fail(`--${key} is required`, jsonOutput);
+  return value;
+}
+
+function addMappedFlag(
+  args: string[],
+  flags: Flags,
+  source: string,
+  target: string,
+  allowEmpty = false,
+): void {
+  const raw = flags[source];
+  const value = typeof raw === "string" && (allowEmpty || raw.length > 0) ? raw : undefined;
+  if (value !== undefined) args.push(target, value);
+}
+
+function addJsonObjectFlag(
+  args: string[],
+  flags: Flags,
+  source: string,
+  target: string,
+  jsonOutput: boolean,
+): void {
+  const value = optionalStringFlag(flags, source);
+  if (value === undefined) return;
+  try {
+    const parsed = JSON.parse(value);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error();
+  } catch {
+    fail(`--${source} must be a JSON object`, jsonOutput);
+  }
+  args.push(target, value);
+}
+
+function addCsvFlag(
+  args: string[],
+  flags: Flags,
+  source: string,
+  target: string,
+  jsonOutput: boolean,
+): void {
+  const value = optionalStringFlag(flags, source);
+  if (value === undefined) return;
+  const values = value.split(",").map((item) => item.trim()).filter(Boolean);
+  if (values.length === 0) fail(`--${source} must contain at least one value`, jsonOutput);
+  args.push(target, JSON.stringify(values));
+}
+
+function addIntegerRangeFlag(
+  args: string[],
+  flags: Flags,
+  source: string,
+  target: string,
+  minimum: number,
+  maximum: number,
+  jsonOutput: boolean,
+): void {
+  const value = optionalStringFlag(flags, source);
+  if (value === undefined) return;
+  if (!/^\d+$/.test(value) || Number(value) < minimum || Number(value) > maximum) {
+    fail(`--${source} must be an integer between ${minimum} and ${maximum}`, jsonOutput);
+  }
+  args.push(target, value);
+}
+
+function addBooleanFlag(
+  args: string[],
+  flags: Flags,
+  source: string,
+  target: string,
+  jsonOutput: boolean,
+): void {
+  const value = flags[source];
+  if (value === undefined) return;
+  if (value === true || value === "true" || value === "false") {
+    args.push(`${target}=${value === true ? "true" : value}`);
+    return;
+  }
+  fail(`--${source} must be true or false`, jsonOutput);
+}
+
+function booleanFlagIsTrue(flags: Flags, key: string): boolean {
+  return flags[key] === true || flags[key] === "true";
+}
+
+function optionalStringFlag(flags: Flags, key: string): string | undefined {
+  const value = flags[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function nonEmptyStringFlag(flags: Flags, key: string): string | undefined {
+  const value = optionalStringFlag(flags, key);
+  return value && value.length > 0 ? value : undefined;
+}
+
+function asRecord(value: unknown): JsonRecord {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as JsonRecord : {};
+}
+
+function stringValue(value: unknown): string {
+  return value === undefined || value === null ? "" : String(value);
+}
+
+function fail(message: string, jsonOutput: boolean): never {
+  if (jsonOutput) outputJson({ error: message });
+  else printError(message);
+  process.exit(1);
+}
+
+function errorMsg(err: unknown): string {
+  if (err instanceof TelnyxCLIError) return err.stderr || err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/cli/src/commands/capabilities.ts
+++ b/cli/src/commands/capabilities.ts
@@ -26,7 +26,7 @@ const CAPABILITIES: Record<string, Capability[]> = {
   "🤖 AI": [
     { name: "Chat Completions", description: "LLM inference via Telnyx AI (executable with telnyx-agent ai-chat)", actions: ["ai_chat"] },
     { name: "Embeddings", description: "Generate text embeddings (executable with telnyx-agent ai-embed)", actions: ["ai_embed"] },
-    { name: "Assistants", description: "Create and manage AI voice assistants", actions: ["list_ai_assistants", "create_ai_assistant"] },
+    { name: "Assistants", description: "Create and manage AI voice assistants", actions: ["list_ai_assistants", "create_ai_assistant", "get_ai_assistant", "update_ai_assistant", "delete_ai_assistant"] },
   ],
   "🔊 Text-to-Speech": [
     { name: "Speech Synthesis", description: "Generate audio from text via Telnyx and third-party TTS providers (telnyx, aws, azure, elevenlabs, minimax, resemble, rime, xai)", actions: ["generate_speech"] },
@@ -95,6 +95,11 @@ const COMPOSITE_COMMANDS = [
   { name: "telnyx-agent setup-ai", description: "Zero to AI assistant: creates assistant, buys number, wires them together" },
   { name: "telnyx-agent ai-chat", description: "Create an OpenAI-compatible chat completion via Telnyx AI inference" },
   { name: "telnyx-agent ai-embed", description: "Create OpenAI-compatible embeddings for text or a JSON array of texts" },
+  { name: "telnyx-agent list-ai-assistants", description: "List AI assistant configurations" },
+  { name: "telnyx-agent create-ai-assistant", description: "Create an AI assistant from a name, instructions, and optional model or voice settings" },
+  { name: "telnyx-agent get-ai-assistant", description: "Retrieve one AI assistant by ID" },
+  { name: "telnyx-agent update-ai-assistant", description: "Update an AI assistant and create a new version" },
+  { name: "telnyx-agent delete-ai-assistant", description: "Delete an AI assistant with explicit confirmation" },
   { name: "telnyx-agent setup-wireguard", description: "Zero to VPN: creates network, WireGuard interface, peer — outputs ready-to-use WG config" },
   { name: "telnyx-edge ship", description: "Deploy an Edge Compute function with the dedicated telnyx-edge CLI (referenced by the Edge Compute guide)" },
   { name: "telnyx-agent edge-doctor", description: "Validate Edge Compute handoff prerequisites and point to the next concrete telnyx-edge steps" },

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -44,6 +44,13 @@ import {
 import { aiChatCommand } from "./commands/ai-chat.ts";
 import { aiEmbedCommand } from "./commands/ai-embed.ts";
 import {
+  createAiAssistantCommand,
+  deleteAiAssistantCommand,
+  getAiAssistantCommand,
+  listAiAssistantsCommand,
+  updateAiAssistantCommand,
+} from "./commands/ai-assistants.ts";
+import {
   disableSimCardCommand,
   enableSimCardCommand,
   listSimCardsCommand,
@@ -101,6 +108,11 @@ Commands:
   lookup-number     Look up carrier and caller-name information
   ai-chat           Create an OpenAI-compatible chat completion
   ai-embed          Create OpenAI-compatible text embeddings
+  list-ai-assistants List AI assistant configurations
+  create-ai-assistant Create an AI assistant
+  get-ai-assistant  Retrieve an AI assistant by ID
+  update-ai-assistant Update an AI assistant by ID
+  delete-ai-assistant Delete an AI assistant by ID (requires --confirm)
 
 Global Flags:
   --json            Output structured JSON instead of human-readable text
@@ -332,6 +344,25 @@ AI Embed Flags:
   --encoding-format Embedding encoding format (Go CLI default: float)
   --user            End-user identifier for monitoring and abuse detection
 
+AI Assistant Lifecycle Flags:
+  --id <assistant-id> AI assistant ID (get, update, delete; --assistant-id alias accepted)
+  --name            Assistant name (create required; update optional)
+  --instructions    System instructions (create required; update optional)
+  --description     Assistant description (create, update)
+  --model           Language model ID (create, update)
+  --greeting        Initial assistant greeting; an empty string makes it wait (create, update)
+  --voice           Voice ID, forwarded as --voice-settings.voice (create, update)
+  --transcription-model Speech-to-text model (create, update)
+  --transcription-language Speech-to-text language (create, update)
+  --dynamic-variables <json> Dynamic variable defaults as a JSON object (create, update)
+  --dynamic-variables-webhook-url <url> Dynamic variable resolver webhook (create, update)
+  --dynamic-variables-webhook-timeout-ms <1-10000> Resolver timeout (create, update)
+  --tags <csv>      Comma-separated assistant tags (create, update)
+  --tool-ids <csv>  Comma-separated shared AI tool IDs (create, update)
+  --version-name    Human-readable version name (update only)
+  --promote-to-main <bool> Promote the new version (update only)
+  --confirm         Explicitly confirm deletion (delete only, required)
+
 IoT SIM Action Flags:
   --id <sim-card-id> SIM card ID (retrieve-sim-card, enable-sim-card, disable-sim-card — required)
   --iccid           Partial ICCID filter (list-sim-cards)
@@ -431,6 +462,11 @@ Examples:
   telnyx-agent ai-chat --message '{"role":"user","content":"Return JSON"}' --response-format '{"type":"json_object"}' --json
   telnyx-agent ai-embed --model thenlper/gte-large --input "Hello world" --json
   telnyx-agent ai-embed --model thenlper/gte-large --input '["one","two"]' --dimensions 256 --json
+  telnyx-agent list-ai-assistants --json
+  telnyx-agent create-ai-assistant --name Concierge --instructions "Help callers" --model meta-llama/Llama-3.1-70B-Instruct --json
+  telnyx-agent get-ai-assistant --id <assistant-id> --json
+  telnyx-agent update-ai-assistant --id <assistant-id> --greeting "How can I help?" --json
+  telnyx-agent delete-ai-assistant --id <assistant-id> --confirm --json
   telnyx-agent list-sim-cards --status enabled,disabled --page-size 25 --json
   telnyx-agent retrieve-sim-card --id <sim-card-id> --json
   telnyx-agent enable-sim-card --id <sim-card-id> --json
@@ -480,6 +516,11 @@ const COMMANDS: Record<string, (
   "lookup-number": lookupNumberCommand,
   "ai-chat": aiChatCommand,
   "ai-embed": aiEmbedCommand,
+  "list-ai-assistants": listAiAssistantsCommand,
+  "create-ai-assistant": createAiAssistantCommand,
+  "get-ai-assistant": getAiAssistantCommand,
+  "update-ai-assistant": updateAiAssistantCommand,
+  "delete-ai-assistant": deleteAiAssistantCommand,
   "list-sim-cards": listSimCardsCommand,
   "retrieve-sim-card": retrieveSimCardCommand,
   "enable-sim-card": enableSimCardCommand,

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -359,6 +359,8 @@ AI Assistant Lifecycle Flags:
   --dynamic-variables-webhook-timeout-ms <1-10000> Resolver timeout (create, update)
   --tags <csv>      Comma-separated assistant tags (create, update)
   --tool-ids <csv>  Comma-separated shared AI tool IDs (create, update)
+  --clear-tags      Clear all assistant tags (update only; exclusive with --tags)
+  --clear-tool-ids  Clear all shared AI tool IDs (update only; exclusive with --tool-ids)
   --version-name    Human-readable version name (update only)
   --promote-to-main <bool> Promote the new version (update only)
   --confirm         Explicitly confirm deletion (delete only, required)

--- a/cli/src/telnyx-cli.ts
+++ b/cli/src/telnyx-cli.ts
@@ -80,20 +80,27 @@ export class TelnyxCLIError extends Error {
  * with `--format json`, so the default is fine for those.
  *
  * @param args - CLI arguments (e.g., ['available-phone-numbers', 'list', '--filter.country-code', 'US'])
- * @param opts - Optional overrides for timeout, env, and output format
+ * @param opts - Optional overrides for timeout, env, output format, and stdin request body
  * @returns Parsed JSON response from the CLI (typically { data: ... } or { data: [...], meta: ... })
  */
 export async function telnyxCli(
   args: string[],
-  opts?: { timeout?: number; env?: Record<string, string | undefined>; format?: "json" | "raw" },
+  opts?: {
+    timeout?: number;
+    env?: Record<string, string | undefined>;
+    format?: "json" | "raw";
+    stdin?: string;
+  },
 ): Promise<any> {
   const timeout = opts?.timeout ?? 60000;
   try {
-    const { stdout } = await execFileAsync(TELNYX_BINARY, [...args, "--format", opts?.format ?? "json"], {
+    const execution = execFileAsync(TELNYX_BINARY, [...args, "--format", opts?.format ?? "json"], {
       env: { ...process.env, ...opts?.env } as NodeJS.ProcessEnv,
       timeout,
       maxBuffer: 10 * 1024 * 1024, // 10MB — some list responses can be large
     });
+    if (opts?.stdin !== undefined) execution.child.stdin?.end(opts.stdin);
+    const { stdout } = await execution;
     const trimmed = stdout.trim();
     if (!trimmed) return {};
     // The Go CLI should output clean JSON with --format json, but keep the

--- a/cli/src/utils/output.ts
+++ b/cli/src/utils/output.ts
@@ -81,7 +81,9 @@ export function parseFlags(args: string[]): {
     if (arg.startsWith("--")) {
       const key = arg.slice(2);
       const next = args[i + 1];
-      if (next && !next.startsWith("--")) {
+      // Empty strings are meaningful for fields such as an AI assistant greeting,
+      // where `--greeting ""` tells the assistant to wait for the user to speak.
+      if (next !== undefined && !next.startsWith("--")) {
         flags[key] = next;
         (occurrences[key] ??= []).push(next);
         i++;

--- a/cli/tests/ai-assistants.test.ts
+++ b/cli/tests/ai-assistants.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Mock-binary coverage for direct AI assistant lifecycle actions.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliRoot = join(__dirname, "..");
+const cliBin = join(cliRoot, "bin", "telnyx-agent.ts");
+
+function setupFakeTelnyx(): { logPath: string; env: NodeJS.ProcessEnv } {
+  const tempDir = mkdtempSync(join(tmpdir(), "telnyx-agent-ai-assistants-"));
+  const binDir = join(tempDir, "bin");
+  const logPath = join(tempDir, "args.jsonl");
+  const fakeTelnyx = join(binDir, "telnyx");
+  mkdirSync(binDir, { recursive: true });
+
+  writeFileSync(
+    fakeTelnyx,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.TELNYX_FAKE_ARGS_LOG, JSON.stringify(args) + "\\n");
+function flag(name) { const index = args.indexOf(name); return index >= 0 ? args[index + 1] : undefined; }
+function equalsFlag(name) { const item = args.find((arg) => arg.startsWith(name + "=")); return item && item.slice(name.length + 1); }
+
+if (args[0] !== "ai:assistants") {
+  console.error("unexpected fake telnyx invocation: " + args.join(" "));
+  process.exit(2);
+} else if (args[1] === "list") {
+  console.log(JSON.stringify({
+    data: [
+      { id: "assistant-1", name: "Concierge", instructions: "Help callers", model: "model-one", greeting: "Hello" },
+      { id: "assistant-2", name: "Scheduler", instructions: "Book visits", model: "model-two", greeting: null }
+    ],
+    meta: { total_results: 2 }
+  }));
+} else if (args[1] === "create") {
+  console.log(JSON.stringify({ data: {
+    id: "assistant-created",
+    name: flag("--name"),
+    instructions: flag("--instructions"),
+    description: flag("--description"),
+    model: flag("--model"),
+    greeting: flag("--greeting"),
+    tags: JSON.parse(flag("--tag") || "[]"),
+    tool_ids: JSON.parse(flag("--tool-id") || "[]")
+  } }));
+} else if (args[1] === "retrieve") {
+  console.log(JSON.stringify({ data: {
+    id: flag("--assistant-id"),
+    name: "Concierge",
+    instructions: "Help callers",
+    model: "model-one",
+    greeting: "Hello"
+  } }));
+} else if (args[1] === "update") {
+  console.log(JSON.stringify({ data: {
+    id: flag("--assistant-id"),
+    name: flag("--name") || "Concierge",
+    instructions: flag("--instructions") || "Help callers",
+    model: flag("--model") || "model-one",
+    greeting: flag("--greeting"),
+    promote_to_main: equalsFlag("--promote-to-main") === "true"
+  } }));
+} else if (args[1] === "delete") {
+  console.log(JSON.stringify({ data: { id: flag("--assistant-id") } }));
+} else {
+  console.error("unexpected fake telnyx invocation: " + args.join(" "));
+  process.exit(2);
+}
+`,
+  );
+  chmodSync(fakeTelnyx, 0o755);
+
+  return {
+    logPath,
+    env: {
+      ...process.env,
+      TELNYX_CLI_PATH: fakeTelnyx,
+      TELNYX_FAKE_ARGS_LOG: logPath,
+      TELNYX_API_KEY: "KEY_fake_test",
+    },
+  };
+}
+
+function runAgent(
+  args: string[],
+  env: NodeJS.ProcessEnv = process.env,
+): { stdout: string; stderr: string; status: number } {
+  try {
+    const stdout = execFileSync(process.execPath, ["--import", "tsx", cliBin, ...args], {
+      cwd: cliRoot,
+      encoding: "utf8",
+      env,
+      timeout: 30_000,
+    });
+    return { stdout, stderr: "", status: 0 };
+  } catch (err: any) {
+    return {
+      stdout: err.stdout?.toString() ?? "",
+      stderr: err.stderr?.toString() ?? "",
+      status: err.status ?? 1,
+    };
+  }
+}
+
+function loggedArgs(logPath: string): string[][] {
+  if (!existsSync(logPath)) return [];
+  const contents = readFileSync(logPath, "utf8");
+  assert.ok(contents.endsWith("\n"), "fake binary should terminate each JSON record with one newline");
+  assert.ok(!contents.endsWith("\n\n"), "fake binary should not write a blank JSONL record");
+  return contents.trimEnd().split("\n").map((line) => JSON.parse(line) as string[]);
+}
+
+function assertFlag(args: string[], flag: string, value: string): void {
+  const index = args.indexOf(flag);
+  assert.notEqual(index, -1, `expected ${flag} in ${args.join(" ")}`);
+  assert.equal(args[index + 1], value);
+}
+
+describe("AI assistant lifecycle action commands", () => {
+  it("lists assistants using the exact generated command and stable list JSON", () => {
+    const fake = setupFakeTelnyx();
+    const result = runAgent(["list-ai-assistants", "--json"], fake.env);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout), {
+      count: 2,
+      ai_assistants: [
+        { id: "assistant-1", name: "Concierge", instructions: "Help callers", model: "model-one", greeting: "Hello" },
+        { id: "assistant-2", name: "Scheduler", instructions: "Book visits", model: "model-two", greeting: null },
+      ],
+      meta: { total_results: 2 },
+    });
+
+    const [args] = loggedArgs(fake.logPath);
+    assert.deepEqual(args, ["ai:assistants", "list", "--format", "raw"]);
+  });
+
+  it("creates an assistant and maps useful scalar, nested, object, and array fields", () => {
+    const fake = setupFakeTelnyx();
+    const dynamicVariables = '{"customer_name":"friend"}';
+    const result = runAgent([
+      "create-ai-assistant",
+      "--name", "Concierge",
+      "--instructions", "Help callers",
+      "--description", "Front desk",
+      "--model", "model-one",
+      "--greeting", "Hello",
+      "--voice", "Telnyx.KokoroTTS.af_heart",
+      "--transcription-model", "deepgram/flux",
+      "--transcription-language", "en",
+      "--dynamic-variables", dynamicVariables,
+      "--dynamic-variables-webhook-url", "https://example.com/variables",
+      "--dynamic-variables-webhook-timeout-ms", "2500",
+      "--tags", "front-desk,production",
+      "--tool-ids", "tool-1,tool-2",
+      "--json",
+    ], fake.env);
+
+    assert.equal(result.status, 0, result.stderr);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.assistant_id, "assistant-created");
+    assert.equal(output.ai_assistant.name, "Concierge");
+    assert.deepEqual(output.ai_assistant.tags, ["front-desk", "production"]);
+    assert.deepEqual(output.ai_assistant.tool_ids, ["tool-1", "tool-2"]);
+
+    const [args] = loggedArgs(fake.logPath);
+    assert.deepEqual(args.slice(0, 2), ["ai:assistants", "create"]);
+    assertFlag(args, "--name", "Concierge");
+    assertFlag(args, "--instructions", "Help callers");
+    assertFlag(args, "--description", "Front desk");
+    assertFlag(args, "--model", "model-one");
+    assertFlag(args, "--greeting", "Hello");
+    assertFlag(args, "--voice-settings.voice", "Telnyx.KokoroTTS.af_heart");
+    assertFlag(args, "--transcription.model", "deepgram/flux");
+    assertFlag(args, "--transcription.language", "en");
+    assertFlag(args, "--dynamic-variables", dynamicVariables);
+    assertFlag(args, "--dynamic-variables-webhook-url", "https://example.com/variables");
+    assertFlag(args, "--dynamic-variables-webhook-timeout-ms", "2500");
+    assertFlag(args, "--tag", JSON.stringify(["front-desk", "production"]));
+    assertFlag(args, "--tool-id", JSON.stringify(["tool-1", "tool-2"]));
+    assertFlag(args, "--format", "json");
+  });
+
+  it("gets one assistant through ai:assistants retrieve", () => {
+    const fake = setupFakeTelnyx();
+    const result = runAgent(["get-ai-assistant", "--id", "assistant-1", "--json"], fake.env);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout), {
+      assistant_id: "assistant-1",
+      ai_assistant: {
+        id: "assistant-1",
+        name: "Concierge",
+        instructions: "Help callers",
+        model: "model-one",
+        greeting: "Hello",
+      },
+    });
+
+    const [args] = loggedArgs(fake.logPath);
+    assert.deepEqual(args.slice(0, 2), ["ai:assistants", "retrieve"]);
+    assertFlag(args, "--assistant-id", "assistant-1");
+    assertFlag(args, "--format", "json");
+  });
+
+  it("updates valid assistant fields and preserves an intentionally empty greeting", () => {
+    const fake = setupFakeTelnyx();
+    const result = runAgent([
+      "update-ai-assistant",
+      "--assistant-id", "assistant-1",
+      "--name", "Night Concierge",
+      "--instructions", "Help callers after hours",
+      "--greeting", "",
+      "--version-name", "Night shift",
+      "--promote-to-main", "false",
+      "--json",
+    ], fake.env);
+
+    assert.equal(result.status, 0, result.stderr);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.assistant_id, "assistant-1");
+    assert.equal(output.ai_assistant.greeting, "");
+    assert.equal(output.ai_assistant.promote_to_main, false);
+
+    const [args] = loggedArgs(fake.logPath);
+    assert.deepEqual(args.slice(0, 2), ["ai:assistants", "update"]);
+    assertFlag(args, "--assistant-id", "assistant-1");
+    assertFlag(args, "--name", "Night Concierge");
+    assertFlag(args, "--instructions", "Help callers after hours");
+    assertFlag(args, "--greeting", "");
+    assertFlag(args, "--version-name", "Night shift");
+    assert.ok(args.includes("--promote-to-main=false"));
+    assertFlag(args, "--format", "json");
+  });
+
+  it("requires explicit confirmation before deleting and never forwards --confirm", () => {
+    const fake = setupFakeTelnyx();
+    const rejected = runAgent(["delete-ai-assistant", "--id", "assistant-1", "--json"], fake.env);
+    assert.notEqual(rejected.status, 0);
+    assert.match(JSON.parse(rejected.stdout).error, /--confirm is required/);
+    assert.deepEqual(loggedArgs(fake.logPath), []);
+
+    const accepted = runAgent([
+      "delete-ai-assistant",
+      "--id", "assistant-1",
+      "--confirm",
+      "--json",
+    ], fake.env);
+    assert.equal(accepted.status, 0, accepted.stderr);
+    assert.deepEqual(JSON.parse(accepted.stdout), { assistant_id: "assistant-1", deleted: true });
+
+    const [args] = loggedArgs(fake.logPath);
+    assert.deepEqual(args.slice(0, 2), ["ai:assistants", "delete"]);
+    assertFlag(args, "--assistant-id", "assistant-1");
+    assert.ok(!args.includes("--confirm"));
+    assertFlag(args, "--format", "json");
+  });
+
+  it("validates required IDs, create fields, update fields, and structured options locally", () => {
+    const invalidCases = [
+      ["create-ai-assistant", "--instructions", "Help", "--json"],
+      ["create-ai-assistant", "--name", "Concierge", "--json"],
+      ["get-ai-assistant", "--json"],
+      ["update-ai-assistant", "--id", "assistant-1", "--json"],
+      ["create-ai-assistant", "--name", "Concierge", "--instructions", "Help", "--dynamic-variables", "[]", "--json"],
+      ["create-ai-assistant", "--name", "Concierge", "--instructions", "Help", "--dynamic-variables-webhook-timeout-ms", "10001", "--json"],
+    ];
+
+    for (const args of invalidCases) {
+      const fake = setupFakeTelnyx();
+      const result = runAgent(args, fake.env);
+      assert.notEqual(result.status, 0, `expected ${args.join(" ")} to fail`);
+      assert.ok(JSON.parse(result.stdout).error);
+      assert.deepEqual(loggedArgs(fake.logPath), []);
+    }
+  });
+
+  it("advertises every lifecycle command in help and capabilities", () => {
+    const commands = [
+      "list-ai-assistants",
+      "create-ai-assistant",
+      "get-ai-assistant",
+      "update-ai-assistant",
+      "delete-ai-assistant",
+    ];
+    const help = runAgent(["help"]);
+    assert.equal(help.status, 0, help.stderr);
+    const capabilitiesResult = runAgent(["capabilities", "--json"]);
+    assert.equal(capabilitiesResult.status, 0, capabilitiesResult.stderr);
+    const capabilities = JSON.parse(capabilitiesResult.stdout);
+
+    for (const command of commands) {
+      assert.match(help.stdout, new RegExp(command));
+      assert.ok(
+        capabilities.composite_commands.some(
+          (entry: { name: string }) => entry.name === `telnyx-agent ${command}`,
+        ),
+        `capabilities should advertise ${command}`,
+      );
+    }
+    assert.match(help.stdout, /--confirm\s+Explicitly confirm deletion/);
+
+    const actions = capabilities.api_capabilities["🤖 AI"].find(
+      (capability: { name: string }) => capability.name === "Assistants",
+    ).actions;
+    assert.deepEqual(actions, [
+      "list_ai_assistants",
+      "create_ai_assistant",
+      "get_ai_assistant",
+      "update_ai_assistant",
+      "delete_ai_assistant",
+    ]);
+  });
+});

--- a/cli/tests/ai-assistants.test.ts
+++ b/cli/tests/ai-assistants.test.ts
@@ -13,10 +13,15 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const cliRoot = join(__dirname, "..");
 const cliBin = join(cliRoot, "bin", "telnyx-agent.ts");
 
-function setupFakeTelnyx(): { logPath: string; env: NodeJS.ProcessEnv } {
+function setupFakeTelnyx(options: { captureStdin?: boolean } = {}): {
+  logPath: string;
+  requestLogPath: string;
+  env: NodeJS.ProcessEnv;
+} {
   const tempDir = mkdtempSync(join(tmpdir(), "telnyx-agent-ai-assistants-"));
   const binDir = join(tempDir, "bin");
   const logPath = join(tempDir, "args.jsonl");
+  const requestLogPath = join(tempDir, "requests.jsonl");
   const fakeTelnyx = join(binDir, "telnyx");
   mkdirSync(binDir, { recursive: true });
 
@@ -27,7 +32,38 @@ const fs = require("node:fs");
 const args = process.argv.slice(2);
 fs.appendFileSync(process.env.TELNYX_FAKE_ARGS_LOG, JSON.stringify(args) + "\\n");
 function flag(name) { const index = args.indexOf(name); return index >= 0 ? args[index + 1] : undefined; }
+function flags(name) {
+  const values = [];
+  for (let index = 0; index < args.length; index++) {
+    if (args[index] === name && args[index + 1] !== undefined) values.push(args[index + 1]);
+  }
+  return values;
+}
 function equalsFlag(name) { const item = args.find((arg) => arg.startsWith(name + "=")); return item && item.slice(name.length + 1); }
+function requestBody() {
+  let body = {};
+  if (process.env.TELNYX_FAKE_CAPTURE_STDIN === "1") {
+    const stdin = fs.readFileSync(0, "utf8");
+    if (stdin) body = JSON.parse(stdin);
+  }
+  function set(name, key) { const value = flag(name); if (value !== undefined) body[key] = value; }
+  set("--name", "name");
+  set("--instructions", "instructions");
+  set("--description", "description");
+  set("--model", "model");
+  set("--greeting", "greeting");
+  set("--version-name", "version_name");
+  const tags = flags("--tag");
+  const toolIds = flags("--tool-id");
+  if (tags.length > 0) body.tags = tags;
+  if (toolIds.length > 0) body.tool_ids = toolIds;
+  const promoteToMain = equalsFlag("--promote-to-main");
+  if (promoteToMain !== undefined) body.promote_to_main = promoteToMain === "true";
+  return body;
+}
+function logRequest(method, body) {
+  fs.appendFileSync(process.env.TELNYX_FAKE_REQUEST_LOG, JSON.stringify({ method, body }) + "\\n");
+}
 
 if (args[0] !== "ai:assistants") {
   console.error("unexpected fake telnyx invocation: " + args.join(" "));
@@ -41,16 +77,9 @@ if (args[0] !== "ai:assistants") {
     meta: { total_results: 2 }
   }));
 } else if (args[1] === "create") {
-  console.log(JSON.stringify({ data: {
-    id: "assistant-created",
-    name: flag("--name"),
-    instructions: flag("--instructions"),
-    description: flag("--description"),
-    model: flag("--model"),
-    greeting: flag("--greeting"),
-    tags: JSON.parse(flag("--tag") || "[]"),
-    tool_ids: JSON.parse(flag("--tool-id") || "[]")
-  } }));
+  const body = requestBody();
+  logRequest("POST", body);
+  console.log(JSON.stringify({ data: { id: "assistant-created", ...body } }));
 } else if (args[1] === "retrieve") {
   console.log(JSON.stringify({ data: {
     id: flag("--assistant-id"),
@@ -60,13 +89,14 @@ if (args[0] !== "ai:assistants") {
     greeting: "Hello"
   } }));
 } else if (args[1] === "update") {
+  const body = requestBody();
+  logRequest("POST", body);
   console.log(JSON.stringify({ data: {
     id: flag("--assistant-id"),
-    name: flag("--name") || "Concierge",
-    instructions: flag("--instructions") || "Help callers",
-    model: flag("--model") || "model-one",
-    greeting: flag("--greeting"),
-    promote_to_main: equalsFlag("--promote-to-main") === "true"
+    name: "Concierge",
+    instructions: "Help callers",
+    model: "model-one",
+    ...body
   } }));
 } else if (args[1] === "delete") {
   console.log(JSON.stringify({ data: { id: flag("--assistant-id") } }));
@@ -80,10 +110,13 @@ if (args[0] !== "ai:assistants") {
 
   return {
     logPath,
+    requestLogPath,
     env: {
       ...process.env,
       TELNYX_CLI_PATH: fakeTelnyx,
       TELNYX_FAKE_ARGS_LOG: logPath,
+      TELNYX_FAKE_REQUEST_LOG: requestLogPath,
+      TELNYX_FAKE_CAPTURE_STDIN: options.captureStdin ? "1" : "0",
       TELNYX_API_KEY: "KEY_fake_test",
     },
   };
@@ -118,10 +151,20 @@ function loggedArgs(logPath: string): string[][] {
   return contents.trimEnd().split("\n").map((line) => JSON.parse(line) as string[]);
 }
 
+function loggedRequests(logPath: string): Array<{ method: string; body: Record<string, unknown> }> {
+  if (!existsSync(logPath)) return [];
+  return readFileSync(logPath, "utf8").trimEnd().split("\n").map((line) => JSON.parse(line));
+}
+
 function assertFlag(args: string[], flag: string, value: string): void {
   const index = args.indexOf(flag);
   assert.notEqual(index, -1, `expected ${flag} in ${args.join(" ")}`);
   assert.equal(args[index + 1], value);
+}
+
+function assertFlagValues(args: string[], flag: string, values: string[]): void {
+  const actual = args.flatMap((arg, index) => arg === flag ? [args[index + 1]] : []);
+  assert.deepEqual(actual, values, `expected repeated ${flag} values in ${args.join(" ")}`);
 }
 
 describe("AI assistant lifecycle action commands", () => {
@@ -184,9 +227,13 @@ describe("AI assistant lifecycle action commands", () => {
     assertFlag(args, "--dynamic-variables", dynamicVariables);
     assertFlag(args, "--dynamic-variables-webhook-url", "https://example.com/variables");
     assertFlag(args, "--dynamic-variables-webhook-timeout-ms", "2500");
-    assertFlag(args, "--tag", JSON.stringify(["front-desk", "production"]));
-    assertFlag(args, "--tool-id", JSON.stringify(["tool-1", "tool-2"]));
+    assertFlagValues(args, "--tag", ["front-desk", "production"]);
+    assertFlagValues(args, "--tool-id", ["tool-1", "tool-2"]);
     assertFlag(args, "--format", "json");
+
+    const [request] = loggedRequests(fake.requestLogPath);
+    assert.deepEqual(request.body.tags, ["front-desk", "production"]);
+    assert.deepEqual(request.body.tool_ids, ["tool-1", "tool-2"]);
   });
 
   it("gets one assistant through ai:assistants retrieve", () => {
@@ -239,6 +286,77 @@ describe("AI assistant lifecycle action commands", () => {
     assertFlag(args, "--version-name", "Night shift");
     assert.ok(args.includes("--promote-to-main=false"));
     assertFlag(args, "--format", "json");
+  });
+
+  it("clears all tags and shared tool IDs through explicit update-only flags", () => {
+    const fake = setupFakeTelnyx({ captureStdin: true });
+    const result = runAgent([
+      "update-ai-assistant",
+      "--id", "assistant-1",
+      "--clear-tags",
+      "--clear-tool-ids",
+      "--json",
+    ], fake.env);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout).ai_assistant.tags, []);
+    assert.deepEqual(JSON.parse(result.stdout).ai_assistant.tool_ids, []);
+
+    const [args] = loggedArgs(fake.logPath);
+    assert.equal(args.includes("--tag"), false);
+    assert.equal(args.includes("--tool-id"), false);
+    assert.equal(args.includes("--clear-tags"), false);
+    assert.equal(args.includes("--clear-tool-ids"), false);
+
+    const [request] = loggedRequests(fake.requestLogPath);
+    assert.deepEqual(request.body, { tags: [], tool_ids: [] });
+  });
+
+  it("does not forward omitted update fields while preserving an intentionally empty greeting", () => {
+    const fake = setupFakeTelnyx();
+    const result = runAgent([
+      "update-ai-assistant",
+      "--id", "assistant-1",
+      "--greeting", "",
+      "--json",
+    ], fake.env);
+
+    assert.equal(result.status, 0, result.stderr);
+    const [request] = loggedRequests(fake.requestLogPath);
+    assert.deepEqual(request.body, { greeting: "" });
+  });
+
+  it("keeps CSV validation and rejects clear flags on create or beside CSV values", () => {
+    const invalidCases = [
+      ["create-ai-assistant", "--name", "Concierge", "--instructions", "Help", "--tags", "", "--json"],
+      ["update-ai-assistant", "--id", "assistant-1", "--tool-ids", " , ", "--json"],
+      ["create-ai-assistant", "--name", "Concierge", "--instructions", "Help", "--clear-tags", "--json"],
+      ["update-ai-assistant", "--id", "assistant-1", "--tags", "production", "--clear-tags", "--json"],
+      ["update-ai-assistant", "--id", "assistant-1", "--clear-tool-ids", "false", "--json"],
+    ];
+
+    for (const args of invalidCases) {
+      const fake = setupFakeTelnyx();
+      const result = runAgent(args, fake.env);
+      assert.notEqual(result.status, 0, `expected ${args.join(" ")} to fail`);
+      assert.ok(JSON.parse(result.stdout).error);
+      assert.deepEqual(loggedArgs(fake.logPath), []);
+    }
+  });
+
+  it("rejects bare array flags on create and update instead of silently omitting them", () => {
+    const invalidCases = [
+      ["create-ai-assistant", "--name", "Concierge", "--instructions", "Help", "--tags", "--json"],
+      ["update-ai-assistant", "--id", "assistant-1", "--tool-ids", "--json"],
+    ];
+
+    for (const args of invalidCases) {
+      const fake = setupFakeTelnyx();
+      const result = runAgent(args, fake.env);
+      assert.notEqual(result.status, 0, `expected ${args.join(" ")} to fail`);
+      assert.match(JSON.parse(result.stdout).error, /--(?:tags|tool-ids) must contain at least one value/);
+      assert.deepEqual(loggedArgs(fake.logPath), []);
+    }
   });
 
   it("requires explicit confirmation before deleting and never forwards --confirm", () => {
@@ -307,6 +425,8 @@ describe("AI assistant lifecycle action commands", () => {
       );
     }
     assert.match(help.stdout, /--confirm\s+Explicitly confirm deletion/);
+    assert.match(help.stdout, /--clear-tags\s+Clear all assistant tags/);
+    assert.match(help.stdout, /--clear-tool-ids\s+Clear all shared AI tool IDs/);
 
     const actions = capabilities.api_capabilities["🤖 AI"].find(
       (capability: { name: string }) => capability.name === "Assistants",


### PR DESCRIPTION
## Summary
- add list/create/get/update/delete AI assistant wrappers
- support useful nested voice, transcription, tool, tag, and dynamic-variable flags
- require explicit confirmation for deletes
- wire commands into help and capabilities with mock-binary tests

## Verification
- `npx tsc --noEmit`
- `npx tsx --test tests/*.test.ts` (206 passed)