### PR TITLE
docs: rewrite Edge Compute section as user-facing guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,26 +227,13 @@ From `tools/mcp-apps`, use `npm install`, `npm run typecheck`, `npm run build`, 
 
 Curl-first operational guides for common Telnyx workflows — SMS messaging, voice call control, AI assistants, phone numbers, porting, verification, webhooks, 10DLC registration, WireGuard networking, MPP and x402 account payments, and Edge Compute handoff patterns.
 
-For Edge Compute specifically, the goal is to make the handoff testable fast: start from a real `telnyx-edge` example, deploy it, and let `team-telnyx/ai` orchestrate against that live endpoint.
-
 See [Guides](/guides) for the full list.
 
 ## Edge Compute
 
-`team-telnyx/ai` does not currently own native Edge Compute lifecycle support.
+Use this repo for agent workflows against Telnyx Edge Compute: the [Agent CLI](/cli) ships `edge-doctor` (readiness checks), `setup-edge-mcp`, and `setup-edge-webhook` for wiring a deployed function into MCP and webhook flows — the [Edge Compute guide](/guides/edge-compute.md) walks through the full workflow, from auth to a live endpoint.
 
-Instead, this repo should be treated as the orchestration/discoverability layer, while the actual function lifecycle lives in the separate `team-telnyx/edge-compute` repo and the `telnyx-edge` CLI.
-
-In practice:
-- use `team-telnyx/ai` for agent workflows, capability discovery, and AI-oriented integration patterns
-- use `team-telnyx/edge-compute` + `telnyx-edge` for function creation, deployment, secrets, bindings, and lifecycle management
-
-The intended end state is a clean bridge:
-- `ai` = orchestrates and explains
-- Edge Compute = deploys and runs (prefer API-key auth for agent flows)
-- the boundary between them is a documented HTTP/MCP/function contract
-
-See [Edge Compute guide](/guides/edge-compute.md).
+To create, deploy, and manage the functions themselves (secrets, bindings, lifecycle), use the `telnyx-edge` CLI from [`team-telnyx/edge-compute`](https://github.com/team-telnyx/edge-compute). For agent flows, prefer API-key auth (`telnyx-edge auth api-key set <key>`).
 
 
 ## License

--- a/cli/README.md
+++ b/cli/README.md
@@ -176,7 +176,7 @@ What they do:
 - prefer `telnyx-edge auth api-key set <your-api-key>` for agents when supported
 - point you at a real Edge example
 - give you the concrete next deploy command
-- preserve an honest handoff instead of pretending `telnyx-agent` owns Edge lifecycle
+- hand off function creation, deployment, and lifecycle management to the `telnyx-edge` CLI, which owns them
 
 ### `telnyx-agent fund-account`
 


### PR DESCRIPTION
## Summary

The README's Edge Compute section read as internal planning notes — "the intended end state is a clean bridge", "this repo should be treated as the orchestration/discoverability layer", "does not currently own native Edge Compute lifecycle support". That's repo-ownership and roadmap language aimed at maintainers; on the public front page it tells a developer nothing actionable.

Rewritten as present-tense user guidance, leaning on what recently shipped (#292/#313/#333/#334):

- **This repo**: Agent CLI `edge-doctor`, `setup-edge-mcp`, `setup-edge-webhook` + the [Edge Compute guide](/guides/edge-compute.md) for agent workflows against a deployed function.
- **`team-telnyx/edge-compute`**: the `telnyx-edge` CLI for creating, deploying, and managing functions (secrets, bindings, lifecycle); API-key auth preferred for agent flows.

Same architectural split, stated as guidance instead of intent. Also removes the matching roadmap sentence from the Guides section and rewrites one `cli/README.md` bullet ("…instead of pretending `telnyx-agent` owns Edge lifecycle") in user terms.

No behavior changes; guide and CLI content untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)