### PR TITLE
feat: Add porting order actions to agent CLI

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "tsx bin/telnyx-agent.ts",
-    "test": "tsx --test tests/ai-assistants.test.ts tests/ai.test.ts tests/edge-handoff.test.ts tests/fax.test.ts tests/integration.test.ts tests/iot.test.ts tests/numbers.test.ts tests/rcs.test.ts tests/setup-10dlc.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice-connections.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
+    "test": "tsx --test tests/ai-assistants.test.ts tests/ai.test.ts tests/edge-handoff.test.ts tests/fax.test.ts tests/integration.test.ts tests/iot.test.ts tests/numbers.test.ts tests/porting.test.ts tests/rcs.test.ts tests/setup-10dlc.test.ts tests/sms.test.ts tests/stt.test.ts tests/telnyx-cli-flags.test.ts tests/tts.test.ts tests/verify.test.ts tests/voice-connections.test.ts tests/voice.test.ts tests/whatsapp.test.ts",
     "typecheck": "tsc --noEmit",
     "postinstall": "tsx scripts/postinstall.ts",
     "build": "npm run typecheck"

--- a/cli/src/commands/capabilities.ts
+++ b/cli/src/commands/capabilities.ts
@@ -69,7 +69,7 @@ const CAPABILITIES: Record<string, Capability[]> = {
     { name: "x402 Crypto Payments", description: "Fund account with USDC on Base blockchain via x402 protocol", actions: ["get_payment_quote", "submit_payment"] },
   ],
   "🔄 Porting": [
-    { name: "Number Porting", description: "Check portability, create and manage port-in orders, track requirements and documents", actions: ["check_portability", "list_porting_orders", "create_porting_order", "get_porting_order", "submit_porting_order", "cancel_porting_order", "list_porting_phone_numbers", "upload_porting_document", "list_porting_requirements"] },
+    { name: "Number Porting", description: "Check portability, create and manage port-in orders, track requirements and documents", actions: ["check_portability", "list_porting_orders", "create_porting_order", "get_porting_order", "update_porting_order", "submit_porting_order", "cancel_porting_order", "list_porting_phone_numbers", "attach_porting_document", "list_porting_documents", "list_porting_requirements"] },
     { name: "Port-Out", description: "List and inspect port-out activity, reject or comment on port-out orders", actions: ["list_portout_orders", "get_portout_order", "list_portout_rejection_codes"] },
   ],
   "💬 WhatsApp": [
@@ -110,6 +110,13 @@ const COMPOSITE_COMMANDS = [
   { name: "telnyx-agent verify-check", description: "Submit a code for verification (--code) or retrieve the current verification status" },
   { name: "telnyx-agent setup-10dlc", description: "Zero to A2P: creates 10DLC brand, campaign, optional number assignment" },
   { name: "telnyx-agent setup-porting", description: "Zero to porting: checks portability, creates porting order, lists requirements, optionally submits" },
+  { name: "telnyx-agent list-porting-orders", description: "List port-in orders with core filters, phone-number inclusion, sorting, and pagination" },
+  { name: "telnyx-agent get-porting-order", description: "Retrieve one porting order by ID" },
+  { name: "telnyx-agent update-porting-order", description: "Update references, FOC settings, documents, messaging, and post-port number configuration" },
+  { name: "telnyx-agent submit-porting-order", description: "Confirm and submit a draft porting order" },
+  { name: "telnyx-agent cancel-porting-order", description: "Cancel a porting order after explicit --confirm acknowledgement" },
+  { name: "telnyx-agent attach-porting-document", description: "Attach an existing Telnyx document resource to a porting order" },
+  { name: "telnyx-agent list-porting-documents", description: "List documents attached to a porting order with type filters and pagination" },
   { name: "telnyx-agent tts", description: "Generate speech from text (text-to-speech) across multiple providers, returning base64-encoded audio data" },
   { name: "telnyx-agent tts-voices", description: "List available TTS voices, optionally filtered by provider (telnyx, aws, azure, elevenlabs, minimax, resemble, rime, xai)" },
   { name: "telnyx-agent setup-whatsapp", description: "Zero to WhatsApp: lists WABA, buys number, initializes & verifies, sets profile" },

--- a/cli/src/commands/porting-orders.ts
+++ b/cli/src/commands/porting-orders.ts
@@ -438,7 +438,7 @@ function responseDataRecord(response: unknown): JsonRecord {
 
 function phoneNumberCount(order: JsonRecord): string {
   if (Array.isArray(order.phone_numbers)) return `${order.phone_numbers.length} phone number(s)`;
-  const count = order.phone_numbers_count;
+  const count = order.porting_phone_numbers_count ?? order.phone_numbers_count;
   return count === undefined || count === null ? "" : `${String(count)} phone number(s)`;
 }
 

--- a/cli/src/commands/porting-orders.ts
+++ b/cli/src/commands/porting-orders.ts
@@ -1,0 +1,475 @@
+/**
+ * Direct porting-order management actions backed by the generated Go CLI.
+ *
+ * List operations request raw output so each response remains one parseable
+ * `{ data, meta }` envelope. Additional documents are already-uploaded Telnyx
+ * document resources; this surface therefore calls the operation "attach"
+ * rather than implying that it uploads local file bytes.
+ */
+
+import { telnyxCli, TelnyxCLIError } from "../telnyx-cli.ts";
+import { outputJson, printError, printSuccess } from "../utils/output.ts";
+
+type Flags = Record<string, string | boolean>;
+type JsonRecord = Record<string, unknown>;
+type PortingAction = "submit" | "cancel";
+
+const DOCUMENT_TYPES = ["loa", "invoice", "csr", "other"] as const;
+const DOCUMENT_TYPE_SET = new Set<string>(DOCUMENT_TYPES);
+
+interface PortingOrderListResult {
+  count: number;
+  porting_orders: JsonRecord[];
+  meta: JsonRecord;
+}
+
+interface PortingOrderResult {
+  porting_order_id: string;
+  porting_order: JsonRecord;
+}
+
+interface PortingActionResult extends PortingOrderResult {
+  action: PortingAction;
+  status: string;
+}
+
+interface PortingDocumentListResult {
+  porting_order_id: string;
+  count: number;
+  documents: JsonRecord[];
+  meta: JsonRecord;
+}
+
+interface AttachPortingDocumentResult {
+  porting_order_id: string;
+  attached_count: number;
+  documents: JsonRecord[];
+}
+
+export async function listPortingOrdersCommand(flags: Flags): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const args = ["porting-orders", "list"];
+
+  addMappedFlag(args, flags, "customer-reference", "--filter.customer-reference");
+  addMappedFlag(args, flags, "customer-group-reference", "--filter.customer-group-reference");
+  addMappedFlag(args, flags, "parent-support-key", "--filter.parent-support-key");
+
+  const phoneNumberFilter: JsonRecord = {};
+  const countryCode = stringFlag(flags, "country-code");
+  const carrierName = stringFlag(flags, "carrier-name");
+  const phoneNumber = stringFlag(flags, "phone-number");
+  if (countryCode) phoneNumberFilter.country_code = countryCode;
+  if (carrierName) phoneNumberFilter.carrier_name = carrierName;
+  if (phoneNumber) phoneNumberFilter.phone_number = { contains: phoneNumber };
+  if (Object.keys(phoneNumberFilter).length > 0) {
+    args.push("--filter.phone-numbers", JSON.stringify(phoneNumberFilter));
+  }
+
+  const portType = stringFlag(flags, "port-type");
+  if (portType) {
+    validateChoice("port-type", portType, ["full", "partial"], jsonOutput);
+    args.push("--filter.misc", JSON.stringify({ type: portType }));
+  }
+
+  const activationFilter: JsonRecord = {};
+  const fastPortEligible = booleanFlag(flags, "fast-port-eligible", jsonOutput);
+  if (fastPortEligible !== undefined) activationFilter.fast_port_eligible = fastPortEligible;
+  const focAfter = stringFlag(flags, "foc-after");
+  const focBefore = stringFlag(flags, "foc-before");
+  if (focAfter) validateDateTime("foc-after", focAfter, jsonOutput);
+  if (focBefore) validateDateTime("foc-before", focBefore, jsonOutput);
+  if (focAfter || focBefore) {
+    activationFilter.foc_datetime_requested = {
+      ...(focAfter ? { gt: focAfter } : {}),
+      ...(focBefore ? { lt: focBefore } : {}),
+    };
+  }
+  if (Object.keys(activationFilter).length > 0) {
+    args.push("--filter.activation-settings", JSON.stringify(activationFilter));
+  }
+
+  addBooleanFlag(args, flags, "include-phone-numbers", "--include-phone-numbers", jsonOutput);
+  addPositiveIntegerFlag(args, flags, "page-number", "--page-number", jsonOutput);
+  addPositiveIntegerFlag(args, flags, "page-size", "--page-size", jsonOutput);
+  addMappedFlag(args, flags, "sort", "--sort.value");
+
+  try {
+    const response = await telnyxCli(args, { format: "raw" });
+    presentPortingOrderList(normalizePortingOrderList(response), jsonOutput);
+  } catch (err) {
+    fail(errorMsg(err), jsonOutput);
+  }
+}
+
+export async function getPortingOrderCommand(flags: Flags): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const portingOrderId = requireId(flags, jsonOutput);
+  const args = ["porting-orders", "retrieve", "--id", portingOrderId];
+  addBooleanFlag(args, flags, "include-phone-numbers", "--include-phone-numbers", jsonOutput);
+
+  try {
+    const response = await telnyxCli(args);
+    presentPortingOrder("Porting order retrieved!", portingOrderId, response, jsonOutput);
+  } catch (err) {
+    fail(errorMsg(err), jsonOutput);
+  }
+}
+
+export async function updatePortingOrderCommand(flags: Flags): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const portingOrderId = requireId(flags, jsonOutput);
+  const args = ["porting-orders", "update", "--id", portingOrderId];
+
+  addMappedFlag(args, flags, "customer-reference", "--customer-reference");
+  addMappedFlag(args, flags, "customer-group-reference", "--customer-group-reference");
+  addMappedFlag(args, flags, "webhook-url", "--webhook-url");
+  addMappedFlag(args, flags, "requirement-group-id", "--requirement-group-id");
+  addMappedFlag(args, flags, "loa-document-id", "--documents.loa");
+  addMappedFlag(args, flags, "invoice-document-id", "--documents.invoice");
+
+  const focDateTime = stringFlag(flags, "foc-datetime-requested");
+  if (focDateTime) {
+    validateDateTime("foc-datetime-requested", focDateTime, jsonOutput);
+    args.push("--activation-settings.foc-datetime-requested", focDateTime);
+  }
+  addBooleanFlag(args, flags, "enable-messaging", "--messaging.enable-messaging", jsonOutput);
+
+  addMappedFlag(args, flags, "billing-group-id", "--phone-number-configuration.billing-group-id");
+  addMappedFlag(args, flags, "connection-id", "--phone-number-configuration.connection-id");
+  addMappedFlag(args, flags, "emergency-address-id", "--phone-number-configuration.emergency-address-id");
+  addMappedFlag(args, flags, "messaging-profile-id", "--phone-number-configuration.messaging-profile-id");
+  addCsvFlag(args, flags, "tags", "--phone-number-configuration.tags", jsonOutput);
+
+  const portType = stringFlag(flags, "port-type");
+  const remainingAction = stringFlag(flags, "remaining-numbers-action");
+  const newBillingPhoneNumber = stringFlag(flags, "new-billing-phone-number");
+  if (portType) validateChoice("port-type", portType, ["full", "partial"], jsonOutput);
+  if (remainingAction) {
+    validateChoice("remaining-numbers-action", remainingAction, ["keep", "disconnect"], jsonOutput);
+  }
+  if (portType === "full" && (remainingAction || newBillingPhoneNumber)) {
+    fail("--remaining-numbers-action and --new-billing-phone-number cannot be used with --port-type full", jsonOutput);
+  }
+  if (remainingAction === "keep" && !newBillingPhoneNumber) {
+    fail("--new-billing-phone-number is required when --remaining-numbers-action is keep", jsonOutput);
+  }
+  if (portType) args.push("--misc.type", portType);
+  if (remainingAction) args.push("--misc.remaining-numbers-action", remainingAction);
+  if (newBillingPhoneNumber) args.push("--misc.new-billing-phone-number", newBillingPhoneNumber);
+
+  if (args.length === 4) {
+    fail("update-porting-order requires at least one update flag", jsonOutput);
+  }
+
+  try {
+    const response = await telnyxCli(args);
+    presentPortingOrder("Porting order updated!", portingOrderId, response, jsonOutput);
+  } catch (err) {
+    fail(errorMsg(err), jsonOutput);
+  }
+}
+
+export async function submitPortingOrderCommand(flags: Flags): Promise<void> {
+  await runPortingAction("submit", "confirm", flags);
+}
+
+export async function cancelPortingOrderCommand(flags: Flags): Promise<void> {
+  const jsonOutput = flags.json === true;
+  if (flags.confirm !== true) {
+    fail("cancel-porting-order is destructive; pass --confirm to continue", jsonOutput);
+  }
+  await runPortingAction("cancel", "cancel", flags);
+}
+
+export async function attachPortingDocumentCommand(flags: Flags): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const portingOrderId = requireId(flags, jsonOutput);
+  const documentId = stringFlag(flags, "document-id");
+  const documentType = stringFlag(flags, "document-type");
+  if (!documentId) fail("--document-id is required (an existing Telnyx document ID)", jsonOutput);
+  if (!documentType) {
+    fail(`--document-type is required (${DOCUMENT_TYPES.join("|")})`, jsonOutput);
+  }
+  validateChoice("document-type", documentType, DOCUMENT_TYPES, jsonOutput);
+
+  const args = [
+    "porting-orders:additional-documents",
+    "create",
+    "--id",
+    portingOrderId,
+    "--additional-document.document-id",
+    documentId,
+    "--additional-document.document-type",
+    documentType,
+  ];
+
+  try {
+    const response = await telnyxCli(args);
+    const documents = dataRecords(response);
+    const result: AttachPortingDocumentResult = {
+      porting_order_id: portingOrderId,
+      attached_count: documents.length,
+      documents,
+    };
+    if (jsonOutput) {
+      outputJson(result);
+    } else {
+      printSuccess("Porting document attached!", {
+        "Porting Order ID": portingOrderId,
+        "Document ID": documentId,
+        "Document Type": documentType,
+        "Attached Records": result.attached_count,
+      });
+    }
+  } catch (err) {
+    fail(errorMsg(err), jsonOutput);
+  }
+}
+
+export async function listPortingDocumentsCommand(flags: Flags): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const portingOrderId = requireId(flags, jsonOutput);
+  const args = ["porting-orders:additional-documents", "list", "--id", portingOrderId];
+
+  const documentTypes = csvValues(flags, "document-type", jsonOutput);
+  if (documentTypes) {
+    for (const documentType of documentTypes) {
+      if (!DOCUMENT_TYPE_SET.has(documentType)) {
+        fail(`--document-type must contain only ${DOCUMENT_TYPES.join(", ")}`, jsonOutput);
+      }
+    }
+    args.push("--filter.document-type", JSON.stringify(documentTypes));
+  }
+  addPositiveIntegerFlag(args, flags, "page-number", "--page-number", jsonOutput);
+  addPositiveIntegerFlag(args, flags, "page-size", "--page-size", jsonOutput);
+  addMappedFlag(args, flags, "sort", "--sort.value");
+
+  try {
+    const response = await telnyxCli(args, { format: "raw" });
+    const envelope = asRecord(response);
+    const result: PortingDocumentListResult = {
+      porting_order_id: portingOrderId,
+      count: dataRecords(response).length,
+      documents: dataRecords(response),
+      meta: asRecord(envelope.meta),
+    };
+    presentPortingDocumentList(result, jsonOutput);
+  } catch (err) {
+    fail(errorMsg(err), jsonOutput);
+  }
+}
+
+async function runPortingAction(action: PortingAction, generatedAction: string, flags: Flags): Promise<void> {
+  const jsonOutput = flags.json === true;
+  const portingOrderId = requireId(flags, jsonOutput);
+  try {
+    const response = await telnyxCli(["porting-orders:actions", generatedAction, "--id", portingOrderId]);
+    const portingOrder = responseDataRecord(response);
+    const result: PortingActionResult = {
+      porting_order_id: stringValue(portingOrder.id) || portingOrderId,
+      action,
+      status: statusValue(portingOrder.status) || (action === "submit" ? "submitted" : "cancelled"),
+      porting_order: portingOrder,
+    };
+    if (jsonOutput) {
+      outputJson(result);
+    } else {
+      printSuccess(`Porting order ${action === "submit" ? "submitted" : "cancelled"}!`, {
+        "Porting Order ID": result.porting_order_id,
+        Action: result.action,
+        Status: result.status,
+      });
+    }
+  } catch (err) {
+    fail(errorMsg(err), jsonOutput);
+  }
+}
+
+function normalizePortingOrderList(response: unknown): PortingOrderListResult {
+  const envelope = asRecord(response);
+  const portingOrders = dataRecords(response);
+  return {
+    count: portingOrders.length,
+    porting_orders: portingOrders,
+    meta: asRecord(envelope.meta),
+  };
+}
+
+function presentPortingOrderList(result: PortingOrderListResult, jsonOutput: boolean): void {
+  if (jsonOutput) {
+    outputJson(result);
+    return;
+  }
+  printSuccess("Porting orders retrieved!", { Count: result.count });
+  for (const order of result.porting_orders) {
+    const id = stringValue(order.id) || "(unknown)";
+    const details = [statusValue(order.status), order.customer_reference, phoneNumberCount(order)]
+      .map(stringValue)
+      .filter(Boolean)
+      .join(" · ");
+    console.log(`  • ${id}${details ? ` — ${details}` : ""}`);
+  }
+  if (result.count === 0) console.log("  (no porting orders returned)");
+  console.log();
+}
+
+function presentPortingOrder(title: string, requestedId: string, response: unknown, jsonOutput: boolean): void {
+  const portingOrder = responseDataRecord(response);
+  const result: PortingOrderResult = {
+    porting_order_id: stringValue(portingOrder.id) || requestedId,
+    porting_order: portingOrder,
+  };
+  if (jsonOutput) {
+    outputJson(result);
+    return;
+  }
+  printSuccess(title, {
+    "Porting Order ID": result.porting_order_id,
+    Status: statusValue(portingOrder.status) || "(not returned)",
+    "Customer Reference": stringValue(portingOrder.customer_reference) || "(not returned)",
+    "Phone Numbers": phoneNumberCount(portingOrder) || "(not returned)",
+  });
+}
+
+function presentPortingDocumentList(result: PortingDocumentListResult, jsonOutput: boolean): void {
+  if (jsonOutput) {
+    outputJson(result);
+    return;
+  }
+  printSuccess("Porting documents retrieved!", {
+    "Porting Order ID": result.porting_order_id,
+    Count: result.count,
+  });
+  for (const document of result.documents) {
+    const id = stringValue(document.id) || stringValue(document.document_id) || "(unknown)";
+    const details = [document.document_type, document.filename].map(stringValue).filter(Boolean).join(" · ");
+    console.log(`  • ${id}${details ? ` — ${details}` : ""}`);
+  }
+  if (result.count === 0) console.log("  (no porting documents returned)");
+  console.log();
+}
+
+function requireId(flags: Flags, jsonOutput: boolean): string {
+  const id = stringFlag(flags, "id");
+  if (!id) fail("--id is required (porting order ID)", jsonOutput);
+  return id;
+}
+
+function addMappedFlag(args: string[], flags: Flags, source: string, target: string): void {
+  const value = stringFlag(flags, source);
+  if (value !== undefined) args.push(target, value);
+}
+
+function addPositiveIntegerFlag(
+  args: string[],
+  flags: Flags,
+  source: string,
+  target: string,
+  jsonOutput: boolean,
+): void {
+  const value = stringFlag(flags, source);
+  if (value === undefined) return;
+  if (!/^\d+$/.test(value) || Number(value) < 1) fail(`--${source} must be a positive integer`, jsonOutput);
+  args.push(target, value);
+}
+
+function addBooleanFlag(
+  args: string[],
+  flags: Flags,
+  source: string,
+  target: string,
+  jsonOutput: boolean,
+): void {
+  const value = booleanFlag(flags, source, jsonOutput);
+  if (value !== undefined) args.push(`${target}=${String(value)}`);
+}
+
+function booleanFlag(flags: Flags, key: string, jsonOutput: boolean): boolean | undefined {
+  const value = flags[key];
+  if (value === undefined) return undefined;
+  if (value === true || value === "true") return true;
+  if (value === "false") return false;
+  fail(`--${key} must be true or false`, jsonOutput);
+}
+
+function addCsvFlag(args: string[], flags: Flags, source: string, target: string, jsonOutput: boolean): void {
+  const values = csvValues(flags, source, jsonOutput);
+  if (values) args.push(target, JSON.stringify(values));
+}
+
+function csvValues(flags: Flags, source: string, jsonOutput: boolean): string[] | undefined {
+  const value = stringFlag(flags, source);
+  if (value === undefined) return undefined;
+  const values = value.split(",").map((item) => item.trim()).filter(Boolean);
+  if (values.length === 0) fail(`--${source} must contain at least one value`, jsonOutput);
+  return values;
+}
+
+function validateChoice(
+  flag: string,
+  value: string,
+  choices: readonly string[],
+  jsonOutput: boolean,
+): void {
+  if (!choices.includes(value)) fail(`--${flag} must be one of: ${choices.join(", ")}`, jsonOutput);
+}
+
+function validateDateTime(flag: string, value: string, jsonOutput: boolean): void {
+  if (!/^\d{4}-\d{2}-\d{2}T/.test(value) || Number.isNaN(Date.parse(value))) {
+    fail(`--${flag} must be a valid ISO 8601 date-time`, jsonOutput);
+  }
+}
+
+function dataRecords(response: unknown): JsonRecord[] {
+  const data = asRecord(response).data;
+  if (Array.isArray(data)) {
+    return data.filter(
+      (item): item is JsonRecord => Boolean(item) && typeof item === "object" && !Array.isArray(item),
+    );
+  }
+  const record = asRecord(data);
+  return Object.keys(record).length > 0 ? [record] : [];
+}
+
+function responseDataRecord(response: unknown): JsonRecord {
+  const envelope = asRecord(response);
+  return asRecord(envelope.data ?? response);
+}
+
+function phoneNumberCount(order: JsonRecord): string {
+  if (Array.isArray(order.phone_numbers)) return `${order.phone_numbers.length} phone number(s)`;
+  const count = order.phone_numbers_count;
+  return count === undefined || count === null ? "" : `${String(count)} phone number(s)`;
+}
+
+function statusValue(value: unknown): string {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return stringValue((value as JsonRecord).value);
+  }
+  return stringValue(value);
+}
+
+function stringFlag(flags: Flags, key: string): string | undefined {
+  const value = flags[key];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function asRecord(value: unknown): JsonRecord {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as JsonRecord : {};
+}
+
+function stringValue(value: unknown): string {
+  return value === undefined || value === null ? "" : String(value);
+}
+
+function fail(message: string, jsonOutput: boolean): never {
+  if (jsonOutput) outputJson({ error: message });
+  else printError(message);
+  process.exit(1);
+}
+
+function errorMsg(err: unknown): string {
+  if (err instanceof TelnyxCLIError) return err.stderr || err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -12,6 +12,15 @@ import { verifySendCommand } from "./commands/verify-send.ts";
 import { verifyCheckCommand } from "./commands/verify-check.ts";
 import { setup10dlcCommand } from "./commands/setup-10dlc.ts";
 import { setupPortingCommand } from "./commands/setup-porting.ts";
+import {
+  attachPortingDocumentCommand,
+  cancelPortingOrderCommand,
+  getPortingOrderCommand,
+  listPortingDocumentsCommand,
+  listPortingOrdersCommand,
+  submitPortingOrderCommand,
+  updatePortingOrderCommand,
+} from "./commands/porting-orders.ts";
 import { edgeDoctorCommand } from "./commands/edge-doctor.ts";
 import { setupEdgeMcpCommand } from "./commands/setup-edge-mcp.ts";
 import { setupEdgeWebhookCommand } from "./commands/setup-edge-webhook.ts";
@@ -84,6 +93,13 @@ Commands:
   verify-check      Verify a code or check verification status
   setup-10dlc       Zero to A2P: create brand, campaign, assign number
   setup-porting     Zero to porting: check portability, create order, submit
+  list-porting-orders List port-in orders with filters and pagination
+  get-porting-order Retrieve one porting order by ID
+  update-porting-order Update porting order details and number configuration
+  submit-porting-order Confirm and submit a draft porting order
+  cancel-porting-order Cancel a porting order (requires --confirm)
+  attach-porting-document Attach an existing Telnyx document to a porting order
+  list-porting-documents List documents attached to a porting order
   edge-doctor       Validate Edge Compute prerequisites and handoff readiness
   setup-edge-mcp    Handoff to an Edge-hosted MCP server example
   setup-edge-webhook Handoff to an Edge-hosted webhook receiver example
@@ -168,6 +184,34 @@ Verify Flags:
   --billing-phone   Billing telephone number on the account (setup-porting)
   --old-provider    Current/losing carrier name (setup-porting)
   --submit          Submit the newly created porting order immediately (setup-porting)
+
+Porting Order Action Flags:
+  --id <id>         Porting order ID (get, update, submit, cancel, attach/list documents — required)
+  --customer-reference Customer bookkeeping reference (list, update)
+  --customer-group-reference Customer group reference (list, update)
+  --parent-support-key Parent support key filter (list-porting-orders)
+  --phone-number    Phone-number substring filter (list-porting-orders)
+  --country-code    Phone-number country filter (list-porting-orders)
+  --carrier-name    Current carrier filter (list-porting-orders)
+  --port-type       full|partial (list, update)
+  --fast-port-eligible <bool> FastPort eligibility filter (list-porting-orders)
+  --foc-after / --foc-before ISO 8601 requested FOC range filters (list-porting-orders)
+  --include-phone-numbers <bool> Include phone-number objects (list, get)
+  --page-number / --page-size Positive pagination values (list orders/documents)
+  --sort            Generated API sort value (list orders/documents)
+  --foc-datetime-requested ISO 8601 requested FOC date-time (update)
+  --enable-messaging <bool> Port messaging capabilities (update)
+  --connection-id / --messaging-profile-id Number assignments after porting (update)
+  --billing-group-id / --emergency-address-id Number configuration (update)
+  --tags            Comma-separated number tags (update)
+  --loa-document-id / --invoice-document-id Primary document IDs (update)
+  --requirement-group-id Requirement group to copy into the order (update)
+  --webhook-url     Porting order webhook URL (update)
+  --remaining-numbers-action keep|disconnect (partial-port update)
+  --new-billing-phone-number Required when keeping remaining numbers (update)
+  --confirm         Required safety acknowledgement (cancel-porting-order)
+  --document-id     Existing Telnyx document ID (attach-porting-document — required)
+  --document-type   loa|invoice|csr|other (attach required; comma-separated list filter)
 
 Fund-account Flags:
   --amount <usd>    Amount to fund in USD (required, e.g., 50.00)
@@ -405,6 +449,13 @@ Examples:
   telnyx-agent setup-voice --webhook https://example.com/calls
   telnyx-agent setup-ai --instructions "You are a pizza ordering bot"
   telnyx-agent setup-porting --phone-numbers +131****0001,+131****0002 --customer-name "Acme Corp"
+  telnyx-agent list-porting-orders --customer-reference migration-2026 --page-size 25 --json
+  telnyx-agent get-porting-order --id <porting-order-id> --json
+  telnyx-agent update-porting-order --id <porting-order-id> --connection-id <connection-id> --enable-messaging true --json
+  telnyx-agent submit-porting-order --id <porting-order-id> --json
+  telnyx-agent cancel-porting-order --id <porting-order-id> --confirm --json
+  telnyx-agent attach-porting-document --id <porting-order-id> --document-id <document-id> --document-type loa --json
+  telnyx-agent list-porting-documents --id <porting-order-id> --document-type loa,invoice --json
   telnyx-agent verify-send --phone-number +131****0001 --verify-profile-id prof_xxx --method sms
   telnyx-agent verify-check --verification-id ver_xxx --code 123456
   telnyx-agent verify-check --verification-id ver_xxx
@@ -509,6 +560,13 @@ const COMMANDS: Record<string, (
   "verify-check": verifyCheckCommand,
   "setup-10dlc": setup10dlcCommand,
   "setup-porting": setupPortingCommand,
+  "list-porting-orders": listPortingOrdersCommand,
+  "get-porting-order": getPortingOrderCommand,
+  "update-porting-order": updatePortingOrderCommand,
+  "submit-porting-order": submitPortingOrderCommand,
+  "cancel-porting-order": cancelPortingOrderCommand,
+  "attach-porting-document": attachPortingDocumentCommand,
+  "list-porting-documents": listPortingDocumentsCommand,
   "edge-doctor": edgeDoctorCommand,
   "setup-edge-mcp": setupEdgeMcpCommand,
   "setup-edge-webhook": setupEdgeWebhookCommand,

--- a/cli/src/utils/output.ts
+++ b/cli/src/utils/output.ts
@@ -64,7 +64,8 @@ function redactSensitive<T>(value: T): T {
 }
 
 function isSensitiveKey(key: string): boolean {
-  return /(^|_)(password|passphrase|secret|token|api_key)$/i.test(key) || /^sipPassword$/i.test(key);
+  return /(^|_)(password|passphrase|secret|token|api_key)$/i.test(key)
+    || /^(sipPassword|pin_?passcode)$/i.test(key);
 }
 
 export function parseFlags(args: string[]): {

--- a/cli/tests/porting.test.ts
+++ b/cli/tests/porting.test.ts
@@ -30,7 +30,10 @@ function flag(name) { const index = args.indexOf(name); return index >= 0 ? args
 
 if (args[0] === "porting-orders" && args[1] === "list") {
   console.log(JSON.stringify({
-    data: [{ id: "po-1", status: "draft", customer_reference: "migration-2026", porting_phone_numbers_count: 3 }],
+    data: [{
+      id: "po-1", status: "draft", customer_reference: "migration-2026", porting_phone_numbers_count: 3,
+      end_user: { admin: { pin_passcode: "list-pin-6152", name: "List Admin" } }
+    }],
     meta: { page_number: 2, page_size: 25, total_results: 1 }
   }));
 } else if (args[0] === "porting-orders" && args[1] === "retrieve") {
@@ -148,6 +151,7 @@ describe("Porting-order management commands", () => {
         status: "draft",
         customer_reference: "migration-2026",
         porting_phone_numbers_count: 3,
+        end_user: { admin: { pin_passcode: "[REDACTED]", name: "List Admin" } },
       }],
       meta: { page_number: 2, page_size: 25, total_results: 1 },
     });
@@ -172,6 +176,24 @@ describe("Porting-order management commands", () => {
     assertFlag(args, "--page-size", "25");
     assertFlag(args, "--sort.value", "-created_at");
     assertFlag(args, "--format", "raw");
+  });
+
+  it("redacts a nested porting admin pin_passcode from list JSON output", () => {
+    const fake = setupFakeTelnyx();
+    const output = runAgent(["list-porting-orders", "--json"], fake.env);
+    const result = JSON.parse(output);
+
+    assert.equal(result.porting_orders[0].end_user.admin.pin_passcode, "[REDACTED]");
+    assert.equal(result.porting_orders[0].end_user.admin.name, "List Admin");
+    assert.doesNotMatch(output, /list-pin-6152/);
+  });
+
+  it("does not expose a porting admin PIN in human list output", () => {
+    const fake = setupFakeTelnyx();
+    const output = runAgent(["list-porting-orders"], fake.env);
+
+    assert.match(output, /po-1 — draft · migration-2026 · 3 phone number\(s\)/);
+    assert.doesNotMatch(output, /list-pin-6152/);
   });
 
   it("retrieves a porting order under stable JSON keys", () => {

--- a/cli/tests/porting.test.ts
+++ b/cli/tests/porting.test.ts
@@ -1,0 +1,385 @@
+/**
+ * Canonical mock-binary coverage for direct porting-order management actions.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliRoot = join(__dirname, "..");
+const cliBin = join(cliRoot, "bin", "telnyx-agent.ts");
+
+function setupFakeTelnyx(): { logPath: string; env: NodeJS.ProcessEnv } {
+  const tempDir = mkdtempSync(join(tmpdir(), "telnyx-agent-porting-"));
+  const binDir = join(tempDir, "bin");
+  const logPath = join(tempDir, "args.jsonl");
+  mkdirSync(binDir, { recursive: true });
+
+  const fakeTelnyx = join(binDir, "telnyx");
+  writeFileSync(
+    fakeTelnyx,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.TELNYX_FAKE_ARGS_LOG, JSON.stringify(args) + "\\n");
+function flag(name) { const index = args.indexOf(name); return index >= 0 ? args[index + 1] : undefined; }
+
+if (args[0] === "porting-orders" && args[1] === "list") {
+  console.log(JSON.stringify({
+    data: [{ id: "po-1", status: "draft", customer_reference: "migration-2026", phone_numbers: [{ phone_number: "+131****0000" }] }],
+    meta: { page_number: 2, page_size: 25, total_results: 1 }
+  }));
+} else if (args[0] === "porting-orders" && args[1] === "retrieve") {
+  console.log(JSON.stringify({ data: {
+    id: flag("--id"), status: "draft", customer_reference: "migration-2026",
+    phone_numbers: [{ phone_number: "+131****0000" }]
+  } }));
+} else if (args[0] === "porting-orders" && args[1] === "update") {
+  console.log(JSON.stringify({ data: {
+    id: flag("--id"), status: "draft", customer_reference: flag("--customer-reference") || "migration-2026",
+    phone_numbers_count: 2
+  } }));
+} else if (args[0] === "porting-orders:actions" && (args[1] === "confirm" || args[1] === "cancel")) {
+  console.log(JSON.stringify({ data: {
+    id: flag("--id"), status: args[1] === "confirm" ? "submitted" : { value: "cancel-pending" }
+  } }));
+} else if (args[0] === "porting-orders:additional-documents" && args[1] === "create") {
+  console.log(JSON.stringify({ data: [{
+    id: "attachment-1", porting_order_id: flag("--id"),
+    document_id: flag("--additional-document.document-id"),
+    document_type: flag("--additional-document.document-type"), filename: "loa.pdf"
+  }] }));
+} else if (args[0] === "porting-orders:additional-documents" && args[1] === "list") {
+  console.log(JSON.stringify({
+    data: [{ id: "attachment-1", porting_order_id: flag("--id"), document_id: "doc-1", document_type: "loa", filename: "loa.pdf" }],
+    meta: { page_number: 1, total_results: 1 }
+  }));
+} else {
+  console.error("unexpected fake telnyx invocation: " + args.join(" "));
+  process.exit(2);
+}
+`,
+  );
+  chmodSync(fakeTelnyx, 0o755);
+
+  return {
+    logPath,
+    env: {
+      ...process.env,
+      TELNYX_CLI_PATH: fakeTelnyx,
+      TELNYX_FAKE_ARGS_LOG: logPath,
+    },
+  };
+}
+
+function runAgent(args: string[], env: NodeJS.ProcessEnv = process.env): string {
+  return execFileSync(process.execPath, ["--import", "tsx", cliBin, ...args], {
+    cwd: cliRoot,
+    encoding: "utf8",
+    env,
+    timeout: 30_000,
+  });
+}
+
+function expectFailure(args: string[], env: NodeJS.ProcessEnv): string {
+  const result = spawnSync(process.execPath, ["--import", "tsx", cliBin, ...args], {
+    cwd: cliRoot,
+    encoding: "utf8",
+    env,
+    timeout: 30_000,
+  });
+  assert.notEqual(result.status, 0, `expected command to fail: ${args.join(" ")}`);
+  return `${result.stdout}${result.stderr}`;
+}
+
+function loggedArgs(logPath: string): string[][] {
+  if (!existsSync(logPath)) return [];
+  const contents = readFileSync(logPath, "utf8");
+  assert.ok(contents.endsWith("\n"), "fake binary should terminate each JSON record with one newline");
+  assert.ok(!contents.endsWith("\n\n"), "fake binary should not write a blank JSONL record");
+  return contents.trimEnd().split("\n").map((line) => JSON.parse(line) as string[]);
+}
+
+function assertFlag(args: string[], flag: string, value: string): void {
+  const index = args.indexOf(flag);
+  assert.notEqual(index, -1, `expected ${flag} in ${args.join(" ")}`);
+  assert.equal(args[index + 1], value);
+}
+
+function assertNoCalls(logPath: string): void {
+  assert.deepEqual(loggedArgs(logPath), []);
+}
+
+describe("Porting-order management commands", () => {
+  it("lists porting orders with generated deep-object filters and stable JSON", () => {
+    const fake = setupFakeTelnyx();
+    const output = runAgent([
+      "list-porting-orders",
+      "--customer-reference", "migration-2026",
+      "--customer-group-reference", "batch-a",
+      "--parent-support-key", "support-1",
+      "--phone-number", "312555",
+      "--country-code", "US",
+      "--carrier-name", "Example Carrier",
+      "--port-type", "partial",
+      "--fast-port-eligible", "true",
+      "--foc-after", "2026-08-03T00:00:00Z",
+      "--foc-before", "2026-09-03T00:00:00Z",
+      "--include-phone-numbers", "false",
+      "--page-number", "2",
+      "--page-size", "25",
+      "--sort", "-created_at",
+      "--json",
+    ], fake.env);
+
+    assert.deepEqual(JSON.parse(output), {
+      count: 1,
+      porting_orders: [{
+        id: "po-1",
+        status: "draft",
+        customer_reference: "migration-2026",
+        phone_numbers: [{ phone_number: "+131****0000" }],
+      }],
+      meta: { page_number: 2, page_size: 25, total_results: 1 },
+    });
+
+    const [args] = loggedArgs(fake.logPath);
+    assert.deepEqual(args.slice(0, 2), ["porting-orders", "list"]);
+    assertFlag(args, "--filter.customer-reference", "migration-2026");
+    assertFlag(args, "--filter.customer-group-reference", "batch-a");
+    assertFlag(args, "--filter.parent-support-key", "support-1");
+    assertFlag(args, "--filter.phone-numbers", JSON.stringify({
+      country_code: "US",
+      carrier_name: "Example Carrier",
+      phone_number: { contains: "312555" },
+    }));
+    assertFlag(args, "--filter.misc", JSON.stringify({ type: "partial" }));
+    assertFlag(args, "--filter.activation-settings", JSON.stringify({
+      fast_port_eligible: true,
+      foc_datetime_requested: { gt: "2026-08-03T00:00:00Z", lt: "2026-09-03T00:00:00Z" },
+    }));
+    assert.ok(args.includes("--include-phone-numbers=false"));
+    assertFlag(args, "--page-number", "2");
+    assertFlag(args, "--page-size", "25");
+    assertFlag(args, "--sort.value", "-created_at");
+    assertFlag(args, "--format", "raw");
+  });
+
+  it("retrieves a porting order under stable JSON keys", () => {
+    const fake = setupFakeTelnyx();
+    const output = runAgent([
+      "get-porting-order", "--id", "po-1", "--include-phone-numbers", "true", "--json",
+    ], fake.env);
+
+    const result = JSON.parse(output);
+    assert.equal(result.porting_order_id, "po-1");
+    assert.equal(result.porting_order.status, "draft");
+    assert.equal(result.porting_order.phone_numbers[0].phone_number, "+131****0000");
+
+    const [args] = loggedArgs(fake.logPath);
+    assert.deepEqual(args.slice(0, 2), ["porting-orders", "retrieve"]);
+    assertFlag(args, "--id", "po-1");
+    assert.ok(args.includes("--include-phone-numbers=true"));
+    assertFlag(args, "--format", "json");
+  });
+
+  it("updates core order and post-port number settings using generated inner flags", () => {
+    const fake = setupFakeTelnyx();
+    const output = runAgent([
+      "update-porting-order",
+      "--id", "po-1",
+      "--customer-reference", "migration-2027",
+      "--customer-group-reference", "batch-b",
+      "--webhook-url", "https://example.com/porting",
+      "--requirement-group-id", "req-group-1",
+      "--loa-document-id", "doc-loa",
+      "--invoice-document-id", "doc-invoice",
+      "--foc-datetime-requested", "2026-08-10T15:30:00Z",
+      "--enable-messaging", "false",
+      "--billing-group-id", "billing-1",
+      "--connection-id", "connection-1",
+      "--emergency-address-id", "address-1",
+      "--messaging-profile-id", "profile-1",
+      "--tags", "migration,vip",
+      "--port-type", "partial",
+      "--remaining-numbers-action", "keep",
+      "--new-billing-phone-number", "+131****9999",
+      "--json",
+    ], fake.env);
+
+    const result = JSON.parse(output);
+    assert.equal(result.porting_order_id, "po-1");
+    assert.equal(result.porting_order.customer_reference, "migration-2027");
+
+    const [args] = loggedArgs(fake.logPath);
+    assert.deepEqual(args.slice(0, 2), ["porting-orders", "update"]);
+    assertFlag(args, "--id", "po-1");
+    assertFlag(args, "--customer-reference", "migration-2027");
+    assertFlag(args, "--customer-group-reference", "batch-b");
+    assertFlag(args, "--webhook-url", "https://example.com/porting");
+    assertFlag(args, "--requirement-group-id", "req-group-1");
+    assertFlag(args, "--documents.loa", "doc-loa");
+    assertFlag(args, "--documents.invoice", "doc-invoice");
+    assertFlag(args, "--activation-settings.foc-datetime-requested", "2026-08-10T15:30:00Z");
+    assert.ok(args.includes("--messaging.enable-messaging=false"));
+    assertFlag(args, "--phone-number-configuration.billing-group-id", "billing-1");
+    assertFlag(args, "--phone-number-configuration.connection-id", "connection-1");
+    assertFlag(args, "--phone-number-configuration.emergency-address-id", "address-1");
+    assertFlag(args, "--phone-number-configuration.messaging-profile-id", "profile-1");
+    assertFlag(args, "--phone-number-configuration.tags", JSON.stringify(["migration", "vip"]));
+    assertFlag(args, "--misc.type", "partial");
+    assertFlag(args, "--misc.remaining-numbers-action", "keep");
+    assertFlag(args, "--misc.new-billing-phone-number", "+131****9999");
+    assertFlag(args, "--format", "json");
+  });
+
+  it("submits through the Go CLI confirm action and normalizes the result", () => {
+    const fake = setupFakeTelnyx();
+    const output = runAgent(["submit-porting-order", "--id", "po-1", "--json"], fake.env);
+
+    assert.deepEqual(JSON.parse(output), {
+      porting_order_id: "po-1",
+      action: "submit",
+      status: "submitted",
+      porting_order: { id: "po-1", status: "submitted" },
+    });
+    const [args] = loggedArgs(fake.logPath);
+    assert.deepEqual(args.slice(0, 2), ["porting-orders:actions", "confirm"]);
+    assertFlag(args, "--id", "po-1");
+    assertFlag(args, "--format", "json");
+  });
+
+  it("requires --confirm before cancelling, then invokes the generated cancel action", () => {
+    const fake = setupFakeTelnyx();
+    const error = expectFailure(["cancel-porting-order", "--id", "po-1", "--json"], fake.env);
+    assert.match(error, /pass --confirm/);
+    assertNoCalls(fake.logPath);
+
+    const output = runAgent(["cancel-porting-order", "--id", "po-1", "--confirm", "--json"], fake.env);
+    assert.deepEqual(JSON.parse(output), {
+      porting_order_id: "po-1",
+      action: "cancel",
+      status: "cancel-pending",
+      porting_order: { id: "po-1", status: { value: "cancel-pending" } },
+    });
+    const [args] = loggedArgs(fake.logPath);
+    assert.deepEqual(args.slice(0, 2), ["porting-orders:actions", "cancel"]);
+    assertFlag(args, "--id", "po-1");
+  });
+
+  it("attaches an existing Telnyx document using exact additional-document inner flags", () => {
+    const fake = setupFakeTelnyx();
+    const output = runAgent([
+      "attach-porting-document",
+      "--id", "po-1",
+      "--document-id", "doc-1",
+      "--document-type", "loa",
+      "--json",
+    ], fake.env);
+
+    assert.deepEqual(JSON.parse(output), {
+      porting_order_id: "po-1",
+      attached_count: 1,
+      documents: [{
+        id: "attachment-1",
+        porting_order_id: "po-1",
+        document_id: "doc-1",
+        document_type: "loa",
+        filename: "loa.pdf",
+      }],
+    });
+    const [args] = loggedArgs(fake.logPath);
+    assert.deepEqual(args.slice(0, 2), ["porting-orders:additional-documents", "create"]);
+    assertFlag(args, "--id", "po-1");
+    assertFlag(args, "--additional-document.document-id", "doc-1");
+    assertFlag(args, "--additional-document.document-type", "loa");
+    assertFlag(args, "--format", "json");
+  });
+
+  it("lists attached documents with type filters, pagination, and stable JSON", () => {
+    const fake = setupFakeTelnyx();
+    const output = runAgent([
+      "list-porting-documents",
+      "--id", "po-1",
+      "--document-type", "loa,invoice",
+      "--page-number", "1",
+      "--page-size", "10",
+      "--sort", "created_at",
+      "--json",
+    ], fake.env);
+
+    const result = JSON.parse(output);
+    assert.equal(result.porting_order_id, "po-1");
+    assert.equal(result.count, 1);
+    assert.equal(result.documents[0].document_id, "doc-1");
+    assert.equal(result.meta.total_results, 1);
+
+    const [args] = loggedArgs(fake.logPath);
+    assert.deepEqual(args.slice(0, 2), ["porting-orders:additional-documents", "list"]);
+    assertFlag(args, "--id", "po-1");
+    assertFlag(args, "--filter.document-type", JSON.stringify(["loa", "invoice"]));
+    assertFlag(args, "--page-number", "1");
+    assertFlag(args, "--page-size", "10");
+    assertFlag(args, "--sort.value", "created_at");
+    assertFlag(args, "--format", "raw");
+  });
+
+  it("validates IDs, updates, dates, pagination, booleans, and document types before invoking telnyx", () => {
+    const invalidCommands = [
+      ["get-porting-order", "--json"],
+      ["update-porting-order", "--id", "po-1", "--json"],
+      ["update-porting-order", "--id", "po-1", "--foc-datetime-requested", "tomorrow", "--json"],
+      ["update-porting-order", "--id", "po-1", "--enable-messaging", "maybe", "--json"],
+      ["update-porting-order", "--id", "po-1", "--port-type", "full", "--remaining-numbers-action", "disconnect", "--json"],
+      ["update-porting-order", "--id", "po-1", "--remaining-numbers-action", "keep", "--json"],
+      ["list-porting-orders", "--page-size", "0", "--json"],
+      ["attach-porting-document", "--id", "po-1", "--document-id", "doc-1", "--document-type", "passport", "--json"],
+      ["list-porting-documents", "--id", "po-1", "--document-type", "loa,passport", "--json"],
+    ];
+
+    for (const args of invalidCommands) {
+      const fake = setupFakeTelnyx();
+      expectFailure(args, fake.env);
+      assertNoCalls(fake.logPath);
+    }
+  });
+
+  it("advertises every direct porting command in help and capabilities", () => {
+    const help = runAgent(["help"]);
+    const capabilities = JSON.parse(runAgent(["capabilities", "--json"]));
+    const commands = [
+      "list-porting-orders",
+      "get-porting-order",
+      "update-porting-order",
+      "submit-porting-order",
+      "cancel-porting-order",
+      "attach-porting-document",
+      "list-porting-documents",
+    ];
+
+    for (const command of commands) {
+      assert.match(help, new RegExp(command));
+      assert.ok(
+        capabilities.composite_commands.some((entry: { name: string }) => entry.name === `telnyx-agent ${command}`),
+        `capabilities should advertise ${command}`,
+      );
+    }
+    const actions = capabilities.api_capabilities["🔄 Porting"][0].actions;
+    for (const action of [
+      "list_porting_orders",
+      "get_porting_order",
+      "update_porting_order",
+      "submit_porting_order",
+      "cancel_porting_order",
+      "attach_porting_document",
+      "list_porting_documents",
+    ]) {
+      assert.ok(actions.includes(action), `Porting capabilities should include ${action}`);
+    }
+    assert.ok(!actions.includes("upload_porting_document"), "attach command should not claim to upload local file bytes");
+  });
+});

--- a/cli/tests/porting.test.ts
+++ b/cli/tests/porting.test.ts
@@ -39,12 +39,14 @@ if (args[0] === "porting-orders" && args[1] === "list") {
     ? { phone_numbers: [{ phone_number: "+131****0000" }], porting_phone_numbers_count: 99 }
     : { porting_phone_numbers_count: id === "po-zero" ? 0 : 2 };
   console.log(JSON.stringify({ data: {
-    id, status: "draft", customer_reference: "migration-2026", ...phoneNumberFields
+    id, status: "draft", customer_reference: "migration-2026", ...phoneNumberFields,
+    end_user: { admin: { pin_passcode: "retrieve-pin-4931", name: "Porting Admin" } }
   } }));
 } else if (args[0] === "porting-orders" && args[1] === "update") {
   console.log(JSON.stringify({ data: {
     id: flag("--id"), status: "draft", customer_reference: flag("--customer-reference") || "migration-2026",
-    phone_numbers_count: 2
+    phone_numbers_count: 2,
+    end_user: { admin: { pinPasscode: "update-pin-8274", name: "Updated Admin" } }
   } }));
 } else if (args[0] === "porting-orders:actions" && (args[1] === "confirm" || args[1] === "cancel")) {
   console.log(JSON.stringify({ data: {
@@ -190,6 +192,16 @@ describe("Porting-order management commands", () => {
     assertFlag(args, "--format", "json");
   });
 
+  it("redacts a nested porting admin pin_passcode from get JSON output", () => {
+    const fake = setupFakeTelnyx();
+    const output = runAgent(["get-porting-order", "--id", "po-1", "--json"], fake.env);
+    const result = JSON.parse(output);
+
+    assert.equal(result.porting_order.end_user.admin.pin_passcode, "[REDACTED]");
+    assert.equal(result.porting_order.end_user.admin.name, "Porting Admin");
+    assert.doesNotMatch(output, /retrieve-pin-4931/);
+  });
+
   it("shows the API count when list and retrieve responses omit phone number arrays", () => {
     const listFake = setupFakeTelnyx();
     const listOutput = runAgent(["list-porting-orders"], listFake.env);
@@ -261,6 +273,32 @@ describe("Porting-order management commands", () => {
     assertFlag(args, "--misc.remaining-numbers-action", "keep");
     assertFlag(args, "--misc.new-billing-phone-number", "+131****9999");
     assertFlag(args, "--format", "json");
+  });
+
+  it("redacts a nested camel-case porting admin pinPasscode from update JSON output", () => {
+    const fake = setupFakeTelnyx();
+    const output = runAgent([
+      "update-porting-order", "--id", "po-1", "--customer-reference", "migration-2027", "--json",
+    ], fake.env);
+    const result = JSON.parse(output);
+
+    assert.equal(result.porting_order.end_user.admin.pinPasscode, "[REDACTED]");
+    assert.equal(result.porting_order.end_user.admin.name, "Updated Admin");
+    assert.doesNotMatch(output, /update-pin-8274/);
+  });
+
+  it("does not include nested porting admin passcodes in human get or update output", () => {
+    const getFake = setupFakeTelnyx();
+    const getOutput = runAgent(["get-porting-order", "--id", "po-1"], getFake.env);
+    assert.match(getOutput, /migration-2026/);
+    assert.doesNotMatch(getOutput, /retrieve-pin-4931/);
+
+    const updateFake = setupFakeTelnyx();
+    const updateOutput = runAgent([
+      "update-porting-order", "--id", "po-1", "--customer-reference", "migration-2027",
+    ], updateFake.env);
+    assert.match(updateOutput, /migration-2027/);
+    assert.doesNotMatch(updateOutput, /update-pin-8274/);
   });
 
   it("submits through the Go CLI confirm action and normalizes the result", () => {

--- a/cli/tests/porting.test.ts
+++ b/cli/tests/porting.test.ts
@@ -30,13 +30,16 @@ function flag(name) { const index = args.indexOf(name); return index >= 0 ? args
 
 if (args[0] === "porting-orders" && args[1] === "list") {
   console.log(JSON.stringify({
-    data: [{ id: "po-1", status: "draft", customer_reference: "migration-2026", phone_numbers: [{ phone_number: "+131****0000" }] }],
+    data: [{ id: "po-1", status: "draft", customer_reference: "migration-2026", porting_phone_numbers_count: 3 }],
     meta: { page_number: 2, page_size: 25, total_results: 1 }
   }));
 } else if (args[0] === "porting-orders" && args[1] === "retrieve") {
+  const id = flag("--id");
+  const phoneNumberFields = id === "po-array-precedence"
+    ? { phone_numbers: [{ phone_number: "+131****0000" }], porting_phone_numbers_count: 99 }
+    : { porting_phone_numbers_count: id === "po-zero" ? 0 : 2 };
   console.log(JSON.stringify({ data: {
-    id: flag("--id"), status: "draft", customer_reference: "migration-2026",
-    phone_numbers: [{ phone_number: "+131****0000" }]
+    id, status: "draft", customer_reference: "migration-2026", ...phoneNumberFields
   } }));
 } else if (args[0] === "porting-orders" && args[1] === "update") {
   console.log(JSON.stringify({ data: {
@@ -142,7 +145,7 @@ describe("Porting-order management commands", () => {
         id: "po-1",
         status: "draft",
         customer_reference: "migration-2026",
-        phone_numbers: [{ phone_number: "+131****0000" }],
+        porting_phone_numbers_count: 3,
       }],
       meta: { page_number: 2, page_size: 25, total_results: 1 },
     });
@@ -178,13 +181,36 @@ describe("Porting-order management commands", () => {
     const result = JSON.parse(output);
     assert.equal(result.porting_order_id, "po-1");
     assert.equal(result.porting_order.status, "draft");
-    assert.equal(result.porting_order.phone_numbers[0].phone_number, "+131****0000");
+    assert.equal(result.porting_order.porting_phone_numbers_count, 2);
 
     const [args] = loggedArgs(fake.logPath);
     assert.deepEqual(args.slice(0, 2), ["porting-orders", "retrieve"]);
     assertFlag(args, "--id", "po-1");
     assert.ok(args.includes("--include-phone-numbers=true"));
     assertFlag(args, "--format", "json");
+  });
+
+  it("shows the API count when list and retrieve responses omit phone number arrays", () => {
+    const listFake = setupFakeTelnyx();
+    const listOutput = runAgent(["list-porting-orders"], listFake.env);
+    assert.match(listOutput, /po-1 — draft · migration-2026 · 3 phone number\(s\)/);
+
+    const retrieveFake = setupFakeTelnyx();
+    const retrieveOutput = runAgent(["get-porting-order", "--id", "po-1"], retrieveFake.env);
+    assert.match(retrieveOutput, /Phone Numbers\s+2 phone number\(s\)/);
+  });
+
+  it("uses phone number arrays before count fields and renders a zero count", () => {
+    const precedenceFake = setupFakeTelnyx();
+    const precedenceOutput = runAgent([
+      "get-porting-order", "--id", "po-array-precedence",
+    ], precedenceFake.env);
+    assert.match(precedenceOutput, /Phone Numbers\s+1 phone number\(s\)/);
+    assert.doesNotMatch(precedenceOutput, /99 phone number\(s\)/);
+
+    const zeroFake = setupFakeTelnyx();
+    const zeroOutput = runAgent(["get-porting-order", "--id", "po-zero"], zeroFake.env);
+    assert.match(zeroOutput, /Phone Numbers\s+0 phone number\(s\)/);
   });
 
   it("updates core order and post-port number settings using generated inner flags", () => {


### PR DESCRIPTION
## Summary
- add list/get/update/submit/cancel porting-order wrappers
- add attached-document upload and list wrappers
- require explicit confirmation before cancellation
- wire exact generated Go CLI flags into help/capabilities with mock-binary coverage

## Verification
- `npx tsc --noEmit`
- `npx tsx --test tests/*.test.ts` (208 passed)