### PR TITLE
ci: gate on SKILL_COUNT markers matching the on-disk skill count

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -25,6 +25,14 @@ jobs:
       - name: Verify provider skill directories match source
         run: ./scripts/check-skills-sync.sh
 
+  skill-count-check:
+    name: Check — Skill-count markers current
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify SKILL_COUNT markers match on-disk count
+        run: ./scripts/check-skill-count.sh
+
   unit-tests:
     name: Unit Tests (no API key)
     runs-on: ubuntu-latest

--- a/scripts/check-skill-count.sh
+++ b/scripts/check-skill-count.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Verify <!-- SKILL_COUNT -->N<!-- /SKILL_COUNT --> markers match the on-disk
+# canonical skill count. The publish pipeline rewrites these markers on every
+# skills update; this check catches drift from skills added or removed by hand
+# between publishes. Docs without markers are skipped, so the check is safe to
+# land before the markers themselves.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+actual=$(find skills -name SKILL.md | wc -l | tr -d ' ')
+status=0
+found=0
+for f in README.md AGENTS.md; do
+  [ -f "$f" ] || continue
+  while read -r n; do
+    [ -n "$n" ] || continue
+    found=1
+    if [ "$n" != "$actual" ]; then
+      echo "FAIL: $f states skill count $n but skills/ contains $actual SKILL.md files." >&2
+      echo "      Update the marker (or let the next skills publish refresh it)." >&2
+      status=1
+    fi
+  done < <(grep -o '<!-- SKILL_COUNT -->[0-9]*<!-- /SKILL_COUNT -->' "$f" 2>/dev/null | grep -o '[0-9]*' || true)
+done
+
+if [ "$found" = 0 ]; then
+  echo "No SKILL_COUNT markers found — nothing to check."
+  exit 0
+fi
+if [ "$status" = 0 ]; then
+  echo "OK: all SKILL_COUNT markers match on-disk count ($actual)."
+fi
+exit $status


### PR DESCRIPTION
## Summary

Companion to #344, which wraps the documented skill counts in `<!-- SKILL_COUNT -->N<!-- /SKILL_COUNT -->` markers, and to the generator-side automation that rewrites them on every skills publish.

This adds a `skill-count-check` job (alongside the existing `skills-sync-check`) running `scripts/check-skill-count.sh`: every marker in README.md/AGENTS.md must equal `find skills -name SKILL.md | wc -l`. It catches the drift source the publisher can't see — **skills added or removed by hand between publishes** (the 238→242 drift happened exactly this way when the 4 email skills landed).

- No markers present → clean pass, so this can land in any order relative to #344.
- Drift → fails with the file, stated count, and actual count.

## Verification

All three paths tested locally: no-markers pass, markers-correct pass (242), deliberately drifted marker fails with exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)