### PR TITLE
docs: fix broken unified-plugin install path, add telnyx-email, plugin decision table

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repo is the one-stop shop for AI Agents and AI-first developers building wi
 
 ## Plugins and Extensions
 
-Install the Telnyx plugins you need to give your AI coding assistant Telnyx MCP server access and Agent Skills covering messaging, voice, numbers, AI, IoT, WebRTC, Twilio migration, account management (signup, MPP/x402 payments), and more. Plugins are split by product area so you only load the skills your project uses — see the ["Which plugin do I need?" table](/plugins/README.md#which-plugin-do-i-need).
+Install the Telnyx plugins you need to give your AI coding assistant Telnyx Agent Skills covering messaging, voice, numbers, AI, IoT, WebRTC, Twilio migration, account management (signup, MPP/x402 payments), and more. Plugins are split by product area so you only load the skills your project uses — see the ["Which plugin do I need?" table](/plugins/README.md#which-plugin-do-i-need). For direct Telnyx API access from your assistant, also add the hosted MCP server — see [MCP](#model-context-protocol-mcp).
 
 Empowers agents to generate correct, production-ready code — and to manage their own accounts — without relying on pre-training or fragile doc retrieval.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repo is the one-stop shop for AI Agents and AI-first developers building wi
 
 ## Plugins and Extensions
 
-Install the unified Telnyx plugin to give your AI coding assistant Telnyx MCP server access and 238 Agent Skills covering messaging, voice, numbers, AI, IoT, WebRTC, Twilio migration, account management (signup, MPP/x402 payments), and more. 
+Install the Telnyx plugins you need to give your AI coding assistant Telnyx MCP server access and Agent Skills covering messaging, voice, numbers, AI, IoT, WebRTC, Twilio migration, account management (signup, MPP/x402 payments), and more. Plugins are split by product area so you only load the skills your project uses — see the ["Which plugin do I need?" table](/plugins/README.md#which-plugin-do-i-need).
 
 Empowers agents to generate correct, production-ready code — and to manage their own accounts — without relying on pre-training or fragile doc retrieval.
 
@@ -37,16 +37,17 @@ Empowers agents to generate correct, production-ready code — and to manage the
 **Step 2.** Install the plugins you need — pick one or more:
 
 ```bash
-/plugin install telnyx-whatsapp@telnyx   # WhatsApp Business API
-/plugin install telnyx-voice@telnyx      # Voice API (call control, AMD, recording, etc.)
 /plugin install telnyx-messaging@telnyx  # SMS / MMS
-/plugin install telnyx-tts@telnyx         # Text-to-speech
-/plugin install telnyx-stt@telnyx         # Speech-to-text
-/plugin install telnyx-verify@telnyx      # Phone verification / 2FA
-/plugin install telnyx-numbers@telnyx     # Number management
-/plugin install telnyx-webrtc@telnyx      # WebRTC
-/plugin install telnyx-ai@telnyx         # AI inference
-/plugin install telnyx-platform@telnyx   # Platform services (numbers, billing, MCP)
+/plugin install telnyx-voice@telnyx      # Voice API (call control, AMD, recording, etc.)
+/plugin install telnyx-whatsapp@telnyx   # WhatsApp Business API
+/plugin install telnyx-email@telnyx      # Email API
+/plugin install telnyx-tts@telnyx        # Text-to-speech
+/plugin install telnyx-stt@telnyx        # Speech-to-text
+/plugin install telnyx-verify@telnyx     # Phone verification / 2FA
+/plugin install telnyx-numbers@telnyx    # Number management, 10DLC, porting
+/plugin install telnyx-webrtc@telnyx     # WebRTC and client SDKs
+/plugin install telnyx-ai@telnyx         # AI inference and assistants
+/plugin install telnyx-platform@telnyx   # Account, fax, IoT, networking, SIP, storage, TeXML, OAuth, Twilio migration
 ```
 
 ### Gemini CLI extension

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -4,7 +4,7 @@ Coding-assistant plugins that wire Telnyx into AI IDEs and CLIs.
 
 ## Which plugin do I need?
 
-Telnyx ships one Claude Code plugin per product area. Install only what your project uses — each plugin loads its own skills into your assistant's context, so smaller installs mean less token overhead and less room for confusion. Plugins are disjoint: no skill ships in two plugins.
+Telnyx ships one Claude Code plugin per product area. Install only what your project uses — each plugin loads its own skills into your assistant's context, so smaller installs mean less token overhead and less room for confusion. Every skill lives in exactly one plugin, so plugins compose cleanly — install any combination and you'll never load duplicate skills or waste context.
 
 | Plugin | Covers | Skills |
 | --- | --- | --- |

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -2,14 +2,37 @@
 
 Coding-assistant plugins that wire Telnyx into AI IDEs and CLIs.
 
-## Current contents
+## Which plugin do I need?
+
+Telnyx ships one Claude Code plugin per product area. Install only what your project uses — each plugin loads its own skills into your assistant's context, so smaller installs mean less token overhead and less room for confusion. Plugins are disjoint: no skill ships in two plugins.
+
+| Plugin | Covers | Skills |
+| --- | --- | --- |
+| `telnyx-messaging` | SMS/MMS — send, schedule, group MMS, delivery webhooks, opt-out handling, messaging profiles | 18 |
+| `telnyx-voice` | Voice API — call control, DTMF, recording, noise suppression, AMD, deepfake detection, number masking, SIPREC, streaming | 37 |
+| `telnyx-whatsapp` | WhatsApp Business API — messages, templates, WABAs, phone numbers | 6 |
+| `telnyx-email` | Email — transactional send, inboxes, sending domains, suppressions, unsubscribe groups | 4 |
+| `telnyx-tts` | Text-to-speech via Telnyx and third-party voices | 1 |
+| `telnyx-stt` | Speech-to-text transcription (OpenAI-compatible endpoint) | 1 |
+| `telnyx-verify` | Phone verification via SMS, call, or flash call (2FA OTP) | 6 |
+| `telnyx-numbers` | Phone numbers — search, buy, manage, 10DLC compliance, porting | 42 |
+| `telnyx-webrtc` | WebRTC — video rooms and browser/mobile client SDKs | 17 |
+| `telnyx-ai` | AI — LLM inference, chat completions, embeddings, AI assistants, conversation insights | 12 |
+| `telnyx-platform` | Everything account-level and cross-product — account management, fax, IoT, networking, SIP, storage, TeXML, OAuth, Twilio migration | 98 |
+
+Install with:
+
+```bash
+/plugin marketplace add team-telnyx/ai   # one-time
+/plugin install <plugin>@telnyx
+```
+
+See the repo root [`README.md`](/README.md#plugins-and-extensions) for Cursor, Gemini CLI, and OpenCode install paths.
+
+## Directory contents
 
 - **`opencode/`** — OpenCode plugin, published as [`@telnyx/opencode`](https://www.npmjs.com/package/@telnyx/opencode). Adds Telnyx as a model provider with auth handling and a TUI for managing hosted models. Absorbed from the now-archived `team-telnyx/opencode-telnyx-auth` repo.
 
-## Coming next
-
-The Claude Code and Cursor plugin payloads currently live at `providers/claude/plugin/` and `providers/cursor/plugin/` and will move to `plugins/claude-code/` and `plugins/cursor/` in a follow-up step. The root `.claude-plugin/marketplace.json` and `.cursor-plugin/marketplace.json` files stay at the repo root (they're consumed by `/plugin marketplace add team-telnyx/ai` and the Cursor marketplace) — only their `source:` fields will be rewired.
+The Claude Code and Cursor plugin payloads live under `providers/claude/plugins/<plugin>/` and `providers/cursor/plugin/`, referenced from the root `.claude-plugin/marketplace.json` and `.cursor-plugin/marketplace.json` (consumed by `/plugin marketplace add team-telnyx/ai` and the Cursor marketplace).
 
 Gemini CLI has no payload directory: its entire integration is the root `gemini-extension.json`, consumed by `gemini extensions install https://github.com/team-telnyx/ai`.
-
-See the repo root `README.md` for install instructions and the broader architecture.

--- a/skills/README.md
+++ b/skills/README.md
@@ -278,7 +278,7 @@ Telnyx ships one plugin per product area, so you install only the skills your pr
 /plugin install telnyx-platform@telnyx   # Account, fax, IoT, networking, SIP, storage, TeXML, OAuth, Twilio migration
 ```
 
-Each plugin bundles that product's skills. Plugins are disjoint — no skill ships in two plugins, so there's no double-install risk. Not sure which you need? See the ["Which plugin do I need?" table](/plugins/README.md#which-plugin-do-i-need). For direct Telnyx API access from your assistant, also add the hosted MCP server (`https://api.telnyx.com/v2/mcp`) — see the [MCP section](/README.md#model-context-protocol-mcp) of the root README.
+Each plugin bundles that product's skills, and every skill lives in exactly one plugin — install any combination and you'll never load duplicates or waste context. Not sure which you need? See the ["Which plugin do I need?" table](/plugins/README.md#which-plugin-do-i-need). For direct Telnyx API access from your assistant, also add the hosted MCP server (`https://api.telnyx.com/v2/mcp`) — see the [MCP section](/README.md#model-context-protocol-mcp) of the root README.
 
 ## Skill Structure
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -250,11 +250,11 @@ npx skills add team-telnyx/ai --skill telnyx-twilio-migration --agent <AGENT>
 
 Includes parameter-by-parameter mapping tables, multi-language code examples (Python, Node, Go, Java, Ruby, curl), error code mapping, and migration plan/report templates.
 
-> **Note:** After migrating, install a language plugin (e.g. `telnyx-python`) for deeper SDK examples, and `telnyx-webrtc-client` if building a calling app.
+> **Note:** After migrating, install the product plugins you use (e.g. `telnyx-messaging@telnyx`, `telnyx-voice@telnyx`) for deeper SDK examples, and `telnyx-webrtc@telnyx` if building a calling app.
 
 ## Install Claude Code Plugin
 
-Install the unified Telnyx plugin with Claude Code marketplace:
+Telnyx ships one plugin per product area, so you install only the skills your project needs (see the token-hygiene note above).
 
 **Step 1.** Add the Telnyx marketplace (one-time setup):
 
@@ -262,15 +262,23 @@ Install the unified Telnyx plugin with Claude Code marketplace:
 /plugin marketplace add team-telnyx/ai
 ```
 
-**Step 2.** Install the plugin:
+**Step 2.** Install the plugins you need — pick one or more:
 
 ```bash
-/plugin install telnyx@telnyx
+/plugin install telnyx-messaging@telnyx  # SMS / MMS
+/plugin install telnyx-voice@telnyx      # Voice API (call control, AMD, recording, etc.)
+/plugin install telnyx-whatsapp@telnyx   # WhatsApp Business API
+/plugin install telnyx-email@telnyx      # Email API
+/plugin install telnyx-tts@telnyx        # Text-to-speech
+/plugin install telnyx-stt@telnyx        # Speech-to-text
+/plugin install telnyx-verify@telnyx     # Phone verification / 2FA
+/plugin install telnyx-numbers@telnyx    # Number management, 10DLC, porting
+/plugin install telnyx-webrtc@telnyx     # WebRTC and client SDKs
+/plugin install telnyx-ai@telnyx         # AI inference and assistants
+/plugin install telnyx-platform@telnyx   # Account, fax, IoT, networking, SIP, storage, TeXML, OAuth, Twilio migration
 ```
 
-This installs MCP server access + all skills listed above.
-
-The plugin includes all skills listed above — all languages, WebRTC client SDKs, Twilio migration workflow, and CLI guidance.
+Each plugin bundles MCP server access plus that product's skills. Plugins are disjoint — no skill ships in two plugins, so there's no double-install risk. Not sure which you need? See the ["Which plugin do I need?" table](/plugins/README.md#which-plugin-do-i-need).
 
 ## Skill Structure
 
@@ -293,7 +301,7 @@ git clone https://github.com/team-telnyx/ai.git
 mkdir -p .github/skills
 
 # Example:
-cp -r ai/skills/telnyx-python/skills/telnyx-messaging-python .github/skills/
+cp -r ai/skills/telnyx-messaging-python .github/skills/
 ```
 
 ## Contributing

--- a/skills/README.md
+++ b/skills/README.md
@@ -278,7 +278,7 @@ Telnyx ships one plugin per product area, so you install only the skills your pr
 /plugin install telnyx-platform@telnyx   # Account, fax, IoT, networking, SIP, storage, TeXML, OAuth, Twilio migration
 ```
 
-Each plugin bundles MCP server access plus that product's skills. Plugins are disjoint — no skill ships in two plugins, so there's no double-install risk. Not sure which you need? See the ["Which plugin do I need?" table](/plugins/README.md#which-plugin-do-i-need).
+Each plugin bundles that product's skills. Plugins are disjoint — no skill ships in two plugins, so there's no double-install risk. Not sure which you need? See the ["Which plugin do I need?" table](/plugins/README.md#which-plugin-do-i-need). For direct Telnyx API access from your assistant, also add the hosted MCP server (`https://api.telnyx.com/v2/mcp`) — see the [MCP section](/README.md#model-context-protocol-mcp) of the root README.
 
 ## Skill Structure
 


### PR DESCRIPTION
## Summary

- `skills/README.md` still said `/plugin install telnyx@telnyx` — **this fails live** (`Plugin "telnyx" not found in marketplace "telnyx"`) because PR #273 split the monolithic plugin into 11 per-product plugins. Replaced with the modular install block, consistent with the root README and with this file's own token-hygiene note.
- Added the missing `telnyx-email@telnyx` to both install lists (it exists in `marketplace.json` but was documented nowhere).
- Fixed `telnyx-platform`'s README description: it claimed "numbers, billing, MCP", but per its `plugin.json` it actually covers account management, fax, IoT, networking, SIP, storage, TeXML, OAuth, and Twilio migration — all numbers skills live in `telnyx-numbers`.
- Added a **"Which plugin do I need?"** decision table to `plugins/README.md` (11 plugins, domains, skill counts; plugins verified pairwise-disjoint) and refreshed that file's stale pre-#273 payload paths.
- Fixed a manual-install example referencing a nonexistent nested path (`ai/skills/telnyx-python/skills/...`) and a nonexistent `telnyx-python` plugin.

## Verification

- `claude plugin marketplace add team-telnyx/ai` then `claude plugin install telnyx-voice@telnyx` (37 skills) and `telnyx-email@telnyx` (4 skills) install successfully; `telnyx@telnyx` reproducibly fails — tested in a sandboxed `CLAUDE_CONFIG_DIR`.
- Script-checked that the set of `/plugin install` commands in README.md and skills/README.md now exactly matches `marketplace.json`'s plugin list.

Note: skill counts in the new table are current as of this branch (they'll shift as skills land; a follow-up will look at generating counts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)