### PR TITLE
feat: Add Edge Compute v0.3 detection to agent CLI

### DIFF
--- a/cli/src/commands/edge-doctor.ts
+++ b/cli/src/commands/edge-doctor.ts
@@ -287,7 +287,7 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
       nextSteps.push("Actor scaffolding is available, but this CLI does not expose actors instances; upgrade telnyx-edge for that view.");
     }
     if (resetFuncSupported) {
-      nextSteps.push(`Recover a failed deployment with: telnyx-edge reset-func <function-name>${resetFuncNoninteractiveConfirmationSupported ? " --yes (scripts/CI)" : ""}`);
+      nextSteps.push(`Recover a failed deployment with: telnyx-edge reset-func <function-name>${resetFuncNoninteractiveConfirmationSupported ? " --yes" : ""}`);
     }
     if (typesSupported) {
       nextSteps.push("Generate TypeScript binding declarations with: telnyx-edge types");

--- a/cli/src/commands/edge-doctor.ts
+++ b/cli/src/commands/edge-doctor.ts
@@ -18,6 +18,7 @@ import {
   supportsNewFuncFromDir,
   supportsNonInteractiveConfirmation,
   supportsResetFunc,
+  supportsResetFuncNonInteractiveConfirmation,
   supportsSecretsAdd,
   supportsShip,
   supportsSqlDatabases,
@@ -40,6 +41,7 @@ interface EdgeDoctorResult {
   inspect_supported: boolean;
   actor_instances_supported: boolean;
   reset_func_supported: boolean;
+  reset_func_noninteractive_confirmation_supported: boolean;
   noninteractive_confirmation_supported: boolean;
   types_supported: boolean;
   kv_storage_supported: boolean;
@@ -65,6 +67,7 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
   let inspectSupported = false;
   let actorInstancesSupported = false;
   let resetFuncSupported = false;
+  let resetFuncNoninteractiveConfirmationSupported = false;
   let noninteractiveConfirmationSupported = false;
   let typesSupported = false;
   let kvStorageSupported = false;
@@ -96,6 +99,7 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
     inspectSupported = supportsInspect();
     actorInstancesSupported = supportsActorInstances();
     resetFuncSupported = supportsResetFunc();
+    resetFuncNoninteractiveConfirmationSupported = supportsResetFuncNonInteractiveConfirmation();
     noninteractiveConfirmationSupported = supportsNonInteractiveConfirmation();
     typesSupported = supportsTypes();
     kvStorageSupported = supportsKvStorage();
@@ -149,6 +153,13 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
       name: "Failed-function reset",
       ok: resetFuncSupported,
       detail: resetFuncSupported ? "reset-func <function-name> is available" : "reset-func --help capability not detected",
+    });
+    checks.push({
+      name: "Non-interactive failed-function reset",
+      ok: resetFuncNoninteractiveConfirmationSupported,
+      detail: resetFuncNoninteractiveConfirmationSupported
+        ? "reset-func --yes is available for scripts and CI"
+        : "reset-func --help did not advertise --yes confirmation bypass",
     });
     checks.push({
       name: "Non-interactive destructive confirmation",
@@ -276,7 +287,7 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
       nextSteps.push("Actor scaffolding is available, but this CLI does not expose actors instances; upgrade telnyx-edge for that view.");
     }
     if (resetFuncSupported) {
-      nextSteps.push(`Recover a failed deployment with: telnyx-edge reset-func <function-name>${noninteractiveConfirmationSupported ? " --yes (scripts/CI)" : ""}`);
+      nextSteps.push(`Recover a failed deployment with: telnyx-edge reset-func <function-name>${resetFuncNoninteractiveConfirmationSupported ? " --yes (scripts/CI)" : ""}`);
     }
     if (typesSupported) {
       nextSteps.push("Generate TypeScript binding declarations with: telnyx-edge types");
@@ -289,6 +300,7 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
     }
     const missingOptional = [
       !resetFuncSupported && "reset-func",
+      resetFuncSupported && !resetFuncNoninteractiveConfirmationSupported && "reset-func --yes",
       !noninteractiveConfirmationSupported && "destructive-command --yes",
       !typesSupported && "types",
       !kvStorageSupported && "KV namespaces",
@@ -315,6 +327,7 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
     inspect_supported: inspectSupported,
     actor_instances_supported: actorInstancesSupported,
     reset_func_supported: resetFuncSupported,
+    reset_func_noninteractive_confirmation_supported: resetFuncNoninteractiveConfirmationSupported,
     noninteractive_confirmation_supported: noninteractiveConfirmationSupported,
     types_supported: typesSupported,
     kv_storage_supported: kvStorageSupported,

--- a/cli/src/commands/edge-doctor.ts
+++ b/cli/src/commands/edge-doctor.ts
@@ -13,7 +13,16 @@ import {
   supportsActorInstances,
   supportsApiKeyAuth,
   supportsInspect,
+  supportsKvKeyManagement,
+  supportsKvStorage,
+  supportsNewFuncFromDir,
+  supportsNonInteractiveConfirmation,
+  supportsResetFunc,
+  supportsSecretsAdd,
+  supportsShip,
+  supportsSqlDatabases,
   supportsStatefulActors,
+  supportsTypes,
 } from "../edge-cli.ts";
 
 interface EdgeDoctorResult {
@@ -24,9 +33,18 @@ interface EdgeDoctorResult {
   auth_mode: "api_key" | "oauth" | "none" | "unknown";
   root_status_passed: boolean;
   api_key_auth_supported: boolean;
+  new_func_from_dir_supported: boolean;
+  secrets_add_supported: boolean;
+  ship_supported: boolean;
   stateful_actors_supported: boolean;
   inspect_supported: boolean;
   actor_instances_supported: boolean;
+  reset_func_supported: boolean;
+  noninteractive_confirmation_supported: boolean;
+  types_supported: boolean;
+  kv_storage_supported: boolean;
+  kv_key_management_supported: boolean;
+  sql_databases_supported: boolean;
   checks: Array<{ name: string; ok: boolean; detail: string }>;
   next_steps: string[];
 }
@@ -40,9 +58,18 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
   let authMode: EdgeDoctorResult["auth_mode"] = "none";
   let rootStatusPassed = false;
   let apiKeyAuthSupported = false;
+  let newFuncFromDirSupported = false;
+  let secretsAddSupported = false;
+  let shipSupported = false;
   let statefulActorsSupported = false;
   let inspectSupported = false;
   let actorInstancesSupported = false;
+  let resetFuncSupported = false;
+  let noninteractiveConfirmationSupported = false;
+  let typesSupported = false;
+  let kvStorageSupported = false;
+  let kvKeyManagementSupported = false;
+  let sqlDatabasesSupported = false;
 
   try {
     getEdgeHelp();
@@ -62,14 +89,42 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
 
   if (installed) {
     apiKeyAuthSupported = supportsApiKeyAuth();
+    newFuncFromDirSupported = supportsNewFuncFromDir();
+    secretsAddSupported = supportsSecretsAdd();
+    shipSupported = supportsShip();
     statefulActorsSupported = supportsStatefulActors();
     inspectSupported = supportsInspect();
     actorInstancesSupported = supportsActorInstances();
+    resetFuncSupported = supportsResetFunc();
+    noninteractiveConfirmationSupported = supportsNonInteractiveConfirmation();
+    typesSupported = supportsTypes();
+    kvStorageSupported = supportsKvStorage();
+    kvKeyManagementSupported = supportsKvKeyManagement();
+    sqlDatabasesSupported = supportsSqlDatabases();
 
     checks.push({
       name: "API-key auth supported",
       ok: apiKeyAuthSupported,
       detail: apiKeyAuthSupported ? "auth api-key set is available" : "no auth api-key set support detected",
+    });
+    checks.push({
+      name: "Source-directory scaffolding",
+      ok: newFuncFromDirSupported,
+      detail: newFuncFromDirSupported
+        ? "new-func --from-dir is available"
+        : "new-func --from-dir was not detected; setup handoffs cannot scaffold their examples",
+    });
+    checks.push({
+      name: "Secret writes",
+      ok: secretsAddSupported,
+      detail: secretsAddSupported
+        ? "secrets add <key> <value> is available"
+        : "secrets add <key> <value> was not detected; setup handoffs cannot install runtime secrets",
+    });
+    checks.push({
+      name: "Function shipping",
+      ok: shipSupported,
+      detail: shipSupported ? "ship is available" : "ship --help capability was not detected",
     });
     checks.push({
       name: "Stateful actors supported",
@@ -88,7 +143,45 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
       ok: actorInstancesSupported,
       detail: actorInstancesSupported
         ? "actors instances <type> is available"
-        : "actors instances --help capability not detected (added in telnyx-edge v0.2.5)",
+        : "actors instances --help capability not detected",
+    });
+    checks.push({
+      name: "Failed-function reset",
+      ok: resetFuncSupported,
+      detail: resetFuncSupported ? "reset-func <function-name> is available" : "reset-func --help capability not detected",
+    });
+    checks.push({
+      name: "Non-interactive destructive confirmation",
+      ok: noninteractiveConfirmationSupported,
+      detail: noninteractiveConfirmationSupported
+        ? "--yes is available for non-interactive destructive commands"
+        : "delete-func --help did not advertise --yes confirmation bypass",
+    });
+    checks.push({
+      name: "Binding type generation",
+      ok: typesSupported,
+      detail: typesSupported ? "types can generate TypeScript binding declarations" : "types --help capability not detected",
+    });
+    checks.push({
+      name: "KV namespace storage",
+      ok: kvStorageSupported,
+      detail: kvStorageSupported
+        ? "storage kv namespace lifecycle commands are available"
+        : "storage kv --help did not advertise create/list/get/delete",
+    });
+    checks.push({
+      name: "KV key management",
+      ok: kvKeyManagementSupported,
+      detail: kvKeyManagementSupported
+        ? "storage kv key list/get/put/delete are available"
+        : "storage kv key --help did not advertise full key management",
+    });
+    checks.push({
+      name: "Remote SQL databases",
+      ok: sqlDatabasesSupported,
+      detail: sqlDatabasesSupported
+        ? "storage sqldb execute supports --remote, --command, and --file"
+        : "storage sqldb execute --help did not advertise --remote, --command, and --file",
     });
 
     try {
@@ -132,7 +225,8 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
     }
   }
 
-  const ready = installed && authenticated && rootStatusPassed;
+  const mandatoryHandoffCapabilities = newFuncFromDirSupported && secretsAddSupported && shipSupported;
+  const ready = installed && authenticated && rootStatusPassed && mandatoryHandoffCapabilities;
   let nextSteps: string[];
   if (!installed) {
     nextSteps = [
@@ -158,6 +252,16 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
       "If credentials are invalid, authenticate again and rerun telnyx-edge status.",
       "Run telnyx-agent edge-doctor again; readiness requires the final 'All checks passed' marker.",
     ];
+  } else if (!mandatoryHandoffCapabilities) {
+    const missing = [
+      !newFuncFromDirSupported && "new-func --from-dir",
+      !secretsAddSupported && "secrets add <key> <value>",
+      !shipSupported && "ship",
+    ].filter((value): value is string => Boolean(value));
+    nextSteps = [
+      `Upgrade telnyx-edge: the executable setup handoffs require ${missing.join(", ")}.`,
+      "Verify each missing command or flag on its own --help surface, then rerun telnyx-agent edge-doctor.",
+    ];
   } else {
     nextSteps = [
       "Create an executable MCP handoff: telnyx-agent setup-edge-mcp --name my-mcp-server",
@@ -171,6 +275,29 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
     } else if (statefulActorsSupported) {
       nextSteps.push("Actor scaffolding is available, but this CLI does not expose actors instances; upgrade telnyx-edge for that view.");
     }
+    if (resetFuncSupported) {
+      nextSteps.push(`Recover a failed deployment with: telnyx-edge reset-func <function-name>${noninteractiveConfirmationSupported ? " --yes (scripts/CI)" : ""}`);
+    }
+    if (typesSupported) {
+      nextSteps.push("Generate TypeScript binding declarations with: telnyx-edge types");
+    }
+    if (kvStorageSupported && kvKeyManagementSupported) {
+      nextSteps.push("Manage KV namespaces and values with: telnyx-edge storage kv --help");
+    }
+    if (sqlDatabasesSupported) {
+      nextSteps.push("Run remote SQL with: telnyx-edge storage sqldb execute <database> --remote --command \"SELECT 1\"");
+    }
+    const missingOptional = [
+      !resetFuncSupported && "reset-func",
+      !noninteractiveConfirmationSupported && "destructive-command --yes",
+      !typesSupported && "types",
+      !kvStorageSupported && "KV namespaces",
+      !kvKeyManagementSupported && "KV keys",
+      !sqlDatabasesSupported && "remote SQL execution",
+    ].filter((value): value is string => Boolean(value));
+    if (missingOptional.length > 0) {
+      nextSteps.push(`Optional capabilities not detected; upgrade telnyx-edge if needed: ${missingOptional.join(", ")}.`);
+    }
   }
 
   const result: EdgeDoctorResult = {
@@ -181,9 +308,18 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
     auth_mode: authMode,
     root_status_passed: rootStatusPassed,
     api_key_auth_supported: apiKeyAuthSupported,
+    new_func_from_dir_supported: newFuncFromDirSupported,
+    secrets_add_supported: secretsAddSupported,
+    ship_supported: shipSupported,
     stateful_actors_supported: statefulActorsSupported,
     inspect_supported: inspectSupported,
     actor_instances_supported: actorInstancesSupported,
+    reset_func_supported: resetFuncSupported,
+    noninteractive_confirmation_supported: noninteractiveConfirmationSupported,
+    types_supported: typesSupported,
+    kv_storage_supported: kvStorageSupported,
+    kv_key_management_supported: kvKeyManagementSupported,
+    sql_databases_supported: sqlDatabasesSupported,
     checks,
     next_steps: nextSteps,
   };
@@ -208,8 +344,10 @@ export async function edgeDoctorCommand(flags: Record<string, string | boolean>)
       printWarning(apiKeyAuthSupported
         ? "telnyx-edge is installed but not positively authenticated. Prefer API-key auth for agents."
         : "telnyx-edge is installed but not positively authenticated.");
-    } else {
+    } else if (!rootStatusPassed) {
       printWarning("Authentication is present, but telnyx-edge status did not pass every config/connectivity/credential check.");
+    } else {
+      printWarning("telnyx-edge is healthy, but it lacks one or more commands required by the executable setup handoffs.");
     }
   }
 

--- a/cli/src/commands/setup-edge-mcp.ts
+++ b/cli/src/commands/setup-edge-mcp.ts
@@ -5,10 +5,14 @@
 import { outputJson, printError, printSuccess, printWarning } from "../utils/output.ts";
 import {
   getEdgeAuthStatus,
+  getEdgeRootStatus,
   hasEdgeCli,
   supportsActorInstances,
   supportsApiKeyAuth,
   supportsInspect,
+  supportsNewFuncFromDir,
+  supportsSecretsAdd,
+  supportsShip,
   supportsStatefulActors,
   validateEdgeFunctionName,
 } from "../edge-cli.ts";
@@ -18,7 +22,11 @@ interface SetupEdgeMcpResult {
   telnyx_edge_installed: boolean;
   authenticated: boolean;
   auth_mode: "api_key" | "oauth" | "none" | "unknown";
+  root_status_passed: boolean;
   api_key_auth_supported: boolean;
+  new_func_from_dir_supported: boolean;
+  secrets_add_supported: boolean;
+  ship_supported: boolean;
   stateful_actors_supported: boolean;
   inspect_supported: boolean;
   actor_instances_supported: boolean;
@@ -43,10 +51,15 @@ export async function setupEdgeMcpCommand(flags: Record<string, string | boolean
 
   const hasEdge = hasEdgeCli();
   const apiKeyAuthSupported = hasEdge ? supportsApiKeyAuth() : false;
+  const newFuncFromDirSupported = hasEdge ? supportsNewFuncFromDir() : false;
+  const secretsAddSupported = hasEdge ? supportsSecretsAdd() : false;
+  const shipSupported = hasEdge ? supportsShip() : false;
   const statefulActorsSupported = hasEdge ? supportsStatefulActors() : false;
   const inspectSupported = hasEdge ? supportsInspect() : false;
   const actorInstancesSupported = hasEdge ? supportsActorInstances() : false;
   const authStatus = hasEdge ? safeAuthStatus() : { authenticated: false, mode: "none" as const };
+  const rootStatusPassed = hasEdge ? safeRootStatus() : false;
+  const mandatoryCapabilitiesSupported = newFuncFromDirSupported && secretsAddSupported && shipSupported;
   const authCommand = apiKeyAuthSupported
     ? `: "\${TELNYX_API_KEY:?Export TELNYX_API_KEY first}" && telnyx-edge auth api-key set "$TELNYX_API_KEY"`
     : "telnyx-edge auth login";
@@ -78,6 +91,9 @@ export async function setupEdgeMcpCommand(flags: Record<string, string | boolean
   if (!inspectSupported && hasEdge) {
     notes.push("This installed CLI did not expose inspect --help; upgrade telnyx-edge to inspect the function after deployment.");
   }
+  if (hasEdge && !mandatoryCapabilitiesSupported) {
+    notes.push("The suggested flow is shown for handoff purposes, but this CLI did not expose every command it emits; do not run it until the missing capabilities are installed.");
+  }
   if (statefulActorsSupported) {
     notes.push("For per-user state, actor scaffolding is available via telnyx-edge new-func --actor --language ts.");
   }
@@ -89,18 +105,32 @@ export async function setupEdgeMcpCommand(flags: Record<string, string | boolean
     ? ["Install telnyx-edge from the Edge Compute releases page, then rerun this command."]
     : !authStatus.authenticated
       ? [`Authenticate first: ${authCommand}`, "Run telnyx-edge status, then rerun this handoff."]
-      : [
-          "Export TELNYX_API_KEY and a high-entropy SHARED_SECRET (for example, openssl rand -hex 32).",
-          "Run deploy_command from the directory where you want the function project created.",
-          `Configure the MCP client to send Authorization: Bearer <SHARED_SECRET> to the ${inspectSupported ? "inspected" : "deployed function's"} invoke URL.`,
-        ];
+      : !rootStatusPassed
+        ? [
+            "Run telnyx-edge status and resolve every failed config, credential, or connectivity check.",
+            "Rerun this handoff only after status prints 'All checks passed - CLI is ready to use'.",
+          ]
+        : !mandatoryCapabilitiesSupported
+          ? [
+              `Upgrade telnyx-edge; this flow requires ${missingCapabilities(newFuncFromDirSupported, secretsAddSupported, shipSupported).join(", ")}.`,
+              "Verify the missing commands on their own --help surfaces, then rerun this handoff.",
+            ]
+          : [
+              "Export TELNYX_API_KEY and a high-entropy SHARED_SECRET (for example, openssl rand -hex 32).",
+              "Run deploy_command from the directory where you want the function project created.",
+              `Configure the MCP client to send Authorization: Bearer *** to the ${inspectSupported ? "inspected" : "deployed function's"} invoke URL.`,
+            ];
 
   const result: SetupEdgeMcpResult = {
-    ready: hasEdge && authStatus.authenticated,
+    ready: hasEdge && authStatus.authenticated && rootStatusPassed && mandatoryCapabilitiesSupported,
     telnyx_edge_installed: hasEdge,
     authenticated: authStatus.authenticated,
     auth_mode: authStatus.mode,
+    root_status_passed: rootStatusPassed,
     api_key_auth_supported: apiKeyAuthSupported,
+    new_func_from_dir_supported: newFuncFromDirSupported,
+    secrets_add_supported: secretsAddSupported,
+    ship_supported: shipSupported,
     stateful_actors_supported: statefulActorsSupported,
     inspect_supported: inspectSupported,
     actor_instances_supported: actorInstancesSupported,
@@ -132,10 +162,18 @@ export async function setupEdgeMcpCommand(flags: Record<string, string | boolean
       Ready: "✓",
     });
   } else {
-    printError(hasEdge ? "telnyx-edge is not positively authenticated." : "telnyx-edge is not installed.");
-    printWarning(hasEdge
-      ? `Authenticate first with: ${authCommand}`
-      : "This command is a handoff helper — it depends on the dedicated Edge Compute CLI.");
+    printError(!hasEdge
+      ? "telnyx-edge is not installed."
+      : !authStatus.authenticated
+        ? "telnyx-edge is not positively authenticated."
+        : !rootStatusPassed
+          ? "telnyx-edge status did not pass every readiness check."
+          : "telnyx-edge lacks commands required by this setup flow.");
+    printWarning(!hasEdge
+      ? "This command is a handoff helper — it depends on the dedicated Edge Compute CLI."
+      : !authStatus.authenticated
+        ? `Authenticate first with: ${authCommand}`
+        : nextSteps[0]);
   }
 
   console.log(`  Source repository: ${SOURCE_REPO}`);
@@ -163,4 +201,20 @@ function safeAuthStatus(): { authenticated: boolean; mode: "api_key" | "oauth" |
   } catch {
     return { authenticated: false, mode: "unknown" };
   }
+}
+
+function safeRootStatus(): boolean {
+  try {
+    return getEdgeRootStatus().passed;
+  } catch {
+    return false;
+  }
+}
+
+function missingCapabilities(fromDir: boolean, secretsAdd: boolean, ship: boolean): string[] {
+  return [
+    !fromDir && "new-func --from-dir",
+    !secretsAdd && "secrets add <key> <value>",
+    !ship && "ship",
+  ].filter((value): value is string => Boolean(value));
 }

--- a/cli/src/commands/setup-edge-mcp.ts
+++ b/cli/src/commands/setup-edge-mcp.ts
@@ -118,7 +118,7 @@ export async function setupEdgeMcpCommand(flags: Record<string, string | boolean
           : [
               "Export TELNYX_API_KEY and a high-entropy SHARED_SECRET (for example, openssl rand -hex 32).",
               "Run deploy_command from the directory where you want the function project created.",
-              `Configure the MCP client to send Authorization: Bearer *** to the ${inspectSupported ? "inspected" : "deployed function's"} invoke URL.`,
+              `Configure the MCP client to send Authorization: Bearer $SHARED_SECRET to the ${inspectSupported ? "inspected" : "deployed function's"} invoke URL.`,
             ];
 
   const result: SetupEdgeMcpResult = {

--- a/cli/src/commands/setup-edge-webhook.ts
+++ b/cli/src/commands/setup-edge-webhook.ts
@@ -5,10 +5,14 @@
 import { outputJson, printError, printSuccess, printWarning } from "../utils/output.ts";
 import {
   getEdgeAuthStatus,
+  getEdgeRootStatus,
   hasEdgeCli,
   supportsActorInstances,
   supportsApiKeyAuth,
   supportsInspect,
+  supportsNewFuncFromDir,
+  supportsSecretsAdd,
+  supportsShip,
   supportsStatefulActors,
   validateEdgeFunctionName,
 } from "../edge-cli.ts";
@@ -18,7 +22,11 @@ interface SetupEdgeWebhookResult {
   telnyx_edge_installed: boolean;
   authenticated: boolean;
   auth_mode: "api_key" | "oauth" | "none" | "unknown";
+  root_status_passed: boolean;
   api_key_auth_supported: boolean;
+  new_func_from_dir_supported: boolean;
+  secrets_add_supported: boolean;
+  ship_supported: boolean;
   stateful_actors_supported: boolean;
   inspect_supported: boolean;
   actor_instances_supported: boolean;
@@ -43,10 +51,15 @@ export async function setupEdgeWebhookCommand(flags: Record<string, string | boo
 
   const hasEdge = hasEdgeCli();
   const apiKeyAuthSupported = hasEdge ? supportsApiKeyAuth() : false;
+  const newFuncFromDirSupported = hasEdge ? supportsNewFuncFromDir() : false;
+  const secretsAddSupported = hasEdge ? supportsSecretsAdd() : false;
+  const shipSupported = hasEdge ? supportsShip() : false;
   const statefulActorsSupported = hasEdge ? supportsStatefulActors() : false;
   const inspectSupported = hasEdge ? supportsInspect() : false;
   const actorInstancesSupported = hasEdge ? supportsActorInstances() : false;
   const authStatus = hasEdge ? safeAuthStatus() : { authenticated: false, mode: "none" as const };
+  const rootStatusPassed = hasEdge ? safeRootStatus() : false;
+  const mandatoryCapabilitiesSupported = newFuncFromDirSupported && secretsAddSupported && shipSupported;
   const authCommand = apiKeyAuthSupported
     ? `: "\${TELNYX_API_KEY:?Export TELNYX_API_KEY first}" && telnyx-edge auth api-key set "$TELNYX_API_KEY"`
     : "telnyx-edge auth login";
@@ -74,6 +87,9 @@ export async function setupEdgeWebhookCommand(flags: Record<string, string | boo
   if (!inspectSupported && hasEdge) {
     notes.push("This installed CLI did not expose inspect --help; upgrade telnyx-edge to inspect the function after deployment.");
   }
+  if (hasEdge && !mandatoryCapabilitiesSupported) {
+    notes.push("The suggested flow is shown for handoff purposes, but this CLI did not expose every command it emits; do not run it until the missing capabilities are installed.");
+  }
   if (statefulActorsSupported) {
     notes.push("For per-entity webhook state, actor scaffolding is available via telnyx-edge new-func --actor --language ts.");
   }
@@ -85,18 +101,32 @@ export async function setupEdgeWebhookCommand(flags: Record<string, string | boo
     ? ["Install telnyx-edge from the Edge Compute releases page, then rerun this command."]
     : !authStatus.authenticated
       ? [`Authenticate first: ${authCommand}`, "Run telnyx-edge status, then rerun this handoff."]
-      : [
-          "Export a high-entropy WEBHOOK_SECRET (for example: export WEBHOOK_SECRET=\"$(openssl rand -hex 32)\").",
-          "Run deploy_command from the directory where you want the function project created.",
-          "Configure the producer with the same secret and HMAC-sign the exact payload bytes before sending.",
-        ];
+      : !rootStatusPassed
+        ? [
+            "Run telnyx-edge status and resolve every failed config, credential, or connectivity check.",
+            "Rerun this handoff only after status prints 'All checks passed - CLI is ready to use'.",
+          ]
+        : !mandatoryCapabilitiesSupported
+          ? [
+              `Upgrade telnyx-edge; this flow requires ${missingCapabilities(newFuncFromDirSupported, secretsAddSupported, shipSupported).join(", ")}.`,
+              "Verify the missing commands on their own --help surfaces, then rerun this handoff.",
+            ]
+          : [
+              "Export a high-entropy WEBHOOK_SECRET (for example: export WEBHOOK_SECRET=\"$(openssl rand -hex 32)\").",
+              "Run deploy_command from the directory where you want the function project created.",
+              "Configure the producer with the same secret and HMAC-sign the exact payload bytes before sending.",
+            ];
 
   const result: SetupEdgeWebhookResult = {
-    ready: hasEdge && authStatus.authenticated,
+    ready: hasEdge && authStatus.authenticated && rootStatusPassed && mandatoryCapabilitiesSupported,
     telnyx_edge_installed: hasEdge,
     authenticated: authStatus.authenticated,
     auth_mode: authStatus.mode,
+    root_status_passed: rootStatusPassed,
     api_key_auth_supported: apiKeyAuthSupported,
+    new_func_from_dir_supported: newFuncFromDirSupported,
+    secrets_add_supported: secretsAddSupported,
+    ship_supported: shipSupported,
     stateful_actors_supported: statefulActorsSupported,
     inspect_supported: inspectSupported,
     actor_instances_supported: actorInstancesSupported,
@@ -129,10 +159,18 @@ export async function setupEdgeWebhookCommand(flags: Record<string, string | boo
       Ready: "✓",
     });
   } else {
-    printError(hasEdge ? "telnyx-edge is not positively authenticated." : "telnyx-edge is not installed.");
-    printWarning(hasEdge
-      ? `Authenticate first with: ${authCommand}`
-      : "This command is a handoff helper — it depends on the dedicated Edge Compute CLI.");
+    printError(!hasEdge
+      ? "telnyx-edge is not installed."
+      : !authStatus.authenticated
+        ? "telnyx-edge is not positively authenticated."
+        : !rootStatusPassed
+          ? "telnyx-edge status did not pass every readiness check."
+          : "telnyx-edge lacks commands required by this setup flow.");
+    printWarning(!hasEdge
+      ? "This command is a handoff helper — it depends on the dedicated Edge Compute CLI."
+      : !authStatus.authenticated
+        ? `Authenticate first with: ${authCommand}`
+        : nextSteps[0]);
   }
 
   console.log(`  Source repository: ${SOURCE_REPO}`);
@@ -160,4 +198,20 @@ function safeAuthStatus(): { authenticated: boolean; mode: "api_key" | "oauth" |
   } catch {
     return { authenticated: false, mode: "unknown" };
   }
+}
+
+function safeRootStatus(): boolean {
+  try {
+    return getEdgeRootStatus().passed;
+  } catch {
+    return false;
+  }
+}
+
+function missingCapabilities(fromDir: boolean, secretsAdd: boolean, ship: boolean): string[] {
+  return [
+    !fromDir && "new-func --from-dir",
+    !secretsAdd && "secrets add <key> <value>",
+    !ship && "ship",
+  ].filter((value): value is string => Boolean(value));
 }

--- a/cli/src/edge-cli.ts
+++ b/cli/src/edge-cli.ts
@@ -120,7 +120,10 @@ export function supportsSecretsAdd(): boolean {
 export function supportsTypes(): boolean {
   try {
     const out = runEdge(["types", "--help"]);
-    return /\btypes\b/i.test(out) && /typescript\s+binding\s+types/i.test(out);
+    const hasTypescript = /\btypescript\b/i.test(out);
+    const hasGenerationIndicator =
+      /\btypes\b/i.test(out) || /\btelnyx-env\.d\.ts\b/i.test(out) || /\bbindings\b/i.test(out);
+    return hasTypescript && hasGenerationIndicator;
   } catch {
     return false;
   }

--- a/cli/src/edge-cli.ts
+++ b/cli/src/edge-cli.ts
@@ -56,6 +56,102 @@ export function supportsStatefulActors(): boolean {
   }
 }
 
+/** Detect the source-directory scaffold used by both setup handoffs. */
+export function supportsNewFuncFromDir(): boolean {
+  try {
+    const out = runEdge(["new-func", "--help"]);
+    return /\bnew-func\b/i.test(out) && /--from-dir\b/i.test(out);
+  } catch {
+    return false;
+  }
+}
+
+/** Detect the command used by setup handoffs to publish a function. */
+export function supportsShip(): boolean {
+  try {
+    const out = runEdge(["ship", "--help"]);
+    return /\bship\b/i.test(out) && /\bfunction\b/i.test(out);
+  } catch {
+    return false;
+  }
+}
+
+/** Detect non-interactive confirmation from a destructive command's own help. */
+export function supportsNonInteractiveConfirmation(): boolean {
+  try {
+    const out = runEdge(["delete-func", "--help"]);
+    return /--yes\b/i.test(out) && /confirm(?:ation)?|scripts?|\bci\b/i.test(out);
+  } catch {
+    return false;
+  }
+}
+
+/** Detect failed-function reset directly, without relying on the CLI version. */
+export function supportsResetFunc(): boolean {
+  try {
+    const out = runEdge(["reset-func", "--help"]);
+    return /\breset-func\s+<[^>]+>/i.test(out) && /reset\b[\s\S]*\bfunction\b/i.test(out);
+  } catch {
+    return false;
+  }
+}
+
+/** Detect the exact secret write command emitted by the setup handoffs. */
+export function supportsSecretsAdd(): boolean {
+  try {
+    const out = runEdge(["secrets", "add", "--help"]);
+    return /\bsecrets\s+add\s+<[^>]+>\s+<[^>]+>/i.test(out) && /\bsecret\b/i.test(out);
+  } catch {
+    return false;
+  }
+}
+
+/** Detect TypeScript binding declaration generation directly. */
+export function supportsTypes(): boolean {
+  try {
+    const out = runEdge(["types", "--help"]);
+    return /\btypes\b/i.test(out) && /typescript\s+binding\s+types/i.test(out);
+  } catch {
+    return false;
+  }
+}
+
+/** Detect KV namespace management, including its basic lifecycle commands. */
+export function supportsKvStorage(): boolean {
+  try {
+    const out = runEdge(["storage", "kv", "--help"]);
+    return /\bstorage\s+kv\b/i.test(out) && /\bkv\b[\s\S]*\bnamespace/i.test(out) &&
+      ["create", "list", "get", "delete"].every((command) => new RegExp(`\\b${command}\\b`, "i").test(out));
+  } catch {
+    return false;
+  }
+}
+
+/** Detect key CRUD beneath a KV namespace rather than inferring it from KV. */
+export function supportsKvKeyManagement(): boolean {
+  try {
+    const out = runEdge(["storage", "kv", "key", "--help"]);
+    return /\bstorage\s+kv\s+key\b/i.test(out) && /\bkeys?\b[\s\S]*\bkv\s+namespace/i.test(out) &&
+      ["list", "get", "put", "delete"].every((command) => new RegExp(`\\b${command}\\b`, "i").test(out));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Detect usable remote SQL execution. The command alone is insufficient: the
+ * v0.3 workflow requires both SQL input forms and the explicit remote switch.
+ */
+export function supportsSqlDatabases(): boolean {
+  try {
+    const out = runEdge(["storage", "sqldb", "execute", "--help"]);
+    return /\bstorage\s+sqldb\s+execute\s+<[^>]+>/i.test(out) &&
+      ["remote", "command", "file"].every((flag) => new RegExp(`--${flag}\\b`, "i").test(out));
+  } catch {
+    return false;
+  }
+}
+
 /** Detect the root function-detail command introduced before v0.2.5. */
 export function supportsInspect(): boolean {
   try {

--- a/cli/src/edge-cli.ts
+++ b/cli/src/edge-cli.ts
@@ -96,6 +96,16 @@ export function supportsResetFunc(): boolean {
   }
 }
 
+/** Detect reset confirmation bypass from reset-func's own help surface. */
+export function supportsResetFuncNonInteractiveConfirmation(): boolean {
+  try {
+    const out = runEdge(["reset-func", "--help"]);
+    return /--yes\b/i.test(out) && /confirm(?:ation)?|scripts?|\bci\b/i.test(out);
+  } catch {
+    return false;
+  }
+}
+
 /** Detect the exact secret write command emitted by the setup handoffs. */
 export function supportsSecretsAdd(): boolean {
   try {

--- a/cli/tests/edge-handoff.test.ts
+++ b/cli/tests/edge-handoff.test.ts
@@ -15,6 +15,15 @@ type FakeEdgeOptions = {
   rootStatus?: "pass" | "fail" | "unknown";
   inspect?: boolean;
   actorInstances?: boolean;
+  newFuncFromDir?: boolean;
+  secretsAdd?: boolean;
+  ship?: boolean;
+  resetFunc?: boolean;
+  noninteractiveConfirmation?: boolean;
+  types?: boolean;
+  kvStorage?: boolean;
+  kvKeyManagement?: boolean;
+  sqlDatabases?: boolean;
   argLog?: boolean;
 };
 
@@ -24,6 +33,15 @@ function withFakeEdgeCli(options: FakeEdgeOptions | AuthMode = "api_key") {
   const rootStatus = config.rootStatus ?? (auth === "api_key" || auth === "oauth" ? "pass" : "fail");
   const inspect = config.inspect ?? true;
   const actorInstances = config.actorInstances ?? true;
+  const newFuncFromDir = config.newFuncFromDir ?? true;
+  const secretsAdd = config.secretsAdd ?? true;
+  const ship = config.ship ?? true;
+  const resetFunc = config.resetFunc ?? true;
+  const noninteractiveConfirmation = config.noninteractiveConfirmation ?? true;
+  const types = config.types ?? true;
+  const kvStorage = config.kvStorage ?? true;
+  const kvKeyManagement = config.kvKeyManagement ?? true;
+  const sqlDatabases = config.sqlDatabases ?? true;
   const tempDir = mkdtempSync(join(tmpdir(), "telnyx-edge-fake-"));
   const binDir = join(tempDir, "bin");
   const argsLog = join(tempDir, "args.jsonl");
@@ -41,11 +59,75 @@ if (args.includes('--version')) {
   process.exit(0);
 }
 if (args[0] === 'new-func' && args.includes('--help')) {
-  console.log(['Create a new edge computing function', '', 'Flags:', '      --actor             Scaffold a StatefulActor project', '      --from-dir string   Copy files from existing directory', '  -h, --help              help for new-func', '  -n, --name string       Name of the function to create'].join('\\n'));
+  console.log(['Create a new edge computing function', '', 'Usage: telnyx-edge new-func [flags]', '', 'Flags:', '      --actor             Scaffold a StatefulActor project', ...(${newFuncFromDir} ? ['      --from-dir string   Copy files from existing directory'] : []), '  -h, --help              help for new-func', '  -n, --name string       Name of the function to create'].join('\\n'));
   process.exit(0);
 }
 if (args[0] === 'auth' && args[1] === 'api-key' && args[2] === 'set' && args.includes('--help')) {
   console.log('Set API key for authentication. The API key must be provided as an argument.');
+  process.exit(0);
+}
+if (args[0] === 'secrets' && args[1] === 'add' && args.includes('--help')) {
+  if (${secretsAdd}) {
+    console.log('Add or update a secret\\nUsage: telnyx-edge secrets add <key> <value> [flags]');
+    process.exit(0);
+  }
+  process.stderr.write('unknown command "add"\\n');
+  process.exit(1);
+}
+if (args[0] === 'ship' && args.includes('--help')) {
+  if (${ship}) {
+    console.log('Ship a function to Telnyx edge infrastructure\\nUsage: telnyx-edge ship [flags]');
+    process.exit(0);
+  }
+  process.stderr.write('unknown command "ship"\\n');
+  process.exit(1);
+}
+if (args[0] === 'reset-func' && args.includes('--help')) {
+  if (${resetFunc}) {
+    console.log('Reset a failed function back to the created state\\nUsage: telnyx-edge reset-func <function-name> [flags]');
+    process.exit(0);
+  }
+  process.stderr.write('unknown command "reset-func"\\n');
+  process.exit(1);
+}
+if (args[0] === 'delete-func' && args.includes('--help')) {
+  if (${noninteractiveConfirmation}) {
+    console.log('Delete an edge function after confirmation\\n  -y, --yes  Skip the confirmation prompt (for scripts and CI)');
+    process.exit(0);
+  }
+  console.log('Delete an edge function');
+  process.exit(0);
+}
+if (args[0] === 'types' && args.includes('--help')) {
+  if (${types}) {
+    console.log('Generate TypeScript binding types\\nUsage: telnyx-edge types [flags]');
+    process.exit(0);
+  }
+  process.stderr.write('unknown command "types"\\n');
+  process.exit(1);
+}
+if (args[0] === 'storage' && args[1] === 'kv' && args[2] === 'key' && args.includes('--help')) {
+  if (${kvKeyManagement}) {
+    console.log('Manage keys in a KV namespace\\nUsage: telnyx-edge storage kv key [command]\\nCommands: list get put delete');
+    process.exit(0);
+  }
+  process.stderr.write('unknown command "key"\\n');
+  process.exit(1);
+}
+if (args[0] === 'storage' && args[1] === 'kv' && args.includes('--help')) {
+  if (${kvStorage}) {
+    console.log('Manage KV storage namespaces\\nUsage: telnyx-edge storage kv [command]\\nCommands: create list get delete key');
+    process.exit(0);
+  }
+  process.stderr.write('unknown command "kv"\\n');
+  process.exit(1);
+}
+if (args[0] === 'storage' && args[1] === 'sqldb' && args[2] === 'execute' && args.includes('--help')) {
+  if (${sqlDatabases}) {
+    console.log('Run SQL against a SQL database\\nUsage: telnyx-edge storage sqldb execute <database> [flags]\\n--remote  --command string  --file string');
+    process.exit(0);
+  }
+  console.log('Usage: telnyx-edge storage sqldb execute <database> [flags]\\n--remote --command string');
   process.exit(0);
 }
 if (args[0] === 'inspect' && args.includes('--help')) {
@@ -163,9 +245,18 @@ describe("CLI — Edge Compute handoff", () => {
     assert.equal(data.auth_mode, "api_key");
     assert.equal(data.root_status_passed, true);
     assert.equal(data.api_key_auth_supported, true);
+    assert.equal(data.new_func_from_dir_supported, true);
+    assert.equal(data.secrets_add_supported, true);
+    assert.equal(data.ship_supported, true);
     assert.equal(data.stateful_actors_supported, true);
     assert.equal(data.inspect_supported, true);
     assert.equal(data.actor_instances_supported, true);
+    assert.equal(data.reset_func_supported, true);
+    assert.equal(data.noninteractive_confirmation_supported, true);
+    assert.equal(data.types_supported, true);
+    assert.equal(data.kv_storage_supported, true);
+    assert.equal(data.kv_key_management_supported, true);
+    assert.equal(data.sql_databases_supported, true);
   });
 
   it("edge-doctor stays unready when root status exits zero but reports a failed check", () => {
@@ -206,11 +297,79 @@ describe("CLI — Edge Compute handoff", () => {
     assert.ok(calls.some((args) => JSON.stringify(args) === JSON.stringify(["actors", "instances", "--help"])));
   });
 
+  it("edge-doctor probes v0.3 capabilities conservatively instead of inferring from version", () => {
+    const fake = withFakeEdgeCli({
+      auth: "api_key",
+      resetFunc: false,
+      noninteractiveConfirmation: false,
+      types: false,
+      kvStorage: false,
+      kvKeyManagement: false,
+      sqlDatabases: false,
+      argLog: true,
+    });
+    const data = JSON.parse(run(["edge-doctor", "--json"], fake.env));
+    assert.equal(data.telnyx_edge_version, "v0.2.5");
+    assert.equal(data.ready, true, "optional v0.3 capabilities do not block the core handoff");
+    assert.equal(data.reset_func_supported, false);
+    assert.equal(data.noninteractive_confirmation_supported, false);
+    assert.equal(data.types_supported, false);
+    assert.equal(data.kv_storage_supported, false);
+    assert.equal(data.kv_key_management_supported, false);
+    assert.equal(data.sql_databases_supported, false);
+    assert.ok(data.next_steps.some((step: string) => step.includes("Optional capabilities not detected")));
+    const calls = readFileSync(fake.argsLog, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    for (const expected of [
+      ["reset-func", "--help"],
+      ["delete-func", "--help"],
+      ["secrets", "add", "--help"],
+      ["types", "--help"],
+      ["storage", "kv", "--help"],
+      ["storage", "kv", "key", "--help"],
+      ["storage", "sqldb", "execute", "--help"],
+    ]) {
+      assert.ok(calls.some((args) => JSON.stringify(args) === JSON.stringify(expected)), `missing probe ${expected.join(" ")}`);
+    }
+  });
+
+  it("requires every capability emitted by setup handoffs", () => {
+    for (const missing of ["newFuncFromDir", "secretsAdd", "ship"] as const) {
+      const fake = withFakeEdgeCli({ auth: "api_key", [missing]: false });
+      const doctor = JSON.parse(run(["edge-doctor", "--json"], fake.env));
+      assert.equal(doctor.authenticated, true);
+      assert.equal(doctor.root_status_passed, true);
+      assert.equal(doctor.ready, false);
+      assert.ok(doctor.next_steps.some((step: string) => step.includes("Upgrade telnyx-edge")));
+      for (const command of ["setup-edge-mcp", "setup-edge-webhook"]) {
+        const data = JSON.parse(run([command, "--json"], fake.env));
+        assert.equal(data.ready, false, `${command} must reject missing ${missing}`);
+        assert.equal(data.root_status_passed, true);
+        assert.equal(data[missing === "newFuncFromDir" ? "new_func_from_dir_supported" : missing === "secretsAdd" ? "secrets_add_supported" : "ship_supported"], false);
+        assert.ok(data.next_steps.some((step: string) => step.includes("Upgrade telnyx-edge")));
+      }
+    }
+  });
+
+  it("setup handoffs require the root status success marker", () => {
+    const fake = withFakeEdgeCli({ auth: "api_key", rootStatus: "fail" });
+    for (const command of ["setup-edge-mcp", "setup-edge-webhook"]) {
+      const data = JSON.parse(run([command, "--json"], fake.env));
+      assert.equal(data.authenticated, true);
+      assert.equal(data.root_status_passed, false);
+      assert.equal(data.ready, false);
+      assert.ok(data.next_steps.some((step: string) => step.includes("telnyx-edge status")));
+    }
+  });
+
   it("setup-edge-mcp emits a repository-aware secure build/deploy/inspect flow", () => {
     const fake = withFakeEdgeCli("api_key");
     const data = JSON.parse(run(["setup-edge-mcp", "--json", "--name", "demo-mcp"], fake.env));
     assert.equal(data.ready, true);
     assert.equal(data.telnyx_edge_installed, true);
+    assert.equal(data.root_status_passed, true);
+    assert.equal(data.new_func_from_dir_supported, true);
+    assert.equal(data.secrets_add_supported, true);
+    assert.equal(data.ship_supported, true);
     assert.equal(data.inspect_supported, true);
     assert.equal(data.actor_instances_supported, true);
     assert.equal(data.source_repo, "https://github.com/team-telnyx/edge-compute.git");

--- a/cli/tests/edge-handoff.test.ts
+++ b/cli/tests/edge-handoff.test.ts
@@ -19,6 +19,7 @@ type FakeEdgeOptions = {
   secretsAdd?: boolean;
   ship?: boolean;
   resetFunc?: boolean;
+  resetNoninteractiveConfirmation?: boolean;
   noninteractiveConfirmation?: boolean;
   types?: boolean;
   kvStorage?: boolean;
@@ -37,6 +38,7 @@ function withFakeEdgeCli(options: FakeEdgeOptions | AuthMode = "api_key") {
   const secretsAdd = config.secretsAdd ?? true;
   const ship = config.ship ?? true;
   const resetFunc = config.resetFunc ?? true;
+  const resetNoninteractiveConfirmation = config.resetNoninteractiveConfirmation ?? false;
   const noninteractiveConfirmation = config.noninteractiveConfirmation ?? true;
   const types = config.types ?? true;
   const kvStorage = config.kvStorage ?? true;
@@ -84,7 +86,7 @@ if (args[0] === 'ship' && args.includes('--help')) {
 }
 if (args[0] === 'reset-func' && args.includes('--help')) {
   if (${resetFunc}) {
-    console.log('Reset a failed function back to the created state\\nUsage: telnyx-edge reset-func <function-name> [flags]');
+    console.log(['Reset a failed function back to the created state', 'Usage: telnyx-edge reset-func <function-name> [flags]', ...(${resetNoninteractiveConfirmation} ? ['  -y, --yes  Skip the confirmation prompt (for scripts and CI)'] : [])].join('\\n'));
     process.exit(0);
   }
   process.stderr.write('unknown command "reset-func"\\n');
@@ -332,6 +334,29 @@ describe("CLI — Edge Compute handoff", () => {
     }
   });
 
+  it("probes reset-func --yes independently from delete-func --yes", () => {
+    const deleteOnly = withFakeEdgeCli({
+      resetFunc: true,
+      resetNoninteractiveConfirmation: false,
+      noninteractiveConfirmation: true,
+    });
+    const withoutResetYes = JSON.parse(run(["edge-doctor", "--json"], deleteOnly.env));
+    assert.equal(withoutResetYes.noninteractive_confirmation_supported, true);
+    assert.equal(withoutResetYes.reset_func_noninteractive_confirmation_supported, false);
+    assert.ok(withoutResetYes.next_steps.some((step: string) => step.includes("reset-func <function-name>")));
+    assert.ok(!withoutResetYes.next_steps.some((step: string) => step.includes("reset-func <function-name> --yes")));
+
+    const resetOnly = withFakeEdgeCli({
+      resetFunc: true,
+      resetNoninteractiveConfirmation: true,
+      noninteractiveConfirmation: false,
+    });
+    const withResetYes = JSON.parse(run(["edge-doctor", "--json"], resetOnly.env));
+    assert.equal(withResetYes.noninteractive_confirmation_supported, false);
+    assert.equal(withResetYes.reset_func_noninteractive_confirmation_supported, true);
+    assert.ok(withResetYes.next_steps.some((step: string) => step.includes("reset-func <function-name> --yes")));
+  });
+
   it("requires every capability emitted by setup handoffs", () => {
     for (const missing of ["newFuncFromDir", "secretsAdd", "ship"] as const) {
       const fake = withFakeEdgeCli({ auth: "api_key", [missing]: false });
@@ -363,7 +388,11 @@ describe("CLI — Edge Compute handoff", () => {
 
   it("setup-edge-mcp emits a repository-aware secure build/deploy/inspect flow", () => {
     const fake = withFakeEdgeCli("api_key");
-    const data = JSON.parse(run(["setup-edge-mcp", "--json", "--name", "demo-mcp"], fake.env));
+    const output = run(["setup-edge-mcp", "--json", "--name", "demo-mcp"], {
+      ...fake.env,
+      SHARED_SECRET: "must-not-appear-in-output",
+    });
+    const data = JSON.parse(output);
     assert.equal(data.ready, true);
     assert.equal(data.telnyx_edge_installed, true);
     assert.equal(data.root_status_passed, true);
@@ -382,6 +411,9 @@ describe("CLI — Edge Compute handoff", () => {
     assert.ok(data.deploy_command.includes("telnyx-edge ship"));
     assert.ok(data.deploy_command.includes("telnyx-edge inspect demo-mcp"));
     assert.ok(!data.deploy_command.includes("<your-api-key>"));
+    assert.ok(data.next_steps.some((step: string) => step.includes("Authorization: Bearer $SHARED_SECRET")));
+    assert.ok(!data.next_steps.some((step: string) => step.includes("Bearer ***")));
+    assert.ok(!output.includes("must-not-appear-in-output"));
   });
 
   it("setup-edge-webhook emits a repository-aware HMAC-secured deploy/inspect flow", () => {

--- a/cli/tests/edge-handoff.test.ts
+++ b/cli/tests/edge-handoff.test.ts
@@ -354,7 +354,11 @@ describe("CLI — Edge Compute handoff", () => {
     const withResetYes = JSON.parse(run(["edge-doctor", "--json"], resetOnly.env));
     assert.equal(withResetYes.noninteractive_confirmation_supported, false);
     assert.equal(withResetYes.reset_func_noninteractive_confirmation_supported, true);
-    assert.ok(withResetYes.next_steps.some((step: string) => step.includes("reset-func <function-name> --yes")));
+    const resetStep = withResetYes.next_steps.find((step: string) => step.includes("reset-func <function-name> --yes"));
+    assert.ok(resetStep);
+    const resetCommand = resetStep.slice(resetStep.indexOf(": ") + 2);
+    assert.doesNotMatch(resetCommand, /\([^)]*\)/, "copyable reset command must not contain inline annotations");
+    assert.doesNotThrow(() => execFileSync("/bin/sh", ["-n", "-c", resetCommand]));
   });
 
   it("requires every capability emitted by setup handoffs", () => {

--- a/cli/tests/edge-handoff.test.ts
+++ b/cli/tests/edge-handoff.test.ts
@@ -22,6 +22,7 @@ type FakeEdgeOptions = {
   resetNoninteractiveConfirmation?: boolean;
   noninteractiveConfirmation?: boolean;
   types?: boolean;
+  typesHelp?: string;
   kvStorage?: boolean;
   kvKeyManagement?: boolean;
   sqlDatabases?: boolean;
@@ -41,6 +42,7 @@ function withFakeEdgeCli(options: FakeEdgeOptions | AuthMode = "api_key") {
   const resetNoninteractiveConfirmation = config.resetNoninteractiveConfirmation ?? false;
   const noninteractiveConfirmation = config.noninteractiveConfirmation ?? true;
   const types = config.types ?? true;
+  const typesHelp = config.typesHelp ?? "Generate TypeScript binding types\nUsage: telnyx-edge types [flags]";
   const kvStorage = config.kvStorage ?? true;
   const kvKeyManagement = config.kvKeyManagement ?? true;
   const sqlDatabases = config.sqlDatabases ?? true;
@@ -102,7 +104,7 @@ if (args[0] === 'delete-func' && args.includes('--help')) {
 }
 if (args[0] === 'types' && args.includes('--help')) {
   if (${types}) {
-    console.log('Generate TypeScript binding types\\nUsage: telnyx-edge types [flags]');
+    console.log(${JSON.stringify(typesHelp)});
     process.exit(0);
   }
   process.stderr.write('unknown command "types"\\n');
@@ -332,6 +334,22 @@ describe("CLI — Edge Compute handoff", () => {
     ]) {
       assert.ok(calls.some((args) => JSON.stringify(args) === JSON.stringify(expected)), `missing probe ${expected.join(" ")}`);
     }
+  });
+
+  it("detects types support from the documented manifest wording", () => {
+    const fake = withFakeEdgeCli({
+      typesHelp: "Generate types for your environment from the manifest in TypeScript (telnyx-env.d.ts)",
+    });
+    const data = JSON.parse(run(["edge-doctor", "--json"], fake.env));
+    assert.equal(data.types_supported, true);
+  });
+
+  it("rejects generic TypeScript help without a types-generation indicator", () => {
+    const fake = withFakeEdgeCli({
+      typesHelp: "Compile JavaScript modules; TypeScript projects are supported",
+    });
+    const data = JSON.parse(run(["edge-doctor", "--json"], fake.env));
+    assert.equal(data.types_supported, false);
   });
 
   it("probes reset-func --yes independently from delete-func --yes", () => {


### PR DESCRIPTION
## Summary
- probe reset, noninteractive confirmation, secrets, types, KV, and SQLDB support from CLI help surfaces
- expose Edge v0.3 capabilities and guidance in edge-doctor
- require root status plus new-func/from-dir, secrets, and ship support before setup handoffs report ready
- add mock-binary capability and readiness tests

## Verification
- `npx tsc --noEmit`
- `npx tsx --test tests/*.test.ts` (202 passed)