### PR TITLE
chore(release): bump agent CLI to 0.4.2

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@telnyx/agent-cli",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@telnyx/agent-cli",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telnyx/agent-cli",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Agent-friendly CLI for Telnyx API v2 — composite setup commands that reduce multi-step workflows to a single command",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- bump `@telnyx/agent-cli` from `0.4.1` to `0.4.2`
- align `cli/package.json` and both lockfile version surfaces
- release the merged Agent CLI feature batch through the targeted `package=cli` npm workflow

## Included since 0.4.1
- generated Telnyx Go CLI v0.24.0 resolution/install hardening
- Anthropic Messages command
- call retry-on-timeout support
- messaging-profile lifecycle actions with bounded pagination
- AI assistants, voice connections, porting orders, Edge v0.3 detection, and the earlier Agent CLI hardening batch

## Verification
- `npm ci`
- `npm run typecheck`
- `npm test` — 456/456 passed
- `npm pack --dry-run --ignore-scripts` — `@telnyx/agent-cli@0.4.2`, 60 files
- npm registry preflight — `0.4.2` is not published
- changed paths restricted to `cli/package.json` and `cli/package-lock.json`
- GitHub release doctor, unit CI, CodeQL, skill-sync, and static analysis — passed
- live API exception — `/networks` and `/global_ips` timed out after retries; 39 other read-only tests passed; unrelated to this manifest-only bump

## Publish plan
- merge this PR
- dispatch `.github/workflows/publish-npm.yml` with `package=cli`
- verify npm version, dist-tag, provenance, and release tag
- do **not** dispatch PyPI: no Python package files changed and `telnyx-agent-toolkit==0.3.0` is already current

Linear: [AIF-389](https://linear.app/telnyx/issue/AIF-389/release-telnyxagent-cli-042)
