### PR TITLE
Update auto-generated Telnyx skills

### DIFF
--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-assistants-curl/SKILL.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-assistants-curl/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: ai-assistants
   language: curl
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-assistants-go/SKILL.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-assistants-go/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: ai-assistants
   language: go
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-assistants-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-assistants-java/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: ai-assistants
   language: java
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.82.0</version>
+    <version>6.85.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.82.0")
+implementation("com.telnyx.sdk:telnyx:6.85.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-assistants-javascript/SKILL.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-assistants-javascript/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: ai-assistants
   language: javascript
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-assistants-python/SKILL.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-assistants-python/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: ai-assistants
   language: python
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-assistants-ruby/SKILL.md
+++ b/providers/claude/plugins/telnyx-ai/skills/telnyx-ai-assistants-ruby/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: ai-assistants
   language: ruby
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/claude/plugins/telnyx-messaging/skills/telnyx-messaging-curl/SKILL.md
+++ b/providers/claude/plugins/telnyx-messaging/skills/telnyx-messaging-curl/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: messaging
   language: curl
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/claude/plugins/telnyx-messaging/skills/telnyx-messaging-go/SKILL.md
+++ b/providers/claude/plugins/telnyx-messaging/skills/telnyx-messaging-go/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: messaging
   language: go
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/claude/plugins/telnyx-messaging/skills/telnyx-messaging-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-messaging/skills/telnyx-messaging-java/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: messaging
   language: java
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.82.0</version>
+    <version>6.85.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.82.0")
+implementation("com.telnyx.sdk:telnyx:6.85.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-messaging/skills/telnyx-messaging-javascript/SKILL.md
+++ b/providers/claude/plugins/telnyx-messaging/skills/telnyx-messaging-javascript/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: messaging
   language: javascript
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/claude/plugins/telnyx-messaging/skills/telnyx-messaging-python/SKILL.md
+++ b/providers/claude/plugins/telnyx-messaging/skills/telnyx-messaging-python/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: messaging
   language: python
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/claude/plugins/telnyx-messaging/skills/telnyx-messaging-ruby/SKILL.md
+++ b/providers/claude/plugins/telnyx-messaging/skills/telnyx-messaging-ruby/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: messaging
   language: ruby
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/claude/plugins/telnyx-numbers/skills/telnyx-10dlc-curl/SKILL.md
+++ b/providers/claude/plugins/telnyx-numbers/skills/telnyx-10dlc-curl/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: 10dlc
   language: curl
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/claude/plugins/telnyx-numbers/skills/telnyx-10dlc-go/SKILL.md
+++ b/providers/claude/plugins/telnyx-numbers/skills/telnyx-10dlc-go/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: 10dlc
   language: go
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/claude/plugins/telnyx-numbers/skills/telnyx-10dlc-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-numbers/skills/telnyx-10dlc-java/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: 10dlc
   language: java
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.82.0</version>
+    <version>6.85.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.82.0")
+implementation("com.telnyx.sdk:telnyx:6.85.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-numbers/skills/telnyx-10dlc-javascript/SKILL.md
+++ b/providers/claude/plugins/telnyx-numbers/skills/telnyx-10dlc-javascript/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: 10dlc
   language: javascript
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/claude/plugins/telnyx-numbers/skills/telnyx-10dlc-python/SKILL.md
+++ b/providers/claude/plugins/telnyx-numbers/skills/telnyx-10dlc-python/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: 10dlc
   language: python
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/claude/plugins/telnyx-numbers/skills/telnyx-10dlc-ruby/SKILL.md
+++ b/providers/claude/plugins/telnyx-numbers/skills/telnyx-10dlc-ruby/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: 10dlc
   language: ruby
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/claude/plugins/telnyx-numbers/skills/telnyx-numbers-curl/SKILL.md
+++ b/providers/claude/plugins/telnyx-numbers/skills/telnyx-numbers-curl/SKILL.md
@@ -6,8 +6,8 @@ metadata:
   author: telnyx
   product: numbers
   language: curl
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/claude/plugins/telnyx-numbers/skills/telnyx-numbers-go/SKILL.md
+++ b/providers/claude/plugins/telnyx-numbers/skills/telnyx-numbers-go/SKILL.md
@@ -6,8 +6,8 @@ metadata:
   author: telnyx
   product: numbers
   language: go
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/claude/plugins/telnyx-numbers/skills/telnyx-numbers-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-numbers/skills/telnyx-numbers-java/SKILL.md
@@ -6,8 +6,8 @@ metadata:
   author: telnyx
   product: numbers
   language: java
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.82.0</version>
+    <version>6.85.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.82.0")
+implementation("com.telnyx.sdk:telnyx:6.85.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-numbers/skills/telnyx-numbers-javascript/SKILL.md
+++ b/providers/claude/plugins/telnyx-numbers/skills/telnyx-numbers-javascript/SKILL.md
@@ -6,8 +6,8 @@ metadata:
   author: telnyx
   product: numbers
   language: javascript
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/claude/plugins/telnyx-numbers/skills/telnyx-numbers-python/SKILL.md
+++ b/providers/claude/plugins/telnyx-numbers/skills/telnyx-numbers-python/SKILL.md
@@ -6,8 +6,8 @@ metadata:
   author: telnyx
   product: numbers
   language: python
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/claude/plugins/telnyx-numbers/skills/telnyx-numbers-ruby/SKILL.md
+++ b/providers/claude/plugins/telnyx-numbers/skills/telnyx-numbers-ruby/SKILL.md
@@ -6,8 +6,8 @@ metadata:
   author: telnyx
   product: numbers
   language: ruby
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/10dlc.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/10dlc.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.82.0</version>
+    <version>6.85.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.82.0")
+implementation("com.telnyx.sdk:telnyx:6.85.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/ai-assistants.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/ai-assistants.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.82.0</version>
+    <version>6.85.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.82.0")
+implementation("com.telnyx.sdk:telnyx:6.85.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/messaging.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/messaging.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.82.0</version>
+    <version>6.85.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.82.0")
+implementation("com.telnyx.sdk:telnyx:6.85.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/numbers.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/numbers.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.82.0</version>
+    <version>6.85.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.82.0")
+implementation("com.telnyx.sdk:telnyx:6.85.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/voice.md
+++ b/providers/claude/plugins/telnyx-platform/skills/telnyx-twilio-migration/sdk-reference/java/voice.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.82.0</version>
+    <version>6.85.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.82.0")
+implementation("com.telnyx.sdk:telnyx:6.85.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-voice/skills/telnyx-voice-curl/SKILL.md
+++ b/providers/claude/plugins/telnyx-voice/skills/telnyx-voice-curl/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: voice
   language: curl
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/claude/plugins/telnyx-voice/skills/telnyx-voice-go/SKILL.md
+++ b/providers/claude/plugins/telnyx-voice/skills/telnyx-voice-go/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: voice
   language: go
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/claude/plugins/telnyx-voice/skills/telnyx-voice-java/SKILL.md
+++ b/providers/claude/plugins/telnyx-voice/skills/telnyx-voice-java/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: voice
   language: java
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.82.0</version>
+    <version>6.85.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.82.0")
+implementation("com.telnyx.sdk:telnyx:6.85.0")
 ```
 
 ## Setup

--- a/providers/claude/plugins/telnyx-voice/skills/telnyx-voice-javascript/SKILL.md
+++ b/providers/claude/plugins/telnyx-voice/skills/telnyx-voice-javascript/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: voice
   language: javascript
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/claude/plugins/telnyx-voice/skills/telnyx-voice-python/SKILL.md
+++ b/providers/claude/plugins/telnyx-voice/skills/telnyx-voice-python/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: voice
   language: python
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/claude/plugins/telnyx-voice/skills/telnyx-voice-ruby/SKILL.md
+++ b/providers/claude/plugins/telnyx-voice/skills/telnyx-voice-ruby/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: voice
   language: ruby
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/cursor/plugin/skills/telnyx-10dlc-curl/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-10dlc-curl/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: 10dlc
   language: curl
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/cursor/plugin/skills/telnyx-10dlc-go/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-10dlc-go/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: 10dlc
   language: go
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/cursor/plugin/skills/telnyx-10dlc-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-10dlc-java/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: 10dlc
   language: java
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.82.0</version>
+    <version>6.85.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.82.0")
+implementation("com.telnyx.sdk:telnyx:6.85.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-10dlc-javascript/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-10dlc-javascript/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: 10dlc
   language: javascript
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/cursor/plugin/skills/telnyx-10dlc-python/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-10dlc-python/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: 10dlc
   language: python
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/cursor/plugin/skills/telnyx-10dlc-ruby/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-10dlc-ruby/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: 10dlc
   language: ruby
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-curl/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-curl/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: ai-assistants
   language: curl
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-go/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-go/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: ai-assistants
   language: go
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-java/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: ai-assistants
   language: java
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.82.0</version>
+    <version>6.85.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.82.0")
+implementation("com.telnyx.sdk:telnyx:6.85.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-javascript/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-javascript/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: ai-assistants
   language: javascript
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-python/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-python/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: ai-assistants
   language: python
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/cursor/plugin/skills/telnyx-ai-assistants-ruby/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-ai-assistants-ruby/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: ai-assistants
   language: ruby
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/cursor/plugin/skills/telnyx-messaging-curl/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-curl/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: messaging
   language: curl
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/cursor/plugin/skills/telnyx-messaging-go/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-go/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: messaging
   language: go
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/cursor/plugin/skills/telnyx-messaging-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-java/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: messaging
   language: java
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.82.0</version>
+    <version>6.85.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.82.0")
+implementation("com.telnyx.sdk:telnyx:6.85.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-messaging-javascript/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-javascript/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: messaging
   language: javascript
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/cursor/plugin/skills/telnyx-messaging-python/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-python/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: messaging
   language: python
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/cursor/plugin/skills/telnyx-messaging-ruby/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-messaging-ruby/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: messaging
   language: ruby
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/cursor/plugin/skills/telnyx-numbers-curl/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-numbers-curl/SKILL.md
@@ -6,8 +6,8 @@ metadata:
   author: telnyx
   product: numbers
   language: curl
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/cursor/plugin/skills/telnyx-numbers-go/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-numbers-go/SKILL.md
@@ -6,8 +6,8 @@ metadata:
   author: telnyx
   product: numbers
   language: go
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/cursor/plugin/skills/telnyx-numbers-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-numbers-java/SKILL.md
@@ -6,8 +6,8 @@ metadata:
   author: telnyx
   product: numbers
   language: java
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.82.0</version>
+    <version>6.85.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.82.0")
+implementation("com.telnyx.sdk:telnyx:6.85.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-numbers-javascript/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-numbers-javascript/SKILL.md
@@ -6,8 +6,8 @@ metadata:
   author: telnyx
   product: numbers
   language: javascript
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/cursor/plugin/skills/telnyx-numbers-python/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-numbers-python/SKILL.md
@@ -6,8 +6,8 @@ metadata:
   author: telnyx
   product: numbers
   language: python
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/cursor/plugin/skills/telnyx-numbers-ruby/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-numbers-ruby/SKILL.md
@@ -6,8 +6,8 @@ metadata:
   author: telnyx
   product: numbers
   language: ruby
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/10dlc.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/10dlc.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.82.0</version>
+    <version>6.85.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.82.0")
+implementation("com.telnyx.sdk:telnyx:6.85.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/ai-assistants.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/ai-assistants.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.82.0</version>
+    <version>6.85.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.82.0")
+implementation("com.telnyx.sdk:telnyx:6.85.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/messaging.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/messaging.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.82.0</version>
+    <version>6.85.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.82.0")
+implementation("com.telnyx.sdk:telnyx:6.85.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/numbers.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/numbers.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.82.0</version>
+    <version>6.85.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.82.0")
+implementation("com.telnyx.sdk:telnyx:6.85.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/voice.md
+++ b/providers/cursor/plugin/skills/telnyx-twilio-migration/sdk-reference/java/voice.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.82.0</version>
+    <version>6.85.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.82.0")
+implementation("com.telnyx.sdk:telnyx:6.85.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-voice-curl/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-curl/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: voice
   language: curl
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/cursor/plugin/skills/telnyx-voice-go/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-go/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: voice
   language: go
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/cursor/plugin/skills/telnyx-voice-java/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-java/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: voice
   language: java
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.82.0</version>
+    <version>6.85.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.82.0")
+implementation("com.telnyx.sdk:telnyx:6.85.0")
 ```
 
 ## Setup

--- a/providers/cursor/plugin/skills/telnyx-voice-javascript/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-javascript/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: voice
   language: javascript
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/cursor/plugin/skills/telnyx-voice-python/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-python/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: voice
   language: python
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/providers/cursor/plugin/skills/telnyx-voice-ruby/SKILL.md
+++ b/providers/cursor/plugin/skills/telnyx-voice-ruby/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: voice
   language: ruby
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/skills/telnyx-10dlc-curl/SKILL.md
+++ b/skills/telnyx-10dlc-curl/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: 10dlc
   language: curl
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/skills/telnyx-10dlc-go/SKILL.md
+++ b/skills/telnyx-10dlc-go/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: 10dlc
   language: go
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/skills/telnyx-10dlc-java/SKILL.md
+++ b/skills/telnyx-10dlc-java/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: 10dlc
   language: java
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.82.0</version>
+    <version>6.85.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.82.0")
+implementation("com.telnyx.sdk:telnyx:6.85.0")
 ```
 
 ## Setup

--- a/skills/telnyx-10dlc-javascript/SKILL.md
+++ b/skills/telnyx-10dlc-javascript/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: 10dlc
   language: javascript
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/skills/telnyx-10dlc-python/SKILL.md
+++ b/skills/telnyx-10dlc-python/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: 10dlc
   language: python
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/skills/telnyx-10dlc-ruby/SKILL.md
+++ b/skills/telnyx-10dlc-ruby/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: 10dlc
   language: ruby
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/skills/telnyx-ai-assistants-curl/SKILL.md
+++ b/skills/telnyx-ai-assistants-curl/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: ai-assistants
   language: curl
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/skills/telnyx-ai-assistants-go/SKILL.md
+++ b/skills/telnyx-ai-assistants-go/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: ai-assistants
   language: go
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/skills/telnyx-ai-assistants-java/SKILL.md
+++ b/skills/telnyx-ai-assistants-java/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: ai-assistants
   language: java
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.82.0</version>
+    <version>6.85.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.82.0")
+implementation("com.telnyx.sdk:telnyx:6.85.0")
 ```
 
 ## Setup

--- a/skills/telnyx-ai-assistants-javascript/SKILL.md
+++ b/skills/telnyx-ai-assistants-javascript/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: ai-assistants
   language: javascript
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/skills/telnyx-ai-assistants-python/SKILL.md
+++ b/skills/telnyx-ai-assistants-python/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: ai-assistants
   language: python
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/skills/telnyx-ai-assistants-ruby/SKILL.md
+++ b/skills/telnyx-ai-assistants-ruby/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: ai-assistants
   language: ruby
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/skills/telnyx-messaging-curl/SKILL.md
+++ b/skills/telnyx-messaging-curl/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: messaging
   language: curl
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/skills/telnyx-messaging-go/SKILL.md
+++ b/skills/telnyx-messaging-go/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: messaging
   language: go
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/skills/telnyx-messaging-java/SKILL.md
+++ b/skills/telnyx-messaging-java/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: messaging
   language: java
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.82.0</version>
+    <version>6.85.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.82.0")
+implementation("com.telnyx.sdk:telnyx:6.85.0")
 ```
 
 ## Setup

--- a/skills/telnyx-messaging-javascript/SKILL.md
+++ b/skills/telnyx-messaging-javascript/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: messaging
   language: javascript
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/skills/telnyx-messaging-python/SKILL.md
+++ b/skills/telnyx-messaging-python/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: messaging
   language: python
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/skills/telnyx-messaging-ruby/SKILL.md
+++ b/skills/telnyx-messaging-ruby/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: messaging
   language: ruby
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/skills/telnyx-numbers-curl/SKILL.md
+++ b/skills/telnyx-numbers-curl/SKILL.md
@@ -6,8 +6,8 @@ metadata:
   author: telnyx
   product: numbers
   language: curl
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/skills/telnyx-numbers-go/SKILL.md
+++ b/skills/telnyx-numbers-go/SKILL.md
@@ -6,8 +6,8 @@ metadata:
   author: telnyx
   product: numbers
   language: go
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/skills/telnyx-numbers-java/SKILL.md
+++ b/skills/telnyx-numbers-java/SKILL.md
@@ -6,8 +6,8 @@ metadata:
   author: telnyx
   product: numbers
   language: java
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->
@@ -21,11 +21,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.82.0</version>
+    <version>6.85.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.82.0")
+implementation("com.telnyx.sdk:telnyx:6.85.0")
 ```
 
 ## Setup

--- a/skills/telnyx-numbers-javascript/SKILL.md
+++ b/skills/telnyx-numbers-javascript/SKILL.md
@@ -6,8 +6,8 @@ metadata:
   author: telnyx
   product: numbers
   language: javascript
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/skills/telnyx-numbers-python/SKILL.md
+++ b/skills/telnyx-numbers-python/SKILL.md
@@ -6,8 +6,8 @@ metadata:
   author: telnyx
   product: numbers
   language: python
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/skills/telnyx-numbers-ruby/SKILL.md
+++ b/skills/telnyx-numbers-ruby/SKILL.md
@@ -6,8 +6,8 @@ metadata:
   author: telnyx
   product: numbers
   language: ruby
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/skills/telnyx-twilio-migration/sdk-reference/java/10dlc.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/10dlc.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.82.0</version>
+    <version>6.85.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.82.0")
+implementation("com.telnyx.sdk:telnyx:6.85.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/ai-assistants.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/ai-assistants.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.82.0</version>
+    <version>6.85.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.82.0")
+implementation("com.telnyx.sdk:telnyx:6.85.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/messaging.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/messaging.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.82.0</version>
+    <version>6.85.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.82.0")
+implementation("com.telnyx.sdk:telnyx:6.85.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/numbers.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/numbers.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.82.0</version>
+    <version>6.85.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.82.0")
+implementation("com.telnyx.sdk:telnyx:6.85.0")
 ```
 
 ## Setup

--- a/skills/telnyx-twilio-migration/sdk-reference/java/voice.md
+++ b/skills/telnyx-twilio-migration/sdk-reference/java/voice.md
@@ -9,11 +9,11 @@
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.82.0</version>
+    <version>6.85.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.82.0")
+implementation("com.telnyx.sdk:telnyx:6.85.0")
 ```
 
 ## Setup

--- a/skills/telnyx-voice-curl/SKILL.md
+++ b/skills/telnyx-voice-curl/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: voice
   language: curl
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/skills/telnyx-voice-go/SKILL.md
+++ b/skills/telnyx-voice-go/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: voice
   language: go
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/skills/telnyx-voice-java/SKILL.md
+++ b/skills/telnyx-voice-java/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: voice
   language: java
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->
@@ -22,11 +22,11 @@ metadata:
 <dependency>
     <groupId>com.telnyx.sdk</groupId>
     <artifactId>telnyx</artifactId>
-    <version>6.82.0</version>
+    <version>6.85.0</version>
 </dependency>
 
 // Gradle
-implementation("com.telnyx.sdk:telnyx:6.82.0")
+implementation("com.telnyx.sdk:telnyx:6.85.0")
 ```
 
 ## Setup

--- a/skills/telnyx-voice-javascript/SKILL.md
+++ b/skills/telnyx-voice-javascript/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: voice
   language: javascript
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/skills/telnyx-voice-python/SKILL.md
+++ b/skills/telnyx-voice-python/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: voice
   language: python
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->

--- a/skills/telnyx-voice-ruby/SKILL.md
+++ b/skills/telnyx-voice-ruby/SKILL.md
@@ -7,8 +7,8 @@ metadata:
   author: telnyx
   product: voice
   language: ruby
-  generated_by: telnyx-ext-skills-generator
-  profile: northstar-v2
+  generated_by: telnyx-openapi-pipeline
+  contract: v2
 ---
 
 <!-- Auto-generated from Telnyx OpenAPI specs. Do not edit. -->


### PR DESCRIPTION
## Auto-generated Telnyx skills update

Updates canonical `skills/` in `team-telnyx/ai` from the OpenAPI skill-generation pipeline and runs `./scripts/sync-skills.sh` to refresh Claude/Cursor provider copies.

- Generated canonical skills copied: 30
- Manual/non-target skills preserved: 206
- Canonical skills total: 236
