### PR TITLE
docs: document the skill regeneration contract (generated vs hand-authored)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -32,11 +32,15 @@ You can verify sync locally with `./scripts/check-skills-sync.sh`.
 
 ### Auto-generated skills
 
-Most skills are automatically generated from Telnyx OpenAPI specifications. Do not modify code examples directly — they will be overwritten on the next generation. If you find an error in a code example, it needs to be fixed in the upstream OpenAPI spec.
+Most skills are automatically generated from the official Telnyx OpenAPI specifications. You can tell them apart mechanically: a generated skill's `SKILL.md` frontmatter contains a `generated_by:` field; a hand-authored skill's does not.
+
+Do not PR changes to generated skills — a daily automated update regenerates them from the specs and will overwrite your edit. If you find an error in one, [open an issue](https://github.com/team-telnyx/ai/issues) describing the problem; code-example errors are fixed upstream in the OpenAPI spec.
 
 ### Hand-authored skills
 
-Skills in `telnyx-twilio-migration/`, `telnyx-webrtc-client/`, and `telnyx-import-voice-ai/` are manually authored. PRs to improve these are welcome.
+Skills without a `generated_by:` frontmatter field (the Twilio migration workflow, WebRTC client SDK skills, provider import skills, payment/signup skills, and others) are manually authored. PRs to improve these are welcome — run `./scripts/sync-skills.sh` after editing and commit the sync output.
+
+Exception: embedded SDK reference files inside some hand-authored skills (`telnyx-twilio-migration/sdk-reference/`, `telnyx-twilio-migration/references/sdk-api-details/`, `telnyx-webrtc-client-*/references/webrtc-server-api.md`) are pipeline-managed and will be overwritten — treat those like generated content.
 
 ## Questions?
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,13 +68,18 @@ Run the relevant package's test suite before declaring a task done. Don't run al
 
 ### Editing skills
 
-`skills/` is the canonical source. After editing any skill, run:
+`skills/` is the canonical source **within this repo** — the `providers/` copies derive from it. But not every skill is editable here. Check the skill's `SKILL.md` frontmatter first:
+
+- **Has a `generated_by:` field** (~90% of skills): the skill is regenerated from the official Telnyx OpenAPI specifications by an automated pipeline, and a daily auto-update PR will overwrite any direct edit. Don't PR changes to these — open an issue describing the problem instead; code-example errors are fixed upstream in the spec.
+- **No `generated_by:` field**: the skill is hand-authored. PRs welcome. After editing, run:
 
 ```bash
 ./scripts/sync-skills.sh
 ```
 
 This propagates changes to `providers/claude/` and `providers/cursor/`. Commit the sync output alongside your skill edits — don't leave them out of sync.
+
+One exception inside hand-authored skills: embedded SDK reference files (`telnyx-twilio-migration/sdk-reference/`, `telnyx-twilio-migration/references/sdk-api-details/`, and `telnyx-webrtc-client-*/references/webrtc-server-api.md`) are pipeline-managed and will also be overwritten — treat those like generated content.
 
 ### Editing `agent.json`
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -298,7 +298,7 @@ cp -r ai/skills/telnyx-python/skills/telnyx-messaging-python .github/skills/
 
 ## Contributing
 
-We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+We welcome contributions! Please see [CONTRIBUTING.md](../.github/CONTRIBUTING.md) for guidelines — in particular the split between auto-generated skills (open an issue) and hand-authored skills (PRs welcome).
 
 ## Support
 


### PR DESCRIPTION
## Summary

Contributors currently get contradictory instructions: AGENTS.md says `skills/` is canonical — edit any skill and run `sync-skills.sh` — while skills/README.md says skills are generated from OpenAPI specs and to file issues. Both are half-right, and the failure mode is real: ~90% of skills are regenerated daily by an automated pipeline, so a contributor following AGENTS.md produces a PR whose content is overwritten by the next auto-update PR.

This makes the contract explicit and **machine-checkable** in all three docs:

- **Generated skills** carry a `generated_by:` field in their SKILL.md frontmatter → don't PR; open an issue (code-example errors are fixed upstream in the spec).
- **Hand-authored skills** have no `generated_by:` field → PRs welcome; run `./scripts/sync-skills.sh` and commit the sync output.
- **Exception**: embedded SDK reference files inside `telnyx-twilio-migration` and `telnyx-webrtc-client-*` are pipeline-managed even though the parent skills are hand-authored.

Also:
- Replaces CONTRIBUTING.md's stale hand-authored directory list (`telnyx-webrtc-client/` and `telnyx-import-voice-ai/` don't exist — actual dirs are `telnyx-webrtc-client-{js,ios,android,flutter,react-native}` and `telnyx-import-{elevenlabs,vapi,retell}`) with the frontmatter rule, which can't rot as skills are added.
- Fixes skills/README.md's Contributing link, which pointed at a nonexistent `skills/CONTRIBUTING.md`.

Keying the docs on **field presence** (not the field's value) keeps them correct even if the generator's marker string changes.

Note: no overlap with #288's path fixes (different hunks); both can land independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)