### PR TITLE
docs: Update edge-compute guide for v0.3.0

### DIFF
--- a/guides/edge-compute.md
+++ b/guides/edge-compute.md
@@ -21,11 +21,13 @@ git clone --depth 1 https://github.com/team-telnyx/edge-compute.git
 
 ## Prerequisites and readiness
 
-1. Download the latest CLI from the [Edge Compute releases page](https://github.com/team-telnyx/edge-compute/releases).
+1. Download the latest CLI from the [Edge Compute releases page](https://github.com/team-telnyx/edge-compute/releases). SQL databases require CLI v0.3.0 or newer.
 2. Authenticate interactively or with an API key stored by the CLI.
 3. Run the root status diagnostic. Unlike `auth status`, this validates configuration, credentials, and API connectivity.
 
 ```bash
+telnyx-edge --version
+
 # Interactive OAuth
 telnyx-edge auth login
 
@@ -171,12 +173,12 @@ telnyx-edge ship
 telnyx-edge inspect my-function
 ```
 
-`inspect <function>` is the per-function detail view: deployment status, invoke URL, timestamps, and actor bindings. Probe it with `telnyx-edge inspect --help` when supporting multiple CLI releases.
+`inspect <function>` is the per-function detail view: deployment status, invoke URL, timestamps, and **every binding the deployed function declares**. Binding rows show the `env.<NAME>` handle, kind, target, and status; actor rows also show their owner/reference role. Probe it with `telnyx-edge inspect --help` when supporting multiple CLI releases.
 
 A failed function can be reset to `created` without changing its identity, fixed, and shipped again:
 
 ```bash
-telnyx-edge reset-func my-function
+telnyx-edge reset-func my-function --yes
 telnyx-edge ship --from-dir=./my-function
 ```
 
@@ -198,16 +200,62 @@ Rollback retargets traffic to a prior healthy revision without rebuilding or re-
 ```bash
 telnyx-edge secrets add NAME "$VALUE"
 telnyx-edge secrets list
-telnyx-edge secrets delete NAME
+telnyx-edge secrets delete NAME --yes
 
 telnyx-edge bindings create
 telnyx-edge bindings get
 telnyx-edge bindings validate
 telnyx-edge bindings update
-telnyx-edge bindings delete
+telnyx-edge bindings delete --yes
 ```
 
-Use secrets for confidential values. Telnyx bindings provide managed Telnyx API access without hardcoding credentials in function source.
+Use secrets for confidential values. Telnyx bindings provide managed Telnyx API access without hardcoding credentials in function source. The commands above manage the account resources; declare the handles a function uses in `func.toml` or `telnyx.toml`:
+
+```toml
+[telnyx]
+binding = "TELNYX_CLIENT"
+
+[[secrets]]
+binding = "MCP_TOKEN"
+name = "SHARED_SECRET"
+```
+
+The secret must already exist under its store name (`telnyx-edge secrets add SHARED_SECRET "$SHARED_SECRET"`). Install the current runtime and Telnyx client, then generate declarations:
+
+```bash
+npm install @telnyx/edge-runtime@latest telnyx
+telnyx-edge types
+```
+
+```text
+✓ Generated binding types for 2 binding(s) at telnyx-env.d.ts
+    env.TELNYX_CLIENT → Telnyx (from "telnyx")
+    env.SECRETS.get("MCP_TOKEN")
+```
+
+The generated `telnyx-env.d.ts` types `env.TELNYX_CLIENT` as the Telnyx client and narrows `env.SECRETS.get(...)` to the declared secret handles:
+
+```typescript
+import { env } from "@telnyx/edge-runtime";
+
+const balance = await env.TELNYX_CLIENT.balance.retrieve();
+const mcpToken: string = await env.SECRETS.get("MCP_TOKEN");
+```
+
+`binding` is the code-facing handle; `name` is the secret-store key. `types` covers all declared actor, Telnyx, secret, KV, SQL database, and Cloud Storage bindings, runs offline without authentication, and should be rerun whenever the manifest changes.
+
+### Non-interactive destructive commands
+
+Destructive commands prompt in a terminal and deliberately fail rather than hang when stdin is not a terminal. Scripts, agents, and CI must pass `--yes` (`-y`) to `delete-func`, `reset-func`, `secrets delete`, `bindings delete`, `actors delete`, `storage sqldb delete`, `storage kv delete`, and `storage kv key delete`. Piping the output of `yes` is not accepted.
+
+```bash
+telnyx-edge delete-func my-function --yes
+telnyx-edge storage sqldb delete "$SQLDB_ID" --yes
+```
+
+`--yes` only waives the CLI's local intent check. On SQL database and KV namespace deletion, `--force` (`-f`) separately tells the API to override its "still bound/in use" precondition; it does **not** confirm intent. To do both in CI, pass both flags, for example `telnyx-edge storage sqldb delete "$SQLDB_ID" --yes --force`. Functions that still bind the deleted resource are not deleted and will break.
+
+For a whole shell or CI job, `TELNYX_EDGE_SKIP_CONFIRMATIONS=1` has the same effect as `--yes`. For a persistent local preference, use `telnyx-edge config set skip_confirmations true` (undo with `false`). Neither setting implies `--force`, which remains per invocation.
 
 ### Persistent KV storage
 
@@ -216,14 +264,14 @@ Use secrets for confidential values. Telnyx bindings provide managed Telnyx API 
 telnyx-edge storage kv create --name my-data
 telnyx-edge storage kv list
 telnyx-edge storage kv get <namespace-id>
-telnyx-edge storage kv delete <namespace-id>
+telnyx-edge storage kv delete <namespace-id> --yes
 
 # Keys
 telnyx-edge storage kv key put <namespace-id> greeting "hello"
 telnyx-edge storage kv key put <namespace-id> blob --path ./data.bin
 telnyx-edge storage kv key get <namespace-id> greeting
 telnyx-edge storage kv key list <namespace-id> --prefix config/
-telnyx-edge storage kv key delete <namespace-id> greeting
+telnyx-edge storage kv key delete <namespace-id> greeting --yes
 ```
 
 Declare a runtime binding in `telnyx.toml` or supported classic project manifests, then regenerate TypeScript declarations:
@@ -239,6 +287,58 @@ telnyx-edge types
 
 `types` generates `telnyx-env.d.ts`; KV handles are typed as `KvNamespace`. Rerun it whenever binding declarations change.
 
+### SQL databases (v0.3.0)
+
+A SQL database is an account-scoped SQLite database. It exists independently of functions and can be shared by every function that binds its UUID.
+
+```bash
+# Lifecycle: copy the UUID printed by create into SQLDB_ID.
+telnyx-edge storage sqldb create --name my-app-db
+SQLDB_ID="<uuid-from-create>"
+telnyx-edge storage sqldb list
+telnyx-edge storage sqldb get "$SQLDB_ID"
+
+# In a script/CI teardown, confirmation must be explicit.
+telnyx-edge storage sqldb delete "$SQLDB_ID" --yes
+```
+
+Wait until `storage sqldb get` reports `provision_ok` before using a new database. There is no server to size or per-database deployment.
+
+Run SQL directly with `--remote` and **exactly one** of `--command`/`-c` or `--file`/`-f`. Add `--json` when a machine-readable result is needed:
+
+```bash
+telnyx-edge storage sqldb execute "$SQLDB_ID" --remote \
+  --command "CREATE TABLE links (id INTEGER PRIMARY KEY, url TEXT NOT NULL)"
+telnyx-edge storage sqldb execute "$SQLDB_ID" --remote -f ./schema.sql
+telnyx-edge storage sqldb execute "$SQLDB_ID" --remote \
+  -c "SELECT id, url FROM links ORDER BY id" --json
+```
+
+Do not combine `--command` and `--file`, and do not omit both. Versioned migrations are created locally, then listed or applied against the remote database. Applied migrations are recorded in the database, so `apply` is safe to rerun and applies only pending files in numeric order.
+
+```bash
+telnyx-edge storage sqldb migrations create "$SQLDB_ID" add-links-table
+# Edit the generated numbered .sql file under migrations/$SQLDB_ID/.
+telnyx-edge storage sqldb migrations list "$SQLDB_ID" --remote
+telnyx-edge storage sqldb migrations apply "$SQLDB_ID" --remote
+```
+
+Bind the database in `func.toml` or `telnyx.toml`, using the real UUID, and regenerate declarations:
+
+```toml
+[storage.sqldb.DB]
+id = "<uuid>"
+```
+
+```bash
+npm install @telnyx/edge-runtime@latest
+telnyx-edge types
+```
+
+`env.DB` is generated as `SqlDatabase` and requires `@telnyx/edge-runtime` **0.9.0 or newer**. Keep the runtime current rather than pinning it to an older CLI-era version.
+
+Do not confuse shared account SQLDB with actor-local SQL. `[storage.sqldb.DB]` exposes one account database as `env.DB` to any functions that bind the same UUID. `ctx.storage.sql` belongs to one StatefulActor instance, is reached only inside that actor, and has no `storage sqldb execute` or migration CLI surface.
+
 ### Cloud Storage binding types (v0.2.4)
 
 CLI v0.2.4 added `[storage.cloudstorage.<name>]` manifest bindings and `CloudStorageBucket` output from `telnyx-edge types`. JavaScript/TypeScript scaffolds include the Cloud Storage dependencies.
@@ -250,7 +350,7 @@ region = "us-east-1"
 ```
 
 ```bash
-npm install @telnyx/edge-runtime@^0.3.0 @aws-sdk/client-s3
+npm install @telnyx/edge-runtime@latest @aws-sdk/client-s3
 telnyx-edge types
 ```
 
@@ -274,12 +374,13 @@ telnyx-edge new-func --actor --language=ts --name=my-actor
 telnyx-edge actors list
 telnyx-edge actors inspect <type>
 telnyx-edge actors instances <type>
+telnyx-edge actors delete <type> --yes
 telnyx-edge inspect <function>
 ```
 
 The two inspect commands answer different questions:
 
-- `inspect <function>` shows one function and its actor bindings.
+- `inspect <function>` shows one function and every declared binding (including actor owner/reference roles).
 - `actors inspect <type>` shows one account-scoped actor type, attached functions, and a best-effort live instance count.
 
 ### v0.2.5 actor-instance support and limitations


### PR DESCRIPTION
## Summary
- document SQL databases, migrations, bindings, generated types, and runtime requirements
- make destructive agent/CI examples noninteractive with `--yes` and explain `--force` separately
- fix executable auth header and TypeScript examples
- update typed binding, runtime, and inspect guidance

## Verification
- `npm run test:guides` (110 passed)
- command and manifest syntax checked against edge-compute-cli v0.3.0