### PR TITLE
fix: unmark hand-authored TTS/STT python skills as generated (pre-publish blocker)

### DIFF
--- a/providers/claude/plugins/telnyx-stt/skills/telnyx-stt-python/SKILL.md
+++ b/providers/claude/plugins/telnyx-stt/skills/telnyx-stt-python/SKILL.md
@@ -8,8 +8,6 @@ metadata:
   author: telnyx
   product: stt
   language: python
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
 ---
 
 # Telnyx Speech-to-Text - Python

--- a/providers/claude/plugins/telnyx-tts/skills/telnyx-tts-python/SKILL.md
+++ b/providers/claude/plugins/telnyx-tts/skills/telnyx-tts-python/SKILL.md
@@ -8,8 +8,6 @@ metadata:
   author: telnyx
   product: tts
   language: python
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
 ---
 
 # Telnyx Text-to-Speech - Python

--- a/providers/cursor/plugin/skills/telnyx-stt-python/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-stt-python/SKILL.md
@@ -8,8 +8,6 @@ metadata:
   author: telnyx
   product: stt
   language: python
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
 ---
 
 # Telnyx Speech-to-Text - Python

--- a/providers/cursor/plugin/skills/telnyx-tts-python/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-tts-python/SKILL.md
@@ -8,8 +8,6 @@ metadata:
   author: telnyx
   product: tts
   language: python
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
 ---
 
 # Telnyx Text-to-Speech - Python

--- a/skills/telnyx-stt-python/SKILL.md
+++ b/skills/telnyx-stt-python/SKILL.md
@@ -8,8 +8,6 @@ metadata:
   author: telnyx
   product: stt
   language: python
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
 ---
 
 # Telnyx Speech-to-Text - Python

--- a/skills/telnyx-tts-python/SKILL.md
+++ b/skills/telnyx-tts-python/SKILL.md
@@ -8,8 +8,6 @@ metadata:
   author: telnyx
   product: tts
   language: python
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
 ---
 
 # Telnyx Text-to-Speech - Python


### PR DESCRIPTION
## Summary

**Merge before the next skills publish** — a full-publish dry run (run locally against a clone, `--dry-run`) caught that the pipeline would DELETE `telnyx-tts-python` and `telnyx-stt-python`.

Root cause: both were hand-authored in #272, but their frontmatter copy-pasted `generated_by: telnyx-ext-skills-generator` + `profile: northstar-v2` from a generated skill. The publisher removes marker-bearing skills it no longer generates (that's how stale generated skills get cleaned up) — and the generator has never emitted tts/stt skills, so these two are deletion-eligible on the next full publish. They've survived only because the daily publish is spec-change-gated.

Fix: strip the two bogus frontmatter lines. Without the marker they fall under the publisher's fail-closed protection for manual skills (it refuses to overwrite non-generated skills). Provider copies resynced; `check-skills-sync.sh` passes.

## Verification

Re-ran the same full-publish dry run with this fix applied locally: both skills survive; deletions are exactly the six `telnyx-seti-*` dirs (intentional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)