### PR TITLE
docs(ffl-cli): make the Friction Feedback Loop CLI properly public

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -79,7 +79,7 @@ out of sync. CI will catch drift.
 - `tools/python/` — Python agent toolkit (PyPI)
 - `tools/typescript/` — TypeScript agent toolkit (npm)
 - `tools/mcp/` — MCP proxy server
-- `tools/ffl-cli/` — Filling-from-life CLI
+- `tools/ffl-cli/` — Friction Feedback Loop (FFL) CLI for reporting Telnyx API friction
 - `cli/` — agent CLI for provisioning Telnyx infrastructure
 - `inference/` — Telnyx inference docs
 - `guides/` — operational guides

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ Run the relevant package's test suite before declaring a task done. Don't run al
 | `tools/typescript/`     | TypeScript agent toolkit (npm).                                           |
 | `tools/mcp/`            | MCP proxy server for the generic Telnyx API MCP endpoint.                |
 | `tools/mcp-apps/`       | Focused app-layer MCP servers with MCP Apps UI resources.                |
-| `tools/ffl-cli/`        | Filling-from-life CLI tooling.                                            |
+| `tools/ffl-cli/`        | Friction Feedback Loop (FFL) CLI — report Telnyx API friction (parameter mismatches, unclear errors, missing docs). |
 | `cli/`                  | Agent CLI for provisioning Telnyx infrastructure.                         |
 | `inference/`            | Documentation for Telnyx-hosted inference.                                |
 | `guides/`               | Step-by-step operational guides.                                          |

--- a/tools/ffl-cli/README.md
+++ b/tools/ffl-cli/README.md
@@ -1,21 +1,19 @@
 # Friction Feedback Loop CLI
 
-Internal CLI for reporting API friction to the FFL (Friction Feedback Loop) backend.
-
-**🔒 Private Repo** - For internal Telnyx testing only.
+CLI for reporting Telnyx API friction to the FFL (Friction Feedback Loop) backend.
 
 ---
 
 ## Overview
 
-When AI agents or developers encounter friction using Telnyx APIs (parameter mismatches, unclear errors, missing docs), they can report it using this CLI. Reports are sent to the FFL backend for analysis and tracking.
+When AI agents or developers encounter friction using Telnyx APIs (parameter mismatches, unclear errors, missing docs), they can report it using this CLI. Reports go to the FFL backend, where the Telnyx team uses them to fix docs, specs, and skills — every report makes the skills in this repo better.
 
 ---
 
 ## Installation
 
 ```bash
-pip install git+https://github.com/team-telnyx/aifde-ffl-cli.git
+pip install "git+https://github.com/team-telnyx/ai.git#subdirectory=tools/ffl-cli"
 ```
 
 ---
@@ -87,7 +85,7 @@ friction-report watchdog --skill <SKILLNAME> --team <TEAM> -- <your-command-here
 
 - `--output auto` (default): Remote if TELNYX_API_KEY set, local otherwise
 - `--output local`: Save to `~/.openclaw/friction-logs/`
-- `--output remote`: Send to FFL backend (requires VPN + API key)
+- `--output remote`: Send to FFL backend (requires a Telnyx API key)
 - `--output both`: Local file + remote report
 
 ---
@@ -255,8 +253,8 @@ See [`templates/SKILL_TEMPLATE.md`](./templates/SKILL_TEMPLATE.md) for a copy-pa
 
 ```bash
 # Clone repo
-git clone https://github.com/team-telnyx/aifde-ffl-cli.git
-cd aifde-ffl-cli
+git clone https://github.com/team-telnyx/ai.git
+cd ai/tools/ffl-cli
 
 # Install in editable mode
 pip install -e .
@@ -316,14 +314,6 @@ python -m pytest tests/
 
 ---
 
-## Related Repos
-
-- **Backend:** [`team-telnyx/aifde-ffl-backend`](https://github.com/team-telnyx/aifde-ffl-backend)
-- **Deployment:** [`team-telnyx/deploy-ai-fde-main`](https://github.com/team-telnyx/deploy-ai-fde-main)
-- **Documentation:** (TBD)
-
----
-
 ## License
 
 MIT
@@ -332,6 +322,4 @@ MIT
 
 ## Support
 
-For questions or issues, contact the AI-FDE team:
-- Slack: `#squad-ai-fde`
-- Email: ai-fde@telnyx.com
+For questions or issues, [open an issue](https://github.com/team-telnyx/ai/issues) on this repo or email ai-fde@telnyx.com.


### PR DESCRIPTION
## Summary

`tools/ffl-cli` ships in this public repo, but its docs still described an internal tool:

- README banner said **"🔒 Private Repo — For internal Telnyx testing only"**
- Install instructions pointed at the private `aifde-ffl-cli` repo — a 404 for anyone outside the org
- "Send to FFL backend (requires **VPN** + API key)" — outdated: the backend resolves via Cloudflare and answers publicly (401 unauthenticated), so it's API-key-gated, not VPN-only
- Related Repos linked two private repositories; support pointed at an internal Slack channel
- AGENTS.md and .claude/CLAUDE.md described it as **"Filling-from-life CLI"** — an incorrect expansion of FFL (it's the *Friction Feedback Loop* CLI)

This PR makes the public framing match reality: friction reports from agents/developers feed the loop that improves the skills in this repo.

## Verification

- `pip install "git+https://github.com/team-telnyx/ai.git#subdirectory=tools/ffl-cli"` tested in a clean venv — installs and `friction-report --help` runs.
- `curl -X POST https://ffl-backend.telnyx.com/v2/friction` (no auth) → 401, confirming public reachability.
- `grep -rn 'Filling-from-life\|Private Repo\|aifde-ffl-cli\|VPN'` across the touched files → clean.

No code changes — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)