### PR TITLE
ci: tag each npm/PyPI publish with package@version

### DIFF
--- a/.github/bin/publish-npm
+++ b/.github/bin/publish-npm
@@ -56,3 +56,15 @@ fi
 
 # Use the system npm (Node 24 ships npm 11+) for OIDC provenance
 npm publish --access public --no-git-checks --tag "$TAG"
+
+# Tag the published version so npm releases are traceable to commits.
+# Runs only after a real publish — the already-published path exits above.
+GIT_TAG="$PACKAGE_NAME@$VERSION"
+if git rev-parse -q --verify "refs/tags/$GIT_TAG" >/dev/null; then
+  echo "Tag $GIT_TAG already exists; skipping tag."
+else
+  git config user.name "github-actions[bot]"
+  git config user.email "github-actions[bot]@users.noreply.github.com"
+  git tag -a "$GIT_TAG" -m "$PACKAGE_NAME $VERSION"
+  git push origin "refs/tags/$GIT_TAG" || echo "WARNING: tag push failed; publish succeeded (tag manually: $GIT_TAG)"
+fi

--- a/.github/bin/publish-pypi
+++ b/.github/bin/publish-pypi
@@ -23,3 +23,17 @@ if [ -n "${PYPI_TOKEN:-}" ]; then
 else
   uv publish
 fi
+
+# Tag the published version so PyPI releases are traceable to commits.
+# Reached only when uv publish succeeded (set -e aborts on failure).
+PACKAGE_NAME="$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['name'])")"
+VERSION="$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")"
+GIT_TAG="$PACKAGE_NAME@$VERSION"
+if git rev-parse -q --verify "refs/tags/$GIT_TAG" >/dev/null; then
+  echo "Tag $GIT_TAG already exists; skipping tag."
+else
+  git config user.name "github-actions[bot]"
+  git config user.email "github-actions[bot]@users.noreply.github.com"
+  git tag -a "$GIT_TAG" -m "$PACKAGE_NAME $VERSION"
+  git push origin "refs/tags/$GIT_TAG" || echo "WARNING: tag push failed; publish succeeded (tag manually: $GIT_TAG)"
+fi

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -36,7 +36,7 @@ jobs:
       github.repository == 'team-telnyx/ai' &&
       (github.event_name == 'release' || github.event.inputs.package == 'all' || github.event.inputs.package == 'typescript')
     permissions:
-      contents: read
+      contents: write  # push per-package release tags
       id-token: write
 
     steps:
@@ -60,7 +60,7 @@ jobs:
       github.repository == 'team-telnyx/ai' &&
       (github.event_name == 'release' || github.event.inputs.package == 'all' || github.event.inputs.package == 'cli')
     permissions:
-      contents: read
+      contents: write  # push per-package release tags
       id-token: write
 
     steps:
@@ -84,7 +84,7 @@ jobs:
       github.repository == 'team-telnyx/ai' &&
       (github.event_name == 'release' || github.event.inputs.package == 'all' || github.event.inputs.package == 'mcp')
     permissions:
-      contents: read
+      contents: write  # push per-package release tags
       id-token: write
 
     steps:
@@ -108,7 +108,7 @@ jobs:
       github.repository == 'team-telnyx/ai' &&
       (github.event_name == 'release' || github.event.inputs.package == 'all' || github.event.inputs.package == 'opencode')
     permissions:
-      contents: read
+      contents: write  # push per-package release tags
       id-token: write
 
     steps:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -23,7 +23,7 @@ jobs:
     # Only run from the canonical repo
     if: github.repository == 'team-telnyx/ai'
     permissions:
-      contents: read
+      contents: write  # push per-package release tags
       id-token: write
 
     steps:


### PR DESCRIPTION
## Summary

Addresses the release-traceability gap from the repo feedback review: npm/PyPI publishes (both toolkits at 0.3.0, @telnyx/mcp, @telnyx/agent-cli, @telnyx/opencode) leave no git tags, so published versions can't be traced to commits.

- `.github/bin/publish-npm` and `.github/bin/publish-pypi` now create + push an annotated `<package>@<version>` tag after a successful publish (changesets-style naming, e.g. `@telnyx/agent-toolkit@0.4.0`).
- Idempotent: the npm already-published path exits before tagging; existing tags are skipped; a tag-push failure warns rather than failing a completed publish.
- Publish jobs get `contents: write`; the MCP-registry job stays `read` (it pushes no tags).
- Deliberately does NOT version the skills catalog — skills stay continuous-update (no vendor semvers skill catalogs); this is for the code packages only.

## Verification

`bash -n` on both scripts; the pyproject name/version parse tested with Python 3.12 tomllib (`telnyx-agent-toolkit@0.3.0`). The tag step itself only runs in the publish workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)